### PR TITLE
Support two-argument extern for functions

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1522,6 +1522,10 @@ namespace Microsoft.Dafny
       if (udt is ArrowType) {
         return ArrowType.Arrow_FullCompileName;
       }
+      string qualification;
+      if (member != null && member.IsExtern(out qualification, out _) && qualification != null) {
+        return qualification;
+      }
       var cl = udt.ResolvedClass;
       if (cl == null) {
         return IdProtect(udt.CompileName);

--- a/Test/dafny0/Extern.dfy
+++ b/Test/dafny0/Extern.dfy
@@ -4,6 +4,7 @@
 method Main() {
   Mod1.Test();
   ConstInit.Test();
+  TwoArgumentExtern.Test();
 }
 
 module {:extern "Modx"} Mod1
@@ -61,5 +62,18 @@ module {:extern "ConstInit"} ConstInit {
     requires o != null
   {
     print if o == null then "null" else "good", "\n";
+  }
+}
+
+module TwoArgumentExtern {
+  method {:extern "ABC.DEF", "MX"} M(x: int) returns (r: int)
+
+  // git issue 423
+  function method {:extern "ABC.DEF", "FX"} F(x: int): int
+
+  method Test() {
+    var y := M(2);  // calls ABC.DEF.MX
+    var z := F(2);  // calls ABC.DEF.FX
+    print y, " ", z, "\n";  // 4 2
   }
 }

--- a/Test/dafny0/Extern.dfy.expect
+++ b/Test/dafny0/Extern.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 6 verified, 0 errors
+Dafny program verifier finished with 7 verified, 0 errors

--- a/Test/dafny0/Extern2.cs
+++ b/Test/dafny0/Extern2.cs
@@ -30,3 +30,14 @@ namespace ConstInit {
     public static C c = new C();
   }
 }
+
+namespace ABC {
+  public class DEF {
+    public static BigInteger MX(BigInteger x) {
+      return x + x;
+    }
+    public static BigInteger FX(BigInteger x) {
+      return x;
+    }
+  }
+}


### PR DESCRIPTION
Compilation of methods to C# support a 2-argument `:extern`, which gives
both a method name and a full qualification to that method. Previously, this
was not supported for functions, which had just ignored the qualification
argument. This commit fixes that.

Fixes #423.