### PR TITLE
Fix null-dereference crash

### DIFF
--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -3204,7 +3204,7 @@ namespace Microsoft.Dafny {
 
     protected override void EmitIntegerRange(Type type, out TargetWriter wLo, out TargetWriter wHi, TargetWriter wr) {
       if (AsNativeType(type) != null) {
-        wr.Write("{0}.IntegerRange(", TypeName_Companion(type.AsNewtype, wr, tok:null));
+        wr.Write("{0}.IntegerRange(", TypeName_Companion(type.AsNewtype, wr, tok:Bpl.Token.NoToken));
       } else {
         wr.Write("_dafny.IntegerRange(");
       }

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -160,6 +160,9 @@ namespace Microsoft.Dafny {
     protected abstract string TypeName_UDT(string fullCompileName, List<Type> typeArgs, TextWriter wr, Bpl.IToken tok);
     protected abstract string/*?*/ TypeName_Companion(Type type, TextWriter wr, Bpl.IToken tok, MemberDecl/*?*/ member);
     protected string TypeName_Companion(TopLevelDecl cls, TextWriter wr, Bpl.IToken tok) {
+      Contract.Requires(cls != null);
+      Contract.Requires(wr != null);
+      Contract.Requires(tok != null);
       return TypeName_Companion(UserDefinedType.FromTopLevelDecl(tok, cls), wr, tok, null);
     }
     /// Return the "native form" of a type, to which EmitCoercionToNativeForm coerces it.


### PR DESCRIPTION
Fixes a precondition contract failure. Since CodeContracts generate full run-time checks only on Windows and this affected only 4 test files when compiled with the Go compiler, the precondition violation was apparently not detected until now.