### PR TITLE
chore: Update test output in accordance with latest Go version

### DIFF
--- a/Test/comp/GoModule.dfy.expect
+++ b/Test/comp/GoModule.dfy.expect
@@ -5,4 +5,4 @@ has the following parts:
 host: localhost:8080
 pathname: /default.htm
 search: year=1915&month=august&day=29
-Parse error: parse http://localhost:8080/default.htm%: invalid URL escape "%"
+Parse error: parse "http://localhost:8080/default.htm%": invalid URL escape "%"


### PR DESCRIPTION
Go's url module changed the format of its output from Go version 1.11 to 1.14.
This PR reflects that change in the Dafny test suite.