### PR TITLE
fix: Stabilize test cases

### DIFF
--- a/Test/allocated1/dafny0/fun-with-slices.dfy
+++ b/Test/allocated1/dafny0/fun-with-slices.dfy
@@ -6,14 +6,15 @@
 method seqIntoArray<A>(s: seq<A>, a: array<A>, index: nat)
   requires index + |s| <= a.Length
   modifies a
-  ensures  a[..] == old(a[0..index]) + s + old(a[index + |s|..]) {
+  ensures  a[..] == old(a[0..index]) + s + old(a[index + |s|..])
+{
     var i := index;
 
     while i < index + |s|
       invariant index <= i <= index + |s| <= a.Length
-      invariant a[..] == old(a[0..index]) + s[0..(i-index)] + old(a[i..]) {
+      invariant a[..] == old(a[0..index]) + s[0..(i-index)] + old(a[i..])
+    {
         a[i] := s[i - index];
         i := i + 1;
-        assert a[..] == old(a[0..index]) + s[0..(i-index)] + old(a[i..]);
     }
 }

--- a/Test/allocated1/dafny0/fun-with-slices.dfy
+++ b/Test/allocated1/dafny0/fun-with-slices.dfy
@@ -6,15 +6,35 @@
 method seqIntoArray<A>(s: seq<A>, a: array<A>, index: nat)
   requires index + |s| <= a.Length
   modifies a
-  ensures  a[..] == old(a[0..index]) + s + old(a[index + |s|..])
+  ensures a[..] == old(a[..index]) + s + old(a[index + |s|..])
 {
-    var i := index;
+  var i := index;
 
-    while i < index + |s|
-      invariant index <= i <= index + |s| <= a.Length
-      invariant a[..] == old(a[0..index]) + s[0..(i-index)] + old(a[i..])
-    {
-        a[i] := s[i - index];
-        i := i + 1;
+  while i < index + |s|
+    invariant index <= i <= index + |s| <= a.Length
+    invariant a[..] == old(a[..index]) + s[..i - index] + old(a[i..])
+  {
+    label A:
+    a[i] := s[i - index];
+    calc {
+      a[..];
+    ==  // assignment statement above
+      old@A(a[..])[i := s[i - index]];
+    ==  // invariant on entry to loop
+      (old(a[..index]) + s[..i - index] + old(a[i..]))[i := s[i - index]];
+    ==  { assert old(a[..index]) + s[..i - index] + old(a[i..]) == (old(a[..index]) + s[..i - index]) + old(a[i..]); }
+      ((old(a[..index]) + s[..i - index]) + old(a[i..]))[i := s[i - index]];
+    ==  { assert |old(a[..index]) + s[..i - index]| == i; }
+      (old(a[..index]) + s[..i - index]) + old(a[i..])[0 := s[i - index]];
+    == { assert old(a[i..])[0 := s[i - index]] == [s[i - index]] + old(a[i..])[1..]; }
+      (old(a[..index]) + s[..i - index]) + [s[i - index]] + old(a[i..])[1..];
+    ==  { assert old(a[i..])[1..] == old(a[i + 1..]); }
+      (old(a[..index]) + s[..i - index]) + [s[i - index]] + old(a[i + 1..]);
+    ==  // redistribute +
+      old(a[..index]) + (s[..i - index] + [s[i - index]]) + old(a[i + 1..]);
+    ==  { assert s[..i - index] + [s[i - index]] == s[..i + 1 - index]; }
+      old(a[..index]) + s[..i + 1 - index] + old(a[i + 1..]);
     }
+    i := i + 1;
+  }
 }

--- a/Test/dafny0/fun-with-slices.dfy
+++ b/Test/dafny0/fun-with-slices.dfy
@@ -3,16 +3,17 @@
 
 // This test was contributed by Bryan. It has shown some instabilities in the past.
 
-method seqIntoArray<A>(s: seq<A>, a: array?<A>, index: nat)
-  requires a != null
+method seqIntoArray<A>(s: seq<A>, a: array<A>, index: nat)
   requires index + |s| <= a.Length
   modifies a
-  ensures  a[..] == old(a[0..index]) + s + old(a[index + |s|..]) {
+  ensures  a[..] == old(a[0..index]) + s + old(a[index + |s|..])
+{
     var i := index;
 
     while i < index + |s|
       invariant index <= i <= index + |s| <= a.Length
-      invariant a[..] == old(a[0..index]) + s[0..(i-index)] + old(a[i..]) {
+      invariant a[..] == old(a[0..index]) + s[0..(i-index)] + old(a[i..])
+    {
         a[i] := s[i - index];
         i := i + 1;
     }


### PR DESCRIPTION
Make the fun-with-slices test look the same in Test/dafny0 and Test/allocated1/dafny0.dfy.
Hopefully improve the stability of this test, on which the verifier has been a bit flakey.