### PR TITLE
Allow "this" among quantified induction variables

### DIFF
--- a/Test/allocated1/dafny0/Termination.dfy.expect
+++ b/Test/allocated1/dafny0/Termination.dfy.expect
@@ -55,4 +55,4 @@ Execution trace:
     (0,0): anon10_Then
     (0,0): anon11_Else
 
-Dafny program verifier finished with 37 verified, 8 errors
+Dafny program verifier finished with 43 verified, 8 errors

--- a/Test/dafny0/AutoContracts.dfy.expect
+++ b/Test/dafny0/AutoContracts.dfy.expect
@@ -230,13 +230,13 @@ module OneModule {
       data < 20
     }
 
-    lemma L()
+    lemma /*{:_induction this}*/ L()
       requires Valid()
       ensures data < 100
     {
     }
 
-    twostate lemma TL()
+    twostate lemma /*{:_induction this}*/ TL()
       requires old(Valid())
       ensures old(data) <= data
     {

--- a/Test/dafny0/PrefixTypeSubst.dfy.expect
+++ b/Test/dafny0/PrefixTypeSubst.dfy.expect
@@ -280,7 +280,7 @@ class MyClass<A, B> {
     L(u, v);
   }
   /***
-  lemma /*{:_induction _k}*/ L#<U, V>[_k: ORDINAL](u: U, v: V)
+  lemma /*{:_induction this, _k}*/ L#<U, V>[_k: ORDINAL](u: U, v: V)
     ensures P#[_k](u, v)
     decreases _k
   {
@@ -303,7 +303,7 @@ class MyClass<A, B> {
     assert R#<char>[_k - 1]();
   }
   /***
-  lemma /*{:_induction _k}*/ M#<W>[_k: ORDINAL]()
+  lemma /*{:_induction this, _k}*/ M#<W>[_k: ORDINAL]()
     ensures R#<char>[_k]()
     decreases _k
   {

--- a/Test/dafny0/Termination.dfy
+++ b/Test/dafny0/Termination.dfy
@@ -486,4 +486,43 @@ datatype Tree = Empty | Node(root: int, left: Tree, right: Tree)
         s := ComputeSum(n - 1);
       }
   }
+
+  lemma {:induction this} EvensSumToEven()  // explicitly use "this" as quantified over by induction hypothesis
+    requires forall u :: u in Elements() ==> u % 2 == 0
+    ensures Sum() % 2 == 0
+    // auto: decreases this
+  {
+    match this
+    case Empty =>
+    case Node(x, left, right) =>
+      assert x in Elements();
+      left.EvensSumToEven();
+      right.EvensSumToEven();
+  }
+
+  lemma EvensSumToEvenAutoInduction()  // {:induction this} is the default
+    requires forall u :: u in Elements() ==> u % 2 == 0
+    ensures Sum() % 2 == 0
+    // auto: decreases this
+  {
+    match this
+    case Empty =>
+    case Node(x, left, right) =>
+      assert x in Elements();
+      left.EvensSumToEvenAutoInduction();
+      right.EvensSumToEvenAutoInduction();
+  }
+}
+
+lemma ExtEvensSumToEven(t: Tree)
+  requires forall u :: u in t.Elements() ==> u % 2 == 0
+  ensures t.Sum() % 2 == 0
+  // auto: decreases t
+{
+  match t
+  case Empty =>
+  case Node(x, left, right) =>
+    assert x in t.Elements();
+    assert left.Sum() % 2 == 0;
+    assert right.Sum() % 2 == 0;
 }

--- a/Test/dafny0/Termination.dfy
+++ b/Test/dafny0/Termination.dfy
@@ -525,4 +525,5 @@ lemma ExtEvensSumToEven(t: Tree)
     assert x in t.Elements();
     assert left.Sum() % 2 == 0;
     assert right.Sum() % 2 == 0;
+    assert t.Sum() % 2 == 0;
 }

--- a/Test/dafny0/Termination.dfy.expect
+++ b/Test/dafny0/Termination.dfy.expect
@@ -55,4 +55,4 @@ Execution trace:
     Termination.dfy(296,3): anon11_Else
     (0,0): anon12_Else
 
-Dafny program verifier finished with 37 verified, 8 errors
+Dafny program verifier finished with 43 verified, 8 errors


### PR DESCRIPTION
`this` can be used explicitly in `:induction` attribute, and is also being considered
for automatic inclusion.