### PR TITLE
Copy local-variable type in Substitute routine

### DIFF
--- a/Test/git-issues/git-issue-443.dfy
+++ b/Test/git-issues/git-issue-443.dfy
@@ -1,0 +1,30 @@
+// RUN: %dafny /compile:3 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Main() {
+  print F(), " ", G(802.11), "\n";  // 12 15
+}
+
+function method F(): int {
+  var rx := false;
+  assert 20 < 30 by {
+    var u := 5.0;  // this once caused a crash in Translator.cs
+    assert u < 6.0;
+  }
+  12
+}
+
+function method G<T>(t: T): int {
+  var rx := false;
+  assert 20 < 30 by {
+    var u: T := t;  // this once caused a crash in Translator.cs
+    {
+      var v: T := u;
+      assert t == v;
+      v := t;
+      assert t == u;
+    }
+    assert u == t;
+  }
+  15
+}

--- a/Test/git-issues/git-issue-443.dfy.expect
+++ b/Test/git-issues/git-issue-443.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 2 verified, 0 errors
+12 15


### PR DESCRIPTION
Previously, the `Substitute` routines in `Translator.cs` did not produce resolved `LocalVariable` nodes.
Now, their `.type` field is filled in from the `.OptionalType` field. Moreover, the resulting local variable
is added to the substitution map.

Fixes #443