### PR TITLE
Added error reporting when a const is mentioned in frame condition

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -8039,6 +8039,8 @@ namespace Microsoft.Dafny
           // error has already been reported by ResolveMember
         } else if (!(member is Field)) {
           reporter.Error(MessageSource.Resolver, fe.E, "member {0} in type {1} does not refer to a field", fe.FieldName, ctype.Name);
+        } else if (member is ConstantField) {
+          reporter.Error(MessageSource.Resolver, fe.E, "expression is not allowed to refer to constant field {0}", fe.FieldName);
         } else {
           Contract.Assert(ctype != null && ctype.ResolvedClass != null);  // follows from postcondition of ResolveMember
           fe.Field = (Field)member;

--- a/Test/dafny0/ResolutionErrors.dfy
+++ b/Test/dafny0/ResolutionErrors.dfy
@@ -1856,8 +1856,8 @@ module DividedConstructors {
       P(g);
       P(this.g);  // "this" is benign here
       modify this;  // error: cannot use "this" here
-      modify this`g;  // error: cannot use "this" here
-      modify `g;  // error: cannot use (implicit) "this" here
+      modify this`c;  // error: cannot use "this" here
+      modify `c;  // error: cannot use (implicit) "this" here
       new;
       a := a + b;
       Helper();
@@ -2847,5 +2847,22 @@ module RegressionGhostTests {
     a[i,5] := 42;  // error: assignment to non-ghost field depends on a ghost
     a[5,i] := 42;  // error: assignment to non-ghost field depends on a ghost
     b[5,5] := 42;  // error: assignment to non-ghost field depends on a ghost
+  }
+}
+
+// --------------- regression test const in frame expression ------------------------------
+
+module RegressionConstFrameExpression {
+  class C {
+    const x: int
+    var y: int
+  }
+  method m(c: C)
+    modifies c`x
+    modifies c`y
+    ensures unchanged(c`x)
+    ensures unchanged(c)
+  {
+
   }
 }

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -441,4 +441,6 @@ ResolutionErrors.dfy(2838,4): Error: ghost variables are allowed only in specifi
 ResolutionErrors.dfy(2847,6): Error: ghost variables are allowed only in specification contexts
 ResolutionErrors.dfy(2848,8): Error: ghost variables are allowed only in specification contexts
 ResolutionErrors.dfy(2849,4): Error: ghost variables are allowed only in specification contexts
-438 resolution/type errors detected in ResolutionErrors.dfy
+ResolutionErrors.dfy(2861,13): Error: expression is not allowed to refer to constant field x
+ResolutionErrors.dfy(2863,22): Error: expression is not allowed to refer to constant field x
+440 resolution/type errors detected in ResolutionErrors.dfy


### PR DESCRIPTION
Dafny created incorrect Boogie files that would talk about constants in the frame condition, thus generating syntacticaly incorrect Boogie.

This commit adds a check that will create an error in Dafny and prevent incorrect Dafny files being compiled into incorrect Boogie.

This issue did not occur when Dafny called Boogie directly, without the detour to a Boogie file.