### PR TITLE
Allow explicit type argument to seq comprehension

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -361,7 +361,8 @@ namespace Microsoft.Dafny
 
       } else if (expr is SeqConstructionExpr) {
         var e = (SeqConstructionExpr)expr;
-        return new SeqConstructionExpr(Tok(e.tok), CloneExpr(e.N), CloneExpr(e.Initializer));
+        var elemType = e.ExplicitElementType == null ? null : CloneType(e.ExplicitElementType);
+        return new SeqConstructionExpr(Tok(e.tok), elemType, CloneExpr(e.N), CloneExpr(e.Initializer));
 
       } else if (expr is MultiSetFormingExpr) {
         var e = (MultiSetFormingExpr)expr;

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -3386,15 +3386,24 @@ MultiSetExpr<out Expression e>
 SeqConstructionExpr<out Expression e>
 = (. Contract.Ensures(Contract.ValueAtReturn(out e) != null);
      IToken x = null;
+     Type explicitTypeArg = null;
      Expression n, f;
      e = dummyExpr;
   .)
   "seq"                          (. x = t; .)
+  [ (. var gt = new List<Type>(); .)
+    GenericInstantiation<gt>     (. if (gt.Count > 1) {
+                                      SemErr("seq type expects only one type argument");
+                                    } else {
+                                      explicitTypeArg = gt[0];
+                                    }
+                                 .)
+  ]
   "("
   Expression<out n, true, true>
   ","
   Expression<out f, true, true>
-  ")"                            (. e = new SeqConstructionExpr(x, n, f); .)
+  ")"                            (. e = new SeqConstructionExpr(x, explicitTypeArg, n, f); .)
   .
 MapDisplayExpr<IToken/*!*/ mapToken, bool finite, out Expression e>
 = (. Contract.Ensures(Contract.ValueAtReturn(out e) != null);

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -9225,13 +9225,15 @@ namespace Microsoft.Dafny {
 
   public class SeqConstructionExpr : Expression
   {
+    public Type/*?*/ ExplicitElementType;
     public Expression N;
     public Expression Initializer;
-    public SeqConstructionExpr(IToken tok, Expression length, Expression initializer)
+    public SeqConstructionExpr(IToken tok, Type/*?*/ elementType, Expression length, Expression initializer)
       : base(tok) {
       Contract.Requires(tok != null);
       Contract.Requires(length != null);
       Contract.Requires(initializer != null);
+      ExplicitElementType = elementType;
       N = length;
       Initializer = initializer;
     }

--- a/Source/Dafny/Parser.cs
+++ b/Source/Dafny/Parser.cs
@@ -5072,17 +5072,28 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 	void SeqConstructionExpr(out Expression e) {
 		Contract.Ensures(Contract.ValueAtReturn(out e) != null);
 		IToken x = null;
+		Type explicitTypeArg = null;
 		Expression n, f;
 		e = dummyExpr;
 		
 		Expect(20);
 		x = t; 
+		if (la.kind == 81) {
+			var gt = new List<Type>(); 
+			GenericInstantiation(gt);
+			if (gt.Count > 1) {
+			 SemErr("seq type expects only one type argument");
+			} else {
+			 explicitTypeArg = gt[0];
+			}
+			
+		}
 		Expect(79);
 		Expression(out n, true, true);
 		Expect(26);
 		Expression(out f, true, true);
 		Expect(80);
-		e = new SeqConstructionExpr(x, n, f); 
+		e = new SeqConstructionExpr(x, explicitTypeArg, n, f); 
 	}
 
 	void ConstAtomExpression(out Expression e, bool allowSemi, bool allowLambda) {

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -2108,7 +2108,11 @@ namespace Microsoft.Dafny {
 
       } else if (expr is SeqConstructionExpr) {
         var e = (SeqConstructionExpr)expr;
-        wr.Write("seq(");
+        wr.Write("seq");
+        if (e.ExplicitElementType != null) {
+          wr.Write("<{0}>", e.ExplicitElementType);
+        }
+        wr.Write("(");
         PrintExpression(e.N, false);
         wr.Write(", ");
         PrintExpression(e.Initializer, false);

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -11871,7 +11871,8 @@ namespace Microsoft.Dafny
 
       } else if (expr is SeqConstructionExpr) {
         var e = (SeqConstructionExpr)expr;
-        var elementType = new InferredTypeProxy();
+        var elementType = e.ExplicitElementType ?? new InferredTypeProxy();
+        ResolveType(e.tok, elementType, opts.codeContext, ResolveTypeOptionEnum.InferTypeProxies, null);
         ResolveExpression(e.N, opts);
         ConstrainToIntegerType(e.N, "sequence construction must use an integer-based expression for the sequence size (got {0})");
         ResolveExpression(e.Initializer, opts);

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -7365,7 +7365,7 @@ namespace Microsoft.Dafny {
           "sequence size might be negative"));
 
         CheckWellformed(e.Initializer, options, locals, builder, etran);
-        var eType = e.Type.AsSeqType.Arg.NormalizeExpand();
+        var eType = e.Type.AsSeqType.Arg;
         CheckElementInit(e.tok, false, new List<Expression>() {e.N}, eType, e.Initializer, null, builder, etran, options);
       } else if (expr is MultiSetFormingExpr) {
         MultiSetFormingExpr e = (MultiSetFormingExpr)expr;
@@ -7580,7 +7580,16 @@ namespace Microsoft.Dafny {
             });
           }
           BplIfIf(e.tok, guard != null, guard, newBuilder, b => {
-            CheckWellformed(body, newOptions, locals, b, newEtran);
+            Bpl.Expr resultIe = null;
+            Type rangeType = null;
+            if (lam != null) {
+              var resultName = CurrentIdGenerator.FreshId("lambdaResult#");
+              var resultVar = new Bpl.LocalVariable(body.tok, new Bpl.TypedIdent(body.tok, resultName, TrType(body.Type)));
+              locals.Add(resultVar);
+              resultIe = new Bpl.IdentifierExpr(body.tok, resultVar);
+              rangeType = lam.Type.AsArrowType.Result;
+            }
+            CheckWellformedWithResult(body, newOptions, resultIe, rangeType, locals, b, newEtran);
           });
 
           if (mc != null) {
@@ -17745,7 +17754,7 @@ namespace Microsoft.Dafny {
           var sn = Substitute(e.N);
           var sinit = Substitute(e.Initializer);
           if (sn != e.N || sinit != e.Initializer) {
-            newExpr = new SeqConstructionExpr(expr.tok, sn, sinit);
+            newExpr = new SeqConstructionExpr(expr.tok, e.ExplicitElementType, sn, sinit);
           }
         } else if (expr is MultiSetFormingExpr) {
           var e = (MultiSetFormingExpr)expr;

--- a/Test/allocated1/dafny0/Comprehensions.dfy.expect
+++ b/Test/allocated1/dafny0/Comprehensions.dfy.expect
@@ -52,5 +52,37 @@ Execution trace:
     (0,0): anon0
     (0,0): anon9_Else
     Comprehensions.dfy(148,12): anon10_Else
+Comprehensions.dfy(168,16): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+    Comprehensions.dfy(168,17): anon7_Else
+Comprehensions.dfy(171,11): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+    Comprehensions.dfy(171,12): anon7_Else
+Comprehensions.dfy(174,4): Error: all sequence indices must be in the domain of the initialization function
+Execution trace:
+    (0,0): anon0
+    (0,0): anon10_Else
+    Comprehensions.dfy(174,12): anon11_Else
+Comprehensions.dfy(180,38): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Else
+Comprehensions.dfy(186,30): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
+Comprehensions.dfy(189,16): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon9_Else
+    Comprehensions.dfy(189,17): anon10_Else
 
-Dafny program verifier finished with 12 verified, 9 errors
+Dafny program verifier finished with 16 verified, 15 errors

--- a/Test/dafny0/Comprehensions.dfy
+++ b/Test/dafny0/Comprehensions.dfy
@@ -157,4 +157,35 @@ class SeqOp {
   {
     seq(n, i reads if i < 20 then {} else {this} => if i < 20 then 2.5 else x)
   }
+
+  function method XT0(n: nat): seq<int> {
+    seq<int>(n, _ => 7)
+  }
+  function method XT1(n: nat): seq<int> {
+    seq<nat>(n, _ => 7)
+  }
+  function method XT2(n: nat): seq<int> {
+    seq<nat>(n, _ => -7)  // error: -7 is not a nat
+  }
+  function method XT3(n: nat): seq<nat> {
+    seq(n, _ => -7)  // error: this is not a seq<nat>
+  }
+  function method XT4(n: nat): seq<nat> {
+    seq(n, i requires 0 <= i < 3 => 10)  // error: init function doesn't accept all indices
+  }
+  function method XT5(n: nat): seq<nat> {
+    seq(n, i requires 0 <= i < n => 10)
+  }
+  function method XT6(n: nat): seq<nat> {
+    seq(n, i => if i < n then 10 else -7)  // error: type of lambda is inferred to be int->nat, so the -7 gives an error
+  }
+  function method XT7(n: nat): seq<nat> {
+    seq(n, i => var u: int := if i < n then 10 else -7; u)  // fine: lambda has type int->int; use of this lambda always gives a nat
+  }
+  function method XT8(n: nat): seq<nat> {
+    seq(n, i => if i < n then -7 else 10)  // error: this can't be assigned to a seq<nat>
+  }
+  function method XT9(n: nat): seq<nat> {
+    seq<nat>(n, i => if i < n then -7 else 10)  // error: this can't be assigned to a seq<nat>
+  }
 }

--- a/Test/dafny0/Comprehensions.dfy.expect
+++ b/Test/dafny0/Comprehensions.dfy.expect
@@ -37,6 +37,38 @@ Execution trace:
     (0,0): anon0
     (0,0): anon9_Else
     Comprehensions.dfy(148,12): anon10_Else
+Comprehensions.dfy(168,16): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+    Comprehensions.dfy(168,17): anon7_Else
+Comprehensions.dfy(171,11): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+    Comprehensions.dfy(171,12): anon7_Else
+Comprehensions.dfy(174,4): Error: all sequence indices must be in the domain of the initialization function
+Execution trace:
+    (0,0): anon0
+    (0,0): anon10_Else
+    Comprehensions.dfy(174,12): anon11_Else
+Comprehensions.dfy(180,38): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Else
+Comprehensions.dfy(186,30): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
+Comprehensions.dfy(189,16): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon9_Else
+    Comprehensions.dfy(189,17): anon10_Else
 Comprehensions.dfy(12,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -53,4 +85,4 @@ Execution trace:
     Comprehensions.dfy(74,25): anon11_Else
     (0,0): anon12_Then
 
-Dafny program verifier finished with 12 verified, 9 errors
+Dafny program verifier finished with 16 verified, 15 errors


### PR DESCRIPTION
Previously, `seq(n, init)` would always infer the element type of the constructed sequence.
Now, it can also be given explicitly by `seq<T>(n, init)`.