### PR TITLE
fix: CodeContract failures

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Dafny{
         targetReturnTypeReplacement = DafnyTupleClassPrefix + nonGhostOuts;
       }
       var customReceiver = NeedsCustomReceiver(m);
-      var receiverType = UserDefinedType.FromTopLevelDecl(m.tok, m.EnclosingClass, m.TypeArgs);
+      var receiverType = UserDefinedType.FromTopLevelDecl(m.tok, m.EnclosingClass);
       wr.Write("public {0}{1}", !createBody ? "abstract " : "", m.IsStatic || customReceiver ? "static " : "");
       if (m.TypeArgs.Count != 0) {
         wr.Write($"<{TypeParameters(m.TypeArgs)}> ");
@@ -453,7 +453,7 @@ namespace Microsoft.Dafny{
         return null;
       }
       var customReceiver = NeedsCustomReceiver(member);
-      var receiverType = UserDefinedType.FromTopLevelDecl(member.tok, member.EnclosingClass, typeArgs);
+      var receiverType = UserDefinedType.FromTopLevelDecl(member.tok, member.EnclosingClass);
       wr.Write("public {0}{1}", !createBody ? "abstract " : "", isStatic || customReceiver ? "static " : "");
       if (typeArgs != null && typeArgs.Count != 0) {
         wr.Write($"<{TypeParameters(typeArgs)}>");
@@ -666,10 +666,9 @@ namespace Microsoft.Dafny{
       }
     }
 
-    protected override string TypeNameArrayBrackets(int dims){
-      Contract.Requires(0 <= dims);
+    protected override string TypeNameArrayBrackets(int dims) {
       var name = "[";
-      for (int i = 1; i < dims; i++){
+      for (int i = 1; i < dims; i++) {
         name += "][";
       }
 

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -1459,7 +1459,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    protected virtual string TypeNameArrayBrackets(int dims){
+    protected virtual string TypeNameArrayBrackets(int dims) {
       Contract.Requires(0 <= dims);
       var name = "[";
       for (int i = 1; i < dims; i++) {


### PR DESCRIPTION
Fix a compile-time warning where a method override mentioned a CodeContracts precondition.
Fix two run-time errors caused by failing CodeContracts, where bad parameter values were supplied.

This shows CodeContracts is beneficial. Alas, the only CodeContracts support we have these days
is on Windows.