### PR TITLE
feat: Allow list of nativeType choices

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -666,9 +666,6 @@ namespace Microsoft.Dafny
     }
 
     protected override void GetNativeInfo(NativeType.Selection sel, out string name, out string literalSuffix, out bool needsCastAfterArithmetic) {
-      if (sel == NativeType.Selection.Number) {
-        sel = NativeType.Selection.Long;
-      }
       base.GetNativeInfo(sel, out name, out literalSuffix, out needsCastAfterArithmetic);
     }
 
@@ -2380,7 +2377,7 @@ namespace Microsoft.Dafny
         }
         crx.cr = provider.CompileAssemblyFromFile(cp, sourceFiles);
       } else {
-        var p = callToMain == null ? targetProgramText : targetProgramText + callToMain; 
+        var p = callToMain == null ? targetProgramText : targetProgramText + callToMain;
         crx.cr = provider.CompileAssemblyFromSource(cp, p);
       }
 
@@ -2463,7 +2460,7 @@ namespace Microsoft.Dafny
           var method = (Method) decl;
           hasReturnValue = method.Outs.Count > 1;
         }
-        
+
         wr.WriteLine("[Xunit.Fact]");
         if (hasReturnValue) {
           wr = wr.NewNamedBlock("public static void {0}_CheckForFailureForXunit()", name);
@@ -2472,7 +2469,7 @@ namespace Microsoft.Dafny
         }
       }
     }
-    
+
     public override void EmitCallToMain(Method mainMethod, TargetWriter wr) {
       var companion = TypeName_Companion(mainMethod.EnclosingClass as ClassDecl, wr, mainMethod.tok);
       var wClass = wr.NewNamedBlock("class __CallToMain");

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -999,7 +999,6 @@ namespace Microsoft.Dafny {
         case NativeType.Selection.ULong:
           name = "uint64";
           break;
-        case NativeType.Selection.Number:
         case NativeType.Selection.Long:
           name = "int64";
           break;
@@ -2490,12 +2489,11 @@ namespace Microsoft.Dafny {
           case NativeType.Selection.Int:
             wr.Write("_dafny.IntOfInt32(");
             break;
-          case NativeType.Selection.Number:
           case NativeType.Selection.Long:
             wr.Write("_dafny.IntOfInt64(");
             break;
           default:
-            throw new cce.UnreachableException();  // unepxected nativeType.Selection value
+            throw new cce.UnreachableException();  // unexpected nativeType.Selection value
         }
       }
 

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Dafny{
           return JavaNativeType.Int;
         case NativeType.Selection.Long:
         case NativeType.Selection.ULong:
-        case NativeType.Selection.Number:
           return JavaNativeType.Long;
         default:
           Contract.Assert(false);
@@ -2008,7 +2007,7 @@ namespace Microsoft.Dafny{
         }
       } else {
         // TODO-RS: This doesn't handle strings printed out as part of datatypes
-        bool isString = arg.Type.AsCollectionType != null && 
+        bool isString = arg.Type.AsCollectionType != null &&
                         arg.Type.AsCollectionType.AsSeqType != null &&
                         arg.Type.AsCollectionType.AsSeqType.Arg is CharType;
         if (!isString) {
@@ -2022,7 +2021,7 @@ namespace Microsoft.Dafny{
         }
       }
     }
-    
+
     protected override string IdProtect(string name) {
       return PublicIdProtect(name);
     }
@@ -3330,7 +3329,7 @@ namespace Microsoft.Dafny{
       if (message == null) {
         message = "unexpected control point";
       }
-      
+
       wr.WriteLine($"throw new IllegalArgumentException(\"{message}\");");
     }
 

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -450,58 +450,95 @@ namespace Microsoft.Dafny
     {:handle}
       TODO
 
-	{:dllimport}
+    {:dllimport}
       TODO
 
-	{:compile}
+    {:compile}
       TODO
 
-	{:main}
+    {:main}
       TODO
 
-	{:axiom}
+    {:axiom}
       TODO
 
-	{:abstemious}
+    {:abstemious}
       TODO
 
-	{:nativeType}
+    {:nativeType}
+      Can be applied to newtype declarations for integer types and
+      indicates an expectation of what native type (or not) the
+      newtype should compile to.
+
+      If a newtype declaration has no explicit :nativeType attribute,
+      then the compiler still attempts to find a suitable native numeric
+      type, which is then reflected in an informational message or
+      hovertext.
+
+      {:nativeType} and {:nativeType true} say that the type is expected
+      to compile to some native numeric type, but leaves it to the
+      compiler to choose which one. If no suitable native target type is
+      found, an error is generated.
+
+      {:nativeType false} says to avoid using a native numeric type.
+      Instead, the type will be compiled as an unbounded integer.
+
+      {:nativeType X} where X is one of the following strings:
+        ""byte""      8 bits, unsigned
+        ""sbyte""     8 bits, signed
+        ""ushort""    16 bits, unsigned
+        ""short""     16 bits, signed
+        ""uint""      32 bits, unsigned
+        ""int""       32 bits, signed
+        ""number""    53 bits, signed
+        ""ulong""     64 bits, unsigned
+        ""long""      64 bits, signed
+      says to use the indicated target type. If the target compiler
+      does not support X, then an error is generated. Also, if, after
+      scrutinizing the constraint predicate, the compiler cannot confirm
+      that the type's values will fit in X, an error is generated.
+
+      {:nativeType XX} where XX is a list of strings from the list above,
+      says to use the first X in XX that the compiler supports. If
+      the compiler doesn't support any native type in XX, then an error
+      is generated. Also, unless the compiler can confirm that all of
+      the listed native types can fit the type's values, an error is
+      generated.
+
+    {:tailrecursion}
       TODO
 
-	{:tailrecursion}
+    {:termination}
       TODO
 
-	{:termination}
+    {:warnShadowing}
       TODO
 
-	{:warnShadowing}
+    {:verify}
       TODO
 
-	{:verify}
+    {:autocontracts}
       TODO
 
-	{:autocontracts}
+    {:opaque}
       TODO
 
-	{:opaque}
+    {:autoReq}
       TODO
 
-	{:autoReq}
+    {:timeLimitMultiplier}
       TODO
 
-	{:timeLimitMultiplier}
+    {:no_inline}
       TODO
 
-	{:no_inline}
+    {:nowarn}
       TODO
 
-	{:nowarn}
+    {:autotriggers}
       TODO
 
-	{:autotriggers}
-      TODO
-
-	{:trigger}
+    {:trigger}
       TODO
 ");
     }

