### PR TITLE
fix: Accept more methods as tail recursive

### DIFF
--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -1936,6 +1936,15 @@ namespace Microsoft.Dafny {
       }
     }
 
+    void TrStmtNonempty(Statement stmt, TargetWriter wr) {
+      Contract.Requires(stmt != null);
+      Contract.Requires(wr != null);
+      TrStmt(stmt, wr);
+      if (stmt.IsGhost) {
+        wr.WriteLine("{ }");
+      }
+    }
+
     void TrStmt(Statement stmt, TargetWriter wr) {
       Contract.Requires(stmt != null);
       Contract.Requires(wr != null);
@@ -2095,7 +2104,7 @@ namespace Microsoft.Dafny {
           TrStmtList(s.Thn.Body, thenWriter);
 
           if (s.Els != null) {
-            TrStmt(s.Els, wr);
+            TrStmtNonempty(s.Els, wr);
           }
         }
 

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -1943,7 +1943,6 @@ namespace Microsoft.Dafny {
       if (stmt.IsGhost) {
         var v = new CheckHasNoAssumes_Visitor(this, wr);
         v.Visit(stmt);
-        wr.WriteLine("{ }");
         return;
       }
       if (stmt is PrintStmt) {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -5971,7 +5971,7 @@ namespace Microsoft.Dafny
     TailRecursionStatus CheckTailRecursive(Statement stmt, Method enclosingMethod, ref CallStmt tailCall, bool reportErrors) {
       Contract.Requires(stmt != null);
       if (stmt.IsGhost) {
-        return TailRecursionStatus.NotTailRecursive;
+        return TailRecursionStatus.CanBeFollowedByAnything;
       }
       if (stmt is PrintStmt) {
       } else if (stmt is RevealStmt) {
@@ -7240,10 +7240,10 @@ namespace Microsoft.Dafny
               local.IsGhost = true;
             }
           }
-          s.IsGhost = (s.Update == null || s.Update.IsGhost) && s.Locals.All(v => v.IsGhost);
           if (s.Update != null) {
             Visit(s.Update, mustBeErasable);
           }
+          s.IsGhost = (s.Update == null || s.Update.IsGhost) && s.Locals.All(v => v.IsGhost);
 
         } else if (stmt is LetStmt) {
           var s = (LetStmt)stmt;

--- a/Test/comp/TailRecursion.dfy
+++ b/Test/comp/TailRecursion.dfy
@@ -52,6 +52,20 @@ method {:tailrecursion} TestMethod(n: nat, acc: nat) returns (r: nat) {
 method {:tailrecursion} GhostAfterCall(n: nat, acc: nat) returns (r: nat) {
   ghost var g := 10;
   if n == 0 {
+    // make sure ghost compilation doesn't produce malformed code
+    var u := 20;
+    if acc == 300 {
+      u := u + 1;
+    } else {
+      // empty (thus ghost) else
+    }
+    if acc == 300 {
+    } else if g < 25 {  // ghost if
+    }
+    if acc == 300 {
+      u := u + 1;
+    }  // this has an omitted else
+
     return acc;
   } else {
     r := GhostAfterCall(n - 1, acc + 1);
@@ -88,6 +102,8 @@ method {:tailrecursion} GhostAfterCall(n: nat, acc: nat) returns (r: nat) {
     }
     if n == 1 {
       label LabeledStatement: assert true;
+    }
+    while 15 < 14 {  // this compiles to nothing, since the whole statement is ghost
     }
   }
 }

--- a/Test/comp/TailRecursion.dfy
+++ b/Test/comp/TailRecursion.dfy
@@ -10,6 +10,10 @@ method Main() {
   var y := F(2_000_000, 0);
   print x, " ", y, "\n";  // 2_000_000 2_000_000
 
+  x := TestMethod(2_000_000, 0);  // too large argument without tail-calls
+  y := GhostAfterCall(2_000_000, 0);  // too large argument without tail-calls
+  print x, " ", y, "\n";  // 2_000_000 2_000_000
+
   // create a cycle of 2 links
   var l0 := new Link(0);
   var l1 := new Link(1);
@@ -27,7 +31,7 @@ method Main() {
 
 method {:tailrecursion} M(n: nat, a: nat) returns (r: nat) {
   if n == 0 {
-    return a;
+    r := a;
   } else {
     // do a test that would fail if the actual parameters are not first
     // computed into temporaries, before they are assigned to the formals
@@ -36,7 +40,60 @@ method {:tailrecursion} M(n: nat, a: nat) returns (r: nat) {
   }
 }
 
+method {:tailrecursion} TestMethod(n: nat, acc: nat) returns (r: nat) {
+  if n == 0 {
+    r := acc + 1;
+    return r - 1;
+  } else {
+    r := TestMethod(n - 1, acc + 1);
+  }
+}
+
+method {:tailrecursion} GhostAfterCall(n: nat, acc: nat) returns (r: nat) {
+  ghost var g := 10;
+  if n == 0 {
+    return acc;
+  } else {
+    r := GhostAfterCall(n - 1, acc + 1);
+    // all of what follows is ghost; this tests that nothing is emitted
+    // (Java would complain if any code were omitted after a "continue;")
+    ghost var gg := 10;
+    { }
+    { g := g + 1; }
+    { ghost var h := 8; g := g + 1; }
+    {
+      // if with ghost guards
+      if g % 2 == 0 {
+        // empty
+      } else if g % 3 == 0 {
+        g := g + 1;  // ghost assignment
+      }  // else omitted
+    }
+    {
+      // if with compilable guards
+      if n % 2 == 0 {
+        // empty
+      } else if n % 3 == 0 {
+        g := g + 1;  // ghost assignment
+      }  // else omitted
+    }
+    {
+      { }  // nested block
+      g := g + 1;
+      { ghost var i: int; }
+      { if n % 5 == 0 { } else { } }  // explicit else block
+    }
+    if n == 0 {
+      label LabeledBlock: { }
+    }
+    if n == 1 {
+      label LabeledStatement: assert true;
+    }
+  }
+}
+
 function method {:tailrecursion} F(n: nat, a: nat): nat {
+  ghost var irrelevantGhost := 10;
   if n == 0 then
     a
   else

--- a/Test/comp/TailRecursion.dfy.expect
+++ b/Test/comp/TailRecursion.dfy.expect
@@ -1,5 +1,6 @@
 
-Dafny program verifier finished with 18 verified, 0 errors
+Dafny program verifier finished with 20 verified, 0 errors
+2000000 2000000
 2000000 2000000
 1000000 1000000
 10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1 == 55
@@ -14,7 +15,8 @@ Sum(List.Cons(100, List.Cons(40, List.Cons(60, List.Nil)))) = 200
 TheBigSubtract(100) = -12
 TailNat(10) = 50
 
-Dafny program verifier finished with 18 verified, 0 errors
+Dafny program verifier finished with 20 verified, 0 errors
+2000000 2000000
 2000000 2000000
 1000000 1000000
 10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1 == 55
@@ -29,7 +31,8 @@ Sum(List.Cons(100, List.Cons(40, List.Cons(60, List.Nil)))) = 200
 TheBigSubtract(100) = -12
 TailNat(10) = 50
 
-Dafny program verifier finished with 18 verified, 0 errors
+Dafny program verifier finished with 20 verified, 0 errors
+2000000 2000000
 2000000 2000000
 1000000 1000000
 10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1 == 55
@@ -44,7 +47,8 @@ Sum(List.Cons(100, List.Cons(40, List.Cons(60, List.Nil)))) = 200
 TheBigSubtract(100) = -12
 TailNat(10) = 50
 
-Dafny program verifier finished with 18 verified, 0 errors
+Dafny program verifier finished with 20 verified, 0 errors
+2000000 2000000
 2000000 2000000
 1000000 1000000
 10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 + 2 + 1 == 55

--- a/Test/dafny0/TailCalls.dfy
+++ b/Test/dafny0/TailCalls.dfy
@@ -322,3 +322,30 @@ function method {:tailrecursion} TailChar(n: int): char
 {
   if n == 0 then 60 as char else TailChar(n - 1) + 1 as char  // error: because char is (currently) not supported in tail calls
 }
+
+// ------------ regression tests --------------------------
+
+method DoSomethingElse() {
+}
+
+method {:tailrecursion} MissingReport(n: nat, acc: nat) returns (r: nat)
+  ensures r == n + acc
+{
+  ghost var g := 10;  // this initial ghost statement once caused the rest of the method body to be ignored
+  if n == 0 {
+    return acc;
+  } else {
+    r := MissingReport(n - 1, acc + 1);  // error: not a tail call
+    DoSomethingElse();
+  }
+}
+
+method {:tailrecursion} NoRecursiveCalls(n: nat, acc: nat) returns (r: nat)
+  ensures r == n + acc
+{
+  ghost var g := 10;
+  var u := 8;
+  DoSomethingElse();
+  u := u + 3;
+  g := g + u;
+}

--- a/Test/dafny0/TailCalls.dfy
+++ b/Test/dafny0/TailCalls.dfy
@@ -323,7 +323,7 @@ function method {:tailrecursion} TailChar(n: int): char
   if n == 0 then 60 as char else TailChar(n - 1) + 1 as char  // error: because char is (currently) not supported in tail calls
 }
 
-// ------------ regression tests --------------------------
+// ------------ more methods --------------------------
 
 method DoSomethingElse() {
 }
@@ -348,4 +348,28 @@ method {:tailrecursion} NoRecursiveCalls(n: nat, acc: nat) returns (r: nat)
   DoSomethingElse();
   u := u + 3;
   g := g + u;
+}
+
+method {:tailrecursion} GhostLoop(n: nat) returns (r: nat) {
+  if n == 0 {
+    return 0;
+  } else {
+    r := GhostLoop(n - 1);  // yes, this is a tail call
+    while 15 < 14 {  // this is a ghost loop
+    }
+  }
+}
+
+method {:tailrecursion} NonGhostLoop(n: nat) returns (r: nat)
+  decreases *
+{
+  if n == 0 {
+    return 0;
+  } else {
+    r := NonGhostLoop(n - 1);  // error: not a tail call
+    while 15 < 14  // because of the "decreases *", this is not a ghost loop
+      decreases *
+    {
+    }
+  }
 }

--- a/Test/dafny0/TailCalls.dfy.expect
+++ b/Test/dafny0/TailCalls.dfy.expect
@@ -17,4 +17,5 @@ TailCalls.dfy(310,19): Error: to be tail recursive, every use of this function m
 TailCalls.dfy(316,24): Error: to be tail recursive, every use of this function must be part of a tail call or a simple accumulating tail call
 TailCalls.dfy(323,33): Error: to be tail recursive, every use of this function must be part of a tail call or a simple accumulating tail call
 TailCalls.dfy(338,22): Error: this recursive call is not recognized as being tail recursive, because it is followed by non-ghost code
-19 resolution/type errors detected in TailCalls.dfy
+TailCalls.dfy(369,21): Error: this recursive call is not recognized as being tail recursive, because it is followed by non-ghost code
+20 resolution/type errors detected in TailCalls.dfy

--- a/Test/dafny0/TailCalls.dfy.expect
+++ b/Test/dafny0/TailCalls.dfy.expect
@@ -16,4 +16,5 @@ TailCalls.dfy(288,14): Error: to be tail recursive, every use of this function m
 TailCalls.dfy(310,19): Error: to be tail recursive, every use of this function must be part of a tail call or a simple accumulating tail call
 TailCalls.dfy(316,24): Error: to be tail recursive, every use of this function must be part of a tail call or a simple accumulating tail call
 TailCalls.dfy(323,33): Error: to be tail recursive, every use of this function must be part of a tail call or a simple accumulating tail call
-18 resolution/type errors detected in TailCalls.dfy
+TailCalls.dfy(338,22): Error: this recursive call is not recognized as being tail recursive, because it is followed by non-ghost code
+19 resolution/type errors detected in TailCalls.dfy


### PR DESCRIPTION
This fix required fixing 3 things:

Previously, a ghost statement caused a statement list to be considered not-tail-recursive,
even without inspecting the subsequent statements.

Previously, the VarDeclStmt.IsGhost field was set to false whenever the was some initializing
assignments, even if ghost assignments were all ghost statements.

Previously, ghost statements would compile to empty `{ }` blocks, which could cause the Java
compiler to complain about unreachable code.