### PR TITLE
pin mono version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono:
-  - 5.20.0
+  - 5.20.1.19
 dist: xenial
 solution: "dafny/Source/Dafny.sln"
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono:
-  - 5.20.1.19
+  - 5.20.1
 dist: xenial
 solution: "dafny/Source/Dafny.sln"
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 5.20.0
 dist: xenial
 solution: "dafny/Source/Dafny.sln"
 addons:


### PR DESCRIPTION
The [latest commit on master](https://github.com/dafny-lang/dafny/commit/5c2d097dac070908069906b1f19c6cffbd98748c) built [successfully](https://travis-ci.org/dafny-lang/dafny/builds/556576411) on Travis using mono 5.20.1.19, but since then, mono 6.0.0 has been released, and since `.travis.yml` does not currently specify a mono version explicitly, Travis always picks the latest mono version, so newer PRs (such as eg https://github.com/dafny-lang/dafny/pull/335) are now built with mono 6.0.0, which introduces a few braking changes, so the CI builds for all PRs fails at the moment.

The failure happens when building boogie, so the the correct fix for this would be to figure out how to port boogie from mono 5.20.1 to mono 6.0.0 (note that this is not visible on Boogie's CI because Boogie's CI uses Ubuntu trusty, while Dafny's CI uses Ubuntu xenial, and Ubuntu trusty is so old that it did not get the update of mono).
However, since we should be [moving to .NET Core](https://github.com/dafny-lang/dafny/pull/311), I'd say it's not worth porting to mono 6.0.0 at the moment, and we should rather focus on getting back a working CI as soon as possible.

Here's the first step towards this: pinning the mono version to 5.20.1. As you can see, it took me three attempts to get it right, and I'd like to keep the bad commits in here for future reference because I couldn't find any documentation about which versions are available (except https://docs.travis-ci.com/user/languages/csharp/ which ends at 3.10.0).

The CI build still fails, but before this PR it was failing while trying to install Boogie, and now it fails inside the Dafny test suite, on the following three tests:
```
Failing Tests (3):
    Dafny :: dafny0/snapshots/Snapshots8.run.dfy
    Dafny :: server/git-issue223.transcript
    Dafny :: server/simple-session.transcript
```

I don't quite understand these failures, but it seems this must have been caused by a change to boogie which was merged between July 9 and now. Anyone who can help with this?
