### PR TITLE
Optimize comparisons to zero

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1402,6 +1402,20 @@ namespace Microsoft.Dafny
       }
     }
 
+    protected override bool CompareZeroUsingSign(Type type) {
+      return AsNativeType(type) == null;
+    }
+
+    protected override TargetWriter EmitSign(Type type, TargetWriter wr) {
+      // Should only be called when CompareZeroUsingSign is true
+      Contract.Assert(AsNativeType(type) == null);
+
+      TargetWriter w = wr.Fork();
+      wr.Write(".Sign");
+
+      return w;
+    }
+
     protected override void EmitEmptyTupleList(string tupleTypeArgs, TargetWriter wr) {
       wr.Write("new System.Collections.Generic.List<System.Tuple<{0}>>()", tupleTypeArgs);
     }

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -2031,6 +2031,19 @@ namespace Microsoft.Dafny {
       }
     }
 
+    protected override bool CompareZeroUsingSign(Type type) {
+      return AsNativeType(type) == null;
+    }
+
+    protected override TargetWriter EmitSign(Type type, TargetWriter wr) {
+      // This is only called when CompareZeroUsingSign returns true
+      Contract.Assert(AsNativeType(type) == null);
+
+      var w = wr.Fork();
+      wr.Write(".Sign()");
+      return w;
+    }
+
     protected override void EmitEmptyTupleList(string tupleTypeArgs, TargetWriter wr) {
       wr.Write("_dafny.NewBuilder()");
     }

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1186,6 +1186,30 @@ namespace Microsoft.Dafny{
                                                         || n.Sel.Equals(NativeType.Selection.Number));
     }
 
