### PR TITLE
fix: Don’t call PropagateFailure() in assign-or-halt

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -10175,10 +10175,9 @@ namespace Microsoft.Dafny
           new UpdateStmt(s.Tok, s.Tok, new List<Expression>() { new IdentifierExpr(s.Tok, temp) }, new List<AssignmentRhs>() { new ExprRhs(s.Rhs) })));
       if (s.ExpectToken != null) {
         var notFailureExpr = new UnaryOpExpr(s.Tok, UnaryOpExpr.Opcode.Not, VarDotMethod(s.Tok, temp, "IsFailure"));
-        var propogateFailureCall = VarDotMethod(s.Tok, temp, "PropagateFailure");
         s.ResolvedStatements.Add(
-          // "expect !temp.IsFailure(), temp.PropagateFailure()"
-          new ExpectStmt(s.Tok, s.Tok, notFailureExpr, propogateFailureCall, null));
+          // "expect !temp.IsFailure(), temp"
+          new ExpectStmt(s.Tok, s.Tok, notFailureExpr, new IdentifierExpr(s.Tok, temp), null));
       } else {
         s.ResolvedStatements.Add(
           // "if temp.IsFailure()"

--- a/Test/exceptions/GenericOutcomeDt.dfy
+++ b/Test/exceptions/GenericOutcomeDt.dfy
@@ -1,0 +1,18 @@
+// Does not test anything Exceptions-related, but is included by other tests
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Outcome<T> =
+| Success(value: T)
+| Failure(error: string)
+{
+    predicate method IsFailure() {
+        this.Failure?
+    }
+    function method PropagateFailure<U>(): Outcome<U> requires IsFailure() {
+        Failure(this.error)
+    }
+    function method Extract(): T requires !IsFailure() {
+        this.value
+    }
+}

--- a/Test/exceptions/GenericOutcomeDt.dfy.expect
+++ b/Test/exceptions/GenericOutcomeDt.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/expectations/ExpectAndExceptions.dfy
+++ b/Test/expectations/ExpectAndExceptions.dfy
@@ -6,10 +6,16 @@
 // RUN: %diff "%s.expect" "%t"
 
 include "../exceptions/NatOutcomeDt.dfy"
+include "../exceptions/GenericOutcomeDt.dfy"
 
 method TestAssignOrHalt() {
     var stmt1: nat :- expect NatSuccess(42);
-    var stmt2: nat :- expect NatFailure("Kaboom!");
+    // Regression test for when assign-or-halt was also calling PropagateFailure, which led
+    // to the error "type variable 'U' in the function call to 'PropagateFailure' could not be determined"
+    // (because of the lack of type constraints).
+    var stmt2: string :- expect Success("Hooray!");
+    
+    var stmt3: nat :- expect NatFailure("Kaboom!");
 }
 
 method Main() {


### PR DESCRIPTION
See Test/expect/ExceptAndExceptions.dfy for details.