### PR TITLE
fix: Don't rely on C# 7.0 feature in Dafny run time

### DIFF
--- a/Binaries/DafnyRuntime.cs
+++ b/Binaries/DafnyRuntime.cs
@@ -660,7 +660,8 @@ namespace Dafny
 #else
       // Initialize the capacity if the size of the enumerable is known
       Dictionary<U, V> d;
-      if (values is ICollection<Pair<U, V>> collection) {
+      if (values is ICollection<Pair<U, V>>) {
+        var collection = (ICollection<Pair<U, V>>)values;
         d = new Dictionary<U, V>(collection.Count);
       } else {
         d = new Dictionary<U, V>();

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -660,7 +660,8 @@ namespace Dafny
 #else
       // Initialize the capacity if the size of the enumerable is known
       Dictionary<U, V> d;
-      if (values is ICollection<Pair<U, V>> collection) {
+      if (values is ICollection<Pair<U, V>>) {
+        var collection = (ICollection<Pair<U, V>>)values;
         d = new Dictionary<U, V>(collection.Count);
       } else {
         d = new Dictionary<U, V>();


### PR DESCRIPTION
Although C# 7.0 has been out for a year, something goes wrong on some machines when
Dafny calls the C# compiler to compile the C# code it generates. The problem has been
detected on a Windows machine running Visual Studio 2019 Community. The simple fix
is to remove the one use of a C# 7 feature, which appeared in DafnyRuntime.cs. We'll have
to find a better fix when we want to start using more new C# features, but for now, this is
an improvement.