### PR TITLE
fix: Non-method functions can’t use {:test}

### DIFF
--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -1106,6 +1106,10 @@ namespace Microsoft.Dafny {
               var v = new CheckHasNoAssumes_Visitor(this, errorWr);
               v.Visit(f.Body);
             }
+
+            if (Attributes.Contains(f.Attributes, "test")) {
+              Error(f.tok, "Function {0} must be compiled to use the {{:test}} attribute", errorWr, f.FullName);
+            }
           } else if (c is TraitDecl && !f.IsStatic) {
             var w = classWriter.CreateFunction(IdName(f), f.TypeArgs, f.Formals, f.ResultType, f.tok, false, false, f);
             Contract.Assert(w == null);  // since we requested no body

--- a/Test/DafnyTests/TestAttribute.dfy
+++ b/Test/DafnyTests/TestAttribute.dfy
@@ -4,25 +4,12 @@
 // RUN: sed 's/[^:]*://' "%t".raw > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-module {:extern} Tests {
+include "../exceptions/VoidOutcomeDt.dfy"
 
-    datatype VoidOutcome =
-    | VoidSuccess
-    | VoidFailure(error: string)
-    {
-        predicate method IsFailure() {
-            this.VoidFailure?
-        }
-        function method PropagateFailure(): VoidOutcome requires IsFailure() {
-            this
-        }
-    }
-    
-    function method {:test} PassingTest(): VoidOutcome {
-        VoidSuccess
-    }
+function method {:test} PassingTest(): VoidOutcome {
+    VoidSuccess()
+}
 
-    function method {:test} FailingTest(): VoidOutcome {
-        VoidFailure("Whoopsie")
-    }
+function method {:test} FailingTest(): VoidOutcome {
+    VoidFailure("Whoopsie")
 }

--- a/Test/DafnyTests/TestAttribute.dfy.expect
+++ b/Test/DafnyTests/TestAttribute.dfy.expect
@@ -1,1 +1,1 @@
- error : Tests_Compile.__default.FailingTest_CheckForFailureForXunit [FAIL]
+ error : _module.__default.FailingTest_CheckForFailureForXunit [FAIL]

--- a/Test/exceptions/TestAttributeErrors.dfy
+++ b/Test/exceptions/TestAttributeErrors.dfy
@@ -3,10 +3,10 @@
 
 include "../exceptions/VoidOutcomeDt.dfy"
 
-function {:test} PassingTest(): VoidOutcome {
+function {:test} PassingTest(): VoidOutcome { // compile error: function must be compiled to use the {:test} attribute
     VoidSuccess
 }
 
-function {:test} FailingTest(): VoidOutcome {
+function {:test} FailingTest(): VoidOutcome { // compile error: function must be compiled to use the {:test} attribute
     VoidFailure("Whoopsie")
 }

--- a/Test/exceptions/TestAttributeErrors.dfy
+++ b/Test/exceptions/TestAttributeErrors.dfy
@@ -1,0 +1,12 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+include "../exceptions/VoidOutcomeDt.dfy"
+
+function {:test} PassingTest(): VoidOutcome {
+    VoidSuccess
+}
+
+function {:test} FailingTest(): VoidOutcome {
+    VoidFailure("Whoopsie")
+}

--- a/Test/exceptions/TestAttributeErrors.dfy.expect
+++ b/Test/exceptions/TestAttributeErrors.dfy.expect
@@ -1,0 +1,4 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+TestAttributeErrors.dfy(6,17): Error: Function _module._default.PassingTest must be compiled to use the {:test} attribute
+TestAttributeErrors.dfy(10,17): Error: Function _module._default.FailingTest must be compiled to use the {:test} attribute


### PR DESCRIPTION
Without these errors, it’s easy to define test functions that are never run.

Also refactored TestAttribute.dfy to use the existing shared outcome datatype.