### PR TITLE
Fix name protect for const

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1570,7 +1570,7 @@ namespace Microsoft.Dafny
       postString = "";
       switch (id) {
         case SpecialField.ID.UseIdParam:
-          compiledName = (string)idParam;
+          compiledName = IdProtect((string)idParam);
           break;
         case SpecialField.ID.ArrayLength:
         case SpecialField.ID.ArrayLengthInt:

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -2259,7 +2259,7 @@ namespace Microsoft.Dafny {
       postString = "";
       switch (id) {
         case SpecialField.ID.UseIdParam:
-          compiledName = (string)idParam;
+          compiledName = IdProtect((string)idParam);
           break;
         case SpecialField.ID.ArrayLength:
         case SpecialField.ID.ArrayLengthInt:

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -891,7 +891,7 @@ namespace Microsoft.Dafny{
       postString = "";
       switch (id) {
         case SpecialField.ID.UseIdParam:
-          compiledName = (string)idParam;
+          compiledName = IdProtect((string)idParam);
           break;
         case SpecialField.ID.ArrayLength:
         case SpecialField.ID.ArrayLengthInt:

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -1372,7 +1372,7 @@ namespace Microsoft.Dafny {
       postString = "";
       switch (id) {
         case SpecialField.ID.UseIdParam:
-          compiledName = (string)idParam;
+          compiledName = IdProtect((string)idParam);
           break;
         case SpecialField.ID.ArrayLength:
         case SpecialField.ID.ArrayLengthInt:

--- a/Test/dafny0/Compilation.dfy
+++ b/Test/dafny0/Compilation.dfy
@@ -155,13 +155,13 @@ module M {
     A
   }
   class public {
-    var private: int;
+    var private: int const namespace: int const fallthrough: int const try: int
   }
 }
 
 method Caller() {
   var p := new M.public;
-  var x := p.private;
+  var x := p.private + p.namespace + p.fallthrough + p.try;
 }
 
 // ----- digits-identifiers for destructors -----


### PR DESCRIPTION
Previously, a `const` named `namespace` (for example) would generate malformed C# (and similarly for other target languages).