### PR TITLE
Lock down Boogie release, avoid recent regression

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,7 +14,7 @@ phases:
       - find . -type f
       # Get Boogie
       # Some recent changes have broken one of our test cases, so lock down to a specific
-      # release for now. See https://github.com/dafny-lang/dafny/issues/476 
+      # release for now. See https://github.com/dafny-lang/dafny/issues/476.
       - git clone --branch v2.4.2 https://github.com/boogie-org/boogie.git
       - nuget restore boogie/Source/Boogie.sln
       - msbuild boogie/Source/Boogie.sln

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,7 +13,9 @@ phases:
       - pip install lit OutputCheck pyyaml
       - find . -type f
       # Get Boogie
-      - git clone https://github.com/boogie-org/boogie.git
+      # Some recent changes have broken one of our test cases, so lock down to a specific
+      # release for now. See https://github.com/dafny-lang/dafny/issues/476 
+      - git clone --branch v2.4.2 https://github.com/boogie-org/boogie.git
       - nuget restore boogie/Source/Boogie.sln
       - msbuild boogie/Source/Boogie.sln
       # Get Z3


### PR DESCRIPTION
Recent changes broke the git-issue223.transcript test case. To work around this and make builds more reproducible, make the build clone a specific release. We can’t depend on the existing nuget Boogie artifact because it only exposes a CLI tool interface.

Fixes #476 