### PR TITLE
Initialize capacity in Map.FromCollection when possible

### DIFF
--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -658,7 +658,13 @@ namespace Dafny
 #if DAFNY_USE_SYSTEM_COLLECTIONS_IMMUTABLE
       var d = ImmutableDictionary<U, V>.Empty.ToBuilder();
 #else
-      var d = new Dictionary<U, V>();
+      // Initialize the capacity if the size of the enumerable is known
+      Dictionary<U, V> d;
+      if (values is ICollection<Pair<U, V>> collection) {
+        d = new Dictionary<U, V>(collection.Count);
+      } else {
+        d = new Dictionary<U, V>();  
+      }
 #endif
       var hasNullValue = false;
       var nullValue = default(V);
@@ -1406,6 +1412,11 @@ namespace Dafny
       BigInteger aa, bb, dd;
       Normalize(this, that, out aa, out bb, out dd);
       return aa.CompareTo(bb);
+    }
+    public int Sign {
+      get {
+        return num.Sign;
+      }
     }
     public override int GetHashCode() {
       return num.GetHashCode() + 29 * den.GetHashCode();

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -659,10 +659,11 @@ namespace Dafny
       var d = ImmutableDictionary<U, V>.Empty.ToBuilder();
 #else
       // Initialize the capacity if the size of the enumerable is known
+      Dictionary<U, V> d;
       if (values is ICollection<Pair<U, V>> collection) {
-        var d = new Dictionary<U, V>(collection.Count);
+        d = new Dictionary<U, V>(collection.Count);
       } else {
-        var d = new Dictionary<U, V>();  
+        d = new Dictionary<U, V>();  
       }
 #endif
       var hasNullValue = false;

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -658,7 +658,12 @@ namespace Dafny
 #if DAFNY_USE_SYSTEM_COLLECTIONS_IMMUTABLE
       var d = ImmutableDictionary<U, V>.Empty.ToBuilder();
 #else
-      var d = new Dictionary<U, V>();
+      // Initialize the capacity if the size of the enumerable is known
+      if (values is ICollection<Pair<U, V>> collection) {
+        var d = new Dictionary<U, V>(collection.Count);
+      } else {
+        var d = new Dictionary<U, V>();  
+      }
 #endif
       var hasNullValue = false;
       var nullValue = default(V);


### PR DESCRIPTION
Recovers the optimization lost when the argument type was generalized to `IEnumerable`.