### PR TITLE
feat!: Set up gitpod IDE - a browser-based/zero-install VSCode clone -

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,11 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update \
+ && sudo apt-get install mono-complete -y \
+ && sudo rm -rf /var/lib/apt/lists/* \
+ && sudo wget https://github.com/dafny-lang/dafny/releases/download/v2.3.0/dafny-2.3.0.10506-x64-ubuntu-16.04.zip \
+ && sudo unzip -d /opt/ dafny-2.3.0.10506-x64-ubuntu-16.04.zip \
+ && sudo rm dafny-2.3.0.10506-x64-ubuntu-16.04.zip \
+ && sudo chmod -R +r /opt/dafny/ \
+ && sudo chmod 755 /opt/dafny/*.exe
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: .gitpod.dockerfile
+  
+vscode:
+  extensions:
+    - correctnessLab.dafny-vscode@0.17.1:y0vNEkuQw4SUFvPIFxLkEA==
+ 
+tasks:
+  - init: git config --global alias.slog 'log --pretty=oneline --abbrev-commit'
+  - init: git config --global alias.co checkout
+  - command: gp open Docs/OnlineTutorial/guide.md
+  - command: gp open Docs/OnlineTutorial/guide.dfy

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,4 @@
+
+{
+    "dafny.basePath": "/opt/dafny"
+}

--- a/Docs/OnlineTutorial/guide.dfy
+++ b/Docs/OnlineTutorial/guide.dfy
@@ -1,0 +1,1 @@
+// Copy & paste the snippets from the tutorial here.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can ask questions about Dafny on [Stack Overflow](https://stackoverflow.com/
 
 # Try Dafny
 
-The easiest way to get started with Dafny is to use [rise4fun](http://rise4fun.com/dafny), where you can write and verify Dafny programs without having install anything. On [rise4fun](http://rise4fun.com/dafny), you will also find the online Dafny tutorial.
+The easiest way to get started with Dafny is to use [rise4fun](http://rise4fun.com/dafny), where you can write and verify Dafny programs without having install anything. On [rise4fun](http://rise4fun.com/dafny), you will also find the online Dafny tutorial. Assuming you have a [Github](https://github.com/join) or [GitLab](https://gitlab.com/users/sign_in) account, you can also open the [tutorial](https://gitpod.io/#https://github.com/dafny-lang/dafny/) - with the more advanced Dafny VSCode extension [(see extension)](https://github.com/DafnyVSCode/Dafny-VSCode) - in your [browser](https://gitpod.io/#https://github.com/dafny-lang/dafny/).
 It is also easy to [install Dafny on your own machine](https://github.com/dafny-lang/dafny/wiki/INSTALL) in VS Code, which gives you a much better user experience than in the web browser.
 
 # Setup


### PR DESCRIPTION
Set up gitpod IDE - a browser-based/zero-install VSCode clone - for the Dafny online tutorial.

Try it out yourself at https://gitpod.io/#https://github.com/dafny-lang/dafny/

Screencast/demo at https://tla.msr-inria.inria.fr/kuppe/gitpod-dafny.mp4