### PR TITLE
C#: Lazy sequence concatenation

### DIFF
--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -804,15 +804,11 @@ namespace Dafny
     }
   }
 
-  public class Sequence<T>
+  public abstract class Sequence<T>
   {
-    readonly T[] elmts;
-    public Sequence(T[] ee) {
-      elmts = ee;
-    }
     public static Sequence<T> Empty {
       get {
-        return new Sequence<T>(new T[0]);
+        return new ArraySequence<T>(new T[0]);
       }
     }
     public static Sequence<T> Create(BigInteger length, System.Func<BigInteger, T> init) {
@@ -821,53 +817,59 @@ namespace Dafny
       for (int i = 0; i < len; i++) {
         values[i] = init(new BigInteger(i));
       }
-      return new Sequence<T>(values);
+      return new ArraySequence<T>(values);
+    }
+    public static Sequence<T> FromArray(T[] values) {
+      return new ArraySequence<T>(values);
     }
     public static Sequence<T> FromElements(params T[] values) {
-      return new Sequence<T>(values);
+      return new ArraySequence<T>(values);
     }
     public static Sequence<char> FromString(string s) {
-      return new Sequence<char>(s.ToCharArray());
+      return new ArraySequence<char>(s.ToCharArray());
     }
     public static Sequence<T> _DafnyDefaultValue() {
       return Empty;
     }
     public int Count {
-      get { return elmts.Length; }
+      get { return Elements.Length; }
     }
     public long LongCount {
-      get { return elmts.LongLength; }
+      get { return Elements.LongLength; }
     }
-    public T[] Elements {
-      get {
-        return elmts;
-      }
+    public abstract T[] Elements { get; }
+    // Return whether the sequence is known to be empty.  May return false
+    // spuriously (see ConcatSequence).
+    public virtual bool KnownEmpty {
+      get { return Elements.Length == 0; }
     }
+
     public IEnumerable<T> UniqueElements {
       get {
-        var st = Set<T>.FromElements(elmts);
+        var st = Set<T>.FromElements(Elements);
         return st.Elements;
       }
     }
+
     public T Select(ulong index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(long index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(uint index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(int index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(BigInteger index) {
-      return elmts[(int)index];
+      return Elements[(int)index];
     }
     public Sequence<T> Update(long index, T t) {
-      T[] a = (T[])elmts.Clone();
+      T[] a = (T[])Elements.Clone();
       a[index] = t;
-      return new Sequence<T>(a);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Update(ulong index, T t) {
       return Update((long)index, t);
@@ -876,32 +878,32 @@ namespace Dafny
       return Update((long)index, t);
     }
     public bool Equals(Sequence<T> other) {
-      int n = elmts.Length;
-      return n == other.elmts.Length && EqualUntil(other, n);
+      int n = Elements.Length;
+      return n == other.Elements.Length && EqualUntil(other, n);
     }
     public override bool Equals(object other) {
       return other is Sequence<T> && Equals((Sequence<T>)other);
     }
     public override int GetHashCode() {
-      if (elmts == null || elmts.Length == 0)
+      if (Elements == null || Elements.Length == 0)
         return 0;
       var hashCode = 0;
-      for (var i = 0; i < elmts.Length; i++) {
-        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(elmts[i]);
+      for (var i = 0; i < Elements.Length; i++) {
+        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(Elements[i]);
       }
       return hashCode;
     }
     public override string ToString() {
-      if (elmts is char[]) {
+      if (Elements is char[]) {
         var s = "";
-        foreach (var t in elmts) {
+        foreach (var t in Elements) {
           s += t.ToString();
         }
         return s;
       } else {
         var s = "[";
         var sep = "";
-        foreach (var t in elmts) {
+        foreach (var t in Elements) {
           s += sep + Dafny.Helpers.ToString(t);
           sep = ", ";
         }
@@ -910,46 +912,43 @@ namespace Dafny
     }
     bool EqualUntil(Sequence<T> other, int n) {
       for (int i = 0; i < n; i++) {
-        if (!Dafny.Helpers.AreEqual(elmts[i], other.elmts[i]))
+        if (!Dafny.Helpers.AreEqual(Elements[i], other.Elements[i]))
           return false;
       }
       return true;
     }
     public bool IsProperPrefixOf(Sequence<T> other) {
-      int n = elmts.Length;
-      return n < other.elmts.Length && EqualUntil(other, n);
+      int n = Elements.Length;
+      return n < other.Elements.Length && EqualUntil(other, n);
     }
     public bool IsPrefixOf(Sequence<T> other) {
-      int n = elmts.Length;
-      return n <= other.elmts.Length && EqualUntil(other, n);
+      int n = Elements.Length;
+      return n <= other.Elements.Length && EqualUntil(other, n);
     }
     public Sequence<T> Concat(Sequence<T> other) {
-      if (elmts.Length == 0)
+      if (KnownEmpty)
         return other;
-      else if (other.elmts.Length == 0)
+      else if (other.KnownEmpty)
         return this;
-      T[] a = new T[elmts.Length + other.elmts.Length];
-      System.Array.Copy(elmts, 0, a, 0, elmts.Length);
-      System.Array.Copy(other.elmts, 0, a, elmts.Length, other.elmts.Length);
-      return new Sequence<T>(a);
+      return new ConcatSequence<T>(this, other);
     }
     public bool Contains<G>(G g) {
       if (g == null || g is T) {
         var t = (T)(object)g;
-        int n = elmts.Length;
+        int n = Elements.Length;
         for (int i = 0; i < n; i++) {
-          if (Dafny.Helpers.AreEqual(t, elmts[i]))
+          if (Dafny.Helpers.AreEqual(t, Elements[i]))
             return true;
         }
       }
       return false;
     }
     public Sequence<T> Take(long m) {
-      if (elmts.LongLength == m)
+      if (Elements.LongLength == m)
         return this;
       T[] a = new T[m];
-      System.Array.Copy(elmts, a, m);
-      return new Sequence<T>(a);
+      System.Array.Copy(Elements, a, m);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Take(ulong n) {
       return Take((long)n);
@@ -960,9 +959,9 @@ namespace Dafny
     public Sequence<T> Drop(long m) {
       if (m == 0)
         return this;
-      T[] a = new T[elmts.Length - m];
-      System.Array.Copy(elmts, m, a, 0, elmts.Length - m);
-      return new Sequence<T>(a);
+      T[] a = new T[Elements.Length - m];
+      System.Array.Copy(Elements, m, a, 0, Elements.Length - m);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Drop(ulong n) {
       return Drop((long)n);
@@ -973,12 +972,12 @@ namespace Dafny
       return Drop((long)n);
     }
     public Sequence<T> Subsequence(long lo, long hi) {
-      if (lo == 0 && hi == elmts.Length) {
+      if (lo == 0 && hi == Elements.Length) {
         return this;
       }
       T[] a = new T[hi - lo];
-      System.Array.Copy(elmts, lo, a, 0, hi - lo);
-      return new Sequence<T>(a);
+      System.Array.Copy(Elements, lo, a, 0, hi - lo);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Subsequence(long lo, ulong hi) {
       return Subsequence(lo, (long)hi);
@@ -1003,6 +1002,73 @@ namespace Dafny
     }
     public Sequence<T> Subsequence(BigInteger lo, BigInteger hi) {
       return Subsequence((long)lo, (long)hi);
+    }
+  }
+  internal class ArraySequence<T> : Sequence<T> {
+    private readonly T[] elmts;
+
+    internal ArraySequence(T[] ee) {
+      elmts = ee;
+    }
+    public override T[] Elements {
+      get {
+        return elmts;
+      }
+    }
+  }
+  internal class ConcatSequence<T> : Sequence<T> {
+    private Sequence<T> left, right;
+    private T[] elmts = null;
+
+    internal ConcatSequence(Sequence<T> left, Sequence<T> right) {
+      this.left = left;
+      this.right = right;
+    }
+
+    public override T[] Elements {
+      get {
+        if (elmts == null) {
+          elmts = ComputeElements();
+          // We don't need the original sequences anymore; let them be
+          // garbage-collected
+          left = null;
+          right = null;
+        }
+        return elmts;
+      }
+    }
+
+    public override bool KnownEmpty {
+      get {
+        // Check for emptiness without triggering lazy computation
+        return elmts != null && elmts.Length == 0;
+      }
+    }
+
+    private T[] ComputeElements() {
+      // Traverse the tree formed by all descendants which are ConcatSequences
+
+      var list = new List<T>();
+      var toVisit = new Stack<Sequence<T>>();
+      toVisit.Push(right);
+      toVisit.Push(left);
+
+      while (toVisit.Count != 0) {
+        var seq = toVisit.Pop();
+        if (seq is ConcatSequence<T>) {
+          var cs = (ConcatSequence<T>)seq;
+          if (cs.elmts != null) {
+            list.AddRange(cs.elmts);
+          } else {
+            toVisit.Push(cs.right);
+            toVisit.Push(cs.left);
+          }
+        } else {
+          list.AddRange(seq.Elements);
+        }
+      }
+
+      return list.ToArray();
     }
   }
   public struct Pair<A, B>
@@ -1199,7 +1265,7 @@ namespace Dafny
       }
     }
     public static Sequence<T> SeqFromArray<T>(T[] array) {
-      return new Sequence<T>((T[])array.Clone());
+      return new ArraySequence<T>((T[])array.Clone());
     }
     // In .NET version 4.5, it it possible to mark a method with "AggressiveInlining", which says to inline the
     // method if possible.  Method "ExpressionSequence" would be a good candidate for it:

--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -885,11 +885,12 @@ namespace Dafny
       return other is Sequence<T> && Equals((Sequence<T>)other);
     }
     public override int GetHashCode() {
-      if (Elements == null || Elements.Length == 0)
+      T[] elmts = Elements;
+      if (elmts == null || elmts.Length == 0)
         return 0;
       var hashCode = 0;
-      for (var i = 0; i < Elements.Length; i++) {
-        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(Elements[i]);
+      for (var i = 0; i < elmts.Length; i++) {
+        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(elmts[i]);
       }
       return hashCode;
     }
@@ -911,8 +912,9 @@ namespace Dafny
       }
     }
     bool EqualUntil(Sequence<T> other, int n) {
+      T[] elmts = Elements, otherElmts = other.Elements;
       for (int i = 0; i < n; i++) {
-        if (!Dafny.Helpers.AreEqual(Elements[i], other.Elements[i]))
+        if (!Dafny.Helpers.AreEqual(elmts[i], otherElmts[i]))
           return false;
       }
       return true;
@@ -935,9 +937,10 @@ namespace Dafny
     public bool Contains<G>(G g) {
       if (g == null || g is T) {
         var t = (T)(object)g;
-        int n = Elements.Length;
+        var elmts = Elements;
+        int n = elmts.Length;
         for (int i = 0; i < n; i++) {
-          if (Dafny.Helpers.AreEqual(t, Elements[i]))
+          if (Dafny.Helpers.AreEqual(t, elmts[i]))
             return true;
         }
       }

--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -832,17 +832,10 @@ namespace Dafny
       return Empty;
     }
     public int Count {
-      get { return Elements.Length; }
+      get { return (int)LongCount; }
     }
-    public long LongCount {
-      get { return Elements.LongLength; }
-    }
+    public abstract long LongCount { get; }
     public abstract T[] Elements { get; }
-    // Return whether the sequence is known to be empty.  May return false
-    // spuriously (see ConcatSequence).
-    public virtual bool KnownEmpty {
-      get { return Elements.Length == 0; }
-    }
 
     public IEnumerable<T> UniqueElements {
       get {
@@ -928,9 +921,9 @@ namespace Dafny
       return n <= other.Elements.Length && EqualUntil(other, n);
     }
     public Sequence<T> Concat(Sequence<T> other) {
-      if (KnownEmpty)
+      if (Count == 0)
         return other;
-      else if (other.KnownEmpty)
+      else if (other.Count == 0)
         return this;
       return new ConcatSequence<T>(this, other);
     }
@@ -1018,14 +1011,21 @@ namespace Dafny
         return elmts;
       }
     }
+    public override long LongCount {
+      get {
+        return elmts.LongLength;
+      }
+    }
   }
   internal class ConcatSequence<T> : Sequence<T> {
     private Sequence<T> left, right;
     private T[] elmts = null;
+    private readonly long count;
 
     internal ConcatSequence(Sequence<T> left, Sequence<T> right) {
       this.left = left;
       this.right = right;
+      this.count = left.LongCount + right.LongCount;
     }
 
     public override T[] Elements {
@@ -1041,10 +1041,9 @@ namespace Dafny
       }
     }
 
-    public override bool KnownEmpty {
+    public override long LongCount {
       get {
-        // Check for emptiness without triggering lazy computation
-        return elmts != null && elmts.Length == 0;
+        return count;
       }
     }
 

--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -1018,6 +1018,8 @@ namespace Dafny
     }
   }
   internal class ConcatSequence<T> : Sequence<T> {
+    // INVARIANT: Either left != null, right != null, and elmts == null or
+    // left == null, right == null, and elmts != null
     private Sequence<T> left, right;
     private T[] elmts = null;
     private readonly long count;
@@ -1050,27 +1052,27 @@ namespace Dafny
     private T[] ComputeElements() {
       // Traverse the tree formed by all descendants which are ConcatSequences
 
-      var list = new List<T>();
+      var ans = new T[count];
+      var nextIndex = 0L;
+
       var toVisit = new Stack<Sequence<T>>();
       toVisit.Push(right);
       toVisit.Push(left);
 
       while (toVisit.Count != 0) {
         var seq = toVisit.Pop();
-        if (seq is ConcatSequence<T>) {
-          var cs = (ConcatSequence<T>)seq;
-          if (cs.elmts != null) {
-            list.AddRange(cs.elmts);
-          } else {
-            toVisit.Push(cs.right);
-            toVisit.Push(cs.left);
-          }
+        var cs = seq as ConcatSequence<T>;
+        if (cs != null && cs.elmts == null) {
+          toVisit.Push(cs.right);
+          toVisit.Push(cs.left);
         } else {
-          list.AddRange(seq.Elements);
+          var array = seq.Elements;
+          array.CopyTo(ans, nextIndex);
+          nextIndex += array.LongLength;
         }
       }
 
-      return list.ToArray();
+      return ans;
     }
   }
   public struct Pair<A, B>

--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -1269,7 +1269,7 @@ namespace Dafny
     public static Sequence<T> SeqFromArray<T>(T[] array) {
       return new ArraySequence<T>((T[])array.Clone());
     }
-    // In .NET version 4.5, it it possible to mark a method with "AggressiveInlining", which says to inline the
+    // In .NET version 4.5, it is possible to mark a method with "AggressiveInlining", which says to inline the
     // method if possible.  Method "ExpressionSequence" would be a good candidate for it:
     // [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static U ExpressionSequence<T, U>(T t, U u)

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -804,15 +804,11 @@ namespace Dafny
     }
   }
 
-  public class Sequence<T>
+  public abstract class Sequence<T>
   {
-    readonly T[] elmts;
-    public Sequence(T[] ee) {
-      elmts = ee;
-    }
     public static Sequence<T> Empty {
       get {
-        return new Sequence<T>(new T[0]);
+        return new ArraySequence<T>(new T[0]);
       }
     }
     public static Sequence<T> Create(BigInteger length, System.Func<BigInteger, T> init) {
@@ -821,53 +817,59 @@ namespace Dafny
       for (int i = 0; i < len; i++) {
         values[i] = init(new BigInteger(i));
       }
-      return new Sequence<T>(values);
+      return new ArraySequence<T>(values);
+    }
+    public static Sequence<T> FromArray(T[] values) {
+      return new ArraySequence<T>(values);
     }
     public static Sequence<T> FromElements(params T[] values) {
-      return new Sequence<T>(values);
+      return new ArraySequence<T>(values);
     }
     public static Sequence<char> FromString(string s) {
-      return new Sequence<char>(s.ToCharArray());
+      return new ArraySequence<char>(s.ToCharArray());
     }
     public static Sequence<T> _DafnyDefaultValue() {
       return Empty;
     }
     public int Count {
-      get { return elmts.Length; }
+      get { return Elements.Length; }
     }
     public long LongCount {
-      get { return elmts.LongLength; }
+      get { return Elements.LongLength; }
     }
-    public T[] Elements {
-      get {
-        return elmts;
-      }
+    public abstract T[] Elements { get; }
+    // Return whether the sequence is known to be empty.  May return false
+    // spuriously (see ConcatSequence).
+    public virtual bool KnownEmpty {
+      get { return Elements.Length == 0; }
     }
+
     public IEnumerable<T> UniqueElements {
       get {
-        var st = Set<T>.FromElements(elmts);
+        var st = Set<T>.FromElements(Elements);
         return st.Elements;
       }
     }
+
     public T Select(ulong index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(long index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(uint index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(int index) {
-      return elmts[index];
+      return Elements[index];
     }
     public T Select(BigInteger index) {
-      return elmts[(int)index];
+      return Elements[(int)index];
     }
     public Sequence<T> Update(long index, T t) {
-      T[] a = (T[])elmts.Clone();
+      T[] a = (T[])Elements.Clone();
       a[index] = t;
-      return new Sequence<T>(a);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Update(ulong index, T t) {
       return Update((long)index, t);
@@ -876,32 +878,32 @@ namespace Dafny
       return Update((long)index, t);
     }
     public bool Equals(Sequence<T> other) {
-      int n = elmts.Length;
-      return n == other.elmts.Length && EqualUntil(other, n);
+      int n = Elements.Length;
+      return n == other.Elements.Length && EqualUntil(other, n);
     }
     public override bool Equals(object other) {
       return other is Sequence<T> && Equals((Sequence<T>)other);
     }
     public override int GetHashCode() {
-      if (elmts == null || elmts.Length == 0)
+      if (Elements == null || Elements.Length == 0)
         return 0;
       var hashCode = 0;
-      for (var i = 0; i < elmts.Length; i++) {
-        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(elmts[i]);
+      for (var i = 0; i < Elements.Length; i++) {
+        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(Elements[i]);
       }
       return hashCode;
     }
     public override string ToString() {
-      if (elmts is char[]) {
+      if (Elements is char[]) {
         var s = "";
-        foreach (var t in elmts) {
+        foreach (var t in Elements) {
           s += t.ToString();
         }
         return s;
       } else {
         var s = "[";
         var sep = "";
-        foreach (var t in elmts) {
+        foreach (var t in Elements) {
           s += sep + Dafny.Helpers.ToString(t);
           sep = ", ";
         }
@@ -910,46 +912,43 @@ namespace Dafny
     }
     bool EqualUntil(Sequence<T> other, int n) {
       for (int i = 0; i < n; i++) {
-        if (!Dafny.Helpers.AreEqual(elmts[i], other.elmts[i]))
+        if (!Dafny.Helpers.AreEqual(Elements[i], other.Elements[i]))
           return false;
       }
       return true;
     }
     public bool IsProperPrefixOf(Sequence<T> other) {
-      int n = elmts.Length;
-      return n < other.elmts.Length && EqualUntil(other, n);
+      int n = Elements.Length;
+      return n < other.Elements.Length && EqualUntil(other, n);
     }
     public bool IsPrefixOf(Sequence<T> other) {
-      int n = elmts.Length;
-      return n <= other.elmts.Length && EqualUntil(other, n);
+      int n = Elements.Length;
+      return n <= other.Elements.Length && EqualUntil(other, n);
     }
     public Sequence<T> Concat(Sequence<T> other) {
-      if (elmts.Length == 0)
+      if (KnownEmpty)
         return other;
-      else if (other.elmts.Length == 0)
+      else if (other.KnownEmpty)
         return this;
-      T[] a = new T[elmts.Length + other.elmts.Length];
-      System.Array.Copy(elmts, 0, a, 0, elmts.Length);
-      System.Array.Copy(other.elmts, 0, a, elmts.Length, other.elmts.Length);
-      return new Sequence<T>(a);
+      return new ConcatSequence<T>(this, other);
     }
     public bool Contains<G>(G g) {
       if (g == null || g is T) {
         var t = (T)(object)g;
-        int n = elmts.Length;
+        int n = Elements.Length;
         for (int i = 0; i < n; i++) {
-          if (Dafny.Helpers.AreEqual(t, elmts[i]))
+          if (Dafny.Helpers.AreEqual(t, Elements[i]))
             return true;
         }
       }
       return false;
     }
     public Sequence<T> Take(long m) {
-      if (elmts.LongLength == m)
+      if (Elements.LongLength == m)
         return this;
       T[] a = new T[m];
-      System.Array.Copy(elmts, a, m);
-      return new Sequence<T>(a);
+      System.Array.Copy(Elements, a, m);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Take(ulong n) {
       return Take((long)n);
@@ -960,9 +959,9 @@ namespace Dafny
     public Sequence<T> Drop(long m) {
       if (m == 0)
         return this;
-      T[] a = new T[elmts.Length - m];
-      System.Array.Copy(elmts, m, a, 0, elmts.Length - m);
-      return new Sequence<T>(a);
+      T[] a = new T[Elements.Length - m];
+      System.Array.Copy(Elements, m, a, 0, Elements.Length - m);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Drop(ulong n) {
       return Drop((long)n);
@@ -973,12 +972,12 @@ namespace Dafny
       return Drop((long)n);
     }
     public Sequence<T> Subsequence(long lo, long hi) {
-      if (lo == 0 && hi == elmts.Length) {
+      if (lo == 0 && hi == Elements.Length) {
         return this;
       }
       T[] a = new T[hi - lo];
-      System.Array.Copy(elmts, lo, a, 0, hi - lo);
-      return new Sequence<T>(a);
+      System.Array.Copy(Elements, lo, a, 0, hi - lo);
+      return new ArraySequence<T>(a);
     }
     public Sequence<T> Subsequence(long lo, ulong hi) {
       return Subsequence(lo, (long)hi);
@@ -1003,6 +1002,73 @@ namespace Dafny
     }
     public Sequence<T> Subsequence(BigInteger lo, BigInteger hi) {
       return Subsequence((long)lo, (long)hi);
+    }
+  }
+  internal class ArraySequence<T> : Sequence<T> {
+    private readonly T[] elmts;
+
+    internal ArraySequence(T[] ee) {
+      elmts = ee;
+    }
+    public override T[] Elements {
+      get {
+        return elmts;
+      }
+    }
+  }
+  internal class ConcatSequence<T> : Sequence<T> {
+    private Sequence<T> left, right;
+    private T[] elmts = null;
+
+    internal ConcatSequence(Sequence<T> left, Sequence<T> right) {
+      this.left = left;
+      this.right = right;
+    }
+
+    public override T[] Elements {
+      get {
+        if (elmts == null) {
+          elmts = ComputeElements();
+          // We don't need the original sequences anymore; let them be
+          // garbage-collected
+          left = null;
+          right = null;
+        }
+        return elmts;
+      }
+    }
+
+    public override bool KnownEmpty {
+      get {
+        // Check for emptiness without triggering lazy computation
+        return elmts != null && elmts.Length == 0;
+      }
+    }
+
+    private T[] ComputeElements() {
+      // Traverse the tree formed by all descendants which are ConcatSequences
+
+      var list = new List<T>();
+      var toVisit = new Stack<Sequence<T>>();
+      toVisit.Push(right);
+      toVisit.Push(left);
+
+      while (toVisit.Count != 0) {
+        var seq = toVisit.Pop();
+        if (seq is ConcatSequence<T>) {
+          var cs = (ConcatSequence<T>)seq;
+          if (cs.elmts != null) {
+            list.AddRange(cs.elmts);
+          } else {
+            toVisit.Push(cs.right);
+            toVisit.Push(cs.left);
+          }
+        } else {
+          list.AddRange(seq.Elements);
+        }
+      }
+
+      return list.ToArray();
     }
   }
   public struct Pair<A, B>
@@ -1199,7 +1265,7 @@ namespace Dafny
       }
     }
     public static Sequence<T> SeqFromArray<T>(T[] array) {
-      return new Sequence<T>((T[])array.Clone());
+      return new ArraySequence<T>((T[])array.Clone());
     }
     // In .NET version 4.5, it it possible to mark a method with "AggressiveInlining", which says to inline the
     // method if possible.  Method "ExpressionSequence" would be a good candidate for it:

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -885,11 +885,12 @@ namespace Dafny
       return other is Sequence<T> && Equals((Sequence<T>)other);
     }
     public override int GetHashCode() {
-      if (Elements == null || Elements.Length == 0)
+      T[] elmts = Elements;
+      if (elmts == null || elmts.Length == 0)
         return 0;
       var hashCode = 0;
-      for (var i = 0; i < Elements.Length; i++) {
-        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(Elements[i]);
+      for (var i = 0; i < elmts.Length; i++) {
+        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(elmts[i]);
       }
       return hashCode;
     }
@@ -911,8 +912,9 @@ namespace Dafny
       }
     }
     bool EqualUntil(Sequence<T> other, int n) {
+      T[] elmts = Elements, otherElmts = other.Elements;
       for (int i = 0; i < n; i++) {
-        if (!Dafny.Helpers.AreEqual(Elements[i], other.Elements[i]))
+        if (!Dafny.Helpers.AreEqual(elmts[i], otherElmts[i]))
           return false;
       }
       return true;
@@ -935,9 +937,10 @@ namespace Dafny
     public bool Contains<G>(G g) {
       if (g == null || g is T) {
         var t = (T)(object)g;
-        int n = Elements.Length;
+        var elmts = Elements;
+        int n = elmts.Length;
         for (int i = 0; i < n; i++) {
-          if (Dafny.Helpers.AreEqual(t, Elements[i]))
+          if (Dafny.Helpers.AreEqual(t, elmts[i]))
             return true;
         }
       }

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -832,17 +832,10 @@ namespace Dafny
       return Empty;
     }
     public int Count {
-      get { return Elements.Length; }
+      get { return (int)LongCount; }
     }
-    public long LongCount {
-      get { return Elements.LongLength; }
-    }
+    public abstract long LongCount { get; }
     public abstract T[] Elements { get; }
-    // Return whether the sequence is known to be empty.  May return false
-    // spuriously (see ConcatSequence).
-    public virtual bool KnownEmpty {
-      get { return Elements.Length == 0; }
-    }
 
     public IEnumerable<T> UniqueElements {
       get {
@@ -928,9 +921,9 @@ namespace Dafny
       return n <= other.Elements.Length && EqualUntil(other, n);
     }
     public Sequence<T> Concat(Sequence<T> other) {
-      if (KnownEmpty)
+      if (Count == 0)
         return other;
-      else if (other.KnownEmpty)
+      else if (other.Count == 0)
         return this;
       return new ConcatSequence<T>(this, other);
     }
@@ -1018,14 +1011,21 @@ namespace Dafny
         return elmts;
       }
     }
+    public override long LongCount {
+      get {
+        return elmts.LongLength;
+      }
+    }
   }
   internal class ConcatSequence<T> : Sequence<T> {
     private Sequence<T> left, right;
     private T[] elmts = null;
+    private readonly long count;
 
     internal ConcatSequence(Sequence<T> left, Sequence<T> right) {
       this.left = left;
       this.right = right;
+      this.count = left.LongCount + right.LongCount;
     }
 
     public override T[] Elements {
@@ -1041,10 +1041,9 @@ namespace Dafny
       }
     }
 
-    public override bool KnownEmpty {
+    public override long LongCount {
       get {
-        // Check for emptiness without triggering lazy computation
-        return elmts != null && elmts.Length == 0;
+        return count;
       }
     }
 

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -1018,6 +1018,8 @@ namespace Dafny
     }
   }
   internal class ConcatSequence<T> : Sequence<T> {
+    // INVARIANT: Either left != null, right != null, and elmts == null or
+    // left == null, right == null, and elmts != null
     private Sequence<T> left, right;
     private T[] elmts = null;
     private readonly long count;
@@ -1050,27 +1052,27 @@ namespace Dafny
     private T[] ComputeElements() {
       // Traverse the tree formed by all descendants which are ConcatSequences
 
-      var list = new List<T>();
+      var ans = new T[count];
+      var nextIndex = 0L;
+
       var toVisit = new Stack<Sequence<T>>();
       toVisit.Push(right);
       toVisit.Push(left);
 
       while (toVisit.Count != 0) {
         var seq = toVisit.Pop();
-        if (seq is ConcatSequence<T>) {
-          var cs = (ConcatSequence<T>)seq;
-          if (cs.elmts != null) {
-            list.AddRange(cs.elmts);
-          } else {
-            toVisit.Push(cs.right);
-            toVisit.Push(cs.left);
-          }
+        var cs = seq as ConcatSequence<T>;
+        if (cs != null && cs.elmts == null) {
+          toVisit.Push(cs.right);
+          toVisit.Push(cs.left);
         } else {
-          list.AddRange(seq.Elements);
+          var array = seq.Elements;
+          array.CopyTo(ans, nextIndex);
+          nextIndex += array.LongLength;
         }
       }
 
-      return list.ToArray();
+      return ans;
     }
   }
   public struct Pair<A, B>

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -1269,7 +1269,7 @@ namespace Dafny
     public static Sequence<T> SeqFromArray<T>(T[] array) {
       return new ArraySequence<T>((T[])array.Clone());
     }
-    // In .NET version 4.5, it it possible to mark a method with "AggressiveInlining", which says to inline the
+    // In .NET version 4.5, it is possible to mark a method with "AggressiveInlining", which says to inline the
     // method if possible.  Method "ExpressionSequence" would be a good candidate for it:
     // [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static U ExpressionSequence<T, U>(T t, U u)


### PR DESCRIPTION
Building a sequence of length n by repeatedly using + to append them takes O(n^2) time, and there isn't a convenient alternative to doing it this way (since Dafny doesn't have variable-length arrays).  This patch changes the C# runtime library to make concatenation lazy to knock this down to O(n) (so long as none of the intermediate sequences are ever accessed besides using +).

The behavior is very simple:  A sequence built by concatenation remains lazy until any operation besides + is performed on it, at which point all the sequences in the chain get concatenated in one go.  At that point, the sequence's elements are stored in an array as usual.

Caveats: There's all the usual laziness overhead---a little extra setup up front, and then an extra few checks on each access (including Select).  Also, Sequence is now an abstract class and all access to the underlying array goes through an abstract property, which may be slow.