### PR TITLE
allow dafny to be invoked from a MINGW/"Git Bash" shell

### DIFF
--- a/Binaries/dafny
+++ b/Binaries/dafny
@@ -17,8 +17,8 @@ if [[ ! -e "$DAFNY" ]]; then
 fi
 
 MY_OS=$(uname -s)
-
-if [ "$(expr substr "$MY_OS" 1 5)" == "MINGW" ]; then
+MY_OS_SUBSTR="${MY_OS:0:5}"
+if [ "$MY_OS_SUBSTR" == "MINGW" ]; then
     "$DAFNY" "$@"
 else
     MONO=$(which mono)

--- a/Binaries/dafny
+++ b/Binaries/dafny
@@ -17,8 +17,7 @@ if [[ ! -e "$DAFNY" ]]; then
 fi
 
 MY_OS=$(uname -s)
-MY_OS_SUBSTR="${MY_OS:0:5}"
-if [ "$MY_OS_SUBSTR" == "MINGW" ]; then
+if [ "${MY_OS:0:5}" == "MINGW" ] || [ "${MY_OS:0:6}" == "CYGWIN" ]; then
     "$DAFNY" "$@"
 else
     MONO=$(which mono)

--- a/Binaries/dafny
+++ b/Binaries/dafny
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-MONO=$(which mono)
-
 # find the source directory for this script even if it's been symlinked [issue #185]
 # from https://stackoverflow.com/questions/59895/
 SOURCE="${BASH_SOURCE[0]}"
@@ -13,14 +11,20 @@ done
 DAFNY_ROOT="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 DAFNY="$DAFNY_ROOT/Dafny.exe"
 
-if [[ ! -x "$MONO" ]]; then
-    echo "Error: Dafny requires Mono to run on non-Windows systems."
-    exit 1
-fi
-
 if [[ ! -e "$DAFNY" ]]; then
     echo "Error: Dafny.exe not found at $DAFNY."
     exit 1
 fi
 
-"$MONO" "$DAFNY" "$@"
+MY_OS=$(uname -s)
+
+if [ "$(expr substr "$MY_OS" 1 5)" == "MINGW" ]; then
+    "$DAFNY" "$@"
+else
+    MONO=$(which mono)
+    if [[ ! -x "$MONO" ]]; then
+	echo "Error: Dafny requires Mono to run on non-Windows systems."
+	exit 1
+    fi
+    "$MONO" "$DAFNY" "$@"
+fi


### PR DESCRIPTION
I'd like to run `dafny` from a MINGW shell (the shell I get when I open "Git Bash" on Windows).
In the current state, this fails, because I don't have `mono`.
But since I'm on Windows, I don't need `mono`, and running `Dafny.exe` directly works.
This PR makes the `dafny` bash script detect whether we're on MINGW, and if so, it does not require/use `mono`.
Only tested on Windows so far.