### PR TITLE
Substitute actual type args in modifies clause of callee

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -11864,7 +11864,9 @@ namespace Microsoft.Dafny {
 
       // Check modifies clause of a subcall is a subset of the current frame.
       if (codeContext is IMethodCodeContext) {
-        CheckFrameSubset(tok, callee.Mod.Expressions, receiver, substMap, etran, builder, "call may violate context's modifies clause", null);
+        var s = new Substituter(null, new Dictionary<IVariable, Expression>(), tySubst);
+        CheckFrameSubset(tok, callee.Mod.Expressions.ConvertAll(s.SubstFrameExpr),
+          receiver, substMap, etran, builder, "call may violate context's modifies clause", null);
       }
 
       // Check termination

--- a/Test/allocated1/dafny0/TypeParameters.dfy.expect
+++ b/Test/allocated1/dafny0/TypeParameters.dfy.expect
@@ -54,4 +54,4 @@ Execution trace:
     (0,0): anon3_Then
     (0,0): anon2
 
-Dafny program verifier finished with 31 verified, 9 errors
+Dafny program verifier finished with 32 verified, 9 errors

--- a/Test/dafny0/TypeParameters.dfy
+++ b/Test/dafny0/TypeParameters.dfy
@@ -400,4 +400,3 @@ module TypeSubstitutionInModifiesClause {
     c.Update();
   }
 }
-

--- a/Test/dafny0/TypeParameters.dfy
+++ b/Test/dafny0/TypeParameters.dfy
@@ -382,3 +382,22 @@ module ParseGenerics {
     assert {:fuel Many<real>, 10} Many(xs) == 18;  // yes
   }
 }
+
+// -------------- regression test: method call where callee is in a different class with type parameters ------
+
+module TypeSubstitutionInModifiesClause {
+  class C<T> {
+    ghost const Repr: set<object>
+    constructor ()
+      ensures fresh(Repr)
+    method Update()
+      modifies Repr
+  }
+
+  method Client() {
+    var c := new C<int>();
+    // The following call once caused malformed Boogie, because of a missing type substitution.
+    c.Update();
+  }
+}
+

--- a/Test/dafny0/TypeParameters.dfy.expect
+++ b/Test/dafny0/TypeParameters.dfy.expect
@@ -54,4 +54,4 @@ Execution trace:
     TypeParameters.dfy(174,3): anon21_Else
     TypeParameters.dfy(174,3): anon23_Else
 
-Dafny program verifier finished with 31 verified, 9 errors
+Dafny program verifier finished with 32 verified, 9 errors


### PR DESCRIPTION
Previously, the translation to Boogie used the formal type parameters of the
callee when checking the frame in callers.