### PR TITLE
fix: Allow exports of members of general types

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -859,6 +859,15 @@ namespace Microsoft.Dafny {
         return udt != null && udt.ResolvedParam == null ? udt.ResolvedClass as TopLevelDeclWithMembers : null;
       }
     }
+    public TopLevelDeclWithMembers/*?*/ AsTopLevelTypeWithMembersBypassInternalSynonym {
+      get {
+        var udt = NormalizeExpand() as UserDefinedType;
+        if (udt != null && udt.ResolvedClass is InternalTypeSynonymDecl isyn) {
+          udt = isyn.RhsWithArgumentIgnoringScope(udt.TypeArgs) as UserDefinedType;
+        }
+        return udt != null && udt.ResolvedParam == null ? udt.ResolvedClass as TopLevelDeclWithMembers : null;
+      }
+    }
     /// <summary>
     /// Returns "true" if the type represents the "object?".
     /// </summary>

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -1008,20 +1008,31 @@ namespace Microsoft.Dafny
           string name = export.Id;
 
           if (export.ClassId != null) {
-            if (sig.TopLevels.TryGetValue(export.ClassId, out cldecl) &&
-              ((cldecl is ClassDecl && ((ClassDecl)cldecl).NonNullTypeDecl == null) || cldecl is NonNullTypeDecl)) {  // we are looking for a class name, not a type name
-              var cl = (ClassDecl)cldecl.ViewAsClass;
-              var lmem = cl.Members.FirstOrDefault(l => l.Name == export.Id);
-              if (lmem != null) {
-                decl = lmem;
-              } else {
-                reporter.Error(MessageSource.Resolver, export.Tok, "No member '{0}' found in class '{1}'", export.Id, export.ClassId);
-                continue;
-              }
-            } else {
-              reporter.Error(MessageSource.Resolver, export.ClassIdTok, "No class '{0}' found", export.ClassId);
+            if (!sig.TopLevels.TryGetValue(export.ClassId, out cldecl)) {
+              reporter.Error(MessageSource.Resolver, export.ClassIdTok, "'{0}' is not a top-level type declaration", export.ClassId);
               continue;
             }
+            if (cldecl is ClassDecl) {
+              // cldecl is a possibly-null type (syntactically given with a question mark at the end)
+              Contract.Assert(((ClassDecl)cldecl).NonNullTypeDecl != null);
+              reporter.Error(MessageSource.Resolver, export.ClassIdTok, "'{0}' is not a type that can declare members", export.ClassId);
+              continue;
+            }
+            if (cldecl is NonNullTypeDecl) {
+              // cldecl was given syntactically like the name of a class, but here it's referring to the corresponding non-null subset type
+              cldecl = cldecl.ViewAsClass;
+            }
+            var mt = cldecl as TopLevelDeclWithMembers;
+            if (mt == null) {
+              reporter.Error(MessageSource.Resolver, export.ClassIdTok, "'{0}' is not a type that can declare members", export.ClassId);
+              continue;
+            }
+            var lmem = mt.Members.FirstOrDefault(l => l.Name == export.Id);
+            if (lmem == null) {
+              reporter.Error(MessageSource.Resolver, export.Tok, "No member '{0}' found in type '{1}'", export.Id, export.ClassId);
+              continue;
+            }
+            decl = lmem;
           } else if (sig.TopLevels.TryGetValue(name, out tdecl) && (!(tdecl is ClassDecl) || ((ClassDecl)tdecl).NonNullTypeDecl == null)) {  // pretend that C? types are not there
             // Member of the enclosing module
             decl = tdecl.ViewAsClass;  // interpret the export as a class name, not a type name
@@ -1220,10 +1231,9 @@ namespace Microsoft.Dafny
         ModuleExportDecl decl = (ModuleExportDecl)top;
 
         foreach (var export in decl.Exports) {
-          if (export.Decl is MemberDecl) {
-            var member = (MemberDecl)export.Decl;
+          if (export.Decl is MemberDecl member) {
             if (!member.EnclosingClass.IsVisibleInScope(decl.Signature.VisibilityScope)) {
-              reporter.Error(MessageSource.Resolver, export.Tok, "Cannot export class member '{0}' without providing its enclosing {1} '{2}'", member.Name, member.EnclosingClass.WhatKind, member.EnclosingClass.Name);
+              reporter.Error(MessageSource.Resolver, export.Tok, "Cannot export type member '{0}' without providing its enclosing {1} '{2}'", member.Name, member.EnclosingClass.WhatKind, member.EnclosingClass.Name);
             }
           }
         }
@@ -11234,7 +11244,7 @@ namespace Microsoft.Dafny
       }
 
       var ctype = receiverType.NormalizeExpand() as UserDefinedType;
-      var cd = ctype == null ? null : ctype.ResolvedClass as TopLevelDeclWithMembers;
+      var cd = ctype?.AsTopLevelTypeWithMembersBypassInternalSynonym;
       if (cd != null) {
         Contract.Assert(ctype.TypeArgs.Count == cd.TypeArgs.Count);  // follows from the fact that ctype was resolved
         MemberDecl member;
@@ -13846,9 +13856,9 @@ namespace Microsoft.Dafny
             }
           }
         }
