### PR TITLE
Changing representation of Reads, Requires, and Apply clauses

### DIFF
--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -313,7 +313,7 @@ axiom (forall s: [ref]bool :: { SetRef_to_SetBox(s) }
 
 // Functions ApplyN, RequiresN, and ReadsN are generated on demand by the translator,
 // but Apply1 is referred to in the prelude, so its definition is hardcoded here.
-function Apply1(Heap, HandleType, Box): Box;
+function Apply1(HandleType): [Heap,Box]Box;
 
 // ---------------------------------------------------------------
 // -- Datatypes --------------------------------------------------
@@ -956,7 +956,7 @@ axiom (forall ty: Ty, heap: Heap, len: int, init: HandleType ::
 axiom (forall ty: Ty, heap: Heap, len: int, init: HandleType, i: int ::
   { Seq#Index(Seq#Create(ty, heap, len, init), i) }
   $IsGoodHeap(heap) && 0 <= i && i < len ==>
-  Seq#Index(Seq#Create(ty, heap, len, init), i) == Apply1(heap, init, $Box(i)));
+  Seq#Index(Seq#Create(ty, heap, len, init), i) == Apply1(init)[heap, $Box(i)]);
 
 function Seq#Append<T>(Seq T, Seq T): Seq T;
 axiom (forall<T> s0: Seq T, s1: Seq T :: { Seq#Length(Seq#Append(s0,s1)) }

--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -181,13 +181,14 @@ axiom (forall<T> v : T, t : Ty, h : Heap ::
     ( $IsAllocBox($Box(v), t, h) <==> $IsAlloc(v,t,h) ));
 
 // ---------------------------------------------------------------
-// -- Is and IsAlloc ---------------------------------------------
+// -- Is, IsAlloc, and Arity -------------------------------------
 // ---------------------------------------------------------------
 
 // Type-argument to $Is is the /representation type/,
 // the second value argument to $Is is the actual type.
 function $Is<T>(T,Ty): bool;           // no heap for now
 function $IsAlloc<T>(T,Ty,Heap): bool;
+function $Arity(HandleType): int;
 
 // Corresponding entries for boxes...
 // This could probably be solved by having Box also inhabit Ty
@@ -312,7 +313,7 @@ axiom (forall s: [ref]bool :: { SetRef_to_SetBox(s) }
 
 // Functions ApplyN, RequiresN, and ReadsN are generated on demand by the translator,
 // but Apply1 is referred to in the prelude, so its definition is hardcoded here.
-function Apply1(Ty, Ty, Heap, HandleType, Box): Box;
+function Apply1(Heap, HandleType, Box): Box;
 
 // ---------------------------------------------------------------
 // -- Datatypes --------------------------------------------------
@@ -955,7 +956,7 @@ axiom (forall ty: Ty, heap: Heap, len: int, init: HandleType ::
 axiom (forall ty: Ty, heap: Heap, len: int, init: HandleType, i: int ::
   { Seq#Index(Seq#Create(ty, heap, len, init), i) }
   $IsGoodHeap(heap) && 0 <= i && i < len ==>
-  Seq#Index(Seq#Create(ty, heap, len, init), i) == Apply1(TInt, TSeq(ty), heap, init, $Box(i)));
+  Seq#Index(Seq#Create(ty, heap, len, init), i) == Apply1(heap, init, $Box(i)));
 
 function Seq#Append<T>(Seq T, Seq T): Seq T;
 axiom (forall<T> s0: Seq T, s1: Seq T :: { Seq#Length(Seq#Append(s0,s1)) }

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -4408,9 +4408,9 @@ namespace Microsoft.Dafny {
         Contract.Ensures(Contract.Result<string>() != null);
 
         if (Name == "requires") {
-          return Translator.Requires(((ArrowTypeDecl)EnclosingClass).Arity);
+          return Translator.RraName(Translator.ReqReadsApp.Requires, ((ArrowTypeDecl)EnclosingClass).Arity);
         } else if (Name == "reads") {
-          return Translator.Reads(((ArrowTypeDecl)EnclosingClass).Arity);
+          return Translator.RraName(Translator.ReqReadsApp.Reads, ((ArrowTypeDecl)EnclosingClass).Arity);
         } else {
           return EnclosingClass.FullSanitizedName + "." + CompileName;
         }
@@ -4422,9 +4422,9 @@ namespace Microsoft.Dafny {
         Contract.Ensures(Contract.Result<string>() != null);
 
         if (Name == "requires") {
-          return Translator.Requires(((ArrowTypeDecl)EnclosingClass).Arity);
+          return Translator.RraName(Translator.ReqReadsApp.Requires, ((ArrowTypeDecl)EnclosingClass).Arity);
         } else if (Name == "reads") {
-          return Translator.Reads(((ArrowTypeDecl)EnclosingClass).Arity);
+          return Translator.RraName(Translator.ReqReadsApp.Reads, ((ArrowTypeDecl)EnclosingClass).Arity);
         } else {
           return EnclosingClass.FullSanitizedRefinementName + "." + CompileName;
         }

--- a/Test/dafny0/MiscTypeInferenceTests.dfy
+++ b/Test/dafny0/MiscTypeInferenceTests.dfy
@@ -21,7 +21,21 @@ module ArrowVariance {
   {
     if * {
       assume forall x :: g.requires(x) && g.reads(x) == {};
-      f := g;  // error: (it would be nice if this didn't produce an error)
+      // When reads and requires clauses used to have take type arguments,
+      // the following assignment used to result in an error.
+      // The error occurred as follows: to prove that g can be assigned
+      // to f, Boogie would check that g is a total function from int to int:
+      //    assert $Is(g#0, Tclass._System.___hTotalFunc1(TInt, TInt));
+      // This can be proved if we know that for all x of type int,
+      // g.requires(x) is true. Since the translateion of the requires clause
+      // used to take a type arguments (corresponding to the function's parameter
+      // and return types), this would mean proving that
+      // g.requires(int, int, x) is true. However, since we only know that
+      // g.requires(int, nat, x) is true, we could not prove it.
+      // Now that we removed type arguments from the requires and reads clauses,
+      // the check can pass. This should not be a problem since typechecking is still
+      // performed by Dafny.
+      f := g;
     } else if * {
       assume forall x :: 0 <= f(x);
       g := f;  // error: (it would be nice if this didn't produce an error)
@@ -105,7 +119,7 @@ module XJ {
     var y: Cell :| y.data == 7;
     var y': Cell? :| y' == null || y'.data == 8;
     var y'': Cell :| true;
-    
+
     var y'3: Cell :| k == 113;  // error: cannot establish existence of LHS
     var y'4: Cell :| false;  // error: cannot establish existence of LHS
     var z: real :| Z(z);
@@ -114,7 +128,7 @@ module XJ {
 
 module Numerics {
   type neg = x: int | x < 0 witness -8
-  
+
   method IntLike() returns (ks: set<nat>, ns: set<neg>, z: bool) {
     var y := -8;
     z := y in ks;

--- a/Test/dafny0/MiscTypeInferenceTests.dfy.expect
+++ b/Test/dafny0/MiscTypeInferenceTests.dfy.expect
@@ -1,42 +1,36 @@
-MiscTypeInferenceTests.dfy(85,11): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'false' (to make it possible for variable 'x' to have the value 'null', declare its type to be 'Node?')
-MiscTypeInferenceTests.dfy(95,16): Warning: the type of the other operand is a set of non-null elements, so the non-inclusion test of 'null' will always return 'true'
+MiscTypeInferenceTests.dfy(99,11): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'false' (to make it possible for variable 'x' to have the value 'null', declare its type to be 'Node?')
+MiscTypeInferenceTests.dfy(109,16): Warning: the type of the other operand is a set of non-null elements, so the non-inclusion test of 'null' will always return 'true'
 MiscTypeInferenceTests.dfy(14,59): Error: value does not satisfy the subset constraints of 'neg'
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Then
     (0,0): anon7_Then
     (0,0): anon8_Then
-MiscTypeInferenceTests.dfy(24,11): Error: value does not satisfy the subset constraints of 'int -> int' (possible cause: it may be partial or have read effects)
-Execution trace:
-    (0,0): anon0
-    (0,0): anon17_Then
-    (0,0): anon18_Then
-    (0,0): anon3
-MiscTypeInferenceTests.dfy(27,11): Error: value does not satisfy the subset constraints of 'int ~> nat'
+MiscTypeInferenceTests.dfy(41,11): Error: value does not satisfy the subset constraints of 'int ~> nat'
 Execution trace:
     (0,0): anon0
     (0,0): anon19_Then
-MiscTypeInferenceTests.dfy(50,13): Error: possible violation of function precondition
+MiscTypeInferenceTests.dfy(64,13): Error: possible violation of function precondition
 Execution trace:
     (0,0): anon0
-MiscTypeInferenceTests.dfy(50,16): Error: assertion violation
+MiscTypeInferenceTests.dfy(64,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-MiscTypeInferenceTests.dfy(109,18): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
-Execution trace:
-    (0,0): anon0
-    (0,0): anon3_Then
-    (0,0): anon2
-MiscTypeInferenceTests.dfy(110,18): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
+MiscTypeInferenceTests.dfy(123,18): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
     (0,0): anon2
-MiscTypeInferenceTests.dfy(143,15): Error: value does not satisfy the subset constraints of 'nat'
+MiscTypeInferenceTests.dfy(124,18): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
 Execution trace:
     (0,0): anon0
-MiscTypeInferenceTests.dfy(155,15): Error: value does not satisfy the subset constraints of 'nat'
+    (0,0): anon3_Then
+    (0,0): anon2
+MiscTypeInferenceTests.dfy(157,15): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+MiscTypeInferenceTests.dfy(169,15): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 10 verified, 9 errors
+Dafny program verifier finished with 10 verified, 8 errors


### PR DESCRIPTION
This PR changes the representation of function handles which currently are translated into a tuple of three functions: `Requires`, `Reads`, and `Apply` (RRA). This commit
- removes type parameters from RRA functions,
- factors out the creation of RRA functions into one central place,
- changes the type of RRA functions from
```
    Requires: [Heap, HandleType, Box, ..., Box]bool
    Reads: [Heap, HandleType, Box, ..., Box]Set Box
    Apply: [Heap, HandleType, Box, ..., Box]Box
```
    to
```
    Requires: HandleType -> [Heap, Box, ..., Box]bool
    Reads: HandleType -> [Heap, Box, ..., Box]Set Box
    Apply: HandleType -> [Heap, Box, ..., Box]Box
```