### PR TITLE
Take compile flag into consideration and return appropriate exit code

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -565,6 +565,9 @@ namespace Microsoft.Dafny
       if (!completeProgram) {
         return false;
       }
+      if (!invokeCompiler) {
+        return true;
+      }
 
       object compilationResult;
       var compiledCorrectly = compiler.CompileTargetProgram(dafnyProgramName, targetProgramText, callToMain, targetFilename, otherFileNames,

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Dafny
         string baseName = cce.NonNull(Path.GetFileName(dafnyFileNames[dafnyFileNames.Count - 1]));
         var verified = Boogie(baseName, boogiePrograms, programId, out statss, out oc);
         var compiled = Compile(dafnyFileNames[0], otherFileNames, dafnyProgram, oc, statss, verified);
-        exitValue = verified && compiled ? ExitValue.VERIFIED : !verified ? ExitValue.NOT_VERIFIED : ExitValue.COMPILE_ERROR;
+        exitValue = verified && (compiled || !DafnyOptions.O.Compile) ? ExitValue.VERIFIED : !verified ? ExitValue.NOT_VERIFIED : ExitValue.COMPILE_ERROR;
       }
 
       if (err == null && dafnyProgram != null && DafnyOptions.O.PrintStats) {

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Dafny
 
       if (exitValue == ExitValue.VERIFIED)
       {
-        exitValue = ProcessFiles(dafnyFiles, otherFiles.AsReadOnly(), reporter);
+        exitValue = ProcessFiles(dafnyFiles, otherFiles.AsReadOnly(), reporter); 
       }
 
       if (CommandLineOptions.Clo.XmlSink != null) {
@@ -204,7 +204,7 @@ namespace Microsoft.Dafny
         string baseName = cce.NonNull(Path.GetFileName(dafnyFileNames[dafnyFileNames.Count - 1]));
         var verified = Boogie(baseName, boogiePrograms, programId, out statss, out oc);
         var compiled = Compile(dafnyFileNames[0], otherFileNames, dafnyProgram, oc, statss, verified);
-        exitValue = verified && (compiled || !DafnyOptions.O.Compile) ? ExitValue.VERIFIED : !verified ? ExitValue.NOT_VERIFIED : ExitValue.COMPILE_ERROR;
+        exitValue = verified && compiled ? ExitValue.VERIFIED : !verified ? ExitValue.NOT_VERIFIED : ExitValue.COMPILE_ERROR;
       }
 
       if (err == null && dafnyProgram != null && DafnyOptions.O.PrintStats) {
@@ -561,8 +561,8 @@ namespace Microsoft.Dafny
       }
 
       // compile the program into an assembly
-      if (!completeProgram || !invokeCompiler) {
-        // don't compile
+      // it should not return false when invokeCompiler is false, not compiling is not same as COMPILE_ERROR
+      if (!completeProgram) {
         return false;
       }
 


### PR DESCRIPTION
This changes reflect the following scenarios

1. If compile flag is set to 0 during invocation of the Dafny command, no compilation should take place, for e.g.
`dafny /spillTargetCode:2 /compile:0 foo.dfy`
hence we can ignore the output returned by 
`var compiled = Compile(dafnyFileNames[0], otherFileNames, dafnyProgram, oc, statss, verified);`
2. If compile flag is anything but 0 during invocation of the Dafny command, then control flow will proceed as normal.

Fixes  https://github.com/dafny-lang/dafny/issues/305