### PR TITLE
Fix: mono SSL handshake issues

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   build:
-    env:
-      MONO_TLS_PROVIDER: legacy
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,6 +17,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
+      with:
+        nuget-version: latest
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0
@@ -44,6 +44,8 @@ jobs:
         cp -r z3* dafny/Binaries/z3
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
+      env:
+        MONO_TLS_PROVIDER: legacy
     - name: Build Dafny
       run: msbuild dafny/Source/Dafny.sln
     - uses: actions/setup-python@v1

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
       env:
-        MONO_TLS_PROVIDER: legacy
+        MONO_TLS_PROVIDER: thisshouldfail
     - name: Build Dafny
       run: msbuild dafny/Source/Dafny.sln
     - uses: actions/setup-python@v1

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -18,7 +18,7 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-      uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '4.8'
     - name: Add msbuild to PATH

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -16,11 +16,11 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-    - uses: nuget/setup-nuget@v1
+    - name: Setup Nuget
+      uses: nuget/setup-nuget@v1
       with:
         nuget-version: latest
-    - name: Add msbuild to PATH
-      if: matrix.os == 'windows-latest'
+    - name: Setup msbuild
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Checkout Boogie
       uses: actions/checkout@v2
@@ -44,8 +44,6 @@ jobs:
         cp -r z3* dafny/Binaries/z3
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
-      env:
-        MONO_TLS_PROVIDER: legacy
     - name: Build Dafny
       run: msbuild dafny/Source/Dafny.sln
     - uses: actions/setup-python@v1

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: nuget/setup-nuget@v1
     - name: Sync cert store
-      run: curl https://curl.haxx.se/ca/cacert.pem > ~/cacert.pem && sudo cert-sync ~/cacert.pem
+      run: sudo cert-sync /etc/ssl/certs/ca-certificates.crt
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
-    - name: Sync cert store
-      run: sudo cert-sync /etc/ssl/certs/ca-certificates.crt
+    - name: Switch Mono TLS Provider to Fix SSL Handshake Issues
+      run: export MONO_TLS_PROVIDER=legacy
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   build:
-
+    env:
+      MONO_TLS_PROVIDER: legacy
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         # Windows build is not yet working due to issues with the checked-in z3.exe
@@ -42,10 +42,6 @@ jobs:
         wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.4/z3-4.8.4.d6df51951f4c-x64-ubuntu-14.04.zip
         unzip z3*.zip && rm *.zip
         cp -r z3* dafny/Binaries/z3
-    - name: Update System Certs
-      run: sudo update-ca-certificates
-    - name: Update Mono Certs
-      run: cert-sync /etc/ssl/certs/ca-certificates.crt
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
     - name: Build Dafny

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
+    - name: Sync cert store
+      run: curl https://curl.haxx.se/ca/cacert.pem > ~/cacert.pem && sudo cert-sync ~/cacert.pem
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -19,10 +19,6 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
-    - name: Update System Certs
-      run: sudo update-ca-certificates
-    - name: Update Mono Certs
-      run: sudo cert-sync /etc/ssl/certs/ca-bundle.crt
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0
@@ -46,6 +42,10 @@ jobs:
         wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.4/z3-4.8.4.d6df51951f4c-x64-ubuntu-14.04.zip
         unzip z3*.zip && rm *.zip
         cp -r z3* dafny/Binaries/z3
+    - name: Update System Certs
+      run: sudo update-ca-certificates
+    - name: Update Mono Certs
+      run: cert-sync /etc/ssl/certs/ca-certificates.crt
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
     - name: Build Dafny

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -16,11 +16,11 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-    - name: Setup Nuget
-      uses: nuget/setup-nuget@v1
+    - uses: nuget/setup-nuget@v1
       with:
         nuget-version: latest
-    - name: Setup msbuild
+    - name: Add msbuild to PATH
+      if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Checkout Boogie
       uses: actions/checkout@v2
@@ -44,6 +44,8 @@ jobs:
         cp -r z3* dafny/Binaries/z3
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
+      env:
+        MONO_TLS_PROVIDER: legacy
     - name: Build Dafny
       run: msbuild dafny/Source/Dafny.sln
     - uses: actions/setup-python@v1

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Update System Certs
       run: sudo update-ca-certificates
     - name: Update Mono Certs
-      run: sudo cert-sync /etc/ssl/certs/ca-certificates.crt
+      run: sudo cert-sync /etc/ssl/certs/ca-bundle.crt
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   build:
+
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         # Windows build is not yet working due to issues with the checked-in z3.exe
@@ -16,9 +18,9 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-    - uses: nuget/setup-nuget@v1
+      uses: actions/setup-dotnet@v1
       with:
