### PR TITLE
fix: Don't add alloc assumption for constructor's receiver

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -9271,7 +9271,7 @@ namespace Microsoft.Dafny {
           var th = new Bpl.IdentifierExpr(tok, "this", TrType(receiverType));
           wh = Bpl.Expr.And(
             ReceiverNotNull(th),
-            GetWhereClause(tok, th, receiverType, etran, NOALLOC));
+            GetWhereClause(tok, th, receiverType, etran, IsAllocType.NEVERALLOC));
         } else {
           var th = new Bpl.IdentifierExpr(tok, "this", TrType(receiverType));
           wh = Bpl.Expr.And(
@@ -12501,7 +12501,7 @@ namespace Microsoft.Dafny {
       Bpl.Expr isAlloc;
       if (type.IsNumericBased() || type.IsBitVectorType || type.IsBoolType || type.IsCharType || type.IsBigOrdinalType) {
         isAlloc = null;
-      } else if ((AlwaysUseHeap || alloc == ISALLOC) && etran.HeapExpr != null) {
+      } else if (((AlwaysUseHeap && alloc != IsAllocType.NEVERALLOC) || alloc == ISALLOC) && etran.HeapExpr != null) {
         isAlloc = MkIsAlloc(x, normType, etran.HeapExpr);
       } else {
         isAlloc = null;
@@ -14009,7 +14009,7 @@ namespace Microsoft.Dafny {
 
     }
 
-    internal enum IsAllocType { ISALLOC, NOALLOC };
+    internal enum IsAllocType { ISALLOC, NOALLOC, NEVERALLOC };  // NEVERALLOC is like NOALLOC, but overrides AlwaysAlloc
     static IsAllocType ISALLOC { get { return IsAllocType.ISALLOC; } }
     static IsAllocType NOALLOC { get { return IsAllocType.NOALLOC; } }
 

--- a/Test/git-issues/git-issue-384.dfy
+++ b/Test/git-issues/git-issue-384.dfy
@@ -1,0 +1,25 @@
+// RUN: %dafny /allocated:2 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class C {
+  constructor ()
+    ensures fresh(this)
+    ensures !old(allocated(this)) && allocated(this)
+  {
+  }
+  constructor NotGood()
+    // the following was once provable under /allocated:2
+    ensures false  // error
+  {
+  }
+  method M()
+  {
+  }
+}
+
+method Main() {
+  var c := new C();
+  assert fresh(c);
+  assert allocated(c) && !old(allocated(c));
+  c.M();
+}

--- a/Test/git-issues/git-issue-384.dfy.expect
+++ b/Test/git-issues/git-issue-384.dfy.expect
@@ -1,0 +1,6 @@
+git-issue-384.dfy(13,2): Error BP5003: A postcondition might not hold on this return path.
+git-issue-384.dfy(12,12): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 2 verified, 1 error


### PR DESCRIPTION
This fix is for /allocated:2.

Fixes #384