### PR TITLE
Treat let-var as Lit if its RHS is Lit

### DIFF
--- a/Test/allocated1/dafny0/LetExpr.dfy.expect
+++ b/Test/allocated1/dafny0/LetExpr.dfy.expect
@@ -6,6 +6,12 @@ Execution trace:
 LetExpr.dfy(344,13): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
+LetExpr.dfy(390,33): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+LetExpr.dfy(403,24): Error: assertion violation
+Execution trace:
+    (0,0): anon0
 LetExpr.dfy(9,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -42,7 +48,7 @@ Execution trace:
     (0,0): anon0
     (0,0): anon11_Then
 
-Dafny program verifier finished with 29 verified, 11 errors
+Dafny program verifier finished with 37 verified, 13 errors
 LetExpr.dfy.tmp.dprint.dfy(281,4): Warning: /!\ No terms found to trigger on.
 LetExpr.dfy.tmp.dprint.dfy(46,2): Warning: /!\ No terms found to trigger on.
 

--- a/Test/dafny0/LetExpr.dfy
+++ b/Test/dafny0/LetExpr.dfy
@@ -370,3 +370,68 @@ module CanCallRegressionTests {
     }
   }
 }
+
+// ---------------------------------- Lit of let RHS
+
+module LitLet {
+  function method Gauss(n: nat): nat {
+    if n == 0 then 0 else n + Gauss(n - 1)
+  }
+
+  method M0() {
+    assert Gauss(12) == 78;
+  }
+  method M1() {
+    assert Gauss(20 - 8) == 78;
+  }
+  method M2() {
+    var twenty := 20;
+    var eight := 8;
+    assert Gauss(twenty - eight) == 78;  // error: Lit doesn't get this case
+  }
+  method M3() {
+    var twelve :=
+      var twenty := 20;
+      var eight := 8;
+      twenty - eight;
+    assert Gauss(twelve) == 78;
+  }
+
+  method P(a: nat, b: nat)
+    requires a == 20 && b == 8
+  {
+    assert Gauss(a - b) == 78;  // error: Lit doesn't get this case
+  }
+
+  // ---
+
+  datatype Nat = O | S(pred: Nat)
+
+  function plus(n: Nat, m: Nat) : Nat {
+    match n
+    case O => m
+    case S(n') => S(plus(n', m))
+  }
+
+  function mult(n: Nat, m: Nat) : Nat {
+    if n.O? then O else
+      var n' := n.pred;
+      plus(m, mult(n', m))
+  }
+
+  function factorial(n: Nat): Nat {
+    match n
+    case O => S(O)
+    case S(n') => mult(n, factorial(n'))
+  }
+
+  lemma Test() {
+    var n2 := S(S(O));
+    var n3 := S(n2);
+    var n5 := S(S(n3));
+    var n10 := plus(n5, n5);
+    var n12 := S(S(n10));
+
+    assert factorial(n5) == mult(n10, n12);
+  }
+}

--- a/Test/dafny0/LetExpr.dfy.expect
+++ b/Test/dafny0/LetExpr.dfy.expect
@@ -6,6 +6,12 @@ Execution trace:
 LetExpr.dfy(344,13): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
+LetExpr.dfy(390,33): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+LetExpr.dfy(403,24): Error: assertion violation
+Execution trace:
+    (0,0): anon0
 LetExpr.dfy(109,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -42,8 +48,8 @@ Execution trace:
     (0,0): anon0
     (0,0): anon10_Then
 
-Dafny program verifier finished with 29 verified, 11 errors
+Dafny program verifier finished with 37 verified, 13 errors
 LetExpr.dfy.tmp.dprint.dfy(97,4): Warning: /!\ No terms found to trigger on.
-LetExpr.dfy.tmp.dprint.dfy(214,2): Warning: /!\ No terms found to trigger on.
+LetExpr.dfy.tmp.dprint.dfy(291,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
If the translation of `R` in the let expression `var x := R; Body` has the form `Lit(...)`, then
for the purpose of lit-lifting, occurrences of `x` in `Body` are now treated as if they had
the form `Lit(...)`.