### PR TITLE
feat: Body-less loops

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -7211,8 +7211,20 @@ namespace Microsoft.Dafny {
 
   public class WhileStmt : LoopStmt
   {
-    public readonly Expression Guard;
-    public readonly BlockStmt Body;
+    public readonly Expression/*?*/ Guard;
+    public readonly BlockStmt/*?*/ Body;
+    public LoopBodySurrogate/*?*/ BodySurrogate;  // set by Resolver; remains null unless Body==null
+
+    public class LoopBodySurrogate
+    {
+      public readonly List<IVariable> LocalLoopTargets;
+      public readonly bool UsesHeap;
+
+      public LoopBodySurrogate(List<IVariable> localLoopTargets, bool usesHeap) {
+        LocalLoopTargets = localLoopTargets;
+        UsesHeap = usesHeap;
+      }
+    }
 
     public WhileStmt(IToken tok, IToken endTok, Expression guard,
                      List<MaybeFreeExpression> invariants, Specification<Expression> decreases, Specification<FrameExpression> mod,

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -6999,8 +6999,10 @@ namespace Microsoft.Dafny
           }
           if (s.Body != null) {
             Visit(s.Body, s.IsGhost);
+            if (s.Body.IsGhost && !s.Decreases.Expressions.Exists(e => e is WildcardExpr)) {
+              s.IsGhost = true;
+            }
           }
-          s.IsGhost = s.IsGhost || s.Body == null || (!s.Decreases.Expressions.Exists(e => e is WildcardExpr) && s.Body.IsGhost);
 
         } else if (stmt is AlternativeLoopStmt) {
           var s = (AlternativeLoopStmt)stmt;
@@ -9231,14 +9233,15 @@ namespace Microsoft.Dafny
       } else if (stmt is WhileStmt) {
         WhileStmt s = (WhileStmt)stmt;
         var fvs = new HashSet<IVariable>();
+        var usesHeap = false;
         if (s.Guard != null) {
           ResolveExpression(s.Guard, new ResolveOpts(codeContext, true));
           Contract.Assert(s.Guard.Type != null);  // follows from postcondition of ResolveExpression
-          Translator.ComputeFreeVariables(s.Guard, fvs);
+          Translator.ComputeFreeVariables(s.Guard, fvs, ref usesHeap);
           ConstrainTypeExprBool(s.Guard, "condition is expected to be of type bool, but is {0}");
         }
 
-        ResolveLoopSpecificationComponents(s.Invariants, s.Decreases, s.Mod, codeContext, fvs);
+        ResolveLoopSpecificationComponents(s.Invariants, s.Decreases, s.Mod, codeContext, fvs, ref usesHeap);
 
         if (s.Body != null) {
           loopStack.Add(s);  // push
@@ -9247,15 +9250,21 @@ namespace Microsoft.Dafny
           dominatingStatementLabels.PopMarker();
           loopStack.RemoveAt(loopStack.Count - 1);  // pop
         } else {
-          reporter.Warning(MessageSource.Resolver, s.Tok, "note, this loop has no body");
-          string text = "havoc {" + Util.Comma(", ", fvs, fv => fv.Name) + "};";  // always terminate with a semi-colon
-          reporter.Info(MessageSource.Resolver, s.Tok, text);
+          Contract.Assert(s.BodySurrogate == null);  // .BodySurrogate is set only once
+          s.BodySurrogate = new WhileStmt.LoopBodySurrogate(new List<IVariable>(fvs.Where(fv => fv.IsMutable)), usesHeap);
+          var text = Util.Comma(", ", s.BodySurrogate.LocalLoopTargets, fv => fv.Name);
+          if (s.BodySurrogate.UsesHeap) {
+            text += text.Length == 0 ? "$Heap" : ", $Heap";
+          }
+          text = string.Format("note, this loop has no body{0}", text.Length == 0 ? "" : " (loop frame: " + text + ")");
+          reporter.Warning(MessageSource.Resolver, s.Tok, text);
         }
 
       } else if (stmt is AlternativeLoopStmt) {
         var s = (AlternativeLoopStmt)stmt;
         ResolveAlternatives(s.Alternatives, s, codeContext);
-        ResolveLoopSpecificationComponents(s.Invariants, s.Decreases, s.Mod, codeContext, null);
+        var usesHeapDontCare = false;
+        ResolveLoopSpecificationComponents(s.Invariants, s.Decreases, s.Mod, codeContext, null, ref usesHeapDontCare);
 
       } else if (stmt is ForallStmt) {
         var s = (ForallStmt)stmt;
@@ -9449,7 +9458,7 @@ namespace Microsoft.Dafny
       }
     }
 
