### PR TITLE
feat: allow more PropagateFailure... members (do not merge; experimental)

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -772,6 +772,11 @@ namespace Microsoft.Dafny {
     [Pure]
     public abstract bool Equals(Type that);
 
+    public virtual bool SameBase(Type that) {
+      Contract.Requires(that != null);
+      return Equals(that);
+    }
+
     public bool IsBoolType { get { return NormalizeExpand() is BoolType; } }
     public bool IsCharType { get { return NormalizeExpand() is CharType; } }
     public bool IsIntegerType { get { return NormalizeExpand() is IntType; } }
@@ -2568,6 +2573,17 @@ namespace Microsoft.Dafny {
         }
       } else {
         return i.Equals(that);
+      }
+    }
+
+    public override bool SameBase(Type that) {
+      var i = NormalizeExpand();
+      if (i is UserDefinedType) {
+        var ii = (UserDefinedType)i;
+        var t = that.NormalizeExpand() as UserDefinedType;
+        return t != null && ii.ResolvedParam == t.ResolvedParam && ii.ResolvedClass == t.ResolvedClass;
+      } else {
+        return i.SameBase(that);
       }
     }
 
@@ -6784,6 +6800,22 @@ namespace Microsoft.Dafny {
       Contract.Requires(lhss.Count <= 1);
       Contract.Requires(rhs != null);
       Rhs = rhs;
+    }
+
+    /// <summary>
+    /// Retrieve the result type of function "member" or the type of the single out-parameter of
+    /// method "member", if possible. Otherwise, return "null".
+    /// </summary>
+    public static Type/*?*/ GetReturnType(MemberDecl member) {
+      Contract.Requires(member != null);
+      if (member is Method m) {
+        if (m.Outs.Count == 1) {
+          return m.Outs[0].Type;
+        }
+      } else if (member is Function f) {
+        return f.ResultType;
+      }
+      return null;
     }
   }
 

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -1523,7 +1523,6 @@ namespace Microsoft.Dafny {
         wr.Write(":- ");
         PrintExpression(stmt.Rhs, true);
         if (DafnyOptions.O.DafnyPrintResolvedFile != null) {
-          Contract.Assert(stmt.ResolvedStatements.Count > 0);  // filled in during resolution
           wr.WriteLine();
           Indent(indent); wr.WriteLine("/*---------- desugared ----------");
           foreach (Statement r in stmt.ResolvedStatements) {

--- a/Test/exceptions/TypecheckErrors.dfy
+++ b/Test/exceptions/TypecheckErrors.dfy
@@ -78,3 +78,152 @@ method TestMissingVoidMethods2(o: BadVoidOutcome2) returns (res: BadVoidOutcome2
 method TestMissingVoidMethods3(o: BadVoidOutcome3) returns (res: BadVoidOutcome3) {
     :- o; return o;
 }
+
+// ---- MultiFailures
+
+datatype Option<T> = None | Some(get: T) {
+  predicate method IsFailure()
+  { None? }
+  function method Extract(): T
+    requires Some?
+  { get }
+
+  function method PropagateFailure<U>(): Option<U>
+    requires None?
+  { Option.None }
+  function method PropagateFailureInt(): int
+    requires None?
+  { -3 }
+  function method PropagateFailureThisIsReal(): real
+    requires None?
+  { 2.7 }
+  function method PropagateFailureNoThisIs(): real
+    requires None?
+  { 2.7 }
+}
+
+method M0(optB: Option<bool>, optI: Option<int>) returns (u: Option<int>) {
+  var b: bool :- optB;  // assigns bool or throws Option<int>
+  var i: int :- optI;  // assigns int or throws Option<int>
+}
+
+method M1(optB: Option<bool>, optI: Option<int>) returns (u: int) {
+  // the following will use PropagateFailureInt()
+  var b: bool :- optB;  // assigns bool or throws int
+  var i: int :- optI;  // assigns int or throws int
+}
+
+method M2(optB: Option<bool>, optI: Option<int>) returns (u: real) {
+  // the following will find both PropagateFailureThisIsReal() and
+  // PropagateFailureNoThisIs(), which is ambiguous
+  var b: bool :- optB;  // error: ambiguous PropagateFailure... members
+  var i: int :- optI;  // error: ambiguous PropagateFailure... members
+}
+
+method M3(opt: Option<int>) returns (u: int, v: int) {
+  var i :- opt;  // error: throws one value, whereas method has two out-parameters
+}
+
+class MayThrow<T(0,==)> {
+  var a: T
+  var b: T
+  predicate method IsFailure()
+    reads this
+  { a == b }
+  method Extract() returns (t: T)
+  { t := a; }
+
+  function method PropagateFailure(): MayThrow<T>
+  { this }
+  function method PropagateFailureTakeThis(): MayThrow<T>
+  { this }
+  function method PropagateFailureReal(): real
+  { 4.0 }
+}
+
+method N0(optB: MayThrow<bool>, optR: MayThrow<real>) returns (u: MayThrow<real>) {
+  var b: bool :- optB;  // error (2x): because may throw MayThrow<bool>
+}
+
+method N1(optB: MayThrow<bool>, optR: MayThrow<real>) returns (u: MayThrow<real>) {
+  // the following will find both PropagateFailure() and
+  // PropagateFailureTakeThis(), which is ambiguous
+  var r: real :- optR;  // error: ambiguous
+}
+
+datatype Fika = Kaffe | Te
+{
+  predicate method IsFailure()
+  { this != Kaffe }
+  function method Extract(): int
+  { 100 }
+
+  function method PropagateFailure(): real
+  { 2.0 }
+  function method PropagateFailureX(): Fika
+  { this }
+  function method PropagateFailureY(): Fika
+  { this }
+  function method PropagateFailureZ0(): Option<bool>
+  { Option.None }
+  function method PropagateFailureZ1(): Option<int>
+  { Option.None }
+  function method PropagateFailureW(): bool
+  { true }
+  function method SimonSaysW(): bool
+  { true }
+}
+
+method P0(f: Fika) returns (r: real) {
+  var i: int :- f;  // assigns int or throws real
+}
+
+method P1(f: Fika) returns (r: Fika) {
+  var i: int :- f;  // error: ambiguous: PropagateFailureX or PropagateFailureY
+}
+
+method P2(f: Fika) returns (r: Option<real>) {
+  var i: int :- f;  // error: ambiguous PropagateFailure[Z0;Z1]; error: Option<bool> not assignable to Option<real>
+}
+
+method P3(f: Fika) returns (r: bool) {
+  var i: int :- f;  // fine (no ambiguity, since SimonSaysW is not considered)
+  :- f;  // error: empty LHS requires no Extract method
+}
+
+datatype NoGood = NoGoodA | NoGoodB
+{
+  predicate method IsFailure()
+  function method Extract(): int
+  // note: missing plain PropagateFailure()
+  function method PropagateFailureX(): real
+  function method PropagateFailureY(): real
+}
+
+method Q(g: NoGood) returns (r: real)
+{
+  var i: int :- g;  // error: NoGood does not have IsFailure/PropagateFailure/Extract
+}
+
+// ------------------------- sans Extract
+
+datatype SansExtract = SeYes | SeNo
+{
+  predicate method IsFailure() { SeNo? }
+  function method PropagateFailure(): int { 7 }
+  function method PropagateFailureX(): bool { false }
+  function method PropagateFailureY(): bool { true }
+}
+
+method R0(s: SansExtract) returns (u: int) {
+  :- s;
+  var o :- s;  // error: LHS allows only when SansExtract has an Extract() member
+}
+
+method R1(s: SansExtract) returns (u: real) {
+  :- s;  // error: may throw int
+}
+
+method R2(s: SansExtract) returns (u: bool) {
+  :- s;  // error: ambiguous PropagateFailure[X;Y]
+}

--- a/Test/exceptions/TypecheckErrors.dfy.expect
+++ b/Test/exceptions/TypecheckErrors.dfy.expect
@@ -1,20 +1,29 @@
+TypecheckErrors.dfy(3,8): Error: the included file NatOutcome.dfy contains error(s)
+NatOutcome.dfy(5,9): Error: duplicate name of top-level declaration: Option
 TypecheckErrors.dfy(7,28): Error: incorrect type of method in-parameter (expected nat, got string)
 TypecheckErrors.dfy(8,28): Error: incorrect type of method in-parameter (expected nat, got string)
 TypecheckErrors.dfy(14,8): Error: Duplicate local-variable name: a
 TypecheckErrors.dfy(16,8): Error: Duplicate local-variable name: b
-TypecheckErrors.dfy(39,10): Error: member IsFailure does not exist in trait BadOutcome1
-TypecheckErrors.dfy(39,10): Error: member PropagateFailure does not exist in trait BadOutcome1
-TypecheckErrors.dfy(39,10): Error: member Extract does not exist in trait BadOutcome1
-TypecheckErrors.dfy(39,10): Error: The right-hand side of ':-', which is of type 'BadOutcome1?', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
-TypecheckErrors.dfy(43,10): Error: member PropagateFailure does not exist in trait BadOutcome2
+TypecheckErrors.dfy(39,10): Error: The right-hand side of ':-', which is of type '?', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
 TypecheckErrors.dfy(43,10): Error: The right-hand side of ':-', which is of type 'BadOutcome2?', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
-TypecheckErrors.dfy(47,10): Error: member Extract does not exist in trait BadOutcome3
 TypecheckErrors.dfy(47,10): Error: The right-hand side of ':-', which is of type 'BadOutcome3?', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
 TypecheckErrors.dfy(51,22): Error: incorrect type of method in-parameter (expected string, got int)
-TypecheckErrors.dfy(71,4): Error: member IsFailure does not exist in trait BadVoidOutcome1
-TypecheckErrors.dfy(71,4): Error: member PropagateFailure does not exist in trait BadVoidOutcome1
-TypecheckErrors.dfy(71,4): Error: The right-hand side of ':-', which is of type 'BadVoidOutcome1?', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'
-TypecheckErrors.dfy(75,4): Error: member PropagateFailure does not exist in trait BadVoidOutcome2
+TypecheckErrors.dfy(71,4): Error: The right-hand side of ':-', which is of type '?', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'
 TypecheckErrors.dfy(75,4): Error: The right-hand side of ':-', which is of type 'BadVoidOutcome2?', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'
-TypecheckErrors.dfy(79,4): Error: The right-hand side of ':-', which is of type 'BadVoidOutcome3?', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'
-19 resolution/type errors detected in TypecheckErrors.dfy
+TypecheckErrors.dfy(79,4): Error: The right-hand side of ':-', which is of type '?', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'
+TypecheckErrors.dfy(119,14): Error: Type of right-hand side of ':-' (Option<?>) has ambiguous selection of PropagateFailure... members for the needed type (real): PropagateFailureThisIsReal, PropagateFailureNoThisIs
+TypecheckErrors.dfy(120,13): Error: Type of right-hand side of ':-' (Option<?>) has ambiguous selection of PropagateFailure... members for the needed type (real): PropagateFailureThisIsReal, PropagateFailureNoThisIs
+TypecheckErrors.dfy(124,8): Error: number of return parameters does not match declaration (found 1, expected 2)
+TypecheckErrors.dfy(145,14): Error: Type of right-hand side of ':-' (?) has ambiguous selection of PropagateFailure... members for the needed type (MayThrow<real>): PropagateFailure, PropagateFailureTakeThis
+TypecheckErrors.dfy(145,14): Error: Member selection requires a subtype of MayThrow?<real> (got something more like MayThrow<bool>) (non-variant type parameter would require real = bool)
+TypecheckErrors.dfy(151,14): Error: Type of right-hand side of ':-' (?) has ambiguous selection of PropagateFailure... members for the needed type (MayThrow<real>): PropagateFailure, PropagateFailureTakeThis
+TypecheckErrors.dfy(182,13): Error: Type of right-hand side of ':-' (Fika) has ambiguous selection of PropagateFailure... members for the needed type (Fika): PropagateFailureX, PropagateFailureY
+TypecheckErrors.dfy(186,13): Error: Type of right-hand side of ':-' (Fika) has ambiguous selection of PropagateFailure... members for the needed type (Option<real>): PropagateFailureZ0, PropagateFailureZ1
+TypecheckErrors.dfy(186,13): Error: RHS (of type Option<bool>) not assignable to LHS (of type Option<real>) (non-variant type parameter would require real = bool)
+TypecheckErrors.dfy(191,2): Error: The right-hand side of ':-', which is of type 'Fika', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'
+TypecheckErrors.dfy(205,13): Error: The right-hand side of ':-', which is of type 'NoGood', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
+TypecheckErrors.dfy(220,8): Error: The right-hand side of ':-', which is of type 'SansExtract', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
+TypecheckErrors.dfy(224,2): Error: RHS (of type int) not assignable to LHS (of type real)
+TypecheckErrors.dfy(228,2): Error: Type of right-hand side of ':-' (SansExtract) has ambiguous selection of PropagateFailure... members for the needed type (bool): PropagateFailureX, PropagateFailureY
+NatOutcome.dfy(10,24): Error: the name 'None' denotes a datatype constructor, but does not do so uniquely; add an explicit qualification (for example, 'Option.None')
+28 resolution/type errors detected in TypecheckErrors.dfy

--- a/Test/exceptions/VerificationErrors.dfy
+++ b/Test/exceptions/VerificationErrors.dfy
@@ -5,13 +5,107 @@ include "./NatOutcome.dfy"
 include "./VoidOutcome.dfy"
 
 method CheckThatVerifierRunsInsideDesugaredExprs_Nat(r1: NatOutcome, r2: NatOutcome) returns (res: NatOutcome) {
-    var a :- MakeNatSuccess(assert r1 == r2; 12);
+    var a :- MakeNatSuccess(assert r1 == r2; 12);  // error: assertion violation
     res := MakeNatSuccess(a);
 }
 
 method CheckThatVerifierRunsInsideDesugaredExprs_Void(r1: VoidOutcome, r2: VoidOutcome) returns (res: VoidOutcome) {
     var x := assert 2 + 2 == 4; 8;
     assert x == 8;
-    :- assert r1 == r2; r1;
+    :- assert r1 == r2; r1;  // error: assertion violation
     res := r1;
+}
+
+// --------------------
+
+module MultiFailures {
+  datatype Option<T> = None | Some(get: T) {
+    predicate method IsFailure()
+    { None? }
+    function method Extract(): T
+      requires Some?
+    { get }
+
+    function method PropagateFailure<U>(): Option<U>
+      requires None?
+    { None }
+    function method PropagateFailureInt(): int
+      requires None?
+    { -3 }
+  }
+
+  method M(x: int) returns (u: Option<int>)
+    ensures x < 0 ==> u == None
+    ensures 0 <= x ==> u == Some(7)
+  {
+    var n := if x < 0 then Option<bool>.None else Some(false);
+    assert x < 0 ==> n.IsFailure();
+    var b :- n;  // this causes a PropagateFailure if n.IsFailure(); otherwise, sets b to false
+    assert !b;
+    return Some(7);
+  }
+
+  method N(x: int) returns (u: int)
+    ensures x < 0 ==> u == -3
+    ensures 0 <= x ==> u == 10
+  {
+    var n := if x < 0 then Option<bool>.None else Some(false);
+    var b :- n;  // this causes a PropagateFailureInt if n.IsFailure() (which causes "return -3"); otherwise, sets b to false
+    assert !b;
+    return 10;
+  }
+
+  // ----
+
+  class C {
+    method Me(x: int) returns (o: Option<real>)
+      ensures match o case None => x < 0 case Some(r) => 0 <= x && r == 3.1
+    {
+      return if x < 0 then None else Some(3.1);
+    }
+    function method Fe(x: int): Option<real> {
+      if x < 0 then None else Some(5.8)
+    }
+  }
+
+  method P() returns (u: int)
+    ensures u == 90
+  {
+    var c := new C;
+    var g :- c.Me(0);
+    assert g == 3.1;
+    var h :- c.Fe(0);
+    assert h == 5.8;
+    return 90;
+  }
+
+  method Q(x: int) returns (u: int)
+    ensures x < 10 ==> u == -3
+    ensures 10 <= x ==> u == 90
+  {
+    var c := new C;
+    var g :- c.Me(x);
+    assert g == 3.1;
+    var h :- c.Fe(x - 10);
+    assert h == 5.8;
+    return 90;
+  }
+
+  method R0(x: int) returns (u: int)
+    ensures u == 90
+  {
+    var c := new C;
+    var g :- c.Me(x);  // error: postcondition might fail
+    assert g == 3.1;
+    return 90;
+  }
+
+  method R1(x: int) returns (u: int)
+    ensures u == 90
+  {
+    var c := new C;
+    var h :- c.Fe(x);  // error: postcondition might fail
+    assert h == 5.8;
+    return 90;
+  }
 }

--- a/Test/exceptions/VerificationErrors.dfy.expect
+++ b/Test/exceptions/VerificationErrors.dfy.expect
@@ -1,3 +1,13 @@
+VerificationErrors.dfy(98,10): Error BP5003: A postcondition might not hold on this return path.
+VerificationErrors.dfy(95,14): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Then
+VerificationErrors.dfy(107,10): Error BP5003: A postcondition might not hold on this return path.
+VerificationErrors.dfy(104,14): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Then
 VerificationErrors.dfy(8,38): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -5,4 +15,4 @@ VerificationErrors.dfy(15,17): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 0 verified, 2 errors
+Dafny program verifier finished with 6 verified, 4 errors


### PR DESCRIPTION
Previously, the `:-` construct would always use the method or function `PropagateFailure()`
when propagating a failure. Now, a type can provide several propagate-failure members with
different result types. This makes it possible in some cases to convert between types in
failure cases.

In more detail, the extended functionality applies only to `:-` statements, not `:-` expressions.
Consider a `:-` statement whose right-hand side has type `G<X>`, where the enclosing method has
one out-parameter, say of type `H<Y>`.

This will now consider all functions and one-out-parameter methods in type `G<X>` whose name
starts with `PropagateFailure`. Consider such a propagate-failure member to be "suited" if its return
type, say `J<Z>`, has the same base-type declaration as `H<Y>`. That is, keep expanding `J<Z>`
along type synonyms and subset-type base types, yielding a type `JJ<ZZ>`, and do the same for
`H<Y>`, yielding `HH<YY>`. Then, the propagate-failure member is "suitable" if `JJ` is the same as `HH`.

If there's a unique suitable propagate-failure member, then it is picked. If there's more than one suitable
propagate-failure member, then an error is generated. If there's no suitable propagate-failure member,
then the plainly named `PropagateFailure()` is picked.

If there is no plainly named `PropagateFailure()` member, then an error is generated, even if there is
a suitable propagate-failure member.

Design note: Since Dafny does not have overloading of user-declared members, this name-prefix trick
appears useful. However, there are no other such name-prefix tricks in Dafny, so the design of this
extension is dubious. Also, the conversion has to be declared in the source type--that is, the type of
the right-hand side of the `:-`. This may not always be the best design choice. Nevertheless, in order
to experiment with ways to extend the current `:-` behavior, this change seems like a good step. It is
backward compatible, and I hope it leads to experimentation that will better inform what a more desirable
extension would be.