### PR TITLE
Simple installation on Mac OS X

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,10 @@ Dafny's sources.
 Building on Mac OS X 
 ====================
 
+You can use [Homebrew](https://brew.sh) to install Dafny:
+
+       brew install dafny
+
 Tested on Mac OS X 10.12.6 (Sierra).  Note that we now have
 [official releases for Mac OS X](https://github.com/Microsoft/dafny/releases),
 so these instructions mostly apply to people interested in looking at


### PR DESCRIPTION
I made dafny available on homebrew. It can be simply installed with one line now.