### PR TITLE
Allow datatype/newtype functions to be opaque

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -3634,16 +3634,16 @@ namespace Microsoft.Dafny {
     }
 
     /// <summary>
-    /// Yields all functions and methods that are members of some class in the given list of
+    /// Yields all functions and methods that are members of some type in the given list of
     /// declarations.
-    /// Note, an iterator declaration is a class, in this sense.
+    /// Note, an iterator declaration is a type, in this sense.
     /// Note, if the given list are the top-level declarations of a module, the yield will include
     /// colemmas but not their associated prefix lemmas (which are tucked into the colemma's
     /// .PrefixLemma field).
     /// </summary>
     public static IEnumerable<ICallable> AllCallables(List<TopLevelDecl> declarations) {
       foreach (var d in declarations) {
-        var cl = d as ClassDecl;
+        var cl = d as TopLevelDeclWithMembers;
         if (cl != null) {
           foreach (var member in cl.Members) {
             var clbl = member as ICallable;
@@ -3656,7 +3656,7 @@ namespace Microsoft.Dafny {
     }
 
     /// <summary>
-    /// Yields all functions and methods that are members of some non-iterator class in the given
+    /// Yields all functions and methods that are members of some non-iterator type in the given
     /// list of declarations, as well as any IteratorDecl's in that list.
     /// </summary>
     public static IEnumerable<ICallable> AllItersAndCallables(List<TopLevelDecl> declarations) {
@@ -3664,8 +3664,8 @@ namespace Microsoft.Dafny {
         if (d is IteratorDecl) {
           var iter = (IteratorDecl)d;
           yield return iter;
-        } else if (d is ClassDecl) {
-          var cl = (ClassDecl)d;
+        } else if (d is TopLevelDeclWithMembers) {
+          var cl = (TopLevelDeclWithMembers)d;
           foreach (var member in cl.Members) {
             var clbl = member as ICallable;
             if (clbl != null) {

--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -908,8 +908,8 @@ namespace Microsoft.Dafny
 
     internal override void PreResolve(ModuleDefinition m) {
       foreach (var d in m.TopLevelDecls) {
-        if (d is ClassDecl) {
-          ProcessOpaqueClassFunctions((ClassDecl)d);
+        if (d is TopLevelDeclWithMembers) {
+          ProcessOpaqueClassFunctions((TopLevelDeclWithMembers)d);
         }
       }
     }
@@ -929,10 +929,10 @@ namespace Microsoft.Dafny
     protected void AnnotateRevealFunction(Lemma lemma, Function f) {
       Expression receiver;
       if (f.IsStatic) {
-        receiver = new StaticReceiverExpr(f.tok, (ClassDecl)f.EnclosingClass, true);
+        receiver = new StaticReceiverExpr(f.tok, (TopLevelDeclWithMembers)f.EnclosingClass, true);
       } else {
         receiver = new ImplicitThisExpr(f.tok);
-        //receiver.Type = GetThisType(expr.tok, (ClassDecl)member.EnclosingClass);  // resolve here
+        //receiver.Type = GetThisType(expr.tok, (TopLevelDeclWithMembers)member.EnclosingClass);  // resolve here
       }
       List<Type> typeApplication = null;
       if (f.TypeArgs.Count > 0) {
@@ -961,7 +961,8 @@ namespace Microsoft.Dafny
 
 
     // Tells the function to use 0 fuel by default
-    protected void ProcessOpaqueClassFunctions(ClassDecl c) {
+    protected void ProcessOpaqueClassFunctions(TopLevelDeclWithMembers c) {
+      Contract.Requires(c != null);
       List<MemberDecl> newDecls = new List<MemberDecl>();
       foreach (MemberDecl member in c.Members) {
         if (member is Function) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -1038,8 +1038,8 @@ namespace Microsoft.Dafny {
     private void ComputeFunctionFuel() {
       foreach (ModuleDefinition m in program.RawModules()) {
         foreach (TopLevelDecl d in m.TopLevelDecls) {
-          if (d is ClassDecl) {
-            ClassDecl c = (ClassDecl)d;
+          if (d is TopLevelDeclWithMembers) {
+            var c = (TopLevelDeclWithMembers)d;
             foreach (MemberDecl member in c.Members) {
               if (member is Function && RevealedInScope(member)) {
                 Function f = (Function)member;

--- a/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
@@ -77,6 +77,48 @@ Execution trace:
 OpaqueFunctions.dfy(215,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
+OpaqueFunctions.dfy(280,16): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon19_Then
+OpaqueFunctions.dfy(282,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon20_Then
+OpaqueFunctions.dfy(284,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon21_Then
+OpaqueFunctions.dfy(297,46): Error: result of operation might violate newtype constraint for 'Small'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon25_Then
+    (0,0): anon26_Then
+    (0,0): anon27_Then
+    (0,0): anon11
+    (0,0): anon28_Then
+    (0,0): anon29_Then
+    (0,0): anon30_Then
+OpaqueFunctions.dfy(304,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon15_Then
+OpaqueFunctions.dfy(306,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon16_Then
+OpaqueFunctions.dfy(308,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon17_Then
+OpaqueFunctions.dfy(321,17): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon21_Then
+    (0,0): anon22_Then
+    (0,0): anon23_Then
+    (0,0): anon11
+    (0,0): anon24_Then
 OpaqueFunctions.dfy(167,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -84,4 +126,4 @@ OpaqueFunctions.dfy(182,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 18 verified, 23 errors
+Dafny program verifier finished with 20 verified, 31 errors

--- a/Test/dafny0/OpaqueFunctions.dfy
+++ b/Test/dafny0/OpaqueFunctions.dfy
@@ -241,3 +241,84 @@ module Regression
 // but it's fine with the new fuel-based version
 function{:opaque} zero<A>():int { 0 }
 
+// ------------------------- opaque for members of non-reference types
+
+module TypeMembers {
+  trait Tr {
+    const fav: bool
+    predicate method {:opaque} IsFavorite() {
+      fav
+    }
+    static predicate method {:opaque} IsFive(x: int) {
+      x == 5
+    }
+  }
+
+  datatype Color = Carrot | Pumpkin
+  {
+    predicate method {:opaque} IsFavorite() {
+      this == Pumpkin
+    }
+    static predicate method {:opaque} IsFive(x: int) {
+      x == 5
+    }
+  }
+
+  newtype Small = x | 30 <= x < 40 witness 30
+  {
+    predicate method {:opaque} IsFavorite() {
+      this == 34
+    }
+    static predicate method {:opaque} IsFive(x: int) {
+      x == 5
+    }
+  }
+
+  method Test(tr: Tr, c: Color, s: Small) {
+    if
+    case tr.IsFavorite() =>
+      assert tr.fav;  // error: this is not known here
+    case c.IsFavorite() =>
+      assert c == Pumpkin;  // error: this is not known here
+    case s.IsFavorite() =>
+      assert s == 34;  // error: this is not known here
+    case tr.IsFavorite() =>
+      reveal tr.IsFavorite();
+      assert tr.fav;
+    case c.IsFavorite() =>
+      reveal c.IsFavorite();
+      assert c == Pumpkin;
+    case s.IsFavorite() =>
+      reveal s.IsFavorite();
+      assert s == 34;
+    case true =>
+      if tr.IsFavorite() && c.IsFavorite() && s.IsFavorite() {
+        reveal tr.IsFavorite(), c.IsFavorite(), s.IsFavorite();
+        assert !tr.fav || c == Carrot || s == 55;  // error: not true
+      }
+  }
+
+  method StaticTest(x: int) {
+    if
+    case Tr.IsFive(x) =>
+      assert x == 5;  // error: this is not known here
+    case Color.IsFive(x) =>
+      assert x == 5;  // error: this is not known here
+    case Small.IsFive(x) =>
+      assert x == 5;  // error: this is not known here
+    case Tr.IsFive(x) =>
+      reveal Tr.IsFive();
+      assert x == 5;  // error: this is not known here
+    case Color.IsFive(x) =>
+      reveal Color.IsFive();
+      assert x == 5;  // error: this is not known here
+    case Small.IsFive(x) =>
+      reveal Small.IsFive();
+      assert x == 5;  // error: this is not known here
+    case true =>
+      if Tr.IsFive(x) && Color.IsFive(x) && Small.IsFive(x) {
+        reveal Tr.IsFive(), Color.IsFive(), Small.IsFive();
+        assert x != 5;  // error: not true
+      }
+  }
+}

--- a/Test/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/dafny0/OpaqueFunctions.dfy.expect
@@ -77,6 +77,48 @@ Execution trace:
 OpaqueFunctions.dfy(215,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
+OpaqueFunctions.dfy(280,16): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon19_Then
+OpaqueFunctions.dfy(282,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon20_Then
+OpaqueFunctions.dfy(284,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon21_Then
+OpaqueFunctions.dfy(297,46): Error: result of operation might violate newtype constraint for 'Small'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon25_Then
+    (0,0): anon26_Then
+    (0,0): anon27_Then
+    (0,0): anon11
+    (0,0): anon28_Then
+    (0,0): anon29_Then
+    (0,0): anon30_Then
+OpaqueFunctions.dfy(304,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon15_Then
+OpaqueFunctions.dfy(306,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon16_Then
+OpaqueFunctions.dfy(308,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon17_Then
+OpaqueFunctions.dfy(321,17): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon21_Then
+    (0,0): anon22_Then
+    (0,0): anon23_Then
+    (0,0): anon11
+    (0,0): anon24_Then
 OpaqueFunctions.dfy(167,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -84,4 +126,4 @@ OpaqueFunctions.dfy(182,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 18 verified, 23 errors
+Dafny program verifier finished with 20 verified, 31 errors


### PR DESCRIPTION
Previously, the machinery to process `{:opaque}` only looked at functions in `ClassDecl`s. Now, it handles opaque functions in all types with members.