### PR TITLE
Assert-by checks

### DIFF
--- a/Test/dafny0/LabeledAssertsResolution.dfy
+++ b/Test/dafny0/LabeledAssertsResolution.dfy
@@ -1,6 +1,6 @@
 // RUN: %dafny /print:"%t.print" /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-
+module ResolutionTests {
 lemma A(b: bool, m: int, n: int)
   requires m < n
   requires sea: m + 3 < n
@@ -111,4 +111,241 @@ twostate lemma T3(c: C)
 {
   reveal A, B, A, A;  // this can be a list
   reveal A, X, A, A;  // error: C not defined
+}
+
+}  // module ResolutionTests
+
+module GitIssue408 {
+  method Test() {
+    ghost var x := 5;
+    assert x == 6 by {
+      // regression test: the following had once been unchecked:
+      x := 6;  // error: x is declared outside the assert-by block
+    }
+    assert x == 5; // This would be provable if the assignment to x above were allowed.
+    assert false;  // And then this assertion, too.
+  }
+
+  method MoreTests() {
+    ghost var x := 5;
+    var y := 9;
+    assert x == 6 by {
+      var u := 10;  // in this ghost context, every local variable is effectively ghost
+      u := u + 1;  // this is fine, since u is declared in the assert-by block
+      ghost var v := 10;
+      v := v + x + 1;  // this is also fine, since v is declared in the assert-by block
+      y := 8;  // error: y is non-ghost (and is declared outside the assert-by block)
+    }
+  }
+
+  class C {
+    ghost var data: real
+  }
+
+  datatype Record = Record(x: int, y: int)
+  method GetRecord(c: C)
+    modifies c
+  {
+    c.data := 21.0;
+  }
+
+  ghost method Six() returns (x: int) {
+    x := 6;
+  }
+
+  method Nesting(c: C, a: array<real>, m: array2<real>)
+    requires a.Length != 0 && m.Length0 == m.Length1 == 100
+    modifies c, a, m
+  {
+    ghost var x := 5;
+
+    assert 2 < 10 by {
+      var y := 9;
+      assert 2 < 11 by {
+        var u := 11;
+        u := 20;
+        x := 20;  // error: x is declared outside this assert-by block
+        x := Six();  // error: x is declared outside this assert-by block
+        y := 20;  // error: y is declared outside this assert-by block
+        c.data := 20.0;  // error: assert-by cannot modify heap locations
+        a[0] := 20.0;  // error: assert-by cannot modify heap locations
+        m[0,0] := 20.0;  // error: assert-by cannot modify heap locations
+        modify c;  // error: assert-by cannot modify heap locations
+      }
+      c.data := 20.0;  // error: assert-by cannot modify heap locations
+      a[0] := 20.0;  // error: assert-by cannot modify heap locations
+      m[0,0] := 20.0;  // error: assert-by cannot modify heap locations
+      modify c;  // error: assert-by cannot modify heap locations
+    }
+
+    calc {
+      5;
+    ==  { x := 10; }  // error: x is declared outside the hint
+      5;
+    ==  { c.data := 20.0;  // error: hint cannot modify heap locations
+          a[0] := 20.0;  // error: hint cannot modify heap locations
+          m[0,0] := 20.0;  // error: hint cannot modify heap locations
+          modify c;  // error: hint cannot modify heap locations
+        }
+      5;
+    ==  { var y := 9;
+          y := 10;
+          x := Six();  // error: x is declared outside this hint
+          assert 2 < 12 by {
+            var u := 11;
+            u := 20;
+            x := 6;  // error: x is declared outside this assert-by block
+            y := 11;  // error: y is declared outside this assert-by block
+            calc {
+              19;
+            ==  { y := 13;  // error: y is declared outside the hint
+                  u := 21;  // error: u is declared outside the hint
+                }
+              19;
+            }
+          }
+          y := 12;
+        }
+      5;
+    }
+
+    forall f | 0 <= f < 82
+      ensures f < 100
+    {
+      var y := 9;
+      assert 2 < 4 by {
+        x := 6;  // error: x is declared outside the assert-by statement
+        y := 11;  // error: y is declared outside the assert-by statement
+      }
+      var rr := (calc { 5; =={ return; /*error: return not allowed in hint*/ } 5; } Record(6, 8));
+      var Record(xx, yy) := (calc { 5; =={ return; /*error: return not allowed in hint*/ } 5; } Record(6, 8));
+    }
+  }
+
+  method Return() {
+    label A: {
+      while true {
+        calc {
+          5;
+        ==  { return; }  // error: return not allowed in hint
+          5;
+        }
+
+        assert 2 < 3 by {
+          return;  // error: return not allowed in assert-by
+        }
+      }
+    }
+  }
+
+  iterator Iter() {
+    calc {
+      5;
+    ==  { yield; }  // error: yield not allowed in hint
+      5;
+    }
+
+    assert 2 < 3 by {
+      yield;  // error: yield not allowed in assert-by
+    }
+  }
+}
+
+module ForallStmtTests {
+  // it so happens that forall statements are checked separately from hints in
+  // the Resolver, so we use a separate module for these tests to avoid having
+  // these errors shadow the others
+
+  class C {
+    ghost var data: real
+  }
+
+  datatype Record = Record(x: int, y: int)
+  method GetRecord(c: C)
+    modifies c
+  {
+    c.data := 21.0;
+  }
+
+  ghost method Six() returns (x: int) {
+    x := 6;
+  }
+
+  method Forall(c: C, a: array<real>, m: array2<real>) {
+    ghost var x := 5;
+
+    forall f | 0 <= f < 82
+      ensures f < 100
+    {
+      var y := 9;
+      x := 6;  // error: x is declared outside forall statement
+      x := Six();  // error: x is declared outside forall statement
+      c.data := 20.0;  // error: proof-forall statement cannot modify heap locations
+      a[0] := 20.0;  // error: proof-forall statement cannot modify heap locations
+      m[0,0] := 20.0;  // error: proof-forall statement cannot modify heap locations
+      modify c;  // error: proof-forall cannot modify heap locations
+    }
+  }
+
+  method Nested(c: C, a: array<real>, m: array2<real>) {
+    ghost var x := 5;
+
+    forall f | 0 <= f < 82
+      ensures f < 100
+    {
+      var y := 9;
+      assert 2 < 4 by {
+        var w := 18;
+        forall u | 0 <= u < w {
+          x := 6;  // error: x is declared outside the forall statement
+          y := 12;  // error: y is declared outside the forall statement
+          w := 19;  // error: w is declared outside the forall statement
+        }
+      }
+    }
+  }
+
+  method Return() {
+    forall f | 0 <= f < 82
+      ensures f < 100
+    {
+      return;  // error: return not allowed in forall statement
+    }
+  }
+
+  iterator Iter() {
+    forall f | 0 <= f < 82
+      ensures f < 100
+    {
+      yield;  // error: yield not allowed in forall statement
+    }
+  }
+}
+
+module Breaks {
+  method Break() {
+    label A: {
+      while true {
+        calc {
+          5;
+        ==  { break; }  // error: break not allowed in hint
+          5;
+        ==  { break A; }  // error: break not allowed in hint
+          5;
+        }
+
+        assert 2 < 3 by {
+          break;  // error: break not allowed in assert-by
+          break A;  // error: break not allowed in assert-by
+        }
+
+        forall f | 0 <= f < 82
+          ensures f < 100
+        {
+          break;  // error: break not allowed in forall statement
+          break A;  // error: break not allowed in forall statement
+        }
+      }
+    }
+  }
 }

