### PR TITLE
Try to treat general map comprehension as the common case

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -10192,7 +10192,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public SetComprehension(IToken tok, bool finite, List<BoundVar> bvars, Expression range, Expression term, Attributes attrs)
+    public SetComprehension(IToken tok, bool finite, List<BoundVar> bvars, Expression range, Expression/*?*/ term, Attributes attrs)
       : base(tok, bvars, range, term ?? new IdentifierExpr(tok, bvars[0].Name), attrs) {
       Contract.Requires(tok != null);
       Contract.Requires(cce.NonNullElements(bvars));
@@ -10222,6 +10222,31 @@ namespace Microsoft.Dafny {
 
       Finite = finite;
       TermLeft = termLeft;
+    }
+
+    /// <summary>
+    /// IsGeneralMapComprehension returns true for general map comprehensions.
+    /// In other words, it returns false if either no TermLeft was given or if
+    /// the given TermLeft is the sole bound variable.
+    /// This property getter requires that the expression has been successfully
+    /// resolved.
+    /// </summary>
+    public bool IsGeneralMapComprehension {
+      get {
+        Contract.Requires(WasResolved());
+        if (TermLeft == null) {
+          return false;
+        } else if (BoundVars.Count != 1) {
+          return true;
+        }
+        var lhs = StripParens(TermLeft).Resolved;
+        if (lhs is IdentifierExpr ide && ide.Var == BoundVars[0]) {
+          // TermLeft is the sole bound variable, so this is the same as
+          // if TermLeft wasn't given at all
+          return false;
+        }
+        return true;
+      }
     }
 
     public override IEnumerable<Expression> SubExpressions {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -6421,7 +6421,7 @@ namespace Microsoft.Dafny {
         if (e.Range != null) {
           canCall = BplAnd(CanCallAssumption(e.Range, etran), BplImp(etran.TrExpr(e.Range), canCall));
         }
-        if (expr is MapComprehension mc && mc.TermLeft != null) {
+        if (expr is MapComprehension mc && mc.IsGeneralMapComprehension) {
           canCall = BplAnd(canCall, CanCallAssumption(mc.TermLeft, etran));
 
           // The translation of "map x,y | R(x,y) :: F(x,y) := G(x,y)" makes use of projection
@@ -7450,7 +7450,7 @@ namespace Microsoft.Dafny {
         var q = e as QuantifierExpr;
         var lam = e as LambdaExpr;
         var mc = e as MapComprehension;
-        if (mc != null && mc.TermLeft == null) {
+        if (mc != null && !mc.IsGeneralMapComprehension) {
           mc = null;  // mc will be non-null when "e" is a general map comprehension
         }
 
@@ -15284,7 +15284,7 @@ namespace Microsoft.Dafny {
           Bpl.Expr typeAntecedent = translator.GetWhereClause(bv.tok, unboxw, bv.Type, this, NOALLOC);
 
           Bpl.Expr keys, values;
-          if (e.TermLeft == null) {
+          if (!e.IsGeneralMapComprehension) {
             var subst = new Dictionary<IVariable,Expression>();
             subst.Add(e.BoundVars[0], new BoogieWrapper(unboxw, e.BoundVars[0].Type));
 
@@ -17831,7 +17831,7 @@ namespace Microsoft.Dafny {
               newExpr = new SetComprehension(expr.tok, ((SetComprehension)e).Finite, newBoundVars, newRange, newTerm, newAttrs);
             } else if (e is MapComprehension) {
               var mc = (MapComprehension)e;
-              var newTermLeft = mc.TermLeft == null ? null : Substitute(mc.TermLeft);
+              var newTermLeft = mc.IsGeneralMapComprehension ? Substitute(mc.TermLeft) : null;
               newExpr = new MapComprehension(expr.tok, mc.Finite, newBoundVars, newRange, newTermLeft, newTerm, newAttrs);
             } else if (expr is ForallExpr) {
               newExpr = new ForallExpr(expr.tok, ((QuantifierExpr)expr).TypeArgs, newBoundVars, newRange, newTerm, newAttrs);

--- a/Test/allocated1/dafny0/Maps.dfy.expect
+++ b/Test/allocated1/dafny0/Maps.dfy.expect
@@ -40,24 +40,23 @@ Maps.dfy(241,41): Error: possible violation of function precondition
 Maps.dfy(215,13): Related location
 Execution trace:
     (0,0): anon0
-    (0,0): anon21_Then
-    (0,0): anon22_Then
-    (0,0): anon23_Then
-    (0,0): anon24_Then
+    (0,0): anon17_Then
+    (0,0): anon18_Then
+    (0,0): anon19_Then
 Maps.dfy(243,36): Error: possible violation of function precondition
 Maps.dfy(215,13): Related location
 Execution trace:
     (0,0): anon0
-    (0,0): anon26_Then
-    (0,0): anon27_Then
-    (0,0): anon28_Then
+    (0,0): anon20_Then
+    (0,0): anon21_Then
+    (0,0): anon22_Then
 Maps.dfy(243,37): Error: key expressions may be referring to the same value
 Execution trace:
     (0,0): anon0
-    (0,0): anon26_Then
-    (0,0): anon27_Then
-    (0,0): anon28_Then
-    (0,0): anon29_Then
-    (0,0): anon30_Then
+    (0,0): anon20_Then
+    (0,0): anon21_Then
+    (0,0): anon22_Then
+    (0,0): anon23_Then
+    (0,0): anon24_Then
 
 Dafny program verifier finished with 19 verified, 9 errors

--- a/Test/dafny0/Maps.dfy.expect
+++ b/Test/dafny0/Maps.dfy.expect
@@ -40,24 +40,23 @@ Maps.dfy(241,41): Error: possible violation of function precondition
 Maps.dfy(215,13): Related location
 Execution trace:
     (0,0): anon0
-    (0,0): anon21_Then
-    (0,0): anon22_Then
-    (0,0): anon23_Then
-    (0,0): anon24_Then
+    (0,0): anon17_Then
+    (0,0): anon18_Then
+    (0,0): anon19_Then
 Maps.dfy(243,36): Error: possible violation of function precondition
 Maps.dfy(215,13): Related location
 Execution trace:
     (0,0): anon0
-    (0,0): anon26_Then
-    (0,0): anon27_Then
-    (0,0): anon28_Then
+    (0,0): anon20_Then
+    (0,0): anon21_Then
+    (0,0): anon22_Then
 Maps.dfy(243,37): Error: key expressions may be referring to the same value
 Execution trace:
     (0,0): anon0
-    (0,0): anon26_Then
-    (0,0): anon27_Then
-    (0,0): anon28_Then
-    (0,0): anon29_Then
-    (0,0): anon30_Then
+    (0,0): anon20_Then
+    (0,0): anon21_Then
+    (0,0): anon22_Then
+    (0,0): anon23_Then
+    (0,0): anon24_Then
 
 Dafny program verifier finished with 19 verified, 9 errors

--- a/Test/git-issues/git-issue-336.dfy
+++ b/Test/git-issues/git-issue-336.dfy
@@ -1,0 +1,27 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+lemma TestMap(a: map<int, (int,int)>) {
+  // The following assertion used to not prove automatically
+  assert (map k | k in a :: k := a[k].0)
+         // the following map comprehension implicitly uses k as the key
+      == (map k | k in a :: a[k].0);
+}
+
+lemma TestSet0(a: set<int>) {
+  assert (set k | k in a && k < 7 :: k)
+         // the following set comprehension implicitly uses k as the term
+      == (set k | k in a && k < 7);
+}
+
+lemma TestSet1(a: set<int>, m: int) {
+  assert (set k | k in a && k < 7 :: k)
+      == (set k | k in a && k < 7 :: m + (k - m));
+}
+
+lemma TestSet2(a: set<int>, m: int)
+  requires m in a && m < 7
+{
+  assert (set k | k < 7 && k in a)
+      == (set k | k in a :: if k < 7 then k else m);
+}

--- a/Test/git-issues/git-issue-336.dfy.expect
+++ b/Test/git-issues/git-issue-336.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 4 verified, 0 errors


### PR DESCRIPTION
If a general map comprehension has the form `map x | R(x) :: x := T(x)`, then
translate it (in the verifier) in the same way as the common `map x | R(x) :: T(x)`.

Fixes #336