### PR TITLE
feat: Branch-coverage profiling

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2503,7 +2503,9 @@ namespace Microsoft.Dafny
 
       var idName = mainMethod.IsStatic ? IdName(mainMethod) : "_StaticMain";
 
+      Coverage.EmitSetup(wBody);
       wBody.WriteLine($"{GetHelperModuleName()}.WithHaltHandling({companion}.{idName});");
+      Coverage.EmitTearDown(wBody);
     }
   }
 }

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Dafny {
   public class GoCompiler : Compiler {
     public GoCompiler(ErrorReporter reporter)
     : base(reporter) {
+      if (DafnyOptions.O.CoverageLegendFile != null) {
+        Imports.Add(new Import {Name = "DafnyProfiling", Path = "DafnyProfiling"});
+      }
     }
 
     public override string TargetLanguage => "Go";
@@ -85,7 +88,9 @@ namespace Microsoft.Dafny {
 
       var wBody = wr.NewNamedBlock("func main()");
       wBody.WriteLine("defer _dafny.CatchHalt()");
+      Coverage.EmitSetup(wBody);
       wBody.WriteLine("{0}.{1}()", companion, IdName(mainMethod));
+      Coverage.EmitTearDown(wBody);
     }
 
     TargetWriter CreateDescribedSection(string desc, TargetWriter wr, params object[] args) {

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -319,7 +319,9 @@ namespace Microsoft.Dafny{
       var wBody = wr.NewNamedBlock("public static void main(String[] args)");
       var modName = mainMethod.EnclosingClass.Module.CompileName == "_module" ? "_System." : "";
       companion = modName + companion;
+      Coverage.EmitSetup(wBody);
       wBody.WriteLine($"{DafnyHelpersClass}.withHaltHandling({companion}::{IdName(mainMethod)});");
+      Coverage.EmitTearDown(wBody);
     }
 
     void EmitImports(TargetWriter wr, out TargetWriter importWriter){

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Dafny {
     }
 
     public override void EmitCallToMain(Method mainMethod, TargetWriter wr) {
+      Coverage.EmitSetup(wr);
       wr.WriteLine("_dafny.HandleHaltExceptions({0}.{1});", mainMethod.EnclosingClass.FullCompileName, IdName(mainMethod));
+      Coverage.EmitTearDown(wr);
     }
 
     protected override BlockTargetWriter CreateStaticMain(IClassWriter cw) {

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Dafny {
   public abstract class Compiler {
     public Compiler(ErrorReporter reporter) {
       Reporter = reporter;
+      Coverage = new CoverageInstrumenter(this);
     }
 
     public abstract string TargetLanguage { get; }
@@ -53,6 +54,8 @@ namespace Microsoft.Dafny {
     }
 
     public ErrorReporter Reporter;
+
+    public CoverageInstrumenter Coverage;
 
     protected void Error(Bpl.IToken tok, string msg, TextWriter/*?*/ wr, params object[] args) {
       Contract.Requires(msg != null);
@@ -291,7 +294,7 @@ namespace Microsoft.Dafny {
     /// The punctuation that comes at the end of a statement.  Note that
     /// statements are followed by newlines regardless.
     protected virtual string StmtTerminator { get => ";"; }
-    protected void EndStmt(TargetWriter wr) { wr.WriteLine(StmtTerminator); }
+    public void EndStmt(TargetWriter wr) { wr.WriteLine(StmtTerminator); }
     protected abstract void DeclareLocalOutVar(string name, Type type, Bpl.IToken tok, string rhs, bool useReturnStyleOuts, TargetWriter wr);
     protected virtual void EmitActualOutArg(string actualOutParamName, TextWriter wr) { }  // actualOutParamName is always the name of a local variable; called only for non-return-style outs
     protected virtual void EmitOutParameterSplits(string outCollector, List<string> actualOutParamNames, TargetWriter wr) { }  // called only for return-style calls
@@ -1307,12 +1310,14 @@ namespace Microsoft.Dafny {
     private void CompileMethod(Method m, IClassWriter cw) {
       Contract.Requires(cw != null);
       Contract.Requires(m != null);
+      Contract.Requires(m.Body != null);
 
       var w = cw.CreateMethod(m, !m.IsExtern(out _, out _));
       if (w != null) {
         if (m.IsTailRecursive) {
           w = EmitTailCallStructure(m, w);
         }
+        Coverage.Instrument(m.Body.Tok, $"entry to method {m.FullName}", w);
 
         int nonGhostOutsCount = 0;
         foreach (var p in m.Outs) {
@@ -1445,7 +1450,7 @@ namespace Microsoft.Dafny {
         var thn = EmitIf(out guardWriter, true, wr);
         TrExpr(e.Test, guardWriter, false);
         TrExprOpt(e.Thn, thn, accumulatorVar);
-        var els = wr.NewBlock("");
+        var els = wr.NewBlock("", null, BlockTargetWriter.BraceStyle.Nothing);
         TrExprOpt(e.Els, els, accumulatorVar);
 
       } else if (expr is MatchExpr) {
@@ -2083,26 +2088,41 @@ namespace Microsoft.Dafny {
           if (s.Els == null) {
             // let's compile the "else" branch, since that involves no work
             // (still, let's leave a marker in the source code to indicate that this is what we did)
+            Coverage.UnusedInstrumentationPoint(s.Thn.Tok, "then branch");
+            wr = wr.NewBlock("if (!false) ");
+            Coverage.Instrument(s.Tok, "implicit else branch", wr);
             wr.WriteLine("if (!false) { }");
           } else {
             // let's compile the "then" branch
-            wr.Write("if (true) ");
-            TrStmt(s.Thn, wr);
+            wr = wr.NewBlock("if (true) ");
+            Coverage.Instrument(s.Thn.Tok, "then branch", wr);
+            TrStmtList(s.Thn.Body, wr);
+            Coverage.UnusedInstrumentationPoint(s.Els.Tok, "else branch");
           }
         } else {
           if (s.IsBindingGuard && DafnyOptions.O.ForbidNondeterminism) {
             Error(s.Tok, "binding if statement forbidden by /definiteAssignment:3 option", wr);
           }
           TargetWriter guardWriter;
-          var thenWriter = EmitIf(out guardWriter, s.Els != null, wr);
+          var coverageForElse = Coverage.IsRecording && !(s.Els is IfStmt);
+          var thenWriter = EmitIf(out guardWriter, s.Els != null || coverageForElse, wr);
           TrExpr(s.IsBindingGuard ? Translator.AlphaRename((ExistsExpr)s.Guard, "eg_d") : s.Guard, guardWriter, false);
 
           // We'd like to do "TrStmt(s.Thn, indent)", except we want the scope of any existential variables to come inside the block
           if (s.IsBindingGuard) {
             IntroduceAndAssignBoundVars((ExistsExpr)s.Guard, thenWriter);
           }
+          Coverage.Instrument(s.Thn.Tok, "then branch", thenWriter);
           TrStmtList(s.Thn.Body, thenWriter);
 
+          if (coverageForElse) {
+            wr = wr.NewBlock("", null, BlockTargetWriter.BraceStyle.Nothing);
+            if (s.Els == null) {
+              Coverage.Instrument(s.Tok, "implicit else branch", wr);
+            } else {
+              Coverage.Instrument(s.Els.Tok, "else branch", wr);
+            }
+          }
           if (s.Els != null) {
             TrStmtNonempty(s.Els, wr);
           }
@@ -4084,6 +4104,86 @@ namespace Microsoft.Dafny {
       Contract.Requires(otherFileNames.Count == 0 || targetFilename != null);
       Contract.Requires(outputWriter != null);
       return true;
+    }
+  }
+
+  public class CoverageInstrumenter
+  {
+    private readonly Compiler compiler;
+    private List<(Bpl.IToken, string)>/*?*/ legend;  // non-null implies DafnyOptions.O.CoverageLegendFile is non-null
+
+    public CoverageInstrumenter(Compiler compiler) {
+      this.compiler = compiler;
+      if (DafnyOptions.O.CoverageLegendFile != null) {
+        legend = new List<(Bpl.IToken, string)>();
+      }
+    }
+
+    public bool IsRecording {
+      get => legend != null;
+    }
+
+    public void Instrument(Bpl.IToken tok, string description, TargetWriter wr) {
+      Contract.Requires(tok != null);
+      Contract.Requires(description != null);
+      Contract.Requires(wr != null || !IsRecording);
+      if (legend != null) {
+        wr.Write("DafnyProfiling.CodeCoverage.Record({0})", legend.Count);
+        compiler.EndStmt(wr);
+        legend.Add((tok, description));
+      }
+    }
+
+    public void UnusedInstrumentationPoint(Bpl.IToken tok, string description) {
+      Contract.Requires(tok != null);
+      Contract.Requires(description != null);
+      if (legend != null) {
+        legend.Add((tok, description));
+      }
+    }
+
+    public void InstrumentExpr(Bpl.IToken tok, string description, bool resultValue, TargetWriter wr) {
+      Contract.Requires(tok != null);
+      Contract.Requires(description != null);
+      Contract.Requires(wr != null || !IsRecording);
+      if (legend != null) {
+        // The "Record" call always returns "true", so we negate it to get the value "false"
+        wr.Write("{1}DafnyProfiling.CodeCoverage.Record({0})", legend.Count, resultValue ? "" : "!");
+        legend.Add((tok, description));
+      }
+    }
+
+    /// <summary>
+    /// Should be called once "n" has reached its final value
+    /// </summary>
+    public void EmitSetup(TargetWriter wr) {
+      Contract.Requires(wr != null);
+      if (legend != null) {
+        wr.Write("DafnyProfiling.CodeCoverage.Setup({0})", legend.Count);
+        compiler.EndStmt(wr);
+      }
+    }
+
+    public void EmitTearDown(TargetWriter wr) {
+      Contract.Requires(wr != null);
+      if (legend != null) {
+        wr.Write("DafnyProfiling.CodeCoverage.TearDown()");
+        compiler.EndStmt(wr);
+      }
+    }
+
+    public void WriteLegendFile() {
+      if (legend != null) {
+        var filename = DafnyOptions.O.CoverageLegendFile;
+        Contract.Assert(filename != null);
+        using (TextWriter wr = filename == "-" ? System.Console.Out : new StreamWriter(new FileStream(Path.GetFullPath(filename), System.IO.FileMode.Create))) {
+          for (var i = 0; i < legend.Count; i++) {
+            var e = legend[i];
+            wr.WriteLine("{0}: {1}({2},{3}): {4}", i, e.Item1.filename, e.Item1.line, e.Item1.col, e.Item2);
+          }
+        }
+        legend = null;
+      }
     }
   }
 

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Dafny
     public CompilationTarget CompileTarget = CompilationTarget.Csharp;
     public bool CompileVerbose = true;
     public string DafnyPrintCompiledFile = null;
+    public string CoverageLegendFile = null;
     public bool ForceCompile = false;
     public bool RunAfterCompile = false;
     public int SpillTargetCode = 0;  // [0..4]
@@ -217,6 +218,13 @@ namespace Microsoft.Dafny
             }
             return true;
           }
+
+        case "coverage": {
+          if (ps.ConfirmArgumentCount(1)) {
+            CoverageLegendFile = args[ps.i];
+          }
+          return true;
+        }
 
         case "dafnycc":
           Dafnycc = true;
@@ -677,6 +685,11 @@ namespace Microsoft.Dafny
                 higher, if manually specified).
   /out:<file>
                 filename and location for the generated .cs, .dll or .exe files
+  /coverage:<file>
+                The compiler emits branch-coverage calls and outputs into
+                <file> a legend that gives a description of each
+                source-location identifier used in the branch-coverage calls.
+                (use - as <file> to print to console)
   /dafnycc      Disable features not supported by DafnyCC
   /noCheating:<n>
                 0 (default) - allow assume statements and free invariants

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -602,6 +602,8 @@ namespace Microsoft.Dafny
       }
       bool completeProgram = dafnyProgram.reporter.Count(ErrorLevel.Error) == oldErrorCount;
 
+      compiler.Coverage.WriteLegendFile();
+
       // blurt out the code to a file, if requested, or if other files were specified for the C# command line.
       string targetFilename = null;
       if (DafnyOptions.O.SpillTargetCode > 0 || otherFileNames.Count > 0 || (invokeCompiler && !compiler.SupportsInMemoryCompilation))

--- a/Test/comp/BranchCoverage.dfy
+++ b/Test/comp/BranchCoverage.dfy
@@ -1,7 +1,7 @@
-// RUN: %dafny /compile:3 /coverage:tmp.out /spillTargetCode:1 /compileTarget:java CodeCoverage.java "%s" > "%t"
-// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" >> "%t"
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" > "%t"
 // RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:js BranchCoverage3.js "%s" >> "%t"
 // RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:go BranchCoverage4.go "%s" >> "%t"
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:java CodeCoverage.java "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The Main method is at the end of this file, because that makes it easier to maintain

--- a/Test/comp/BranchCoverage.dfy
+++ b/Test/comp/BranchCoverage.dfy
@@ -1,32 +1,25 @@
 // RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-method Main() {
-  // we get here 1 time
-  var y := M(5);
-  y := M(y);
-  y := M(y);
+// The Main method is at the end of this file, because that makes it easier to maintain
+// this test file when adding more tests.
 
-  y := N(5);
-  y := N(y);
-  y := N(y);
+// ---------- class constructor ----------
 
-  P(5);
-
-  // do else-if correctly
-  // if-then-else expressions
-  // &&, ||, ==>, <==
-  // if-case
-  // if *
-  // while
-  // match
-  // beginning of functions, methods, including tail recursion?
-  // beginning of forall/exists bodies, set comprehensions, map comprehensions
-  // beginning of labmdas
+class MyClass {
+  constructor () {  // 3 times
+  }
 }
+
+// ---------- routines that are never called ----------
 
 method NeverCalled() {
   // we get here 0 times
+}
+
+function method FunctionNeverCalled(): int {
+  // we get here 0 times
+  75
 }
 
 // ---------- if ----------
@@ -79,4 +72,126 @@ method P(x: int) {
     // we get here 0 times
     y := y + 1;
   }  // implicit else: 1 time
+}
+
+// ---------- if case ----------
+
+method Q(x: int) returns (y: int) {
+  // we get here 3 times
+
+  // the following statement is all ghost, so there are no coverage locations in it
+  if {
+    case x < 100 =>
+    case x < 1000 =>
+      assert x < 1_000_000;
+    case 50 <= x =>
+  }
+
+  if
+  case x < 100 =>
+    // we get here 1 time
+  case x < 1000 =>
+    // we get here 1 time, since the compiler lays down the cases in order
+    return 8;
+  case 50 <= x =>
+    // we get here 1 time
+}
+
+// ---------- while ----------
+
+method R(x: int) returns (y: int) {
+  // we get here 1 time
+  var i: nat := 0;
+  while i < x {
+    // we get here 111 times
+    i := i + 1;
+  }
+
+  while * {
+    // we get here 0 times
+    break;
+  }
+
+  while
+    decreases i
+  {
+    case i % 2 == 0 =>
+      // we get here 56 times
+      if i == 0 {
+        // we get here 1 time
+        break;
+      }  // implicit else: 55 times
+      i := i - 1;
+    case i % 4 == 1 =>
+      // we get here 28 times
+      i := i - 1;
+    case 0 < i =>
+      // we get here 28 times
+      i := i - 1;
+  }
+
+  return 40;
+}
+
+// ---------- top-level if-then-else ----------
+
+function method Fib(n: nat): nat {
+  // we get here 465 times
+  if n < 2 then  // then: 233 times
+    n
+  else if false then  // then: 0 times (else-if is omitted)
+    8
+  else  // else: 232 times
+    Fib(n - 2) + Fib(n - 1)
+}
+
+// ---------- top-level match expression, match statement, and tail recursion ----------
+
+function method {:tailrecursion} Factorial(n: nat): nat {
+  // 11 times
+  match n
+  case 0 => 1  // 1 time
+  case _ => n * Factorial(n - 1)  // 10 times
+}
+
+method {:tailrecursion} ComputeFactorial(n: nat, acc: nat) returns (f: nat)
+  ensures f == Factorial(n) * acc
+{
+  // 11 times
+  match n
+  case 0 =>  // 1 time
+    return acc;
+  case _ =>  // 10 times
+    f := ComputeFactorial(n - 1, acc * n);
+}
+
+// ---------- Main ----------
+
+method Main() {
+  // we get here 1 time
+
+  var mc := new MyClass();
+  mc := new MyClass();
+  mc := new MyClass();
+
+  var y := M(5);
+  y := M(y);
+  y := M(y);
+
+  y := N(5);
+  y := N(y);
+  y := N(y);
+
+  P(5);
+
+  y := Q(50);
+  y := Q(101);
+  y := Q(1010);
+
+  y := R(111);
+
+  y := Fib(12);
+
+  y := Factorial(10);
+  y := ComputeFactorial(10, 1);
 }

--- a/Test/comp/BranchCoverage.dfy
+++ b/Test/comp/BranchCoverage.dfy
@@ -1,7 +1,7 @@
-// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" > "%t"
+// RUN: %dafny /compile:3 /coverage:tmp.out /spillTargetCode:1 /compileTarget:java CodeCoverage.java "%s" > "%t"
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" >> "%t"
 // RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:js BranchCoverage3.js "%s" >> "%t"
 // RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:go BranchCoverage4.go "%s" >> "%t"
-// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:java CodeCoverage.java "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The Main method is at the end of this file, because that makes it easier to maintain

--- a/Test/comp/BranchCoverage.dfy
+++ b/Test/comp/BranchCoverage.dfy
@@ -1,4 +1,7 @@
 // RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" > "%t"
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:js BranchCoverage3.js "%s" >> "%t"
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:go BranchCoverage4.go "%s" >> "%t"
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:java CodeCoverage.java "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The Main method is at the end of this file, because that makes it easier to maintain

--- a/Test/comp/BranchCoverage.dfy
+++ b/Test/comp/BranchCoverage.dfy
@@ -1,0 +1,82 @@
+// RUN: %dafny /compile:3 /coverage:- /spillTargetCode:1 /compileTarget:cs BranchCoverage2.cs "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Main() {
+  // we get here 1 time
+  var y := M(5);
+  y := M(y);
+  y := M(y);
+
+  y := N(5);
+  y := N(y);
+  y := N(y);
+
+  P(5);
+
+  // do else-if correctly
+  // if-then-else expressions
+  // &&, ||, ==>, <==
+  // if-case
+  // if *
+  // while
+  // match
+  // beginning of functions, methods, including tail recursion?
+  // beginning of forall/exists bodies, set comprehensions, map comprehensions
+  // beginning of labmdas
+}
+
+method NeverCalled() {
+  // we get here 0 times
+}
+
+// ---------- if ----------
+
+method M(x: int) returns (y: int) {
+  // we get here 3 times
+  if x < 10 {
+    return x + 20;  // we get here 1 time
+  } else if x < 20 {  // note: the location between th "else" and the "if" does not get recorded
+    return x + 20;  // we get here 0 times
+  } else {
+    return 100;  // we get here 2 times
+  }
+}
+
+method N(x: int) returns (y: int) {
+  // we get here 3 times
+  y := 100;
+  if x < 10 {
+    return x + 20;  // we get here 1 time
+  } else if x < 20 {  // note: the location between th "else" and the "if" does not get recorded
+    return x + 20;  // we get here 0 times
+  }  // we get to this implicit else 2 times
+}
+
+
+method P(x: int) {
+  // we get here 1 time
+  var y := 100;
+  if * {
+    // we get here 0 times, because the compiler picks the other branch, which is empty
+    y := y + 2;
+  }  // we get to the implicit else 1 time
+
+  if * {
+    // we get here 1 time
+  } else {
+    // we get here 0 times, because the compiler picks the other branch, which is empty
+    y := y + 2;
+  }
+
+  // the following if is all ghost, so there are no branch-coverage locations in it
+  if x < 2 {
+  } else if * {
+  }
+
+  if x < 2 {
+    // get here 0 times
+  } else if * {
+    // we get here 0 times
+    y := y + 1;
+  }  // implicit else: 1 time
+}

--- a/Test/comp/BranchCoverage.dfy.expect
+++ b/Test/comp/BranchCoverage.dfy.expect
@@ -1,47 +1,305 @@
 
 Dafny program verifier finished with 6 verified, 0 errors
-0: BranchCoverage.dfy(10,18): entry to method _module.MyClass._ctor
-1: BranchCoverage.dfy(16,22): entry to method _module._default.NeverCalled
-2: BranchCoverage.dfy(22,3): entry to function _module._default.FunctionNeverCalled
-3: BranchCoverage.dfy(27,35): entry to method _module._default.M
-4: BranchCoverage.dfy(29,13): then branch
-5: BranchCoverage.dfy(31,20): then branch
-6: BranchCoverage.dfy(33,10): else branch
-7: BranchCoverage.dfy(38,35): entry to method _module._default.N
-8: BranchCoverage.dfy(41,13): then branch
-9: BranchCoverage.dfy(43,20): then branch
-10: BranchCoverage.dfy(43,10): implicit else branch
-11: BranchCoverage.dfy(49,18): entry to method _module._default.P
-12: BranchCoverage.dfy(52,8): then branch
-13: BranchCoverage.dfy(52,3): implicit else branch
-14: BranchCoverage.dfy(57,8): then branch
-15: BranchCoverage.dfy(59,10): else branch
-16: BranchCoverage.dfy(69,12): then branch
-17: BranchCoverage.dfy(71,15): then branch
-18: BranchCoverage.dfy(71,10): implicit else branch
-19: BranchCoverage.dfy(79,35): entry to method _module._default.Q
-20: BranchCoverage.dfy(91,3): if-case branch
-21: BranchCoverage.dfy(93,3): if-case branch
-22: BranchCoverage.dfy(96,3): if-case branch
-23: BranchCoverage.dfy(102,35): entry to method _module._default.R
-24: BranchCoverage.dfy(105,15): while body
-25: BranchCoverage.dfy(110,11): while body
-26: BranchCoverage.dfy(118,5): while-case branch
-27: BranchCoverage.dfy(120,17): then branch
-28: BranchCoverage.dfy(120,7): implicit else branch
-29: BranchCoverage.dfy(125,5): while-case branch
-30: BranchCoverage.dfy(128,5): while-case branch
-31: BranchCoverage.dfy(140,3): entry to function _module._default.Fib
-32: BranchCoverage.dfy(141,5): then branch
-33: BranchCoverage.dfy(143,5): then branch
-34: BranchCoverage.dfy(143,5): else branch
-35: BranchCoverage.dfy(152,3): entry to function _module._default.Factorial
-36: BranchCoverage.dfy(153,13): then branch
-37: BranchCoverage.dfy(153,13): else branch
-38: BranchCoverage.dfy(159,1): entry to method _module._default.ComputeFactorial
-39: BranchCoverage.dfy(162,3): then branch
-40: BranchCoverage.dfy(164,3): else branch
-41: BranchCoverage.dfy(170,15): entry to method _module._default.Main
+0: BranchCoverage.dfy(13,18): entry to method _module.MyClass._ctor
+1: BranchCoverage.dfy(19,22): entry to method _module._default.NeverCalled
+2: BranchCoverage.dfy(25,3): entry to function _module._default.FunctionNeverCalled
+3: BranchCoverage.dfy(30,35): entry to method _module._default.M
+4: BranchCoverage.dfy(32,13): then branch
+5: BranchCoverage.dfy(34,20): then branch
+6: BranchCoverage.dfy(36,10): else branch
+7: BranchCoverage.dfy(41,35): entry to method _module._default.N
+8: BranchCoverage.dfy(44,13): then branch
+9: BranchCoverage.dfy(46,20): then branch
+10: BranchCoverage.dfy(46,10): implicit else branch
+11: BranchCoverage.dfy(52,18): entry to method _module._default.P
+12: BranchCoverage.dfy(55,8): then branch
+13: BranchCoverage.dfy(55,3): implicit else branch
+14: BranchCoverage.dfy(60,8): then branch
+15: BranchCoverage.dfy(62,10): else branch
+16: BranchCoverage.dfy(72,12): then branch
+17: BranchCoverage.dfy(74,15): then branch
+18: BranchCoverage.dfy(74,10): implicit else branch
+19: BranchCoverage.dfy(82,35): entry to method _module._default.Q
+20: BranchCoverage.dfy(94,3): if-case branch
+21: BranchCoverage.dfy(96,3): if-case branch
+22: BranchCoverage.dfy(99,3): if-case branch
+23: BranchCoverage.dfy(105,35): entry to method _module._default.R
+24: BranchCoverage.dfy(108,15): while body
+25: BranchCoverage.dfy(113,11): while body
+26: BranchCoverage.dfy(121,5): while-case branch
+27: BranchCoverage.dfy(123,17): then branch
+28: BranchCoverage.dfy(123,7): implicit else branch
+29: BranchCoverage.dfy(128,5): while-case branch
+30: BranchCoverage.dfy(131,5): while-case branch
+31: BranchCoverage.dfy(143,3): entry to function _module._default.Fib
+32: BranchCoverage.dfy(144,5): then branch
+33: BranchCoverage.dfy(146,5): then branch
+34: BranchCoverage.dfy(146,5): else branch
+35: BranchCoverage.dfy(155,3): entry to function _module._default.Factorial
+36: BranchCoverage.dfy(156,13): then branch
+37: BranchCoverage.dfy(156,13): else branch
+38: BranchCoverage.dfy(162,1): entry to method _module._default.ComputeFactorial
+39: BranchCoverage.dfy(165,3): then branch
+40: BranchCoverage.dfy(167,3): else branch
+41: BranchCoverage.dfy(173,15): entry to method _module._default.Main
+0: 3
+1: 0
+2: 0
+3: 3
+4: 1
+5: 0
+6: 2
+7: 3
+8: 1
+9: 0
+10: 2
+11: 1
+12: 0
+13: 1
+14: 1
+15: 0
+16: 0
+17: 0
+18: 1
+19: 3
+20: 1
+21: 1
+22: 1
+23: 1
+24: 111
+25: 0
+26: 56
+27: 1
+28: 55
+29: 28
+30: 28
+31: 465
+32: 233
+33: 0
+34: 232
+35: 11
+36: 1
+37: 10
+38: 11
+39: 1
+40: 10
+41: 1
+
+Dafny program verifier finished with 6 verified, 0 errors
+0: BranchCoverage.dfy(13,18): entry to method _module.MyClass._ctor
+1: BranchCoverage.dfy(19,22): entry to method _module._default.NeverCalled
+2: BranchCoverage.dfy(25,3): entry to function _module._default.FunctionNeverCalled
+3: BranchCoverage.dfy(30,35): entry to method _module._default.M
+4: BranchCoverage.dfy(32,13): then branch
+5: BranchCoverage.dfy(34,20): then branch
+6: BranchCoverage.dfy(36,10): else branch
+7: BranchCoverage.dfy(41,35): entry to method _module._default.N
+8: BranchCoverage.dfy(44,13): then branch
+9: BranchCoverage.dfy(46,20): then branch
+10: BranchCoverage.dfy(46,10): implicit else branch
+11: BranchCoverage.dfy(52,18): entry to method _module._default.P
+12: BranchCoverage.dfy(55,8): then branch
+13: BranchCoverage.dfy(55,3): implicit else branch
+14: BranchCoverage.dfy(60,8): then branch
+15: BranchCoverage.dfy(62,10): else branch
+16: BranchCoverage.dfy(72,12): then branch
+17: BranchCoverage.dfy(74,15): then branch
+18: BranchCoverage.dfy(74,10): implicit else branch
+19: BranchCoverage.dfy(82,35): entry to method _module._default.Q
+20: BranchCoverage.dfy(94,3): if-case branch
+21: BranchCoverage.dfy(96,3): if-case branch
+22: BranchCoverage.dfy(99,3): if-case branch
+23: BranchCoverage.dfy(105,35): entry to method _module._default.R
+24: BranchCoverage.dfy(108,15): while body
+25: BranchCoverage.dfy(113,11): while body
+26: BranchCoverage.dfy(121,5): while-case branch
+27: BranchCoverage.dfy(123,17): then branch
+28: BranchCoverage.dfy(123,7): implicit else branch
+29: BranchCoverage.dfy(128,5): while-case branch
+30: BranchCoverage.dfy(131,5): while-case branch
+31: BranchCoverage.dfy(143,3): entry to function _module._default.Fib
+32: BranchCoverage.dfy(144,5): then branch
+33: BranchCoverage.dfy(146,5): then branch
+34: BranchCoverage.dfy(146,5): else branch
+35: BranchCoverage.dfy(155,3): entry to function _module._default.Factorial
+36: BranchCoverage.dfy(156,13): then branch
+37: BranchCoverage.dfy(156,13): else branch
+38: BranchCoverage.dfy(162,1): entry to method _module._default.ComputeFactorial
+39: BranchCoverage.dfy(165,3): then branch
+40: BranchCoverage.dfy(167,3): else branch
+41: BranchCoverage.dfy(173,15): entry to method _module._default.Main
+0: 3
+1: 0
+2: 0
+3: 3
+4: 1
+5: 0
+6: 2
+7: 3
+8: 1
+9: 0
+10: 2
+11: 1
+12: 0
+13: 1
+14: 1
+15: 0
+16: 0
+17: 0
+18: 1
+19: 3
+20: 1
+21: 1
+22: 1
+23: 1
+24: 111
+25: 0
+26: 56
+27: 1
+28: 55
+29: 28
+30: 28
+31: 465
+32: 233
+33: 0
+34: 232
+35: 11
+36: 1
+37: 10
+38: 11
+39: 1
+40: 10
+41: 1
+
+Dafny program verifier finished with 6 verified, 0 errors
+0: BranchCoverage.dfy(13,18): entry to method _module.MyClass._ctor
+1: BranchCoverage.dfy(19,22): entry to method _module._default.NeverCalled
+2: BranchCoverage.dfy(25,3): entry to function _module._default.FunctionNeverCalled
+3: BranchCoverage.dfy(30,35): entry to method _module._default.M
+4: BranchCoverage.dfy(32,13): then branch
+5: BranchCoverage.dfy(34,20): then branch
+6: BranchCoverage.dfy(36,10): else branch
+7: BranchCoverage.dfy(41,35): entry to method _module._default.N
+8: BranchCoverage.dfy(44,13): then branch
+9: BranchCoverage.dfy(46,20): then branch
+10: BranchCoverage.dfy(46,10): implicit else branch
+11: BranchCoverage.dfy(52,18): entry to method _module._default.P
+12: BranchCoverage.dfy(55,8): then branch
+13: BranchCoverage.dfy(55,3): implicit else branch
+14: BranchCoverage.dfy(60,8): then branch
+15: BranchCoverage.dfy(62,10): else branch
+16: BranchCoverage.dfy(72,12): then branch
+17: BranchCoverage.dfy(74,15): then branch
+18: BranchCoverage.dfy(74,10): implicit else branch
+19: BranchCoverage.dfy(82,35): entry to method _module._default.Q
+20: BranchCoverage.dfy(94,3): if-case branch
+21: BranchCoverage.dfy(96,3): if-case branch
+22: BranchCoverage.dfy(99,3): if-case branch
+23: BranchCoverage.dfy(105,35): entry to method _module._default.R
+24: BranchCoverage.dfy(108,15): while body
+25: BranchCoverage.dfy(113,11): while body
+26: BranchCoverage.dfy(121,5): while-case branch
+27: BranchCoverage.dfy(123,17): then branch
+28: BranchCoverage.dfy(123,7): implicit else branch
+29: BranchCoverage.dfy(128,5): while-case branch
+30: BranchCoverage.dfy(131,5): while-case branch
+31: BranchCoverage.dfy(143,3): entry to function _module._default.Fib
+32: BranchCoverage.dfy(144,5): then branch
+33: BranchCoverage.dfy(146,5): then branch
+34: BranchCoverage.dfy(146,5): else branch
+35: BranchCoverage.dfy(155,3): entry to function _module._default.Factorial
+36: BranchCoverage.dfy(156,13): then branch
+37: BranchCoverage.dfy(156,13): else branch
+38: BranchCoverage.dfy(162,1): entry to method _module._default.ComputeFactorial
+39: BranchCoverage.dfy(165,3): then branch
+40: BranchCoverage.dfy(167,3): else branch
+41: BranchCoverage.dfy(173,15): entry to method _module._default.Main
+0: 3
+1: 0
+2: 0
+3: 3
+4: 1
+5: 0
+6: 2
+7: 3
+8: 1
+9: 0
+10: 2
+11: 1
+12: 0
+13: 1
+14: 1
+15: 0
+16: 0
+17: 0
+18: 1
+19: 3
+20: 1
+21: 1
+22: 1
+23: 1
+24: 111
+25: 0
+26: 56
+27: 1
+28: 55
+29: 28
+30: 28
+31: 465
+32: 233
+33: 0
+34: 232
+35: 11
+36: 1
+37: 10
+38: 11
+39: 1
+40: 10
+41: 1
+
+Dafny program verifier finished with 6 verified, 0 errors
+0: BranchCoverage.dfy(13,18): entry to method _module.MyClass._ctor
+1: BranchCoverage.dfy(19,22): entry to method _module._default.NeverCalled
+2: BranchCoverage.dfy(25,3): entry to function _module._default.FunctionNeverCalled
+3: BranchCoverage.dfy(30,35): entry to method _module._default.M
+4: BranchCoverage.dfy(32,13): then branch
+5: BranchCoverage.dfy(34,20): then branch
+6: BranchCoverage.dfy(36,10): else branch
+7: BranchCoverage.dfy(41,35): entry to method _module._default.N
+8: BranchCoverage.dfy(44,13): then branch
+9: BranchCoverage.dfy(46,20): then branch
+10: BranchCoverage.dfy(46,10): implicit else branch
+11: BranchCoverage.dfy(52,18): entry to method _module._default.P
+12: BranchCoverage.dfy(55,8): then branch
+13: BranchCoverage.dfy(55,3): implicit else branch
+14: BranchCoverage.dfy(60,8): then branch
+15: BranchCoverage.dfy(62,10): else branch
+16: BranchCoverage.dfy(72,12): then branch
+17: BranchCoverage.dfy(74,15): then branch
+18: BranchCoverage.dfy(74,10): implicit else branch
+19: BranchCoverage.dfy(82,35): entry to method _module._default.Q
+20: BranchCoverage.dfy(94,3): if-case branch
+21: BranchCoverage.dfy(96,3): if-case branch
+22: BranchCoverage.dfy(99,3): if-case branch
+23: BranchCoverage.dfy(105,35): entry to method _module._default.R
+24: BranchCoverage.dfy(108,15): while body
+25: BranchCoverage.dfy(113,11): while body
+26: BranchCoverage.dfy(121,5): while-case branch
+27: BranchCoverage.dfy(123,17): then branch
+28: BranchCoverage.dfy(123,7): implicit else branch
+29: BranchCoverage.dfy(128,5): while-case branch
+30: BranchCoverage.dfy(131,5): while-case branch
+31: BranchCoverage.dfy(143,3): entry to function _module._default.Fib
+32: BranchCoverage.dfy(144,5): then branch
+33: BranchCoverage.dfy(146,5): then branch
+34: BranchCoverage.dfy(146,5): else branch
+35: BranchCoverage.dfy(155,3): entry to function _module._default.Factorial
+36: BranchCoverage.dfy(156,13): then branch
+37: BranchCoverage.dfy(156,13): else branch
+38: BranchCoverage.dfy(162,1): entry to method _module._default.ComputeFactorial
+39: BranchCoverage.dfy(165,3): then branch
+40: BranchCoverage.dfy(167,3): else branch
+41: BranchCoverage.dfy(173,15): entry to method _module._default.Main
 0: 3
 1: 0
 2: 0

--- a/Test/comp/BranchCoverage.dfy.expect
+++ b/Test/comp/BranchCoverage.dfy.expect
@@ -1,38 +1,86 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
-0: BranchCoverage.dfy(4,15): entry to method _module._default.Main
-1: BranchCoverage.dfy(28,22): entry to method _module._default.NeverCalled
-2: BranchCoverage.dfy(34,35): entry to method _module._default.M
-3: BranchCoverage.dfy(36,13): then branch
-4: BranchCoverage.dfy(38,20): then branch
-5: BranchCoverage.dfy(40,10): else branch
-6: BranchCoverage.dfy(45,35): entry to method _module._default.N
-7: BranchCoverage.dfy(48,13): then branch
-8: BranchCoverage.dfy(50,20): then branch
-9: BranchCoverage.dfy(50,10): implicit else branch
-10: BranchCoverage.dfy(56,18): entry to method _module._default.P
-11: BranchCoverage.dfy(59,8): then branch
-12: BranchCoverage.dfy(59,3): implicit else branch
-13: BranchCoverage.dfy(64,8): then branch
-14: BranchCoverage.dfy(66,10): else branch
-15: BranchCoverage.dfy(76,12): then branch
-16: BranchCoverage.dfy(78,15): then branch
-17: BranchCoverage.dfy(78,10): implicit else branch
-0: 1
+Dafny program verifier finished with 6 verified, 0 errors
+0: BranchCoverage.dfy(10,18): entry to method _module.MyClass._ctor
+1: BranchCoverage.dfy(16,22): entry to method _module._default.NeverCalled
+2: BranchCoverage.dfy(22,3): entry to function _module._default.FunctionNeverCalled
+3: BranchCoverage.dfy(27,35): entry to method _module._default.M
+4: BranchCoverage.dfy(29,13): then branch
+5: BranchCoverage.dfy(31,20): then branch
+6: BranchCoverage.dfy(33,10): else branch
+7: BranchCoverage.dfy(38,35): entry to method _module._default.N
+8: BranchCoverage.dfy(41,13): then branch
+9: BranchCoverage.dfy(43,20): then branch
+10: BranchCoverage.dfy(43,10): implicit else branch
+11: BranchCoverage.dfy(49,18): entry to method _module._default.P
+12: BranchCoverage.dfy(52,8): then branch
+13: BranchCoverage.dfy(52,3): implicit else branch
+14: BranchCoverage.dfy(57,8): then branch
+15: BranchCoverage.dfy(59,10): else branch
+16: BranchCoverage.dfy(69,12): then branch
+17: BranchCoverage.dfy(71,15): then branch
+18: BranchCoverage.dfy(71,10): implicit else branch
+19: BranchCoverage.dfy(79,35): entry to method _module._default.Q
+20: BranchCoverage.dfy(91,3): if-case branch
+21: BranchCoverage.dfy(93,3): if-case branch
+22: BranchCoverage.dfy(96,3): if-case branch
+23: BranchCoverage.dfy(102,35): entry to method _module._default.R
+24: BranchCoverage.dfy(105,15): while body
+25: BranchCoverage.dfy(110,11): while body
+26: BranchCoverage.dfy(118,5): while-case branch
+27: BranchCoverage.dfy(120,17): then branch
+28: BranchCoverage.dfy(120,7): implicit else branch
+29: BranchCoverage.dfy(125,5): while-case branch
+30: BranchCoverage.dfy(128,5): while-case branch
+31: BranchCoverage.dfy(140,3): entry to function _module._default.Fib
+32: BranchCoverage.dfy(141,5): then branch
+33: BranchCoverage.dfy(143,5): then branch
+34: BranchCoverage.dfy(143,5): else branch
+35: BranchCoverage.dfy(152,3): entry to function _module._default.Factorial
+36: BranchCoverage.dfy(153,13): then branch
+37: BranchCoverage.dfy(153,13): else branch
+38: BranchCoverage.dfy(159,1): entry to method _module._default.ComputeFactorial
+39: BranchCoverage.dfy(162,3): then branch
+40: BranchCoverage.dfy(164,3): else branch
+41: BranchCoverage.dfy(170,15): entry to method _module._default.Main
+0: 3
 1: 0
-2: 3
-3: 1
-4: 0
-5: 2
-6: 3
-7: 1
-8: 0
-9: 2
-10: 1
-11: 0
-12: 1
+2: 0
+3: 3
+4: 1
+5: 0
+6: 2
+7: 3
+8: 1
+9: 0
+10: 2
+11: 1
+12: 0
 13: 1
-14: 0
+14: 1
 15: 0
 16: 0
-17: 1
+17: 0
+18: 1
+19: 3
+20: 1
+21: 1
+22: 1
+23: 1
+24: 111
+25: 0
+26: 56
+27: 1
+28: 55
+29: 28
+30: 28
+31: 465
+32: 233
+33: 0
+34: 232
+35: 11
+36: 1
+37: 10
+38: 11
+39: 1
+40: 10
+41: 1

--- a/Test/comp/BranchCoverage.dfy.expect
+++ b/Test/comp/BranchCoverage.dfy.expect
@@ -1,0 +1,38 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+0: BranchCoverage.dfy(4,15): entry to method _module._default.Main
+1: BranchCoverage.dfy(28,22): entry to method _module._default.NeverCalled
+2: BranchCoverage.dfy(34,35): entry to method _module._default.M
+3: BranchCoverage.dfy(36,13): then branch
+4: BranchCoverage.dfy(38,20): then branch
+5: BranchCoverage.dfy(40,10): else branch
+6: BranchCoverage.dfy(45,35): entry to method _module._default.N
+7: BranchCoverage.dfy(48,13): then branch
+8: BranchCoverage.dfy(50,20): then branch
+9: BranchCoverage.dfy(50,10): implicit else branch
+10: BranchCoverage.dfy(56,18): entry to method _module._default.P
+11: BranchCoverage.dfy(59,8): then branch
+12: BranchCoverage.dfy(59,3): implicit else branch
+13: BranchCoverage.dfy(64,8): then branch
+14: BranchCoverage.dfy(66,10): else branch
+15: BranchCoverage.dfy(76,12): then branch
+16: BranchCoverage.dfy(78,15): then branch
+17: BranchCoverage.dfy(78,10): implicit else branch
+0: 1
+1: 0
+2: 3
+3: 1
+4: 0
+5: 2
+6: 3
+7: 1
+8: 0
+9: 2
+10: 1
+11: 0
+12: 1
+13: 1
+14: 0
+15: 0
+16: 0
+17: 1

--- a/Test/comp/BranchCoverage2.cs
+++ b/Test/comp/BranchCoverage2.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DafnyProfiling {
+    public class CodeCoverage {
+        static uint[] tallies;
+        public static void Setup(int size) {
+            tallies = new uint[size];
+        }
+        public static void TearDown() {
+            for (var i = 0; i < tallies.Length; i++) {
+                Console.WriteLine("{0}: {1}", i, tallies[i]);
+            }
+            tallies = null;
+        }
+        public static bool Record(int id) {
+            tallies[id]++;
+            return true;
+        }
+    }
+}

--- a/Test/comp/BranchCoverage3.js
+++ b/Test/comp/BranchCoverage3.js
@@ -1,0 +1,25 @@
+let DafnyProfiling = (function() {
+  let $module = {};
+
+  $module.tallies = []
+
+  $module.CodeCoverage = class CodeCoverage {
+    static Setup(size) {
+      for (let i = 0; i < size; i++) {
+        $module.tallies[i] = 0
+      }
+    }
+    static TearDown() {
+      for (let i = 0; i < $module.tallies.length; i++) {
+        process.stdout.write("" + i + ": " + $module.tallies[i] + "\n");
+      }
+      $module.tallies = null;
+    }
+    static Record(id) {
+      $module.tallies[id]++
+      return true;
+    }
+  };
+
+  return $module;
+})();

--- a/Test/comp/BranchCoverage4.go
+++ b/Test/comp/BranchCoverage4.go
@@ -1,0 +1,32 @@
+package DafnyProfiling
+
+import (
+  "fmt"
+)
+
+// The Dummy__ type, which each compiled Dafny module declares, is just so that
+// we can generate "var _ dafny.Dummy__" to suppress the unused-import error.
+type Dummy__ struct{}
+
+type CodeCoverage_ struct {
+  tallies []int
+}
+var CodeCoverage = CodeCoverage_ {
+}
+
+func (_static *CodeCoverage_) Setup(size int) {
+  _static.tallies = make([]int, size)
+}
+
+func (_static *CodeCoverage_) TearDown() {
+  for i := 0; i < len(_static.tallies); i++ {
+    fmt.Printf("%d: %d\n", i, _static.tallies[i])
+  }
+  empty := [0]int{}
+  _static.tallies = empty[:]
+}
+
+func (_static *CodeCoverage_) Record(id int) bool {
+  _static.tallies[id]++
+  return true;
+}

--- a/Test/comp/CodeCoverage.java
+++ b/Test/comp/CodeCoverage.java
@@ -6,7 +6,7 @@ public class CodeCoverage {
         tallies = new int[size];
     }
     public static void TearDown() {
-        for (var i = 0; i < tallies.length; i++) {
+        for (int i = 0; i < tallies.length; i++) {
             System.out.println(i + ": " + tallies[i]);
         }
         tallies = null;

--- a/Test/comp/CodeCoverage.java
+++ b/Test/comp/CodeCoverage.java
@@ -1,0 +1,18 @@
+package DafnyProfiling;
+
+public class CodeCoverage {
+    static int[] tallies;
+    public static void Setup(int size) {
+        tallies = new int[size];
+    }
+    public static void TearDown() {
+        for (var i = 0; i < tallies.length; i++) {
+            System.out.println(i + ": " + tallies[i]);
+        }
+        tallies = null;
+    }
+    public static boolean Record(int id) {
+        tallies[id]++;
+        return true;
+    }
+}


### PR DESCRIPTION
Add new command-line option `/coverage:<file>`.

It identifies a set of source locations and gives these distinct numeric identifiers.
The corresponding numbers and source-location descriptions are written to `<file>`.
As for similar command-line options, `<file>` can be `-`, which writes to standard output.

The option also emits into the target compiled code three calls.
* `DafnyProfiling.CodeCoverage.Setup(n)` is called before calling `Main`, where `n` is the number of identified source locations.
* `DafnyProfiling.CodeCoverage.TearDown()` is called upon return from `Main`.
* `DafnyProfiling.CodeCoverage.Record(x)` is called when when the source location numbered `x` is reached, where `0 <= x < n`. This method must always return `true`.

The compiled program should be linked with implementations for these three methods. For useful and representative implementations in C#, JavaScript, Go, and Java, see `Test/comp/BranchCoverage.dfy`. The ones used there tally up the number of times each source location has been reached and prints these tallies to standard output when the program terminates.

The identified source locations are:
* method entry
* `if`, `if *`, and `if-case` statements
* `while`, `while *`, and `while-case` statements
* function entry
* in function bodies, top-level `if-then-else` expressions
* in function bodies, top-level `match` expressions