--- a/Test/comp/Numbers.dfy
+++ b/Test/comp/Numbers.dfy
@@ -270,7 +270,7 @@ method MoreBvTests() {
   print u, "\n";  // as 0 as ever
 }
 
-newtype {:nativeType "number"} MyNumber = x | -100 <= x < 0x10_0000_0000
+newtype {:nativeType "number", "long"} MyNumber = x | -100 <= x < 0x10_0000_0000
 
 method NewTypeTest() {
   var a, b := 200, 300;

--- a/Test/dafny0/NativeTypeResolution.dfy
+++ b/Test/dafny0/NativeTypeResolution.dfy
@@ -1,0 +1,39 @@
+// RUN: %dafny /printTooltips /compileTarget:cs "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+newtype V = x | 0 <= x < 200  // byte
+newtype {:nativeType "byte"} W = x | -2 <= x < 2  // error: cannot be byte
+newtype {:nativeType "int","byte"} X = x | -2 <= x < 2  // error: cannot be byte
+newtype {:nativeType "byte"} Y = x | 0 <= x < 2  // byte (but no tool tip)
+newtype {:nativeType "int","byte","long"} Z = x | -2 <= x < 2  // error: cannot be byte
+
+newtype {:nativeType "number","int","int","byte"} A = x | 0 <= x < 256  // int
+newtype {:nativeType "byte","number","int","int"} B = x | 0 <= x < 256  // byte
+newtype {:nativeType "int","number","int","byte"} C = x | 0 <= x < 256  // int
+
+newtype {:nativeType "reallylong"} O = x | 0 <= x < 3000  // error: "reallylong" unknown
+newtype {:nativeType "int","reallylong"} P = x | 0 <= x < 3000  // error: "reallylong" unknown
+
+newtype {:nativeType "number"} Q = x | 0 <= x < 3000  // error: "number" not supported by C#
+newtype {:nativeType "number","number"} R = x | 0 <= x < 3000  // error: "number" not supported by C#
+
+newtype G = x | x < 30  // no native type, but that's okay
+newtype {:nativeType} H = x | x < 30  // error: no native type, but one was requested
+newtype {:nativeType} I = x | -2 <= x < 30  // sbyte
+newtype {:nativeType true} J = x | x < 30  // error: no native type, but one was requested
+newtype {:nativeType true} K = x | -2 <= x < 30  // sbyte
+
+newtype {:nativeType false} E = x | x < 30  // no native type, and that's just as well
+newtype {:nativeType false} F = x | -2 <= x < 30  // there is a native type, but they don't want it
+
+newtype {:nativeType "int",false,"int"} PP = x | x == 16  // error: bad nativeType argument
+newtype {:nativeType 3.14} QQ = x | x == 16  // error: bad nativeType argument
+newtype {:nativeType "int"} RR = x: real | 0.0 <= x <= 3.0  // error: not integer type
+
+newtype {:nativeType "long"} AA = int  // error: not a long
+newtype {:nativeType "long"} BB = AA  // error: not a long
+newtype {:nativeType "long"} CC = x: BB | -20 <= x < 20
+newtype {:nativeType "long"} DD = CC
+newtype {:nativeType "int"} EE = DD
+newtype FF = EE  // sbyte
+newtype {:nativeType "byte"} GG = EE  // error: not a byte

--- a/Test/dafny0/NativeTypeResolution.dfy.expect
+++ b/Test/dafny0/NativeTypeResolution.dfy.expect
@@ -1,0 +1,23 @@
+NativeTypeResolution.dfy(4,8): Info: {:nativeType "byte"}
+NativeTypeResolution.dfy(5,29): Error: Dafny's heuristics failed to confirm 'byte' to be a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(6,35): Error: Dafny's heuristics failed to confirm 'byte' to be a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(8,42): Error: Dafny's heuristics failed to confirm 'byte' to be a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(10,50): Info: {:nativeType "int"}
+NativeTypeResolution.dfy(11,50): Info: {:nativeType "byte"}
+NativeTypeResolution.dfy(12,50): Info: {:nativeType "int"}
+NativeTypeResolution.dfy(14,35): Error: :nativeType 'reallylong' not known
+NativeTypeResolution.dfy(15,41): Error: :nativeType 'reallylong' not known
+NativeTypeResolution.dfy(17,31): Error: None of the types given in :nativeType arguments is supported by the current compilation target. Try supplying others.
+NativeTypeResolution.dfy(18,40): Error: None of the types given in :nativeType arguments is supported by the current compilation target. Try supplying others.
+NativeTypeResolution.dfy(21,22): Error: Dafny's heuristics cannot find a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(22,22): Info: {:nativeType "sbyte"}
+NativeTypeResolution.dfy(23,27): Error: Dafny's heuristics cannot find a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(24,27): Info: {:nativeType "sbyte"}
+NativeTypeResolution.dfy(29,27): Error: unexpected :nativeType argument
+NativeTypeResolution.dfy(30,21): Error: unexpected :nativeType argument
+NativeTypeResolution.dfy(31,28): Error: :nativeType can only be used on integral types
+NativeTypeResolution.dfy(33,29): Error: Dafny's heuristics failed to confirm 'long' to be a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(34,29): Error: Dafny's heuristics failed to confirm 'long' to be a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+NativeTypeResolution.dfy(38,8): Info: {:nativeType "sbyte"}
+NativeTypeResolution.dfy(39,29): Error: Dafny's heuristics failed to confirm 'byte' to be a compatible native type.  Hint: try writing a newtype constraint of the form 'i:int | lowerBound <= i < upperBound && (...any additional constraints...)'
+15 resolution/type errors detected in NativeTypeResolution.dfy


### PR DESCRIPTION
Support `{:nativeType XX}` where `XX` is a list of native types. The first of
these that the target compiler supports is picked. For additional details,
see the `/attrHelp` message.

Don't pretend to support `number` outside JavaScript. Previously,
`{:nativeType "number"}` worked for a multi-target compilation, but it
does not any more. Instead, use the new attribute
`{:nativeType "number", "long"}`, which does what the previous one
did.