--- a/Test/dafny0/LabeledAssertsResolution.dfy.expect
+++ b/Test/dafny0/LabeledAssertsResolution.dfy.expect
@@ -10,4 +10,66 @@ LabeledAssertsResolution.dfy(72,4): Error: break label is undefined or not in sc
 LabeledAssertsResolution.dfy(80,15): Error: unresolved identifier: reveal_C
 LabeledAssertsResolution.dfy(93,15): Error: no label 'XYZ' in scope at this time
 LabeledAssertsResolution.dfy(113,12): Error: unresolved identifier: reveal_X
-12 resolution/type errors detected in LabeledAssertsResolution.dfy
+LabeledAssertsResolution.dfy(244,10): Error: yield statement is not allowed in this context (because it is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(249,6): Error: yield statement is not allowed in this context (because it is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(244,10): Error: yield statement is not allowed inside a hint
+LabeledAssertsResolution.dfy(249,6): Error: yield statement is not allowed inside an assert-by body
+LabeledAssertsResolution.dfy(123,6): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(137,8): Error: Assignment to non-ghost variable is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(137,6): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(171,13): Error: Assignment to array element is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(172,15): Error: Assignment to array element is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(176,11): Error: Assignment to array element is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(177,13): Error: Assignment to array element is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(186,15): Error: Assignment to array element is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(187,17): Error: Assignment to array element is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(167,8): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(168,8): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(169,8): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(170,10): Error: an assert-by body is not allowed to update heap locations
+LabeledAssertsResolution.dfy(171,9): Error: an assert-by body is not allowed to update heap locations
+LabeledAssertsResolution.dfy(172,9): Error: an assert-by body is not allowed to update heap locations
+LabeledAssertsResolution.dfy(173,8): Error: modify statements are not allowed inside an assert-by body
+LabeledAssertsResolution.dfy(175,8): Error: an assert-by body is not allowed to update heap locations
+LabeledAssertsResolution.dfy(176,7): Error: an assert-by body is not allowed to update heap locations
+LabeledAssertsResolution.dfy(177,7): Error: an assert-by body is not allowed to update heap locations
+LabeledAssertsResolution.dfy(178,6): Error: modify statements are not allowed inside an assert-by body
+LabeledAssertsResolution.dfy(201,18): Error: a hint is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(202,18): Error: a hint is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(197,12): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(198,12): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(183,10): Error: a hint is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(185,12): Error: a hint is not allowed to update heap locations
+LabeledAssertsResolution.dfy(186,11): Error: a hint is not allowed to update heap locations
+LabeledAssertsResolution.dfy(187,11): Error: a hint is not allowed to update heap locations
+LabeledAssertsResolution.dfy(188,10): Error: modify statements are not allowed inside a hint
+LabeledAssertsResolution.dfy(193,10): Error: a hint is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(217,8): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(218,8): Error: an assert-by body is not allowed to update a variable it doesn't declare
+LabeledAssertsResolution.dfy(220,31): Error: return statement is not allowed inside a hint
+LabeledAssertsResolution.dfy(220,31): Error: return statement is not allowed in this context (because it is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(221,43): Error: return statement is not allowed inside a hint
+LabeledAssertsResolution.dfy(221,43): Error: return statement is not allowed in this context (because it is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(230,14): Error: return statement is not allowed in this context (because it is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(235,10): Error: return statement is not allowed in this context (because it is guarded by a specification-only expression)
+LabeledAssertsResolution.dfy(230,14): Error: return statement is not allowed inside a hint
+LabeledAssertsResolution.dfy(235,10): Error: return statement is not allowed inside an assert-by body
+LabeledAssertsResolution.dfy(320,6): Error: yield statement is not allowed inside a forall statement
+LabeledAssertsResolution.dfy(281,6): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+LabeledAssertsResolution.dfy(282,6): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+LabeledAssertsResolution.dfy(283,8): Error: the body of the enclosing forall statement is not allowed to update heap locations
+LabeledAssertsResolution.dfy(284,7): Error: the body of the enclosing forall statement is not allowed to update heap locations
+LabeledAssertsResolution.dfy(285,7): Error: the body of the enclosing forall statement is not allowed to update heap locations
+LabeledAssertsResolution.dfy(286,6): Error: body of forall statement is not allowed to use a modify statement
+LabeledAssertsResolution.dfy(299,8): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+LabeledAssertsResolution.dfy(300,10): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+LabeledAssertsResolution.dfy(301,10): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+LabeledAssertsResolution.dfy(302,10): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+LabeledAssertsResolution.dfy(312,6): Error: return statement is not allowed inside a forall statement
+LabeledAssertsResolution.dfy(331,14): Error: trying to break out of more loop levels than there are enclosing loops
+LabeledAssertsResolution.dfy(333,14): Error: break label is undefined or not in scope: A
+LabeledAssertsResolution.dfy(338,10): Error: trying to break out of more loop levels than there are enclosing loops
+LabeledAssertsResolution.dfy(339,10): Error: break label is undefined or not in scope: A
+LabeledAssertsResolution.dfy(345,10): Error: trying to break out of more loop levels than there are enclosing loops
+LabeledAssertsResolution.dfy(346,10): Error: break label is undefined or not in scope: A
+73 resolution/type errors detected in LabeledAssertsResolution.dfy

--- a/Test/dafny0/ParallelResolveErrors.dfy.expect
+++ b/Test/dafny0/ParallelResolveErrors.dfy.expect
@@ -1,7 +1,7 @@
 ParallelResolveErrors.dfy(20,4): Error: LHS of assignment must denote a mutable variable
-ParallelResolveErrors.dfy(25,6): Error: body of forall statement is attempting to update a variable declared outside the forall statement
-ParallelResolveErrors.dfy(42,6): Error: body of forall statement is attempting to update a variable declared outside the forall statement
-ParallelResolveErrors.dfy(43,6): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+ParallelResolveErrors.dfy(25,4): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+ParallelResolveErrors.dfy(42,4): Error: body of forall statement is attempting to update a variable declared outside the forall statement
+ParallelResolveErrors.dfy(43,4): Error: body of forall statement is attempting to update a variable declared outside the forall statement
 ParallelResolveErrors.dfy(55,13): Error: new allocation not supported in forall statements
 ParallelResolveErrors.dfy(60,13): Error: new allocation not allowed in ghost context
 ParallelResolveErrors.dfy(61,13): Error: new allocation not allowed in ghost context
@@ -16,7 +16,7 @@ ParallelResolveErrors.dfy(84,20): Error: trying to break out of more loop levels
 ParallelResolveErrors.dfy(85,20): Error: break label is undefined or not in scope: OutsideLoop
 ParallelResolveErrors.dfy(94,24): Error: trying to break out of more loop levels than there are enclosing loops
 ParallelResolveErrors.dfy(95,24): Error: break label is undefined or not in scope: OutsideLoop
-ParallelResolveErrors.dfy(106,9): Error: the body of the enclosing forall statement is not allowed to update heap locations
+ParallelResolveErrors.dfy(106,5): Error: the body of the enclosing forall statement is not allowed to update heap locations
 ParallelResolveErrors.dfy(114,29): Error: the body of the enclosing forall statement is not allowed to update heap locations, so any call must be to a method with an empty modifies clause
 ParallelResolveErrors.dfy(119,29): Error: the body of the enclosing forall statement is not allowed to update heap locations, so any call must be to a method with an empty modifies clause
 ParallelResolveErrors.dfy(129,11): Error: Assignment to non-ghost field is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -67,8 +67,8 @@ ResolutionErrors.dfy(416,8): Error: arguments must have comparable types (got bo
 ResolutionErrors.dfy(420,8): Error: arguments must have comparable types (got bool and int)
 ResolutionErrors.dfy(420,8): Error: arguments must have comparable types (got bool and int)
 ResolutionErrors.dfy(454,13): Error: calls to methods with side-effects are not allowed inside a hint
-ResolutionErrors.dfy(456,16): Error: a hint is not allowed to update heap locations
-ResolutionErrors.dfy(458,12): Error: a hint is not allowed to update a variable declared outside the hint
+ResolutionErrors.dfy(456,10): Error: a hint is not allowed to update heap locations
+ResolutionErrors.dfy(458,10): Error: a hint is not allowed to update a variable it doesn't declare
 ResolutionErrors.dfy(479,4): Error: More than one anonymous constructor
 ResolutionErrors.dfy(485,8): Error: when allocating an object of type 'Y', one of its constructor methods must be called
 ResolutionErrors.dfy(490,8): Error: when allocating an object of type 'Luci', one of its constructor methods must be called
@@ -89,7 +89,7 @@ ResolutionErrors.dfy(635,23): Error: 'new' is not allowed in ghost contexts
 ResolutionErrors.dfy(642,15): Error: 'new' is not allowed in ghost contexts
 ResolutionErrors.dfy(651,17): Error: 'new' is not allowed in ghost contexts
 ResolutionErrors.dfy(668,14): Error: new allocation not supported in forall statements
-ResolutionErrors.dfy(673,11): Error: the body of the enclosing forall statement is not allowed to update heap locations
+ResolutionErrors.dfy(673,7): Error: the body of the enclosing forall statement is not allowed to update heap locations
 ResolutionErrors.dfy(673,14): Error: new allocation not allowed in ghost context
 ResolutionErrors.dfy(690,26): Error: second argument to "in" must be a set, multiset, or sequence with elements of type int, or a map with domain int (instead got bool)
 ResolutionErrors.dfy(685,18): Error: second argument to "in" must be a set, multiset, or sequence with elements of type int, or a map with domain int (instead got ?)
@@ -219,14 +219,14 @@ ResolutionErrors.dfy(1436,15): Error: type of left argument to + (int) must agre
 ResolutionErrors.dfy(1436,15): Error: type of right argument to + (int) must agree with the result type (bool)
 ResolutionErrors.dfy(1436,15): Error: type of + must be of a numeric type, a bitvector type, ORDINAL, char, a sequence type, or a set-like type (instead got bool)
 ResolutionErrors.dfy(1479,20): Error: calls to methods with side-effects are not allowed inside a hint
-ResolutionErrors.dfy(1501,18): Error: a hint is not allowed to update heap locations
-ResolutionErrors.dfy(1502,23): Error: a hint is not allowed to update heap locations
+ResolutionErrors.dfy(1501,10): Error: a hint is not allowed to update heap locations
+ResolutionErrors.dfy(1502,10): Error: a hint is not allowed to update heap locations
 ResolutionErrors.dfy(1503,20): Error: calls to methods with side-effects are not allowed inside a hint
 ResolutionErrors.dfy(1506,21): Error: a while statement used inside a hint is not allowed to have a modifies clause
 ResolutionErrors.dfy(1488,24): Error: only ghost methods can be called from this context
 ResolutionErrors.dfy(1501,18): Error: Assignment to non-ghost field is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)
-ResolutionErrors.dfy(1530,18): Error: a hint is not allowed to update heap locations
-ResolutionErrors.dfy(1531,23): Error: a hint is not allowed to update heap locations
+ResolutionErrors.dfy(1530,10): Error: a hint is not allowed to update heap locations
+ResolutionErrors.dfy(1531,10): Error: a hint is not allowed to update heap locations
 ResolutionErrors.dfy(1532,11): Error: calls to methods with side-effects are not allowed inside a hint
 ResolutionErrors.dfy(1535,21): Error: a while statement used inside a hint is not allowed to have a modifies clause
 ResolutionErrors.dfy(1523,24): Error: only ghost methods can be called from this context


### PR DESCRIPTION
Do hints checks not just in `calc` hints, but also in `assert-by` hints.

Check LHSs of call statements in hints (to abide by the same rules as LHSs in assignment statements).
Disallow `modify` statement in hints.

Disallow `modify` statements in `forall` statements.

Fixes #408.