### PR TITLE
Java: Fix explicit cast of literal to native type

### DIFF
--- a/Test/comp/NativeNumbers.dfy
+++ b/Test/comp/NativeNumbers.dfy
@@ -88,7 +88,7 @@ method CastTests() {
     u32 as int64, " ",
     u32 as uint32, " ", u32 as uint64, "\n";
 
-  u64 := 0xffff_ffff_ffff_ffff;
+  u64 := 0xffff_ffff_ffff_ffff as uint64; // test explicit conversion of literal
   print u64 as int, " ",
     u64 as uint64, "\n";
 


### PR DESCRIPTION
Casting a literal to a native type is optimized to simply output the literal
differently, but the logic to output the cast literal wasn't shared with the
logic that normally outputs a literal, so corner cases were neglected.

In particular, the expression `0xffff_ffff_ffff_ffff as uint64` (given the
obvious definition of `uint64`) caused a Java syntax error because it's above
Java's maximum long (which is always signed).