### PR TITLE
Change argument type of Map.FromCollection from List to IEnumerable

### DIFF
--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -654,11 +654,11 @@ namespace Dafny
       }
       return new Map<U, V>(d, hasNullValue, nullValue);
     }
-    public static Map<U, V> FromCollection(List<Pair<U, V>> values) {
+    public static Map<U, V> FromCollection(IEnumerable<Pair<U, V>> values) {
 #if DAFNY_USE_SYSTEM_COLLECTIONS_IMMUTABLE
       var d = ImmutableDictionary<U, V>.Empty.ToBuilder();
 #else
-      var d = new Dictionary<U, V>(values.Count);
+      var d = new Dictionary<U, V>();
 #endif
       var hasNullValue = false;
       var nullValue = default(V);

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -654,11 +654,11 @@ namespace Dafny
       }
       return new Map<U, V>(d, hasNullValue, nullValue);
     }
-    public static Map<U, V> FromCollection(List<Pair<U, V>> values) {
+    public static Map<U, V> FromCollection(IEnumerable<Pair<U, V>> values) {
 #if DAFNY_USE_SYSTEM_COLLECTIONS_IMMUTABLE
       var d = ImmutableDictionary<U, V>.Empty.ToBuilder();
 #else
-      var d = new Dictionary<U, V>(values.Count);
+      var d = new Dictionary<U, V>();
 #endif
       var hasNullValue = false;
       var nullValue = default(V);


### PR DESCRIPTION
The only advantage with the `List` was that the underlying `Dictionary` could then be
created with an accurate capacity. That doesn't seem very important compared to having
to always to make a `List` from an `IEnumerable`.