### PR TITLE
Fix ordering of static const's

### DIFF
--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -884,7 +884,7 @@ namespace Microsoft.Dafny {
           consts.Add((ConstantField)decl);
         }
       }
-      consts.Sort((a, b) => (c.Module.CallGraph.GetSCCRepresentativeId(b) - c.Module.CallGraph.GetSCCRepresentativeId(a)));
+      consts.Sort((a, b) => c.Module.CallGraph.GetSCCRepresentativeId(a) - c.Module.CallGraph.GetSCCRepresentativeId(b));
       foreach (var con in consts) {
         decls.Remove(con);
       }

--- a/Test/comp/Class.dfy
+++ b/Test/comp/Class.dfy
@@ -122,6 +122,7 @@ method Main() {
   t3 := t;
   // Upcast via function call
   CallEm(c, t, i);
+  DependentStaticConsts.Test();
 }
 
 module Module1 {
@@ -132,4 +133,20 @@ module Module2 {
   import Module1
 
   class ClassExtendingTraitInOtherModule extends Module1.TraitInModule { } 
+}
+
+module DependentStaticConsts {
+  newtype ID = x: int | 0 <= x < 100
+
+  // regression test: const's A,B,C,D should all be initialized before Suite is
+  const A: ID := 0
+  const B: ID := 1
+  const C: ID := 2
+  const Suite := map[A := "hello", B := "hi", C := "bye", D := "later"]
+  const D: ID := 3
+
+  method Test()
+  {
+    print Suite[B], " ", Suite[D], "\n";  // hi later
+  }
 }

--- a/Test/comp/Class.dfy.expect
+++ b/Test/comp/Class.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 8 verified, 0 errors
 true true false
 103 103 103 106 106 106
 203 17 0 18 8 9 69 70
@@ -8,8 +8,9 @@ true true false
 0 18 9 70
 0 18 9 70
 0 18 9 70
+hi later
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 8 verified, 0 errors
 true true false
 103 103 103 106 106 106
 203 17 0 18 8 9 69 70
@@ -18,8 +19,9 @@ true true false
 0 18 9 70
 0 18 9 70
 0 18 9 70
+hi later
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 8 verified, 0 errors
 true true false
 103 103 103 106 106 106
 203 17 0 18 8 9 69 70
@@ -28,8 +30,9 @@ true true false
 0 18 9 70
 0 18 9 70
 0 18 9 70
+hi later
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 8 verified, 0 errors
 true true false
 103 103 103 106 106 106
 203 17 0 18 8 9 69 70
@@ -38,3 +41,4 @@ true true false
 0 18 9 70
 0 18 9 70
 0 18 9 70
+hi later


### PR DESCRIPTION
Dafny does not care about the order in which static or module-level `const` declarations are given, but there must not be any cyclic dependencies among them. The semantics is independent of the order of declaration. Target languages may care about this ordering, so the compiler sorts the declarations according to the dependency relation computed in the Resolver. Alas, the comparison operation used to sort the declarations was reversed, so the declarations ended up in the opposite order of what was needed.