### PR TITLE
fix: Remove RevealExpr

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -329,9 +329,6 @@ namespace Microsoft.Dafny
       } else if (expr is ApplySuffix) {
         var e = (ApplySuffix) expr;
         return CloneApplySuffix(e);
-      } else if (expr is RevealExpr) {
-        var e = (RevealExpr) expr;
-        return new RevealExpr(Tok(e.tok), CloneExpr(e.Expr));
       } else if (expr is MemberSelectExpr) {
         var e = (MemberSelectExpr)expr;
         return new MemberSelectExpr(Tok(e.tok), CloneExpr(e.Obj), e.MemberName);

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -427,7 +427,7 @@ bool IsIdentColonOrBar() {
 }
 
 bool SemiFollowsCall(bool allowSemi, Expression e) {
-  return allowSemi && la.kind == _semicolon && (e is ApplySuffix || (e is RevealExpr && (((RevealExpr)e).Expr is ApplySuffix)));
+  return allowSemi && la.kind == _semicolon && e is ApplySuffix;
 }
 
 bool IsNotEndOfCase() {
@@ -3522,8 +3522,6 @@ EndlessExpression<out Expression e, bool allowSemi, bool allowLambda, bool allow
     MapComprehensionExpr<x, true, out e, allowSemi, allowLambda, allowBitwiseOps>
   | "imap"                          (. x = t; .)
     MapComprehensionExpr<x, false, out e, allowSemi, allowLambda, true>
-  | "reveal"
-    Expression<out e, false, false, allowBitwiseOps> (. e = new RevealExpr(e.tok, e); .)
   | NamedExpr<out e, allowSemi, allowLambda, allowBitwiseOps>
   )
   .
@@ -3533,6 +3531,7 @@ StmtInExpr<out Statement s>
   ( AssertStmt<out s, true>
   | ExpectStmt<out s>
   | AssumeStmt<out s>
+  | RevealStmt<out s>
   | CalcStmt<out s>
   )
   .

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -6247,7 +6247,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(expr != null);
       this.Message = message;
     }
