### PR TITLE
Report errors for all WrappedToken locations

### DIFF
--- a/Source/Dafny/Reporting.cs
+++ b/Source/Dafny/Reporting.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Dafny {
 
     // This is the only thing that needs to be overriden
     public virtual bool Message(MessageSource source, ErrorLevel level, IToken tok, string msg) {
-      bool discard = (ErrorsOnly && level != ErrorLevel.Error) || // Discard non-errors if ErrorsOnly is set
-                     (tok is TokenWrapper && !(tok is IncludeToken) && !(tok is NestedToken) && !(tok is RefinementToken)); // Discard wrapped tokens, except for included, nested and refinement
-      if (!discard) {
-        AllMessages[level].Add(new ErrorMessage { token = tok, message = msg });
+      if (ErrorsOnly && level != ErrorLevel.Error) {
+        // discard the message
+        return false;
       }
-      return !discard;
+      AllMessages[level].Add(new ErrorMessage { token = tok, message = msg });
+      return true;
     }
 
     public int Count(ErrorLevel level) {

--- a/Test/git-issues/git-issue-484.dfy
+++ b/Test/git-issues/git-issue-484.dfy
@@ -1,0 +1,53 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+newtype MyInt = int
+
+datatype Bar = Bar(b: MyInt)
+
+function update0(bar: Bar, i: int): Bar {
+  // Regression test: the following once suppressed the error:
+  bar.(b := i) // error: int not assignable to MyInt
+}
+
+function update1(bar: Bar, i: int): Bar {
+  bar.(b := i as MyInt)
+}
+
+function update2(bar: Bar, i: real): Bar {
+  // Regression test: the following once caused a crash:
+  bar.(b := i) // error: real is not assignable to MyInt
+}
+
+function update3(bar: Bar, i: int): Bar {
+  Bar(i) // error: int is not assignable to MyInt
+}
+
+newtype byte = b:int | 0 <= b < 0x100
+
+datatype Foo = Foo(b: byte)
+
+function update10(foo: Foo, i: int): Foo
+  requires 0 <= i < 0x100
+{
+  // Regression test: the following once suppressed the error:
+  foo.(b := i) // error: int is not assignable to byte
+}
+
+function update11(foo: Foo, i: int) : Foo
+  requires 0 <= i < 0x100
+{
+  Foo(i) // error: int is not assignable to byte
+}
+
+function update12(foo: Foo, i: int): Foo
+  requires 0 <= i < 0x100
+{
+  foo.(b := i as byte)
+}
+
+function update13(foo: Foo, i: int) : Foo
+  requires 0 <= i < 0x100
+{
+  Foo(i as byte)
+}

--- a/Test/git-issues/git-issue-484.dfy.expect
+++ b/Test/git-issues/git-issue-484.dfy.expect
@@ -1,0 +1,6 @@
+git-issue-484.dfy(10,6): Error: type of corresponding source/RHS (int) does not match type of bound variable (MyInt)
+git-issue-484.dfy(19,6): Error: type of corresponding source/RHS (real) does not match type of bound variable (MyInt)
+git-issue-484.dfy(23,6): Error: incorrect type of datatype constructor argument (found int, expected MyInt)
+git-issue-484.dfy(34,6): Error: type of corresponding source/RHS (int) does not match type of bound variable (byte)
+git-issue-484.dfy(40,6): Error: incorrect type of datatype constructor argument (found int, expected byte)
+5 resolution/type errors detected in git-issue-484.dfy


### PR DESCRIPTION
Previously, any error/warning/info message for the two kinds of source-location tokens
AutoGeneratedToken and ForceCheckToken were suppressed.

Fixes #484.