### PR TITLE
Typecheck variables in the Requires clause of lambda functions (handles)

### DIFF
--- a/Test/lambdas/LambdaEq.dfy
+++ b/Test/lambdas/LambdaEq.dfy
@@ -1,0 +1,18 @@
+// RUN: %dafny /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+lemma Eq1(b: bool)
+{
+  var f: nat -> int := (x: nat) => x;
+  var g: int -> int := (x: int) => x;
+  var h: int -> int := (x: int) => x;
+  assert g == h; // should pass
+  assert f == g; // should fail because f's and g's domains are different
+}
+
+lemma Eq2(b: bool)
+{
+  var f: nat -> int := (x: nat) => x;
+  var i: nat -> int := (x: int) => x;
+  assert f == i; // should fail because f's and i's actual domains are different
+}

--- a/Test/lambdas/LambdaEq.dfy.expect
+++ b/Test/lambdas/LambdaEq.dfy.expect
@@ -1,0 +1,13 @@
+LambdaEq.dfy(10,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    LambdaEq.dfy(6,24): anon7_Else
+    LambdaEq.dfy(7,24): anon8_Else
+    LambdaEq.dfy(8,24): anon9_Else
+LambdaEq.dfy(17,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    LambdaEq.dfy(15,24): anon5_Else
+    LambdaEq.dfy(16,24): anon6_Else
+
+Dafny program verifier finished with 0 verified, 2 errors


### PR DESCRIPTION
In order to be able to compare two functions for equality we want to ensure that the domains of the functions are the same. In order to achieve that we want to be able to compare two functions' `requires` clauses. For example, the following functions should be considered unequal in Dafny:
```
f: int -> int := (x: int) => x
g: nat -> int := (x: nat) => x
```
However, at the moment, the translations of the `requires` clauses of `f` and `g` would quantify over _all_ inputs and always return true without taking into account that we should quantify only over inputs of type `int` or `nat`. In Boogie pseudocode the translation would look like this:
```
forall x :: f.requires == true
forall x :: g.requires == true
```
As a result, the two functions will be considered equal.
To avoid this, we must take a function's parameter type into account when translating `requires` clauses, which is the purpose of this PR. As a result, the `requires` clauses of the above functions would be translated as follows:
```
forall x :: f.requires == x is an int
forall x :: g.requires == is a nat
```
Since the `requires` clauses for `f` and `g` are different, the functions will not be considered equal.

@RustanLeino @samuelgruetter