-        if (r == null && ty.IsTopLevelTypeWithMembers) {
-          // ----- LHS is a class
-          var cd = (TopLevelDeclWithMembers)((UserDefinedType)ty).ResolvedClass;
+        var cd = r == null ? ty.AsTopLevelTypeWithMembersBypassInternalSynonym : null;
+        if (cd != null) {
+          // ----- LHS is a type with members
           Dictionary<string, MemberDecl> members;
           if (classMembers.TryGetValue(cd, out members) && members.TryGetValue(name, out member)) {
             if (!VisibleInScope(member)) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -1201,6 +1201,10 @@ namespace Microsoft.Dafny {
         }
       } else {
         AddTypeDecl(d.SelfSynonymDecl());
+        var dd = d as TopLevelDeclWithMembers;
+        if (dd != null) {
+          AddClassMembers(dd, true);
+        }
       }
     }
 

--- a/Test/exports/DatatypeExport.dfy.expect
+++ b/Test/exports/DatatypeExport.dfy.expect
@@ -1,7 +1,7 @@
 DatatypeExport.dfy(41,24): Error: unresolved identifier: CT1
 DatatypeExport.dfy(44,10): Error: the type of the match source expression must be a datatype (instead found A.T)
 DatatypeExport.dfy(46,21): Error: unresolved identifier: n
-DatatypeExport.dfy(48,34): Error: type T does not have a member CT1?
-DatatypeExport.dfy(48,53): Error: type T does not have a member X
+DatatypeExport.dfy(48,34): Error: member 'CT1?' has not been imported in this scope and cannot be accessed here
+DatatypeExport.dfy(48,53): Error: member 'X' has not been imported in this scope and cannot be accessed here
 DatatypeExport.dfy(56,24): Error: unresolved identifier: CT1
 6 resolution/type errors detected in DatatypeExport.dfy

--- a/Test/exports/ExportErrorLocations.dfy
+++ b/Test/exports/ExportErrorLocations.dfy
@@ -7,9 +7,9 @@ module MyModule {
   export
     provides F, FunctionG, Y  // error: not a member ("FunctionG")
     provides Undeniable, YourClass.M  // error: not a class ("YourClass")
-    provides Datatype.Ctor  // error: not a class ("Datatype")
+    provides Datatype.UndefinedFunction  // error: not a member ("UndefinedFunction")
   export Alt
-    provides MyClass.SomeMethod, MyClass.UndefinedMethod, MyClass.x  // error: member not found in class ("UndefinedMethod")
+    provides MyClass.SomeMethod, MyClass.UndefinedMethod, MyClass.x  // error: not a member ("UndefinedMethod")
   export Another
     reveals MyClass.SomeMethod  // error: cannot be revealed ("SomeMethod")
     provides Alt  // error: cannot be exported ("Alt")

--- a/Test/exports/ExportErrorLocations.dfy.expect
+++ b/Test/exports/ExportErrorLocations.dfy.expect
@@ -1,7 +1,7 @@
 ExportErrorLocations.dfy(8,16): Error: 'FunctionG' must be a member of 'MyModule' to be exported
-ExportErrorLocations.dfy(9,25): Error: No class 'YourClass' found
-ExportErrorLocations.dfy(10,13): Error: No class 'Datatype' found
-ExportErrorLocations.dfy(12,41): Error: No member 'UndefinedMethod' found in class 'MyClass'
+ExportErrorLocations.dfy(9,25): Error: 'YourClass' is not a top-level type declaration
+ExportErrorLocations.dfy(10,22): Error: No member 'UndefinedFunction' found in type 'Datatype'
+ExportErrorLocations.dfy(12,41): Error: No member 'UndefinedMethod' found in type 'MyClass'
 ExportErrorLocations.dfy(14,20): Error: 'SomeMethod' cannot be revealed in an export. Use "provides" instead.
 ExportErrorLocations.dfy(15,13): Error: 'Alt' is an export set and cannot be provided/revealed by another export set (did you intend to list it in an "extends"?)
 6 resolution/type errors detected in ExportErrorLocations.dfy

--- a/Test/exports/ExportResolve.dfy
+++ b/Test/exports/ExportResolve.dfy
@@ -1,0 +1,311 @@
+// RUN: %dafny /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module NamesThatDontExist {
+  export
+    // --- reveals
+    reveals DoesNotExist  // error: unknown identiifer
+    reveals Trait?.Valid  // error: not a type declaration with members
+    reveals Klass?.Valid  // error: not a type declaration with members
+    reveals Trait.Valid, Klass.Valid  // fine
+    reveals Trait.NotThere  // error: not a member
+    reveals TypeSynonym.Valid  // error: not a type declaration with members
+    reveals Opaque.Valid  // error: not a type declaration with members
+    reveals DtValue.Valid  // error: not a type declaration with members
+    reveals Color, Dt, Dt.Valid, Dt.M, Dt.N  // all good
+    reveals Color.Magenta  // error: cannot mention datatype constructor in export
+    reveals Color.More?  // error: cannot mention datatype discriminator in export
+    reveals Color.u  // error: cannot mention datatype destructor in export
+    reveals Trait?  // error: Trait and Trait? should be exported together, using Trait
+    reveals Klass?  // error: Klass and Klass? should be exported together, using Klass
+    // --- provides
+    provides DoesNotExist  // error: unknown identiifer
+    provides Trait?.Valid  // error: not a type declaration with members
+    provides Klass?.Valid  // error: not a type declaration with members
+    provides Trait.Valid, Klass.Valid  // fine
+    provides Trait.NotThere  // error: not a member
+    provides TypeSynonym.Valid  // error: not a type declaration with members
+    provides Opaque.Valid  // error: not a type declaration with members
+    provides DtValue.Valid  // error: not a type declaration with members
+    provides Color, Dt.Valid, Dt.M, Dt.N  // all good
+    provides Color.Magenta  // error: cannot mention datatype constructor in export
+    provides Color.More?  // error: cannot mention datatype discriminator in export
+    provides Color.u  // error: cannot mention datatype destructor in export
+    provides Trait?  // error: Trait and Trait? should be exported together, using Trait
+    provides Klass?  // error: Klass and Klass? should be exported together, using Klass
+
+  export DisallowDatatypeSignatureMembers0
+    provides Dt
+    provides Dt.X  // error: datatype constructors cannot be individually exported
+    provides Dt.Cons?  // error: datatype discriminators cannot be individually exported
+    provides Dt.u  // error: datatype denstructors cannot be individually exported
+
+  export DisallowDatatypeSignatureMembers1
+    reveals Dt
+    provides Dt.X  // error: datatype constructors cannot be individually exported
+    provides Dt.Cons?  // error: datatype discriminators cannot be individually exported
+    provides Dt.u  // error: datatype denstructors cannot be individually exported
+
+  class Trait {
+    predicate Valid() { true }
+  }
+  class Klass {
+    constructor () { }
+    constructor FromInt(w: int) { }
+    predicate Valid() { true }
+  }
+  type TypeSynonym = Klass
+  type Opaque
+  datatype Color = Magenta | Cyan
+  datatype Dt = X | Y | More(u: int) {
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+  const DtValue: Dt := X
+
+  export ExtremeVsPrefix0
+    provides P, L
+  export ExtremeVsPrefix1
+    reveals P, L  // error: L is a lemma and cannot be revealed, only provided
+
+  // The following two declarations also declare P# and L#, but the parser does not allow
+  // such names in export declarations. (They are exported whenever P and L, respectively,
+  // are.)
+  inductive predicate P(r: real)
+  inductive lemma L(r: real)
+}
+
+module ConsistencyErrors {
+  // Providing a type exports the type name as an opaque type, along with any
+  // type characteristics, type parameters, and the variance of the type parameters.
+  // In the case of a class C, both type C and C? are exported.
+  // But no datatype constructors, discriminators, or destructors, class constructors,
+  // or type members are exported.
+  export ProvideTypes
+    provides Trait, Klass, Dt
+  export P0 extends ProvideTypes  // error: export set not consistent (X, More?, u)
+    provides DatatypeSignature  // TODO: should be error
+  export P1 extends ProvideTypes
+    provides Nullity  // TODO: should be error
+  export P2 extends ProvideTypes  // error: export set not consistent
+    provides SubsetEquality
+  export P3 extends ProvideTypes  // error: export set not consistent
+    provides UsesValid
+  export P4 extends ProvideTypes  // error: export set not consistent
+    provides UsesStatic
+  export P5 extends ProvideTypes  // error: export set not consistent
+    provides UsesField
+
+  export Constructor
+    provides Klass.FromInt  // error: cannot provide constructor without revealing enclosing class
+
+  class Trait {
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+  class Klass {
+    constructor () { }
+    constructor FromInt(w: int) { }
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+  datatype Dt = X | Y | More(u: int) {
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+
+  method DatatypeSignature(t: Trait, tn: Trait?, k: Klass, kn: Klass?, d: Dt)
+    requires d == X == Dt.X || (d.More? && d.u == 16)
+  method Nullity(t: Trait, tn: Trait?, k: Klass, kn: Klass?, d: Dt)
+    requires tn == null || kn == null
+  method SubsetEquality(t: Trait, tn: Trait?, k: Klass, kn: Klass?, d: Dt)
+    requires t == tn && k == kn
+  method UsesValid(t: Trait, k: Klass, d: Dt)
+    requires t.Valid() && k.Valid() && d.Valid()
+  method UsesStatic(t: Trait, k: Klass, d: Dt)
+    requires Trait.N == Klass.N == Dt.N
+  method UsesField(t: Trait, k: Klass, d: Dt)
+    requires t.M == k.M == d.M
+}
+
+module GoodExports {
+  export JustProvideTypes
+    provides Trait, Klass, Dt
+  export JustRevealTypes
+    reveals Trait, Klass, Dt
+
+  // Type members (except constructors in classes) can be explicitly exported,
+  // as long as the type itself is either provided or revealed.
+  export MembersOfProvidedTypes
+    provides Trait, Klass, Dt
+    provides Trait.Valid, Trait.M, Trait.N
+    provides Klass.Valid, Klass.M, Klass.N
+    provides Dt.Valid, Dt.M, Dt.N
+
+  export MembersOfRevealedTypes
+    reveals Trait, Klass, Dt
+    provides Trait.Valid, Trait.M, Trait.N
+    provides Klass.Valid, Klass.M, Klass.N
+    provides Dt.Valid, Dt.M, Dt.N
+
+  export BothConstructors
+    reveals Klass
+    provides Klass.FromInt
+
+  class Trait {
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+  class Klass {
+    constructor () { }
+    constructor FromInt(w: int) { }
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+  datatype Dt = X | Y | More(u: int) {
+    predicate Valid() { true }
+    const M := 100
+    static const N := 101
+  }
+
+  export ProvideExtreme
+    provides P, L
+    provides OpaqueFunction
+  export RevealExtreme
+    reveals P
+    provides L
+    reveals OpaqueFunction
+
+  inductive predicate P(r: real)
+  inductive lemma L(r: real)
+  function {:opaque} OpaqueFunction(r: real): int { 10 }
+}
+
+module Client_ProvideTypes {
+  // This module checks that the outside world looks like it does inside module ConsistencyErrors above.
+  import G = GoodExports`JustProvideTypes
+
+  method DatatypeSignature(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires d == G.X || (d.More? && d.u == 16)  // error (3x): unknown identifiers X, More?, u
+  method Nullity(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires tn == null || kn == null  // TODO: should be error
+  method SubsetEquality(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires t == tn && k == kn  // TODO: should be error
+  method UsesValid(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.Valid() && k.Valid() && d.Valid()  // error (3x): unknown identifiers Valid
+  method UsesStatic(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires G.Trait.N == G.Klass.N == G.Dt.N  // error (3x): unknown identifiers N
+  method UsesField(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.M == k.M == d.M  // error (3x): unknown identifiers M
+  method Constructor() {
+    var k := new G.Klass();  // error: no anonymous constructor has been exported
+  }
+}
+
+module Client_RevealTypes {
+  // This module checks that the outside world looks like it does inside module ConsistencyErrors above.
+  import G = GoodExports`JustRevealTypes
+
+  method DatatypeSignature(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires d == G.X || (d.More? && d.u == 16)
+  method Nullity(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires tn == null || kn == null
+  method SubsetEquality(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires t == tn && k == kn
+  method UsesValid(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.Valid() && k.Valid() && d.Valid()  // error (TODO 3x): unknown identifiers Valid
+  method UsesStatic(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires G.Trait.N == G.Klass.N == G.Dt.N  // error (TODO 3x): unknown identifiers Valid
+  method UsesField(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.M == k.M == d.M  // error (TODO 3x): unknown identifiers Valid
+  method Constructor() {
+    var k := new G.Klass();  // fine; the anonymous constructor gets exported with the class
+  }
+}
+
+module Client_MembersOfProvidedTypes {
+  // This module checks that the outside world looks like it does inside module ConsistencyErrors above.
+  import G = GoodExports`MembersOfProvidedTypes
+
+  method DatatypeSignature(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires d == G.X || (d.More? && d.u == 16)  // error (3x): unknown identifiers X, More?, u
+  method Nullity(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires tn == null || kn == null  // TODO: should be error
+  method SubsetEquality(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires t == tn && k == kn  // TODO: should be error
+  method UsesValid(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.Valid() && k.Valid() && d.Valid()
+  method UsesStatic(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires G.Trait.N == G.Klass.N == G.Dt.N
+  method UsesField(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.M == k.M == d.M
+  method Constructor() {
+    var k := new G.Klass();  // error: no anonymous constructor has been exported
+  }
+}
+
+module Client_MembersOfRevealedTypes {
+  // This module checks that the outside world looks like it does inside module ConsistencyErrors above.
+  import G = GoodExports`MembersOfRevealedTypes
+
+  method DatatypeSignature(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires d == G.X || (d.More? && d.u == 16)
+  method Nullity(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires tn == null || kn == null
+  method SubsetEquality(t: G.Trait, tn: G.Trait?, k: G.Klass, kn: G.Klass?, d: G.Dt)
+    requires t == tn && k == kn
+  method UsesValid(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.Valid() && k.Valid() && d.Valid()
+  method UsesStatic(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires G.Trait.N == G.Klass.N == G.Dt.N
+  method UsesField(t: G.Trait, k: G.Klass, d: G.Dt)
+    requires t.M == k.M == d.M
+  method Constructor() {
+    var k := new G.Klass();  // fine; the anonymous constructor gets exported with the class
+  }
+}
+
+module Client_BothConstructors {
+  import G = GoodExports`BothConstructors
+
+  method Constructors() returns (k: G.Klass) {
+    k := new G.Klass();
+    k := new G.Klass.FromInt(25);
+  }
+}
+
+module Client_ProvideExtreme {
+  import E = GoodExports`ProvideExtreme
+
+  lemma Lemma(k: ORDINAL, r: real)
+    requires E.P(r)
+    // TODO: requires E.P#[k](r)
+  {
+    E.L(r);
+    // TODO: E.L#[k](r);
+    assert E.OpaqueFunction(r) == 10 by {
+      reveal E.OpaqueFunction();  // error: no reveal lemma
+    }
+  }
+}
+
+module Client_RevealExtreme {
+  import E = GoodExports`RevealExtreme
+
+  lemma Lemma(k: ORDINAL, r: real)
+    requires E.P(r)
+    requires E.P#[k](r)
+  {
+    E.L(r);
+    // TODO: E.L#[k](r);
+    assert E.OpaqueFunction(r) == 10 by {
+      reveal E.OpaqueFunction();
+    }
+  }
+}

--- a/Test/exports/ExportResolve.dfy.expect
+++ b/Test/exports/ExportResolve.dfy.expect
@@ -1,0 +1,74 @@
+ExportResolve.dfy(7,12): Error: 'DoesNotExist' must be a member of 'NamesThatDontExist' to be exported
+ExportResolve.dfy(8,12): Error: 'Trait?' is not a type that can declare members
+ExportResolve.dfy(9,12): Error: 'Klass?' is not a type that can declare members
+ExportResolve.dfy(11,18): Error: No member 'NotThere' found in type 'Trait'
+ExportResolve.dfy(12,12): Error: 'TypeSynonym' is not a type that can declare members
+ExportResolve.dfy(13,12): Error: 'Opaque' is not a type that can declare members
+ExportResolve.dfy(14,12): Error: 'DtValue' is not a top-level type declaration
+ExportResolve.dfy(16,18): Error: No member 'Magenta' found in type 'Color'
+ExportResolve.dfy(17,18): Error: No member 'More?' found in type 'Color'
+ExportResolve.dfy(18,18): Error: No member 'u' found in type 'Color'
+ExportResolve.dfy(19,12): Error: 'Trait?' must be a member of 'NamesThatDontExist' to be exported
+ExportResolve.dfy(20,12): Error: 'Klass?' must be a member of 'NamesThatDontExist' to be exported
+ExportResolve.dfy(22,13): Error: 'DoesNotExist' must be a member of 'NamesThatDontExist' to be exported
+ExportResolve.dfy(23,13): Error: 'Trait?' is not a type that can declare members
+ExportResolve.dfy(24,13): Error: 'Klass?' is not a type that can declare members
+ExportResolve.dfy(26,19): Error: No member 'NotThere' found in type 'Trait'
+ExportResolve.dfy(27,13): Error: 'TypeSynonym' is not a type that can declare members
+ExportResolve.dfy(28,13): Error: 'Opaque' is not a type that can declare members
+ExportResolve.dfy(29,13): Error: 'DtValue' is not a top-level type declaration
+ExportResolve.dfy(31,19): Error: No member 'Magenta' found in type 'Color'
+ExportResolve.dfy(32,19): Error: No member 'More?' found in type 'Color'
+ExportResolve.dfy(33,19): Error: No member 'u' found in type 'Color'
+ExportResolve.dfy(34,13): Error: 'Trait?' must be a member of 'NamesThatDontExist' to be exported
+ExportResolve.dfy(35,13): Error: 'Klass?' must be a member of 'NamesThatDontExist' to be exported
+ExportResolve.dfy(39,16): Error: No member 'X' found in type 'Dt'
+ExportResolve.dfy(40,16): Error: No member 'Cons?' found in type 'Dt'
+ExportResolve.dfy(41,16): Error: No member 'u' found in type 'Dt'
+ExportResolve.dfy(45,16): Error: No member 'X' found in type 'Dt'
+ExportResolve.dfy(46,16): Error: No member 'Cons?' found in type 'Dt'
+ExportResolve.dfy(47,16): Error: No member 'u' found in type 'Dt'
+ExportResolve.dfy(70,15): Error: 'L' cannot be revealed in an export. Use "provides" instead.
+ExportResolve.dfy(122,18): Error: Raised while checking export set P0: unresolved identifier: X
+ExportResolve.dfy(122,26): Error: Raised while checking export set P0: member 'X' does not exist in type 'Dt'
+ExportResolve.dfy(122,34): Error: Raised while checking export set P0: type Dt does not have a member More?
+ExportResolve.dfy(122,45): Error: Raised while checking export set P0: type Dt does not have a member u
+ExportResolve.dfy(87,9): Error: This export set is not consistent: P0
+ExportResolve.dfy(128,15): Error: Raised while checking export set P3: member Valid does not exist in class Trait
+ExportResolve.dfy(128,28): Error: Raised while checking export set P3: member Valid does not exist in class Klass
+ExportResolve.dfy(128,41): Error: Raised while checking export set P3: type Dt does not have a member Valid
+ExportResolve.dfy(93,9): Error: This export set is not consistent: P3
+ExportResolve.dfy(130,19): Error: Raised while checking export set P4: member 'N' does not exist in type 'Trait'
+ExportResolve.dfy(130,30): Error: Raised while checking export set P4: member 'N' does not exist in type 'Klass'
+ExportResolve.dfy(130,38): Error: Raised while checking export set P4: member 'N' does not exist in type 'Dt'
+ExportResolve.dfy(95,9): Error: This export set is not consistent: P4
+ExportResolve.dfy(132,15): Error: Raised while checking export set P5: member M does not exist in class Trait
+ExportResolve.dfy(132,22): Error: Raised while checking export set P5: member M does not exist in class Klass
+ExportResolve.dfy(132,29): Error: Raised while checking export set P5: type Dt does not have a member M
+ExportResolve.dfy(97,9): Error: This export set is not consistent: P5
+ExportResolve.dfy(101,19): Error: Cannot export type member 'FromInt' without providing its enclosing class 'Klass'
+ExportResolve.dfy(195,20): Error: unresolved identifier: X
+ExportResolve.dfy(195,28): Error: member 'More?' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(195,39): Error: member 'u' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(201,15): Error: member 'Valid' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(201,28): Error: member 'Valid' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(201,41): Error: member 'Valid' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(203,21): Error: member 'N' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(203,34): Error: member 'N' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(203,44): Error: member 'N' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(205,15): Error: member 'M' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(205,22): Error: member 'M' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(205,29): Error: member 'M' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(207,13): Error: member '_ctor' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(207,10): Error: when allocating an object of type 'Klass', one of its constructor methods must be called
+ExportResolve.dfy(222,41): Error: member 'Valid' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(224,44): Error: member 'N' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(226,29): Error: member 'M' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(237,20): Error: unresolved identifier: X
+ExportResolve.dfy(237,28): Error: member 'More?' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(237,39): Error: member 'u' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(249,13): Error: member '_ctor' has not been imported in this scope and cannot be accessed here
+ExportResolve.dfy(249,10): Error: when allocating an object of type 'Klass', one of its constructor methods must be called
+ExportResolve.dfy(293,15): Error: unresolved identifier: reveal_OpaqueFunction
+ExportResolve.dfy(293,29): Error: expression has no reveal lemma
+73 resolution/type errors detected in ExportResolve.dfy


### PR DESCRIPTION
Previously, only members of traits and classes could be mentioned in export declarations