### PR TITLE
Treat receiver like other parameters in lit axioms

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -5338,12 +5338,25 @@ namespace Microsoft.Dafny {
   /// An ImplicitFormal is a parameter that is declared implicitly, in particular the "_k" depth parameter
   /// of each colemma (for use in the comethod body only, not the specification).
   /// </summary>
-  public class ImplicitFormal : Formal
-  {
+  public class ImplicitFormal : Formal {
     public ImplicitFormal(IToken tok, string name, Type type, bool inParam, bool isGhost)
       : base(tok, name, type, inParam, isGhost) {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
+      Contract.Requires(type != null);
+    }
+  }
+
+  /// <summary>
+  /// ThisSurrogate represents the implicit parameter "this". It is used to allow more uniform handling of
+  /// parameters. A pointer value of a ThisSurrogate object is not important, only the fact that it is
+  /// a ThisSurrogate is. ThisSurrogate objects are only used in specially marked places in the Dafny
+  /// implementation.
+  /// </summary>
+  public class ThisSurrogate : ImplicitFormal {
+    public ThisSurrogate(IToken tok, Type type)
+      : base(tok, "this", type, true, false) {
+      Contract.Requires(tok != null);
       Contract.Requires(type != null);
     }
   }
@@ -8661,6 +8674,32 @@ namespace Microsoft.Dafny {
     public ThisExpr(IToken tok)
       : base(tok) {
       Contract.Requires(tok != null);
+    }
+
+    /// <summary>
+    /// This constructor creates a ThisExpr and sets its Type field to denote the receiver type
+    /// of member "m". This constructor is intended to be used by post-resolution code that needs
+    /// to obtain a Dafny "this" expression.
+    /// </summary>
+    public ThisExpr(MemberDecl m)
+      : base(m.tok) {
+      Contract.Requires(m != null);
+      Contract.Requires(m.tok != null);
+      Contract.Requires(m.EnclosingClass != null);
+      Contract.Requires(!m.IsStatic);
+      Type = Resolver.GetReceiverType(m.tok, m);
+    }
+
+    /// <summary>
+    /// This constructor creates a ThisExpr and sets its Type field to denote the receiver type
+    /// of member "m". This constructor is intended to be used by post-resolution code that needs
+    /// to obtain a Dafny "this" expression.
+    /// </summary>
+    public ThisExpr(TopLevelDeclWithMembers cl)
+      : base(cl.tok) {
+      Contract.Requires(cl != null);
+      Contract.Requires(cl.tok != null);
+      Type = Resolver.GetThisType(cl.tok, cl);
     }
   }
   public class ExpressionPair {

--- a/Test/allocated1/dafny0/LitTriggers.dfy.expect
+++ b/Test/allocated1/dafny0/LitTriggers.dfy.expect
@@ -1,2 +1,7 @@
+LitTriggers.dfy(56,21): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+    (0,0): anon2
 
-Dafny program verifier finished with 4 verified, 0 errors
+Dafny program verifier finished with 5 verified, 1 error

--- a/Test/dafny0/LitTriggers.dfy
+++ b/Test/dafny0/LitTriggers.dfy
@@ -34,6 +34,24 @@ lemma L4(x:int, y:int)
     assert P(x, y + 1);
 }
 
-// Local Variables:
-// dafny-prover-local-args: ("/autoTriggers:1")
-// End:
+// Include "this" among parameters of lit axioms
+
+datatype Tree = Empty | Node(left: Tree, right: Tree)
+{
+  function Elements(): set<int>
+    decreases this
+  {
+    match this
+    case Empty => {}
+    case Node(left, right) => left.Elements() + right.Elements()
+  }
+}
+
+function Sum(t: Tree): int
+predicate IsEven(x: int)
+
+lemma TimesOut(t: Tree)
+  requires forall u :: u in t.Elements() ==> IsEven(u)
+{
+  assert t.Node? ==> IsEven(Sum(t));  // error (but this once used to time out due to bad translation of member functions)
+}

--- a/Test/dafny0/LitTriggers.dfy.expect
+++ b/Test/dafny0/LitTriggers.dfy.expect
@@ -1,2 +1,7 @@
+LitTriggers.dfy(56,21): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+    (0,0): anon2
 
-Dafny program verifier finished with 4 verified, 0 errors
+Dafny program verifier finished with 5 verified, 1 error

--- a/Test/hofs/TreeMapSimple.dfy
+++ b/Test/hofs/TreeMapSimple.dfy
@@ -1,55 +1,94 @@
 // RUN: %dafny /compile:3 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-datatype List<A> = Nil | Cons(head: A,tail: List<A>)
+method Main() {
+  TestY();
+  TestZ();
+}
 
-datatype Tree<A> = Branch(val: A,trees: List<Tree<A>>)
+datatype List<A> = Nil | Cons(head: A, tail: List<A>)
 
-function ListData(xs : List) : set
+datatype Tree<A> = Branch(val: A, trees: List<Tree<A>>)
+
+function ListData(xs: List): set
   ensures forall x :: x in ListData(xs) ==> x < xs
 {
   match xs
-    case Nil => {}
-    case Cons(x,xs) => {x} + ListData(xs)
+  case Nil => {}
+  case Cons(x,xs) => {x} + ListData(xs)
 }
 
-function TreeData(t0 : Tree) : set
+function TreeData(t0: Tree): set
   ensures forall t :: t in TreeData(t0) ==> t < t0
 {
-  var Branch(x,ts) := t0;
+  var Branch(x, ts) := t0;
   {x} + set t, y | t in ListData(ts) && y in TreeData(t) :: y
 }
 
-function Pre<A,B>(f : A ~> B, s : set<A>) : bool
-  reads (set x, y | x in s && y in f.reads(x) :: y)
-{
-  forall x :: x in s ==> f.reads(x) == {} && f.requires(x)
+// ---------- Partial functions ----------
+
+predicate PreY<A,B>(f: A --> B, s: set<A>) {
+  forall x :: x in s ==> f.requires(x)
 }
 
-function method Map<A,B>(xs : List<A>, f : A ~> B): List<B>
-  reads Pre.reads(f, ListData(xs))
-  requires Pre(f, ListData(xs))
+function method MapY<A,B>(xs: List<A>, f: A --> B): List<B>
+  requires PreY(f, ListData(xs))
   decreases xs
 {
   match xs
-    case Nil => Nil
-    case Cons(x,xs) => Cons(f(x),Map(xs,f))
+  case Nil => Nil
+  case Cons(x, xs) => Cons(f(x), MapY(xs, f))
 }
 
-function method TMap<A,B>(t0 : Tree<A>, f : A ~> B) : Tree<B>
-  reads Pre.reads(f, TreeData(t0))
-  requires Pre(f, TreeData(t0))
+function method TreeMapY<A,B>(t0: Tree<A>, f: A --> B): Tree<B>
+  requires PreY(f, TreeData(t0))
   decreases t0
 {
-  var Branch(x,ts) := t0;
-  Branch(f(x),Map(ts, t  requires t in ListData(ts)
-                         requires Pre(f, TreeData(t))
-                      => TMap(t,f)))
+  var Branch(x, ts) := t0;
+  Branch(f(x), MapY(ts, t requires t in ListData(ts) && PreY(f, TreeData(t)) => TreeMapY(t, f)))
 }
 
-method Main()
+method TestY() {
+  var f := x requires x != 0 => 100 / x;
+  var t := TreeMapY(Branch(1, Cons(Branch(2, Nil), Nil)), f);
+  assert t == Branch(100, Cons(Branch(50, Nil), Nil));  // proved via Lit axioms
+  print t, "\n";
+}
+
+// ---------- Read-effect functions ----------
+
+predicate PreZ<A,B>(f: A ~> B, s: set<A>)
+  reads set x, y | x in s && y in f.reads(x) :: y
 {
-  var t := TMap(Branch(1,Cons(Branch(2,Nil),Nil)), x requires x != 0 => 100 / x);
-  assert t   == Branch(100,Cons(Branch(50,Nil),Nil));
+  forall x :: x in s ==> f.requires(x)
+}
+
+function method MapZ<A,B>(xs: List<A>, f: A ~> B): List<B>
+  requires PreZ(f, ListData(xs))
+  reads PreZ.reads(f, ListData(xs))
+  decreases xs
+{
+  match xs
+  case Nil => Nil
+  case Cons(x, xs) => Cons(f(x), MapZ(xs, f))
+}
+
+function method TreeMapZ<A,B>(t0: Tree<A>, f: A ~> B): Tree<B>
+  requires PreZ(f, TreeData(t0))
+  reads PreZ.reads(f, TreeData(t0))
+  decreases t0
+{
+  var Branch(x, ts) := t0;
+  var g := t requires t in ListData(ts) && PreZ(f, TreeData(t))
+            reads set x, y | x in TreeData(t) && y in f.reads(x) :: y
+           => TreeMapZ(t, f);
+  Branch(f(x), MapZ(ts, g))
+}
+
+method TestZ() {
+  var f := x requires x != 0 => 100 / x;
+  var t := TreeMapZ(Branch(1, Cons(Branch(2, Nil), Nil)), f);
+  // Functions with reads clauses don't get Lit axioms, so we can't prove the same
+  // assertion as we did in TestY.
   print t, "\n";
 }

--- a/Test/hofs/TreeMapSimple.dfy.expect
+++ b/Test/hofs/TreeMapSimple.dfy.expect
@@ -1,3 +1,4 @@
 
-Dafny program verifier finished with 6 verified, 0 errors
+Dafny program verifier finished with 11 verified, 0 errors
+Tree.Branch(100, List.Cons(Tree.Branch(50, List.Nil), List.Nil))
 Tree.Branch(100, List.Cons(Tree.Branch(50, List.Nil), List.Nil))


### PR DESCRIPTION
Previously, `this` was not treated like other parameters in the "lit axioms"
that allow function definitions to be expanded without consuming fuel in
the verifier. Perhaps that was okay before, we `this` was usually the same
in a recursive call. With type members for other types, like `datatype`,
a recursive function is likely to be called on something other than `this`.

In effect, this meant that the verifier could get stuck in infinite matching,
especially when faced with a false proof obligation (and in at least one
observed true proof obligation). The assertion in LitTriggers.dfy would
cause the verifier to never come back, but with this fix, the assertion is
quickly reported as an error.

This fix required `ThisExpr` nodes to be translated into Boogie AST nodes
with a filled-in type. Evidently, that was not needed before. For this reason,
this commit changed a number of calls to `ThisExpr` constructor.

Another parameter passed to Boogie functions is the heap. Since functions
do not change the heap, the heap parameter does not need to be lit-wrapped.
However, to reduce the chances that lit axioms will loop forever, dependencies
in the heap are disallowed--that is, if a function has a dependency on the
heap, it does not get lit axioms. This was done before. This could be improved
in two ways. (0) Checking an empty `reads` clause (which is what the code
does) does not detect dependencies on `const` fields. It is conceivable
that such dependencies could cause infinite matching of lit axioms, but I
have not seen any such example. (1) Instead of checking `reads` clauses,
perhaps the code could see if `decreases` expressions depend on the heap.
This would allow more examples to go through, and perhaps it could be done
without introducing infinite matching.

A final remark, the code previously had a special case: the nonemptiness of
the `reads` clause was ignored if the function signature contained an arrow
type. This let an example in TreeMapSimple.dfy go through. This special
case does not seem good, since the empty-`reads`-clause check can then
be subverted by introducing an unused arrow-typed parameter. So, I removed
this special case. I adjusted TreeMapSimple.dfy accordingly. Annoyingly, this
means the `TestY` assertion cannot be proved in `TestZ`--even with a manual
proof (because of lack of function extensionality, or as the case may be here,
lack of extensionality for functions with read effects).