### PR TITLE
Add support for {:test} attribute (C# only for now)

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Dafny
       wr.WriteLine("using System;");
       wr.WriteLine("using System.Numerics;");
       EmitDafnySourceAttribute(program, wr);
-      ReadRuntimeSystem("DafnyRuntime.cs", wr);
+      if (!DafnyOptions.O.UseRuntimeLib) {
+        ReadRuntimeSystem("DafnyRuntime.cs", wr);
+      }
     }
 
     void EmitDafnySourceAttribute(Program program, TextWriter wr) {
@@ -721,10 +723,9 @@ namespace Microsoft.Dafny
       }
 
       var customReceiver = NeedsCustomReceiver(m);
-      var isTest = Attributes.Contains(m.Attributes, "test");
-      
-      wr.Write("{0}{1}{2}{3}{4} {5}",
-        isTest ? "[Xunit.Fact] " : "",
+
+      AddTestCheckerIfNeeded(m.Name, m, wr);
+      wr.Write("{0}{1}{2}{3} {4}",
         createBody ? "public " : "",
         m.IsStatic || customReceiver ? "static " : "",
         hasDllImportAttribute ? "extern " : "",
@@ -773,9 +774,9 @@ namespace Microsoft.Dafny
       var hasDllImportAttribute = ProcessDllImport(member, wr);
 
       var customReceiver = NeedsCustomReceiver(member);
-      var isTest = Attributes.Contains(member.Attributes, "test");
       
-      wr.Write("{0}{1}{2}{3}{4} {5}", isTest ? "[Xunit.Fact] " : "", createBody ? "public " : "", isStatic || customReceiver ? "static " : "", hasDllImportAttribute ? "extern " : "", TypeName(resultType, wr, tok), name);
+      AddTestCheckerIfNeeded(name, member, wr);
+      wr.Write("{0}{1}{2}{3}  {4}", createBody ? "public " : "", isStatic || customReceiver ? "static " : "", hasDllImportAttribute ? "extern " : "", TypeName(resultType, wr, tok), name);
       if (typeArgs != null && typeArgs.Count != 0) {
         wr.Write("<{0}>", TypeParameters(typeArgs));
       }
@@ -2420,6 +2421,21 @@ namespace Microsoft.Dafny
         outputWriter.WriteLine(e.ToString());
       }
       return false;
+    }
+
+    private void AddTestCheckerIfNeeded(string name, Declaration decl, TargetWriter wr)
+    {
+      if (Attributes.Contains(decl.Attributes, "test")) {
+        // TODO: The resolver needs to check the assumptions about the declaration
+        // (i.e. must be public and static, must return a "result type", etc.)
+        wr.WriteLine("[Xunit.Fact]");
+        wr.WriteLine("public static void {0}_CheckForFailureForXunit()", name);
+        wr.WriteLine("{");
+        wr.WriteLine("  var result = {0}();", name);
+        wr.WriteLine("  Xunit.Assert.False(result.IsFailure(), \"Dafny test failed: \" + result);");
+        wr.WriteLine("}");
+        wr.WriteLine("");
+      }
     }
   }
 }

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -776,7 +776,7 @@ namespace Microsoft.Dafny
       var customReceiver = NeedsCustomReceiver(member);
       
       AddTestCheckerIfNeeded(name, member, wr);
-      wr.Write("{0}{1}{2}{3}  {4}", createBody ? "public " : "", isStatic || customReceiver ? "static " : "", hasDllImportAttribute ? "extern " : "", TypeName(resultType, wr, tok), name);
+      wr.Write("{0}{1}{2}{3} {4}", createBody ? "public " : "", isStatic || customReceiver ? "static " : "", hasDllImportAttribute ? "extern " : "", TypeName(resultType, wr, tok), name);
       if (typeArgs != null && typeArgs.Count != 0) {
         wr.Write("<{0}>", TypeParameters(typeArgs));
       }

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -721,8 +721,10 @@ namespace Microsoft.Dafny
       }
 
       var customReceiver = NeedsCustomReceiver(m);
-
-      wr.Write("{0}{1}{2}{3} {4}",
+      var isTest = Attributes.Contains(m.Attributes, "test");
+      
+      wr.Write("{0}{1}{2}{3}{4} {5}",
+        isTest ? "[Xunit.Fact] " : "",
         createBody ? "public " : "",
         m.IsStatic || customReceiver ? "static " : "",
         hasDllImportAttribute ? "extern " : "",
@@ -771,8 +773,9 @@ namespace Microsoft.Dafny
       var hasDllImportAttribute = ProcessDllImport(member, wr);
 
       var customReceiver = NeedsCustomReceiver(member);
-
-      wr.Write("{0}{1}{2}{3} {4}", createBody ? "public " : "", isStatic || customReceiver ? "static " : "", hasDllImportAttribute ? "extern " : "", TypeName(resultType, wr, tok), name);
+      var isTest = Attributes.Contains(member.Attributes, "test");
+      
+      wr.Write("{0}{1}{2}{3}{4} {5}", isTest ? "[Xunit.Fact] " : "", createBody ? "public " : "", isStatic || customReceiver ? "static " : "", hasDllImportAttribute ? "extern " : "", TypeName(resultType, wr, tok), name);
       if (typeArgs != null && typeArgs.Count != 0) {
         wr.Write("<{0}>", TypeParameters(typeArgs));
       }


### PR DESCRIPTION
This allows Dafny codebases to specify tests in a convenient and natural way. It currently assumes that actually running the tests is left up to a tool in the target language (in this case Xunit), which (at least initially) relieves Dafny from having to implement discovery, test runners, reports, etc. 

This is an early PR for initial feedback. I'm working on adding explicit lit "testing tests" to show examples of Dafny tests and Xunit output for them.

Known TODOs and open questions to address before merging:

- Reject programs that use {:test} incorrectly before attempting to compile them (must be "static", must return a "result type", etc.)
- Explicitly report the lack of support in the other target languages
- Add lit tests (once I work out a clean way of having them depend on Xunit)
- Define minimal requirements for {:test} semantics, in order to specify correctness for translation to each target language. I'd propose that there must at least exist a command that provides a non-zero exit code IFF at least one {:test} method returns a result for which `IsFailure()` returns true.
- Provide CLI switches for running tests using the target language tooling? Something like `dafny /test`?
- Create a mechanism for customizing the compiler per language? It would be better not to reference specific libraries in the compiler itself.