### PR TITLE
Fixing a problem with indentation after generated declarations for ou…

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -969,10 +969,13 @@ namespace Microsoft.Dafny{
         Contract.Assert(rhs == null); // follows from precondition
       } else if (rhs != null){
         wr.WriteLine($" = {rhs};");
+        wr.Write(wr.IndentString);
       } else if (type.IsIntegerType) {
         wr.WriteLine(" = java.math.BigInteger.ZERO;");
+        wr.Write(wr.IndentString);
       } else {
         wr.WriteLine(";");
+        wr.Write(wr.IndentString);
       }
     }
 


### PR DESCRIPTION
The indentation was absent after declarations generated for output variables in the Java source output. This fixes that problem.