### PR TITLE
fix: Export-provide prefix predicates/lemmas

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -1979,7 +1979,7 @@ namespace Microsoft.Dafny
               // In the call graph, add an edge from M# to M, since this will have the desired effect of detecting unwanted cycles.
               moduleDef.CallGraph.AddEdge(com.PrefixLemma, com);
             }
-            extraMember.InheritVisibility(m);
+            extraMember.InheritVisibility(m, false);
             members.Add(extraName, extraMember);
           }
         } else if (m is Constructor && !((Constructor)m).HasName) {

--- a/Test/exports/ExportResolve.dfy
+++ b/Test/exports/ExportResolve.dfy
@@ -285,10 +285,10 @@ module Client_ProvideExtreme {
 
   lemma Lemma(k: ORDINAL, r: real)
     requires E.P(r)
-    // TODO: requires E.P#[k](r)
+    requires E.P#[k](r)
   {
     E.L(r);
-    // TODO: E.L#[k](r);
+    E.L#[k](r);
     assert E.OpaqueFunction(r) == 10 by {
       reveal E.OpaqueFunction();  // error: no reveal lemma
     }
@@ -303,7 +303,7 @@ module Client_RevealExtreme {
     requires E.P#[k](r)
   {
     E.L(r);
-    // TODO: E.L#[k](r);
+    E.L#[k](r);
     assert E.OpaqueFunction(r) == 10 by {
       reveal E.OpaqueFunction();
     }


### PR DESCRIPTION
Previously, prefix predicates and prefix lemmas could be exported only be export-revealing the extreme predicate/lemma.