### PR TITLE
use platform.system() instead of os.name to detect whether to use mono

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -102,7 +102,7 @@ else:
 
 dafnyExecutable = quotePath(dafnyExecutable)
 
-if os.name == 'posix':
+if platform.system() != 'Windows':
     dafnyExecutable = 'mono ' + dafnyExecutable
     serverExecutable = 'mono ' + serverExecutable
     if lit.util.which('mono') == None:


### PR DESCRIPTION
In some environments with cygwin (see https://github.com/dafny-lang/dafny/pull/318), os.name returned "posix", which caused mono to be used on Windows.
`platform.system()` returns
- "Windows" in my cmd, git bash, and cygwin shell
- "Linux" on the Ubuntu Travis
- "Darwin" on Mac as tested by Prath

So the most reliable check seems to be `platform.system() != "Windows"`