-    private void ResolveLoopSpecificationComponents(List<MaybeFreeExpression> invariants, Specification<Expression> decreases, Specification<FrameExpression> modifies, ICodeContext codeContext, HashSet<IVariable> fvs) {
+    private void ResolveLoopSpecificationComponents(List<MaybeFreeExpression> invariants, Specification<Expression> decreases, Specification<FrameExpression> modifies, ICodeContext codeContext, HashSet<IVariable> fvs, ref bool usesHeap) {
       Contract.Requires(invariants != null);
       Contract.Requires(decreases != null);
       Contract.Requires(modifies != null);
@@ -9460,7 +9469,7 @@ namespace Microsoft.Dafny
         ResolveExpression(inv.E, new ResolveOpts(codeContext, true));
         Contract.Assert(inv.E.Type != null);  // follows from postcondition of ResolveExpression
         if (fvs != null) {
-          Translator.ComputeFreeVariables(inv.E, fvs);
+          Translator.ComputeFreeVariables(inv.E, fvs, ref usesHeap);
         }
         ConstrainTypeExprBool(inv.E, "invariant is expected to be of type bool, but is {0}");
       }
@@ -9473,16 +9482,17 @@ namespace Microsoft.Dafny
             reporter.Error(MessageSource.Resolver, e, "a possibly infinite loop is allowed only if the enclosing method is declared (with 'decreases *') to be possibly non-terminating");
           }
         }
+        if (fvs != null) {
+          Translator.ComputeFreeVariables(e, fvs, ref usesHeap);
+        }
         // any type is fine
       }
 
       ResolveAttributes(modifies.Attributes, null, new ResolveOpts(codeContext, true));
       if (modifies.Expressions != null) {
+        usesHeap = true;  // bearing a modifies clause counts as using the heap
         foreach (FrameExpression fe in modifies.Expressions) {
           ResolveFrameExpression(fe, FrameExpressionUse.Modifies, codeContext);
-          if (fvs != null) {
-            Translator.ComputeFreeVariables(fe.E, fvs);
-          }
         }
       }
     }