+    protected override bool CompareZeroUsingSign(Type type) {
+      // Everything is boxed, so everything benefits from avoiding explicit 0
+      return true;
+    }
+
+    protected override TargetWriter EmitSign(Type type, TargetWriter wr) {
+      TargetWriter w;
+      var nt = AsNativeType(type);
+      if (nt == null || nt.LowerBound >= 0) {
+        w = wr.Fork();
+        wr.Write(".signum()");
+      } else {
+        if (TypeName(type, wr, Bpl.Token.NoToken) == "Long") {
+          wr.Write("Long");
+        } else {
+          wr.Write("Integer");
+        }
+        wr.Write(".signum(");
+        w = wr.Fork();
+        wr.Write(")");
+      }
+      return w;
+    }
+
     protected override IClassWriter/*?*/ DeclareDatatype(DatatypeDecl dt, TargetWriter wr) {
       if (dt is TupleTypeDecl){
         tuples.Add(((TupleTypeDecl) dt).Dims);

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -435,6 +435,19 @@ namespace Microsoft.Dafny {
     protected delegate void FCE_Arg_Translator(Expression e, TargetWriter wr, bool inLetExpr=false);
 
     protected abstract void EmitRotate(Expression e0, Expression e1, bool isRotateLeft, TargetWriter wr, bool inLetExprBody, FCE_Arg_Translator tr);
+    /// <summary>
+    /// Return true if x < 0 should be rendered as sign(x) < 0 when x has the
+    /// given type.  Typically, this is only a win at non-native types, since
+    /// BigIntegers benefit from not having to access the number zero.
+    /// </summary>
+    protected virtual bool CompareZeroUsingSign(Type type) {
+      return false;
+    }
+    protected virtual TargetWriter EmitSign(Type type, TargetWriter wr) {
+      // Currently, this should only be called when CompareZeroUsingSign is true
+      Contract.Assert(false);
+      throw new cce.UnreachableException();
+    }
     protected abstract void EmitEmptyTupleList(string tupleTypeArgs, TargetWriter wr);
     protected abstract TargetWriter EmitAddTupleToList(string ingredients, string tupleTypeArgs, TargetWriter wr);
     protected abstract void EmitTupleSelect(string prefix, int i, TargetWriter wr);
@@ -3229,67 +3242,76 @@ namespace Microsoft.Dafny {
 
       } else if (expr is BinaryExpr) {
         var e = (BinaryExpr)expr;
-        string opString, preOpString, postOpString, callString, staticCallString;
-        bool reverseArguments, truncateResult, convertE1_to_int;
-        CompileBinOp(e.ResolvedOp, e.E0, e.E1, e.tok, expr.Type,
-          out opString,
-          out preOpString,
-          out postOpString,
-          out callString,
-          out staticCallString,
-          out reverseArguments,
-          out truncateResult,
-          out convertE1_to_int,
-          wr);
 
-        if (truncateResult && e.Type.IsBitVectorType) {
-          wr = EmitBitvectorTruncation(e.Type.AsBitVectorType, true, wr);
-        }
-        var e0 = reverseArguments ? e.E1 : e.E0;
-        var e1 = reverseArguments ? e.E0 : e.E1;
-        if (opString != null) {
-          var nativeType = AsNativeType(e.Type);
-          string nativeName = null, literalSuffix = null;
-          bool needsCast = false;
-          if (nativeType != null) {
-            GetNativeInfo(nativeType.Sel, out nativeName, out literalSuffix, out needsCast);
+        if (IsComparisonToZero(e, out var arg, out var sign, out var negated) &&
+            CompareZeroUsingSign(arg.Type)) {
+          // Transform e.g. x < BigInteger.Zero into x.Sign == -1
+          var w = EmitSign(arg.Type, wr);
+          TrParenExpr(arg, w, inLetExprBody);
+          wr.Write(negated ? " != " : " == ");
+          wr.Write(sign);
+        } else {
+          string opString, preOpString, postOpString, callString, staticCallString;
+          bool reverseArguments, truncateResult, convertE1_to_int;
+          CompileBinOp(e.ResolvedOp, e.E0, e.E1, e.tok, expr.Type,
+            out opString,
+            out preOpString,
+            out postOpString,
+            out callString,
+            out staticCallString,
+            out reverseArguments,
+            out truncateResult,
+            out convertE1_to_int,
+            wr);
+
+          if (truncateResult && e.Type.IsBitVectorType) {
+            wr = EmitBitvectorTruncation(e.Type.AsBitVectorType, true, wr);
           }
-          if (needsCast) {
-            wr.Write("(" + nativeName + ")(");
-          }
-          wr.Write(preOpString);
-          TrParenExpr(e0, wr, inLetExprBody);
-          wr.Write(" {0} ", opString);
-          if (convertE1_to_int) {
-            EmitExprAsInt(e1, inLetExprBody, wr);
-          } else {
-            TrParenExpr(e1, wr, inLetExprBody);
-          }
-          if (needsCast) {
+          var e0 = reverseArguments ? e.E1 : e.E0;
+          var e1 = reverseArguments ? e.E0 : e.E1;
+          if (opString != null) {
+            var nativeType = AsNativeType(e.Type);
+            string nativeName = null, literalSuffix = null;
+            bool needsCast = false;
+            if (nativeType != null) {
+              GetNativeInfo(nativeType.Sel, out nativeName, out literalSuffix, out needsCast);
+            }
+            if (needsCast) {
+              wr.Write("(" + nativeName + ")(");
+            }
+            wr.Write(preOpString);
+            TrParenExpr(e0, wr, inLetExprBody);
+            wr.Write(" {0} ", opString);
+            if (convertE1_to_int) {
+              EmitExprAsInt(e1, inLetExprBody, wr);
+            } else {
+              TrParenExpr(e1, wr, inLetExprBody);
+            }
+            if (needsCast) {
+              wr.Write(")");
+            }
+            wr.Write(postOpString);
+          } else if (callString != null) {
+            wr.Write(preOpString);
+            TrBvExpr(e0, wr, inLetExprBody);
+            wr.Write(".{0}(", callString);
+            if (convertE1_to_int) {
+              EmitExprAsInt(e1, inLetExprBody, wr);
+            } else {
+              TrBvExpr(e1, wr, inLetExprBody);
+            }
             wr.Write(")");
+            wr.Write(postOpString);
+          } else if (staticCallString != null) {
+            wr.Write(preOpString);
+            wr.Write("{0}(", staticCallString);
+            TrExpr(e0, wr, inLetExprBody);
+            wr.Write(", ");
+            TrExpr(e1, wr, inLetExprBody);
+            wr.Write(")");
+            wr.Write(postOpString);
           }
-          wr.Write(postOpString);
-        } else if (callString != null) {
-          wr.Write(preOpString);
-          TrBvExpr(e0, wr, inLetExprBody);
-          wr.Write(".{0}(", callString);
-          if (convertE1_to_int) {
-            EmitExprAsInt(e1, inLetExprBody, wr);
-          } else {
-            TrBvExpr(e1, wr, inLetExprBody);
-          }
-          wr.Write(")");
-          wr.Write(postOpString);
-        } else if (staticCallString != null) {
-          wr.Write(preOpString);
-          wr.Write("{0}(", staticCallString);
-          TrExpr(e0, wr, inLetExprBody);
-          wr.Write(", ");
-          TrExpr(e1, wr, inLetExprBody);
-          wr.Write(")");
-          wr.Write(postOpString);
         }
-
       } else if (expr is TernaryExpr) {
         Contract.Assume(false);  // currently, none of the ternary expressions is compilable
 
@@ -3713,6 +3735,74 @@ namespace Microsoft.Dafny {
         }
       }
       wr.Write(")");
+    }
+
+    private bool IsComparisonToZero(BinaryExpr expr, out Expression/*?*/ arg, out int sign, out bool negated) {
+      int s;
+      if (IsComparisonWithZeroOnRight(expr.Op, expr.E1, out s, out negated)) {
+        // e.g. x < 0
+        arg = expr.E0;
+        sign = s;
+        return true;
+      } else if (IsComparisonWithZeroOnRight(expr.Op, expr.E0, out s, out negated)) {
+        // e.g. 0 < x, equivalent to x < 0
+        arg = expr.E1;
+        sign = -s;
+        return true;
+      } else {
+        arg = null;
+        sign = 0;
+        return false;
+      }
+    }
+
+    private bool IsComparisonWithZeroOnRight(
+      BinaryExpr.Opcode op, Expression right,
+      out int sign, out bool negated) {
+
+      var rightVal = PartiallyEvaluate(right);
+      if (rightVal == null || rightVal != BigInteger.Zero) {
+        sign = 0; // need to assign something
+        negated = true; // need to assign something
+        return false;
+      } else {
+        switch (op) {
+          case BinaryExpr.Opcode.Lt:
+            // x < 0 <==> sign(x) == -1
+            sign = -1;
+            negated = false;
+            return true;
+          case BinaryExpr.Opcode.Le:
+            // x <= 0 <==> sign(x) != 1
+            sign = 1;
+            negated = true;
+            return true;
+          case BinaryExpr.Opcode.Eq:
+            // x == 0 <==> sign(x) == 0
+            sign = 0;
+            negated = false;
+            return true;
+          case BinaryExpr.Opcode.Neq:
+            // x != 0 <==> sign(x) != 0
+            sign = 0;
+            negated = true;
+            return true;
+          case BinaryExpr.Opcode.Gt:
+            // x > 0 <==> sign(x) == 1
+            sign = 1;
+            negated = false;
+            return true;
+          case BinaryExpr.Opcode.Ge:
+            // x >= 0 <==> sign(x) != -1
+            sign = -1;
+            negated = true;
+            return true;
+          default:
+            sign = 0; // need to assign something
+            negated = false; // ditto
+            return false;
+        }
+      }
     }
 
     public virtual bool SupportsInMemoryCompilation { get => true; }

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -1407,6 +1407,11 @@ namespace Dafny
       Normalize(this, that, out aa, out bb, out dd);
       return aa.CompareTo(bb);
     }
+    public int Sign {
+      get {
+        return num.Sign;
+      }
+    }
     public override int GetHashCode() {
       return num.GetHashCode() + 29 * den.GetHashCode();
     }

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/BigRational.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/BigRational.java
@@ -146,6 +146,10 @@ public class BigRational {
         return n.dtor__0().compareTo(n.dtor__1());
     }
 
+    public int signum() {
+        return this.num.signum();
+    }
+
     @Override
     public int hashCode() {
         return num.hashCode() + 29 * den.hashCode();

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/UByte.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/UByte.java
@@ -56,6 +56,10 @@ public class UByte {
         return Integer.compareUnsigned(inner, other.inner);
     }
 
+    public int signum() {
+        return inner == 0 ? 0 : 1;
+    }
+
     public int intValue(){
         return inner;
     }

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/UInt.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/UInt.java
@@ -53,6 +53,10 @@ public class UInt {
         return Integer.compareUnsigned(inner, other.inner);
     }
 
+    public int signum() {
+        return inner == 0 ? 0 : 1;
+    }
+
     public int value(){
         return inner;
     }

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/ULong.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/ULong.java
@@ -72,6 +72,10 @@ public class ULong {
         return Long.compareUnsigned(inner, other.inner);
     }
 
+    public int signum() {
+        return inner == 0 ? 0 : 1;
+    }
+
     //Invariant that other.inner is positive, so no underflow check needed
     public ULong add(ULong other) {
         assert asBigInteger().add(other.asBigInteger()).compareTo(ULONG_LIMIT) < 0 : "Precondition Failure";

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/UShort.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/UShort.java
@@ -51,6 +51,10 @@ public class UShort {
         return Integer.compareUnsigned(inner, other.inner);
     }
 
+    public int signum() {
+        return inner == 0 ? 0 : 1;
+    }
+
     public int intValue(){
         return inner;
     }

--- a/Test/comp/NativeNumbers.dfy
+++ b/Test/comp/NativeNumbers.dfy
@@ -9,12 +9,20 @@ method Main() {
   Int8Test();
   Int16Test();
   BvTests();
+  ZeroComparisonTests();
 }
 
-// test handling of byte/short arithmetic in Java
 newtype {:nativeType "sbyte"} int8 = x | -0x80 <= x < 0x80
 newtype {:nativeType "short"} int16 = x | -0x8000 <= x < 0x8000
+newtype {:nativeType "int"} int32 = x : int | -0x8000_0000 <= x < 0x8000_0000
+newtype {:nativeType "long"} int64 = x : int | -0x8000_0000 <= x < 0x8000_0000_0000_0000
 
+newtype {:nativeType "byte"} uint8 = x : int | 0 <= x < 0x100
+newtype {:nativeType "ushort"} uint16 = x : int | 0 <= x < 0x10000
+newtype {:nativeType "uint"} uint32 = x : int | 0 <= x < 0x1_0000_0000
+newtype {:nativeType "ulong"} uint64 = x : int | 0 <= x < 0x1_0000_0000_0000_0000
+
+// test handling of byte/short arithmetic in Java
 method Int8Test() {
   var a, b := 20, 30;
   var r0 := MInt8(a, b);
@@ -74,4 +82,135 @@ method BvTests() {
   assert d == 1;
 
   print a, " ", b, " ", c, " ", d, "\n";
+}
+
+// Test zero comparisons in Java
+method ZeroComparisonTests() {
+  print "int8:\n";
+  ZCInt8Tests(-42);
+  ZCInt8Tests(0);
+  ZCInt8Tests(23);
+
+  print "int16:\n";
+  ZCInt16Tests(-42);
+  ZCInt16Tests(0);
+  ZCInt16Tests(23);
+
+  print "int32:\n";
+  ZCInt32Tests(-42);
+  ZCInt32Tests(0);
+  ZCInt32Tests(23);
+
+  print "int64:\n";
+  ZCInt64Tests(-42);
+  ZCInt64Tests(0);
+  ZCInt64Tests(23);
+
+  print "uint8:\n";
+  ZCUint8Tests(0);
+  ZCUint8Tests(23);
+
+  print "uint16:\n";
+  ZCUint16Tests(0);
+  ZCUint16Tests(23);
+
+  print "uint32:\n";
+  ZCUint32Tests(0);
+  ZCUint32Tests(23);
+
+  print "uint64:\n";
+  ZCUint64Tests(0);
+  ZCUint64Tests(23);
+}
+
+function method YN(b : bool) : string {
+  if b then "Y" else "N"
+}
+
+method ZCInt8Tests(n : int8) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCInt16Tests(n : int16) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCInt32Tests(n : int32) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCInt64Tests(n : int64) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCUint8Tests(n : uint8) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCUint16Tests(n : uint16) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCUint32Tests(n : uint32) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCUint64Tests(n : uint64) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
 }

--- a/Test/comp/NativeNumbers.dfy.expect
+++ b/Test/comp/NativeNumbers.dfy.expect
@@ -1,21 +1,105 @@
 
-Dafny program verifier finished with 8 verified, 0 errors
+Dafny program verifier finished with 23 verified, 0 errors
 20 30
 10 10 18
 20 30
 10 10 18
 0 3 4 1
+int8:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int16:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int32:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int64:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint8:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint16:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint32:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint64:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
 
-Dafny program verifier finished with 8 verified, 0 errors
+Dafny program verifier finished with 23 verified, 0 errors
 20 30
 10 10 18
 20 30
 10 10 18
 0 3 4 1
+int8:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int16:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int32:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int64:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint8:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint16:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint32:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint64:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
 
-Dafny program verifier finished with 8 verified, 0 errors
+Dafny program verifier finished with 23 verified, 0 errors
 20 30
 10 10 18
 20 30
 10 10 18
 0 3 4 1
+int8:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int16:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int32:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+int64:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint8:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint16:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint32:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+uint64:
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N

--- a/Test/comp/Numbers.dfy
+++ b/Test/comp/Numbers.dfy
@@ -13,6 +13,7 @@ method Main() {
   MoreBvTests();
   NewTypeTest();
   OrdinalTests();
+  ZeroComparisonTests();
 }
 
 method Print(description: string, x: int) {
@@ -302,4 +303,42 @@ method PrintOrdinalInfo(o : ORDINAL) {
   print ", Offset: ", o.Offset;
   print ", IsLimit: ", o.IsLimit;
   print ", IsSucc: ", o.IsSucc, "\n";
+}
+
+method ZeroComparisonTests() {
+  print "int:\n";
+  ZCIntTests(-42);
+  ZCIntTests(0);
+  ZCIntTests(23);
+
+  print "MyNumber:\n";
+  ZCMyNumberTests(-42);
+  ZCMyNumberTests(0);
+  ZCMyNumberTests(23);
+}
+
+function method YN(b : bool) : string {
+  if b then "Y" else "N"
+}
+
+method ZCIntTests(n : int) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
+}
+
+method ZCMyNumberTests(n : MyNumber) {
+  print n, "\t",
+    " <0 ",  YN(n < 0),  " <=0 ", YN(n <= 0),
+    " ==0 ", YN(n == 0), " !=0 ", YN(n != 0),
+    " >0 ",  YN(n > 0),  " >=0 ", YN(n >= 0),
+    " 0< ",  YN(0 < n),  " 0<= ", YN(0 <= n),
+    " 0== ", YN(0 == n), " 0!= ", YN(0 != n),
+    " 0> ",  YN(0 > n),  " 0>= ", YN(0 >= n),
+    "\n";
 }

--- a/Test/comp/Numbers.dfy.expect
+++ b/Test/comp/Numbers.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 17 verified, 0 errors
+Dafny program verifier finished with 19 verified, 0 errors
 0
 0
 3
@@ -76,8 +76,16 @@ true false
 0: IsNat: true, Offset: 0, IsLimit: true, IsSucc: false
 1: IsNat: true, Offset: 1, IsLimit: false, IsSucc: true
 42: IsNat: true, Offset: 42, IsLimit: false, IsSucc: true
+int:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+MyNumber:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
 
-Dafny program verifier finished with 17 verified, 0 errors
+Dafny program verifier finished with 19 verified, 0 errors
 0
 0
 3
@@ -154,8 +162,16 @@ true false
 0: IsNat: true, Offset: 0, IsLimit: true, IsSucc: false
 1: IsNat: true, Offset: 1, IsLimit: false, IsSucc: true
 42: IsNat: true, Offset: 42, IsLimit: false, IsSucc: true
+int:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+MyNumber:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
 
-Dafny program verifier finished with 17 verified, 0 errors
+Dafny program verifier finished with 19 verified, 0 errors
 0
 0
 3
@@ -232,8 +248,16 @@ true false
 0: IsNat: true, Offset: 0, IsLimit: true, IsSucc: false
 1: IsNat: true, Offset: 1, IsLimit: false, IsSucc: true
 42: IsNat: true, Offset: 42, IsLimit: false, IsSucc: true
+int:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+MyNumber:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
 
-Dafny program verifier finished with 17 verified, 0 errors
+Dafny program verifier finished with 19 verified, 0 errors
 0
 0
 3
@@ -310,3 +334,11 @@ true false
 0: IsNat: true, Offset: 0, IsLimit: true, IsSucc: false
 1: IsNat: true, Offset: 1, IsLimit: false, IsSucc: true
 42: IsNat: true, Offset: 42, IsLimit: false, IsSucc: true
+int:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N
+MyNumber:
+-42	 <0 Y <=0 Y ==0 N !=0 Y >0 N >=0 N 0< N 0<= N 0== N 0!= Y 0> Y 0>= Y
+0	 <0 N <=0 Y ==0 Y !=0 N >0 N >=0 Y 0< N 0<= Y 0== Y 0!= N 0> N 0>= Y
+23	 <0 N <=0 N ==0 N !=0 Y >0 Y >=0 Y 0< Y 0<= Y 0== N 0!= Y 0> N 0>= N


### PR DESCRIPTION
As a C# example, x < BigInteger.Zero is slower than x.Sign < 0, possibly
because of the access of BigInteger.Zero (or perhaps just because
BigInteger.Sign is cheap).

Currently only implemented for C#, Java, and Go; the JavaScript BigInteger class we're using doesn't have a sign() method.  (We could use .isZero(), .isPositive(), and isNegative() in that case.)