### PR TITLE
Make lit more robust on cygwin

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -102,7 +102,7 @@ else:
 
 dafnyExecutable = quotePath(dafnyExecutable)
 
-if os.name == 'posix':
+if platform.system() == 'Linux':
     dafnyExecutable = 'mono ' + dafnyExecutable
     serverExecutable = 'mono ' + serverExecutable
     if lit.util.which('mono') == None:


### PR DESCRIPTION
lit would complain about mono missing on cygwin. Changing the check from posix to Linux does prevent a cygwin shell from passing it and the complaint about mono goes away.