--- a/Test/allocated1/dafny0/DirtyLoops.dfy.expect
+++ b/Test/allocated1/dafny0/DirtyLoops.dfy.expect
@@ -1,20 +1,410 @@
-DirtyLoops.dfy(7,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy(13,4): Warning: note, this loop has no body
-DirtyLoops.dfy(20,4): Warning: note, this loop has no body
-DirtyLoops.dfy(31,4): Warning: note, this loop has no body
-DirtyLoops.dfy(40,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy(43,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy(43,4): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
-DirtyLoops.dfy(43,4): Warning: /!\ No terms found to trigger on.
+DirtyLoops.dfy(26,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(35,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(46,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(55,2): Warning: note, this loop has no body (loop frame: i, s)
+DirtyLoops.dfy(68,2): Warning: note, this loop has no body (loop frame: i, s, $Heap)
+DirtyLoops.dfy(80,2): Warning: note, this loop has no body (loop frame: i, s, r)
+DirtyLoops.dfy(88,2): Warning: note, this loop has no body
+DirtyLoops.dfy(106,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(118,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(130,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(145,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(159,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(173,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(189,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(203,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(216,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(229,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(242,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(251,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(260,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(268,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(279,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(293,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(305,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(319,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(332,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(343,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(354,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(365,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(377,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(388,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(400,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(413,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(497,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(504,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(512,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(515,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(515,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy(427,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy(436,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy(452,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(468,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(485,6): Warning: note, this loop has no body (loop frame: j, $Heap)
+DirtyLoops.dfy(515,2): Warning: /!\ No terms found to trigger on.
+DirtyLoops.dfy(30,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(26,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(26,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(39,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(35,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(35,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(48,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(46,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(46,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(57,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(55,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(55,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(59,12): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(55,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(55,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(70,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(68,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(68,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(72,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(68,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(68,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(82,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(80,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(80,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(83,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(80,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(80,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(90,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(88,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(88,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(110,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(106,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(106,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(122,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(118,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(118,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(136,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(130,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(130,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(137,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(130,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(130,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(149,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(145,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(145,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(151,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(145,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(145,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(164,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(159,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(159,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(165,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(159,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(159,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(180,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(173,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(173,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(181,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(173,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(173,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(193,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(189,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(189,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(195,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(189,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(189,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(196,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(189,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(189,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(208,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(203,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(203,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(221,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(216,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(216,3): anon9_Else
+    (0,0): anon11_Then
+DirtyLoops.dfy(234,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(229,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(229,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(244,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(242,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(242,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(253,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(251,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(251,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(261,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(260,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(260,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(270,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(268,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(268,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(285,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(279,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(279,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(297,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(293,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(293,3): anon10_Else
+    (0,0): anon11_Then
+    (0,0): anon12_Then
+    (0,0): anon8
+DirtyLoops.dfy(298,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(293,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(293,3): anon10_Else
+    (0,0): anon11_Then
+    DirtyLoops.dfy(296,18): anon12_Else
+    (0,0): anon8
+DirtyLoops.dfy(308,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(305,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(305,3): anon10_Else
+    DirtyLoops.dfy(305,15): anon11_Else
+    (0,0): anon5
+    (0,0): anon12_Then
+DirtyLoops.dfy(309,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(305,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(305,3): anon10_Else
+    DirtyLoops.dfy(305,15): anon11_Else
+    (0,0): anon5
+    (0,0): anon12_Then
+DirtyLoops.dfy(321,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(319,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(319,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(356,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(354,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(354,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(369,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(365,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(365,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(380,9): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(377,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(377,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(401,18): Error BP5004: This loop invariant might not hold on entry.
+DirtyLoops.dfy(401,18): Related message: loop invariant violation
+Execution trace:
+    (0,0): anon0
+DirtyLoops.dfy(414,16): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(413,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    (0,0): anon7_Then
+DirtyLoops.dfy(506,22): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+    (0,0): anon7_Then
+    (0,0): anon5
+DirtyLoops.dfy(452,6): Error: loop modifies clause may violate context's modifies clause
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(446,5): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(446,5): anon13_Else
+    DirtyLoops.dfy(446,5): anon14_Else
+DirtyLoops.dfy(468,6): Error: loop modifies clause may violate context's modifies clause
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(462,5): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(462,5): anon13_Else
+    DirtyLoops.dfy(462,5): anon14_Else
+DirtyLoops.dfy(485,6): Error: loop modifies clause may violate context's modifies clause
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(480,5): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(480,5): anon13_Else
+    DirtyLoops.dfy(480,5): anon14_Else
 
-Dafny program verifier finished with 4 verified, 0 errors
-DirtyLoops.dfy.tmp.dprint.dfy(8,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy.tmp.dprint.dfy(15,4): Warning: note, this loop has no body
-DirtyLoops.dfy.tmp.dprint.dfy(22,4): Warning: note, this loop has no body
-DirtyLoops.dfy.tmp.dprint.dfy(33,4): Warning: note, this loop has no body
-DirtyLoops.dfy.tmp.dprint.dfy(43,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy.tmp.dprint.dfy(45,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy.tmp.dprint.dfy(45,4): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
-DirtyLoops.dfy.tmp.dprint.dfy(45,4): Warning: /!\ No terms found to trigger on.
+Dafny program verifier finished with 21 verified, 45 errors
+DirtyLoops.dfy.tmp.dprint.dfy(426,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(435,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(451,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(467,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(484,6): Warning: note, this loop has no body (loop frame: j, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(8,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(18,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(29,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(39,2): Warning: note, this loop has no body (loop frame: i, s)
+DirtyLoops.dfy.tmp.dprint.dfy(54,2): Warning: note, this loop has no body (loop frame: i, s, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(67,2): Warning: note, this loop has no body (loop frame: i, s, r)
+DirtyLoops.dfy.tmp.dprint.dfy(76,2): Warning: note, this loop has no body
+DirtyLoops.dfy.tmp.dprint.dfy(87,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(99,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(111,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(125,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(138,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(151,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(167,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(181,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(193,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(205,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(217,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(226,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(236,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(245,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(255,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(268,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(281,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(295,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(308,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(319,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(330,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(341,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(353,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(364,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(374,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(385,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(391,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(398,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(407,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/dafny0/DirtyLoops.dfy
+++ b/Test/dafny0/DirtyLoops.dfy
@@ -2,44 +2,515 @@
 // RUN: %dafny /noVerify /compile:1 "%t.dprint.dfy" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
-class MyClass {
-  method M0(S: set<int>) {
-    forall s | s in S ensures s < 0;
-  }
+// For a body-less loop specification, a local variable or
+// out-parameter "x" is havocked by the loop translation
+// if "x" is mentioned in the loop guard, loop invariant,
+// or loop decreases clause (but what's in the loop's modifies
+// clause does not matter).
+// A heap location "o.f" is havocked by the loop translation
+// if
+//   - the heap location is mutable (that is, not a const field)
+//   - the heap is mentioned in the loop guard, loop
+//     invariant, or loop decreases clause, or the loop bears
+//     a modifies clause, AND
+//   - "o.f" would be allowed to be modified in the loop body
+//     (because "o.f" is newly allocated in the method body,
+//     or the loop bears a modifies clause that allows
+//     "o.f", or the loop bears no modifies clause but the
+//     method's modifies clause allows "o.f".
 
-  method M1(x: int)
+// Local variables and out-parameters
+
+method L0(n: nat) {
+  var i, j := 0, 2;
+  while i < n  // targets: i
+    invariant 0 <= i <= n
+  assert i == n;
+  assert j == 2;
+  assert n == 0;  // error: should not be provable
+}
+
+method L1(n: nat) returns (i: int, j: int) {
+  i, j := 0, 2;
+  while i < n  // targets: i
+    invariant 0 <= i <= n
+  assert i == n;
+  assert j == 2;
+  assert n == 0;  // error: should not be provable
+}
+
+method L2(n: int) returns (r: int, s: int)
+{
+  r := s;
+  var i := 0;
+  while i < n  // targets: i
+  assert r == s;
+  assert i == 0;  // error: should not be provable, since i is in guard
+}
+
+method L3(n: int) returns (r: int, s: int)
+{
+  var kn, kr, ks := n, r, s;
+  var i := 0;
+  while i < n + s  // targets: i, s
+  assert kn == n;  // of course, since n never changes
+  assert i == 0;  // error: should not be provable, since i is in guard
+  assert kr == r;
+  assert ks == s;  // error: should not be provable, since s is in guard
+}
+
+method L4(a: array<int>, n: int) returns (r: int, s: int)
+  modifies a
+{
+  var ks := s;
+  r := n;
+  var i := 0;
+  while i < n + s  // targets: i, s, $Heap
+    modifies if r < 3 then {a} else {}
+  assert i == 0;  // error: should not be provable, since i is in guard
+  assert r == n;  // yes, because the mention of r just in the modifies clause doesn't count
+  assert s == ks;  // error: should not be provable, since s is in guard
+}
+
+method L5(a: array<int>, n: int) returns (r: int, s: int)
+{
+  var ks := s;
+  r := n;
+  var i := 0;
+  while i < n + s  // targets: i, s, r
+    decreases r
+  assert r == n;  // error: since r was mentioned in the decreases clause
+  assert s == ks;  // error: should not be provable, since s is in guard
+}
+
+method L6() {
+  var i, j := 0, 2;
+  while false  // no targets
+  assert i == 0;
+  assert j == 0;  // error: j is 2
+}
+
+// Heap
+
+class C {
+  var y: int
+  var m: nat
+  const u: int
+}
+
+method M0(a: array<int>, n: nat)
+  requires a.Length == 10
+  modifies a
+{
+  var i := 0;
+  while i < n  // targets: i
+    invariant 0 <= i <= n
+  assert i == n;
+  assert a[0] == old(a[0]);  // provable, because heap is not mentioned in loop spec
+  assert n == 0;  // error: should not be provable
+}
+
+method M1(a: array<int>, b: array<int>, n: nat)
+  requires a != b && a.Length == 10
+  modifies a
+{
+  var i := 0;
+  while i < n  // targets: i
+    invariant 0 <= i <= n && a != b
+  assert i == n;
+  assert a[0] == old(a[0]);  // provable, because heap is not mentioned in loop spec
+  assert n == 0;  // error: should not be provable
+}
+
+method M2(a: array<int>, b: array<int>, n: nat)
+  requires a != b && 10 <= a.Length == b.Length
+  modifies a
+{
+  var i := 0;
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n && a != b
+    invariant a[0] == old(a[0])
+  assert i == n;
+  assert a[0] == old(a[0]);  // follows from invariant
+  assert b[1] == old(b[1]);  // b is not in any modifies clause
+  assert a[1] == old(a[1]);  // error: should not be provable
+  assert n == 0;  // error: should not be provable
+}
+
+method M3(a: array<int>, b: array<int>, n: nat)
+  requires a != b && 10 <= a.Length == b.Length
+  modifies a
+{
+  var i := 0;
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n && a != b
+    invariant b[0] == old(b[0])  // redundant, but this mentions the heap
+  assert i == n;
+  assert a[0] == old(a[0]);  // error: should not be provable
+  assert b[1] == old(b[1]);  // b is not in any modifies clause
+  assert n == 0;  // error: should not be provable
+}
+
+method M4(a: array<int>, b: array<int>, n: nat)
+  requires a != b && 10 <= a.Length == b.Length
+  modifies a, b
+{
+  var i := 0;
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n && a != b
+    invariant a[0] == old(a[0])
+  assert i == n;
+  assert a[0] == old(a[0]);
+  assert b[1] == old(b[1]);  // error: should not be provable
+  assert a[1] == old(a[1]);  // error: should not be provable
+}
+
+method M5(a: array<int>, b: array<int>, n: nat)
+  requires a != b && 10 <= a.Length == b.Length
+  modifies a, b
+{
+  var i := 0;
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n && a != b
+    invariant a[0] == old(a[0])
+    modifies a
+  assert i == n;
+  assert a[0] == old(a[0]);  // fine, because of invariant
+  assert b[1] == old(b[1]);  // fine, because loop says "modifies a"
+  assert a[1] == old(a[1]);  // error: should not be provable
+  assert n == 0;  // error: should not be provable
+}
+
+method M6(a: array<int>, b: array<int>, n: nat)
+  requires a != b && 10 <= a.Length == b.Length
+  modifies a, b
+{
+  var i := 0;
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n && a != b
+    modifies a
+  assert i == n;
+  assert a[0] == old(a[0]);  // error: should not be provable
+  assert b[1] == old(b[1]);  // fine, because loop says "modifies a"
+  assert a[1] == old(a[1]);  // error: should not be provable
+  assert n == 0;  // error: should not be provable
+}
+
+method M7(c: C, n: nat)
+  modifies c
+{
+  var i := 0;
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n
+    invariant unchanged(c)
+  assert i == n;
+  assert c.y == old(c.y);
+  assert n == 0;  // error: should not be provable
+}
+
+method M8(c: C, n: nat)
+  modifies c
+{
+  var i := 0;
+  label L:
+  while i < n  // targets: i, $Heap
+    invariant 0 <= i <= n
+    invariant unchanged@L(c)
+  assert i == n;
+  assert c.y == old(c.y);
+  assert n == 0;  // error: should not be provable
+}
+
+method M9(c: C, n:nat)
+  modifies c
+{
+  var k := c.y;
+  var i := 0;
+  while i < n  // targets: i, k
+    invariant 0 <= i <= n
+    invariant k == old(c.y)  // this is not a mention of the current heap
+  assert k == old(c.y);
+  assert k == c.y;  // should be provable, since heap was not havocked
+  assert n == 0;  // error: should not be provable
+}
+
+method M10(c: C)
+  modifies c
+{
+  var k := c.y;
+  var i := 0;
+  while i < 100  // targets: i, $Heap
+    decreases c.m  // this mentions the heap
+  assert k == c.y;  // error: should not be provable
+}
+
+method M11(c: C)
+  modifies c
+{
+  var i := 0;
+  while i < c.u  // targets: i
+  assert c.y == old(c.y);  // fine, since c.u above is an immutable field
+  assert i == c.u;  // error: should not be provable
+}
+
+method M12(c: C)
+  modifies c
+{
+  var i := 0;
+  while i < c.y  // targets: i, $Heap
+  assert c.y == old(c.y);  // error: should not be provable
+}
+
+method M13(c: C)
+  modifies c
+{
+  var i := 0;
+  while i < 7  // targets: i, $Heap
+    invariant allocated(c)  // this uses the heap
+  assert c.y == old(c.y);  // error: should not be provable
+}
+
+// fresh
+
+method H0a() returns (k: C) {
+  var i := 0;
+  k := new C;
+  var k0 := k;
+  while i < 7  // targets: i, k
+    invariant fresh(k)  // this is not a use of the current heap
+  assert fresh(k);
+  // The following assertion is provable, because there's no indication that
+  // the loop above modifies the heap and d0 is the only fresh object around.
+  assert k == k0;
+  assert i == 7;  // error: should not be provable
+}
+
+method H0b() returns (k: C) {
+  var i := 0;
+  var c := new C;  // one fresh object here
+  k := new C;  // and another one here
+  var k0 := k;
+  while i < 7  // targets: i, k
+    invariant fresh(k)  // this is not a use of the current heap
+  assert fresh(k);
+  assert k == k0 || k == c;  // yes, provable
+  assert k == k0;  // error: no longer provable (cmp. H0a), because of the 2 fresh objects
+  assert i == 7;  // error: should not be provable
+}
+
+method H0c() returns (k: C) {
+  var i := 0;
+  k := new C;  // and another one here
+  var k0 := k;
+  while i < 7 && k.y == k.y  // targets: i, k, $Heap
+    invariant fresh(k)  // this is not a use of the current heap
+  assert fresh(k);
+  assert k == k0;  // error: no longer provable (cmp. H0a), because $Heap is a loop target
+  assert i == 7;  // error: should not be provable
+}
+
+method H1(a: array<int>) returns (k: C)
+  requires a.Length == 10
+  modifies a
+{
+  var i := 0;
+  k := new C;
+  k.y := 12;
+  while i < 7  // targets: i, $Heap
+    invariant a[0] == old(a[0])  // this mentions the heap
+  assert k.y == 12;  // error: should not be provable
+}
+
+method H2(a: array<int>) returns (k: C)
+  requires a.Length == 10 && a[0] == 8
+  modifies a
+{
+  var i := 0;
+  k := new C;
+  label L:
+  k.y := 12;
+  while i < 7  // targets: i
+    invariant old(a[0]) == 8 == old@L(a[0])  // no mention of the heap
+  assert k.y == 12;  // therefore, this is provable
+}
+
+method H3(a: array<int>) returns (k: C)
+  requires a.Length == 10 && a[0] == 8
+{
+  var i := 0;
+  k := new C;
+  k.y := 12;
+  while i < 7  // targets: i
+    invariant i <= 7  // no mention of the heap
+  assert k.y == 12;  // therefore, this is provable
+}
+
+method H4(a: array<int>) returns (k: C)
+  requires a.Length == 10 && a[0] == 8
+{
+  var i := 0;
+  k := new C;
+  k.y := 12;
+  while i < 7  // targets: i, k, $Heap
+    invariant k.y % 2 == 0  // this mentions the heap
+  assert k.y == 12;  // error: should not be provable
+}
+
+method H5() returns (k: C)
+{
+  var i := 0;
+  k := new C;
+  k.y := 12;
+  var c := k;
+  while i < 7  // targets: i, k, $Heap
+    invariant k.y % 2 == 0
+    modifies {}  // so, only objects allocated in loop can be modified
+  assert c.y == 12;
+  assert k.y == 12;  // error: should not be provable
+}
+
+method H6(c: C) returns (k: C)
+  requires c.y == 3
+{
+  k := c;
+  var i := 0;
+  while i < 7  // targets: i, k, $Heap
+    invariant k.y == 3  // this mentions the heap
+    modifies {}  // loop bears a modifies clause
+  assert old(allocated(k));  // error: k might be newly allocated by the loop
+}
+
+method H7(c: C) returns (k: C)
+  requires c.u == 3
+{
+  k := c;
+  var i := 0;
+  while i < 7  // targets: i, k
+    invariant k.u == 3  // this is a const field, so does not count as reading the heap
+  assert old(allocated(k));  // yes, since heap is not havocked by the loop
+}
+
+// On entry
+
+method E0(c: C) returns (k: C)
+  modifies c
+{
+  k := c;
+  var i := 0;
+  while i < 7  // targets: i, k, $Heap
+    invariant k.y == 3  // error: does not hold on entry
+    modifies c
+}
+
+// Well-definedness
+
+method W0(c: C) returns (k: C?)
+  requires c.y == 3
+  modifies c
+{
+  k := c;
+  var i := 0;
+  while i < 7  // targets: i, k, $Heap
+    invariant k.y == 3  // error: k may be null
+}
+
+// fine-grained modifies clauses, and nested loops
+
+class FineGrained {
+  var f: int
+  var g: int
+
+  method R0(x: int)
+    requires f <= x
+    modifies `f
   {
-    var i := x;
-    while (0 < i)
-      invariant i <= x;
+    while 0 < f  // targets: $Heap
+      invariant f <= x
+    assert g == old(g);
   }
 
-  method M2(x: int)
+  method R1(x: int)
+    requires f <= x
+    modifies this
   {
-    var i := x;
-    while (0 < i)
-      invariant i <= x;
-      decreases i;
+    while 0 < f  // targets: $Heap
+      invariant f <= x
+      modifies `f
+    assert g == old(g);
   }
 
-  var f: int;
-
-  method M3(x: int)
-    requires f <= x;
-    modifies `f;
+  method R2(x: int)
+    requires f <= x
+    modifies this
   {
-    while (0 < f)
-      invariant f <= x;
-      decreases f;
-      modifies `f;
+    while 0 < f
+      invariant f <= x
+      decreases f
+      modifies `f
+    {
+      var i, prev := 0, f;
+      while i < 7  // error: this modifies violates modifies of context
+        modifies this
+      f := prev - 1;
+    }
   }
 
-  predicate P(y: int)
-
-  method M4() {
-    forall y: int  // this once used to crash Dafny
-      ensures P(y)
-
-    forall x: int  // this once used to crash Dafny
+  method R3(x: int)
+    requires f <= x
+    modifies this
+  {
+    while 0 < f
+      invariant f <= x
+      decreases f
+      modifies {}
+    {
+      var i := 0;
+      while i < 7  // error: this modifies violates modifies of context
+        modifies `f
+      assert g == old(g);
+      f := f - 1;
+    }
   }
+
+  method R4(c: FineGrained, x: int)
+    requires this != c
+    modifies this, c
+  {
+    var i := 0;
+    while i < 7  // targets: i, $Heap
+      invariant i <= 7
+      modifies {}
+    {
+      var j := 0;
+      while j < 7  // error: this modifies violates modifies of context
+        modifies c
+      assert g == old(g);
+      i := i + 1;
+    }
+  }
+}
+
+// forall statements
+
+method F0(S: set<int>, y: int)
+{
+  forall s | s in S
+    ensures s < 0
+  assert y in S ==> y < 0;
+}
+
+method F1(S: set<int>, y: int)
+{
+  forall s | s in S
+    ensures s < 0
+  assert y in S ==> y == -18;  // error: does not hold
+}
+
+predicate P(y: int)
+
+method F2() {
+  forall y: int  // this once used to crash Dafny
+    ensures P(y)
+
+  forall x: int  // this once used to crash Dafny
 }

--- a/Test/dafny0/DirtyLoops.dfy.expect
+++ b/Test/dafny0/DirtyLoops.dfy.expect
@@ -1,20 +1,410 @@
-DirtyLoops.dfy(7,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy(13,4): Warning: note, this loop has no body
-DirtyLoops.dfy(20,4): Warning: note, this loop has no body
-DirtyLoops.dfy(31,4): Warning: note, this loop has no body
-DirtyLoops.dfy(40,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy(43,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy(43,4): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
-DirtyLoops.dfy(43,4): Warning: /!\ No terms found to trigger on.
+DirtyLoops.dfy(427,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy(436,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy(452,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(468,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(485,6): Warning: note, this loop has no body (loop frame: j, $Heap)
+DirtyLoops.dfy(26,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(35,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(46,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(55,2): Warning: note, this loop has no body (loop frame: i, s)
+DirtyLoops.dfy(68,2): Warning: note, this loop has no body (loop frame: i, s, $Heap)
+DirtyLoops.dfy(80,2): Warning: note, this loop has no body (loop frame: i, s, r)
+DirtyLoops.dfy(88,2): Warning: note, this loop has no body
+DirtyLoops.dfy(106,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(118,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(130,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(145,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(159,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(173,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(189,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(203,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(216,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(229,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(242,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(251,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(260,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(268,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(279,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(293,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(305,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(319,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy(332,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(343,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy(354,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(365,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(377,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(388,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy(400,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(413,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy(497,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(504,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(512,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(515,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy(515,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy(515,2): Warning: /!\ No terms found to trigger on.
+DirtyLoops.dfy(452,6): Error: loop modifies clause may violate context's modifies clause
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(446,5): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(446,5): anon13_Else
+    DirtyLoops.dfy(446,5): anon14_Else
+DirtyLoops.dfy(468,6): Error: loop modifies clause may violate context's modifies clause
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(462,5): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(462,5): anon13_Else
+    DirtyLoops.dfy(462,5): anon14_Else
+DirtyLoops.dfy(485,6): Error: loop modifies clause may violate context's modifies clause
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(480,5): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(480,5): anon13_Else
+    DirtyLoops.dfy(480,5): anon14_Else
+DirtyLoops.dfy(30,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(26,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(26,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(39,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(35,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(35,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(48,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(46,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(46,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(57,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(55,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(55,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(59,12): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(55,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(55,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(70,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(68,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(68,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(72,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(68,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(68,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(82,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(80,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(80,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(83,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(80,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(80,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(90,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(88,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(88,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(110,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(106,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(106,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(122,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(118,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(118,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(136,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(130,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(130,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(137,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(130,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(130,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(149,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(145,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(145,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(151,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(145,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(145,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(164,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(159,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(159,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(165,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(159,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(159,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(180,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(173,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(173,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(181,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(173,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(173,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(193,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(189,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(189,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(195,14): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(189,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(189,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(196,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(189,3): anon11_LoopHead
+    (0,0): anon11_LoopBody
+    DirtyLoops.dfy(189,3): anon12_Else
+    (0,0): anon15_Then
+DirtyLoops.dfy(208,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(203,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(203,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(221,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(216,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(216,3): anon9_Else
+    (0,0): anon11_Then
+DirtyLoops.dfy(234,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(229,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(229,3): anon10_Else
+    (0,0): anon12_Then
+DirtyLoops.dfy(244,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(242,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(242,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(253,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(251,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(251,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(261,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(260,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(260,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(270,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(268,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(268,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(285,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(279,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(279,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(297,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(293,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(293,3): anon10_Else
+    (0,0): anon11_Then
+    (0,0): anon12_Then
+    (0,0): anon8
+DirtyLoops.dfy(298,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(293,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(293,3): anon10_Else
+    (0,0): anon11_Then
+    DirtyLoops.dfy(296,18): anon12_Else
+    (0,0): anon8
+DirtyLoops.dfy(308,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(305,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(305,3): anon10_Else
+    DirtyLoops.dfy(305,15): anon11_Else
+    (0,0): anon5
+    (0,0): anon12_Then
+DirtyLoops.dfy(309,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(305,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(305,3): anon10_Else
+    DirtyLoops.dfy(305,15): anon11_Else
+    (0,0): anon5
+    (0,0): anon12_Then
+DirtyLoops.dfy(321,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(319,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(319,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(356,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(354,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(354,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(369,13): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(365,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(365,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(380,9): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(377,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    DirtyLoops.dfy(377,3): anon8_Else
+    (0,0): anon9_Then
+DirtyLoops.dfy(401,18): Error BP5004: This loop invariant might not hold on entry.
+DirtyLoops.dfy(401,18): Related message: loop invariant violation
+Execution trace:
+    (0,0): anon0
+DirtyLoops.dfy(414,16): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(413,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    (0,0): anon7_Then
+DirtyLoops.dfy(506,22): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+    (0,0): anon7_Then
+    (0,0): anon5
 
-Dafny program verifier finished with 4 verified, 0 errors
-DirtyLoops.dfy.tmp.dprint.dfy(8,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy.tmp.dprint.dfy(15,4): Warning: note, this loop has no body
-DirtyLoops.dfy.tmp.dprint.dfy(22,4): Warning: note, this loop has no body
-DirtyLoops.dfy.tmp.dprint.dfy(33,4): Warning: note, this loop has no body
-DirtyLoops.dfy.tmp.dprint.dfy(43,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy.tmp.dprint.dfy(45,4): Warning: note, this forall statement has no body
-DirtyLoops.dfy.tmp.dprint.dfy(45,4): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
-DirtyLoops.dfy.tmp.dprint.dfy(45,4): Warning: /!\ No terms found to trigger on.
+Dafny program verifier finished with 21 verified, 45 errors
+DirtyLoops.dfy.tmp.dprint.dfy(19,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(28,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(44,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(60,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(77,6): Warning: note, this loop has no body (loop frame: j, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(88,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(98,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(109,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(119,2): Warning: note, this loop has no body (loop frame: i, s)
+DirtyLoops.dfy.tmp.dprint.dfy(134,2): Warning: note, this loop has no body (loop frame: i, s, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(147,2): Warning: note, this loop has no body (loop frame: i, s, r)
+DirtyLoops.dfy.tmp.dprint.dfy(156,2): Warning: note, this loop has no body
+DirtyLoops.dfy.tmp.dprint.dfy(167,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(179,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(191,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(205,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(218,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(231,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(247,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(261,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(273,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(285,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(297,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(306,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(316,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(325,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(335,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(348,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(361,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(375,2): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(388,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(399,2): Warning: note, this loop has no body (loop frame: i)
+DirtyLoops.dfy.tmp.dprint.dfy(410,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(421,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(433,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(444,2): Warning: note, this loop has no body (loop frame: i, k)
+DirtyLoops.dfy.tmp.dprint.dfy(454,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(465,2): Warning: note, this loop has no body (loop frame: i, k, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(471,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(478,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(487,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: note, this forall statement has no body
+DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Syntactically, Dafny has allowed `while` loops without bodies. This PR
adds verification support for such loops. Specifically:

Compute loop targets as those free mutable variables (including the
heap) that occur in the guard, invariant, or decreases clause. If the
loop has a modifies clause--whatever the modifies clause says--then
the heap is counted as a free loop target.

Verify context of body-less loop based on loop specification and
the computed loop targets.

Change loop-target hovertext to be part of the "no body" warning.

fix: body-less loops are not always ghost.

fix: `unchanged` expressions use the current heap.