### PR TITLE
Fix crash when using `bv` as type in top-level module

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Dafny
         new ValuetypeDecl("int", builtIns.SystemModule, 0, t => t.IsNumericBased(Type.NumericPersuation.Int), typeArgs => Type.Int),
         new ValuetypeDecl("real", builtIns.SystemModule, 0, t => t.IsNumericBased(Type.NumericPersuation.Real), typeArgs => Type.Real),
         new ValuetypeDecl("ORDINAL", builtIns.SystemModule, 0, t => t.IsBigOrdinalType, typeArgs => Type.BigOrdinal),
-        new ValuetypeDecl("bv", builtIns.SystemModule, 0, t => t.IsBitVectorType, null),  // "bv" represents a family of classes, so no typeTester or type creator is supplied
+        new ValuetypeDecl("_bv", builtIns.SystemModule, 0, t => t.IsBitVectorType, null),  // "_bv" represents a family of classes, so no typeTester or type creator is supplied
         new ValuetypeDecl("map", builtIns.SystemModule, 2, t => t.IsMapType, typeArgs => new MapType(true, typeArgs[0], typeArgs[1])),
         new ValuetypeDecl("imap", builtIns.SystemModule, 2, t => t.IsIMapType, typeArgs => new MapType(false, typeArgs[0], typeArgs[1]))
       };

--- a/Test/dafny0/AutoContracts.dfy.expect
+++ b/Test/dafny0/AutoContracts.dfy.expect
@@ -76,7 +76,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/Bitvectors.dfy.expect
+++ b/Test/dafny0/Bitvectors.dfy.expect
@@ -76,7 +76,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/BitvectorsMore.dfy.expect
+++ b/Test/dafny0/BitvectorsMore.dfy.expect
@@ -92,7 +92,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/ModuleInsertion.dfy.expect
+++ b/Test/dafny0/ModuleInsertion.dfy.expect
@@ -162,7 +162,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/PrefixTypeSubst.dfy.expect
+++ b/Test/dafny0/PrefixTypeSubst.dfy.expect
@@ -108,7 +108,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/TypeConstraints.dfy.expect
+++ b/Test/dafny0/TypeConstraints.dfy.expect
@@ -93,7 +93,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/TypeConversions.dfy.expect
+++ b/Test/dafny0/TypeConversions.dfy.expect
@@ -92,7 +92,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny0/TypeConversionsCompile.dfy.expect
+++ b/Test/dafny0/TypeConversionsCompile.dfy.expect
@@ -76,7 +76,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny2/CalcDefaultMainOperator.dfy.expect
+++ b/Test/dafny2/CalcDefaultMainOperator.dfy.expect
@@ -76,7 +76,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype

--- a/Test/dafny4/Regression20.dfy
+++ b/Test/dafny4/Regression20.dfy
@@ -1,0 +1,6 @@
+// RUN: %dafny /compile:0  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// The type name "bv" once crashed the resolver
+
+method M(x: bv)  // error: undeclared type bv

--- a/Test/dafny4/Regression20.dfy.expect
+++ b/Test/dafny4/Regression20.dfy.expect
@@ -1,0 +1,2 @@
+Regression20.dfy(6,12): Error: Undeclared top-level type or type parameter: bv (did you forget to qualify a name or declare a module import 'opened?')
+1 resolution/type errors detected in Regression20.dfy

--- a/Test/dafny4/git-issue228.dfy.expect
+++ b/Test/dafny4/git-issue228.dfy.expect
@@ -139,7 +139,7 @@ module _System {
     var IsNat: bool  // immutable
   }
 
-  type bv {
+  type _bv {
     function method RotateLeft(w: nat): selftype
 
     function method RotateRight(w: nat): selftype


### PR DESCRIPTION
The name "bv" was used internally in a lookup table with built-in types.
This caused a crash if the identifier was actually used in a program.