-        nuget-version: 5.5.0
+        dotnet-version: '4.8'
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -18,11 +18,10 @@ jobs:
         shard: [1, 2, 3, 4, 5]
       fail-fast: false
     steps:
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.201'
     - name: Setup Nuget
       uses: nuget/setup-nuget@v1
+    - name: Manually sync certs
+      run: cert-sync /etc/ssl/certs/ca-certificates.crt
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '4.8'
+        dotnet-version: '3.1.201'
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -19,8 +19,10 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
-    - name: Switch Mono TLS Provider to Fix SSL Handshake Issues
-      run: export MONO_TLS_PROVIDER=legacy
+    - name: Update System Certs
+      run: sudo update-ca-certificates
+    - name: Update Mono Certs
+      run: sudo cert-sync /etc/ssl/certs/ca-certificates.crt
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,6 +21,8 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.201'
+    - name: Setup Nuget
+      uses: nuget/setup-nuget@v1
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,8 +17,6 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
-      with:
-        nuget-version: latest
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,6 +17,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: nuget/setup-nuget@v1
+      with:
+        nuget-version: 5.5.0
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0
@@ -42,8 +44,6 @@ jobs:
         cp -r z3* dafny/Binaries/z3
     - name: Nuget Restore Dafny
       run: nuget restore dafny/Source/Dafny.sln
-      env:
-        MONO_TLS_PROVIDER: thisshouldfail
     - name: Build Dafny
       run: msbuild dafny/Source/Dafny.sln
     - uses: actions/setup-python@v1

--- a/Source/Dafny/DafnyPipeline.csproj
+++ b/Source/Dafny/DafnyPipeline.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Dafny</RootNamespace>
     <AssemblyName>DafnyPipeline</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>
     <SignAssembly>true</SignAssembly>

--- a/Source/Dafny/DafnyPipeline.csproj
+++ b/Source/Dafny/DafnyPipeline.csproj
@@ -139,10 +139,10 @@
     <Reference Include="BoogieParserHelper">
       <HintPath>..\..\..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
     </Reference>
-    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <Reference Include="System" />
     <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+      <RequiredTargetFramework>4.8</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Numerics" />
   </ItemGroup>

--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dafny</RootNamespace>
     <AssemblyName>Dafny</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>
     <SignAssembly>true</SignAssembly>

--- a/Source/DafnyDriver/app.config
+++ b/Source/DafnyDriver/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.8" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Source/DafnyDriver/app.config
+++ b/Source/DafnyDriver/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.8" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DafnyRuntime</RootNamespace>
     <AssemblyName>DafnyRuntime</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -126,7 +126,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime">

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -126,7 +126,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime">

--- a/Source/DafnyRuntime/packages.config
+++ b/Source/DafnyRuntime/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.7.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.3.1" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.7.0" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
 </packages>

--- a/Source/DafnyServer/App.config
+++ b/Source/DafnyServer/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.8" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/Source/DafnyServer/App.config
+++ b/Source/DafnyServer/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup>
-        <supportedRuntime version="v4.8" sku=".NETFramework,Version=v4.8" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DafnyServer</RootNamespace>
     <AssemblyName>DafnyServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartupObject>Microsoft.Dafny.Server</StartupObject>
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>


### PR DESCRIPTION
Attempting to fix the SSL handshake issues that are experienced by mono is msbuild.

The following changes were attempted...
1. I updated the system certs per fsprojects Paket issues 3009 This adds a few more certs and also updates mono certs. Mono has it’s own certs, I believe
2. Per https://www.mono-project.com/docs/about-mono/releases/3.12.0/#cert-sync I re-synced mono certs with system certs
3. Per  fsprojects Paket issues 3009 and others, I tried using ENV MONO_TLS_PROVIDER=legacy Eventually, I realized I *was* passing the env var correctly (tried a few variations) but mono removed legacy support in  https://github.com/mono/mono/pull/17391 and made legacy = default = boring tls (so that solution won’t work anymore)
4. Tried getting msbuild via action (this didn’t make sense anyways, since we’re not on windows)
5. Tried forcing nugget action to use latest approved nuget version (latest is default anyways, so this shouldn’t affect anything)
6.Tried forcing nuget 5.5.0. For reference, setup-nuget, latest uses 5.4.0 (which isn’t actually latest)

Ultimately, the settled solution was to...
1. Manually call cert-sync to prevent cert issues
2. Update from Target framework 4.5 to 4.8 (and update mono.cecil). From chatting with co-workers, I learned that .Net 4.6+ supports ECDSA. The intermittent failures could be caused by some calls reaching ECDSA vs RSA hosts.