-    
+
     public override IEnumerable<Expression> SubExpressions {
       get {
         foreach (var e in base.SubExpressions) { yield return e; }
@@ -9187,26 +9187,6 @@ namespace Microsoft.Dafny {
     }
   }
 
-  public class RevealExpr : Expression
-  {
-    public readonly Expression Expr;
-    public Expression ResolvedExpression;
-
-    public override IEnumerable<Expression> SubExpressions {
-      get {
-        if (ResolvedExpression != null) {
-          yield return ResolvedExpression;
-        }
-      }
-    }
-
-    public RevealExpr(IToken tok, Expression expr)
-      : base(tok)
-    {
-      this.Expr = expr;
-    }
-  }
-
   public class FunctionCallExpr : Expression {
     public readonly string Name;
     public readonly Expression Receiver;
@@ -10502,6 +10482,8 @@ namespace Microsoft.Dafny {
       } else if (S is CalcStmt) {
         var s = (CalcStmt)S;
         return s.Result;
+      } else if (S is RevealStmt) {
+        return new LiteralExpr(tok, true);  // one could use the definition axiom or the referenced labeled assertions, but "true" is conservative and much simpler :)
       } else if (S is UpdateStmt) {
         return new LiteralExpr(tok, true);  // one could use the postcondition of the method, suitably instantiated, but "true" is conservative and much simpler :)
       } else {

--- a/Source/Dafny/Parser.cs
+++ b/Source/Dafny/Parser.cs
@@ -536,7 +536,7 @@ bool IsIdentColonOrBar() {
 }
 
 bool SemiFollowsCall(bool allowSemi, Expression e) {
-  return allowSemi && la.kind == _semicolon && (e is ApplySuffix || (e is RevealExpr && (((RevealExpr)e).Expr is ApplySuffix)));
+  return allowSemi && la.kind == _semicolon && e is ApplySuffix;
 }
 
 bool IsNotEndOfCase() {
@@ -5018,7 +5018,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			SetComprehensionExpr(x, false, out e, allowSemi, allowLambda, true);
 			break;
 		}
-		case 36: case 37: case 90: case 120: {
+		case 36: case 37: case 89: case 90: case 120: {
 			StmtInExpr(out s);
 			Expression(out e, allowSemi, allowLambda, allowBitwiseOps);
 			e = new StmtExpr(s.Tok, s, e); 
@@ -5038,12 +5038,6 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			Get();
 			x = t; 
 			MapComprehensionExpr(x, false, out e, allowSemi, allowLambda, true);
-			break;
-		}
-		case 89: {
-			Get();
-			Expression(out e, false, false, allowBitwiseOps);
-			e = new RevealExpr(e.tok, e); 
 			break;
 		}
 		case 112: {
@@ -5490,6 +5484,8 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			ExpectStmt(out s);
 		} else if (la.kind == 36) {
 			AssumeStmt(out s);
+		} else if (la.kind == 89) {
+			RevealStmt(out s);
 		} else if (la.kind == 37) {
 			CalcStmt(out s);
 		} else SynErr(289);

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -1968,11 +1968,6 @@ namespace Microsoft.Dafny {
         PrintActualArguments(e.Args, name);
         if (parensNeeded) { wr.Write(")"); }
 
-      } else if (expr is RevealExpr) {
-        var e = (RevealExpr)expr;
-        wr.Write("reveal ");
-        PrintExpression(e.Expr, true);
-
       } else if (expr is MemberSelectExpr) {
         MemberSelectExpr e = (MemberSelectExpr)expr;
         // determine if parens are needed

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -10089,11 +10089,6 @@ namespace Microsoft.Dafny
             var cRhs = ResolveApplySuffix(a, new ResolveOpts(codeContext, true), true);
             isEffectful = cRhs != null;
             methodCallInfo = methodCallInfo ?? cRhs;
-          } else if (er.Expr is RevealExpr) {
-            var r = (RevealExpr)er.Expr;
-            var cRhs = ResolveRevealExpr(r, new ResolveOpts(codeContext, true), true);
-            isEffectful = cRhs != null;
-            methodCallInfo = methodCallInfo ?? cRhs;
           } else {
             ResolveExpression(er.Expr, new ResolveOpts(codeContext, true));
             isEffectful = false;
@@ -11796,11 +11791,6 @@ namespace Microsoft.Dafny
       } else if (expr is ApplySuffix) {
         var e = (ApplySuffix)expr;
         ResolveApplySuffix(e, opts, false);
-
-      } else if (expr is RevealExpr) {
-        var e = (RevealExpr)expr;
-        ResolveRevealExpr(e, opts, true);
-        e.ResolvedExpression = e.Expr;
 
       } else if (expr is MemberSelectExpr) {
         var e = (MemberSelectExpr)expr;
@@ -13818,17 +13808,6 @@ namespace Microsoft.Dafny
         this.Callee = callee;
         this.Args = args;
       }
-    }
-
-    MethodCallInformation ResolveRevealExpr(RevealExpr e, ResolveOpts opts, bool allowMethodCall) {
-      var revealOpts = new ResolveOpts(opts.codeContext, opts.twoState, true, opts.isPostCondition, opts.InsideOld);
-      MethodCallInformation info = null;
-      if (e.Expr is ApplySuffix) {
-        info = ResolveApplySuffix((ApplySuffix)e.Expr, revealOpts, true);
-      } else {
-        ResolveExpression(e.Expr, revealOpts);
-      }
-      return info;
     }
 
     MethodCallInformation ResolveApplySuffix(ApplySuffix e, ResolveOpts opts, bool allowMethodCall) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -6547,9 +6547,6 @@ namespace Microsoft.Dafny {
       } else if (expr is ConcreteSyntaxExpression) {
         var e = (ConcreteSyntaxExpression)expr;
         return CanCallAssumption(e.ResolvedExpression, etran);
-      } else if (expr is RevealExpr) {
-        var e = (RevealExpr)expr;
-        return CanCallAssumption(e.ResolvedExpression, etran);
       } else if (expr is BoogieFunctionCall) {
         var e = (BoogieFunctionCall)expr;
         return CanCallAssumption(e.Args, etran);
@@ -7709,11 +7706,6 @@ namespace Microsoft.Dafny {
 
       } else if (expr is ConcreteSyntaxExpression) {
         var e = (ConcreteSyntaxExpression)expr;
-        CheckWellformedWithResult(e.ResolvedExpression, options, result, resultType, locals, builder, etran);
-        result = null;
-
-      } else if (expr is RevealExpr) {
-        var e = (RevealExpr)expr;
         CheckWellformedWithResult(e.ResolvedExpression, options, result, resultType, locals, builder, etran);
         result = null;
 
@@ -9896,7 +9888,7 @@ namespace Microsoft.Dafny {
           ExpectStmt s = (ExpectStmt)stmt;
           stmtContext = StmtType.ASSUME;
           TrStmt_CheckWellformed(s.Expr, builder, locals, etran, false);
-          
+
           // Need to check the message is well-formed, assuming the expected expression
           // does NOT hold:
           //
@@ -15469,10 +15461,6 @@ namespace Microsoft.Dafny {
           var e = (ConcreteSyntaxExpression)expr;
           return TrExpr(e.ResolvedExpression);
 
-        } else if (expr is RevealExpr) {
-          var e = (RevealExpr)expr;
-          return TrExpr(e.ResolvedExpression);
-
         } else if (expr is BoxingCastExpr) {
           BoxingCastExpr e = (BoxingCastExpr)expr;
           return translator.CondApplyBox(e.tok, TrExpr(e.E), e.FromType, e.ToType);
@@ -16721,10 +16709,6 @@ namespace Microsoft.Dafny {
 
       } else if (expr is ConcreteSyntaxExpression) {
         var e = (ConcreteSyntaxExpression)expr;
-        return TrSplitExpr(e.ResolvedExpression, splits, position, heightLimit, inlineProtectedFunctions, apply_induction, etran);
-
-      } else if (expr is RevealExpr) {
-        var e = (RevealExpr)expr;
         return TrSplitExpr(e.ResolvedExpression, splits, position, heightLimit, inlineProtectedFunctions, apply_induction, etran);
 
       } else if (expr is LetExpr) {
@@ -18001,10 +17985,6 @@ namespace Microsoft.Dafny {
 
         } else if (expr is ConcreteSyntaxExpression) {
           var e = (ConcreteSyntaxExpression)expr;
-          return Substitute(e.ResolvedExpression);
-
-        } else if (expr is RevealExpr) {
-          var e = (RevealExpr)expr;
           return Substitute(e.ResolvedExpression);
 
         } else if (expr is BoogieFunctionCall) {


### PR DESCRIPTION
`reveal` expressions had their own AST node, which was redundant and buggy
(in particular, the parser previously alllowed a `reveal` expression that wasn't followed
by an actual expression, and this caused the resolver to keel over).
This has been fixed to instead use a RevealStmt inside a StmtExpr.