### PR TITLE
C#: Add Dafny.Sequence.Subsequence()

### DIFF
--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -972,6 +972,38 @@ namespace Dafny
         return this;
       return Drop((long)n);
     }
+    public Sequence<T> Subsequence(long lo, long hi) {
+      if (lo == 0 && hi == elmts.Length) {
+        return this;
+      }
+      T[] a = new T[hi - lo];
+      System.Array.Copy(elmts, lo, a, 0, hi - lo);
+      return new Sequence<T>(a);
+    }
+    public Sequence<T> Subsequence(long lo, ulong hi) {
+      return Subsequence(lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(long lo, BigInteger hi) {
+      return Subsequence(lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(ulong lo, long hi) {
+      return Subsequence((long)lo, hi);
+    }
+    public Sequence<T> Subsequence(ulong lo, ulong hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(ulong lo, BigInteger hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(BigInteger lo, long hi) {
+      return Subsequence((long)lo, hi);
+    }
+    public Sequence<T> Subsequence(BigInteger lo, ulong hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(BigInteger lo, BigInteger hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
   }
   public struct Pair<A, B>
   {

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1692,10 +1692,19 @@ namespace Microsoft.Dafny
       }
       TrParenExpr(source, wr, inLetExprBody);
       if (hi != null) {
-        TrParenExpr(".Take", hi, wr, inLetExprBody);
-      }
-      if (lo != null) {
-        TrParenExpr(".Drop", lo, wr, inLetExprBody);
+        if (lo != null) {
+          wr.Write(".Subsequence(");
+          TrExpr(lo, wr, inLetExprBody);
+          wr.Write(", ");
+          TrExpr(hi, wr, inLetExprBody);
+          wr.Write(")");
+        } else {
+          TrParenExpr(".Take", hi, wr, inLetExprBody);
+        }
+      } else {
+        if (lo != null) {
+          TrParenExpr(".Drop", lo, wr, inLetExprBody);
+        }
       }
     }
 

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -972,6 +972,38 @@ namespace Dafny
         return this;
       return Drop((long)n);
     }
+    public Sequence<T> Subsequence(long lo, long hi) {
+      if (lo == 0 && hi == elmts.Length) {
+        return this;
+      }
+      T[] a = new T[hi - lo];
+      System.Array.Copy(elmts, lo, a, 0, hi - lo);
+      return new Sequence<T>(a);
+    }
+    public Sequence<T> Subsequence(long lo, ulong hi) {
+      return Subsequence(lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(long lo, BigInteger hi) {
+      return Subsequence(lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(ulong lo, long hi) {
+      return Subsequence((long)lo, hi);
+    }
+    public Sequence<T> Subsequence(ulong lo, ulong hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(ulong lo, BigInteger hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(BigInteger lo, long hi) {
+      return Subsequence((long)lo, hi);
+    }
+    public Sequence<T> Subsequence(BigInteger lo, ulong hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
+    public Sequence<T> Subsequence(BigInteger lo, BigInteger hi) {
+      return Subsequence((long)lo, (long)hi);
+    }
   }
   public struct Pair<A, B>
   {


### PR DESCRIPTION
Currently, s[lo..hi] is translated as s.Take(hi).Drop(lo), which is very expensive if lo is high.  This patch writes s.Subsequence(lo, hi) instead, where Subsequence is a new Sequence method.