### PR TITLE
fix: Relocate NetCore build files to obj_core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Package/
 
 Source/*/bin/
 Source/*/obj/
+Source/*/obj_core/
 Source/packages
 
 Source/Dafny/Parser.cs.old
@@ -35,6 +36,7 @@ Source/DafnyExtension/z3.exe
 
 Test/*/bin/
 Test/*/obj/
+Test/*/obj_core/
 Test/packages
 
 Test/**/*.exe

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup Condition="$(MSBuildProjectName.Contains('NetCore'))">
+        <BaseIntermediateOutputPath>obj_core\</BaseIntermediateOutputPath>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
There is a known issue with using both old and new build systems in the same intermediate output directory: https://github.com/NuGet/Home/issues/5126

Note if you are affected by this and getting the “Your project is not referencing the ".NETFramework,Version=v4.0" framework.” error, you need to not only apply this patch but also manually delete the affected obj/ directory. MSBuild/dotnet does not clean the file at fault automatically (project.json).