### PR TITLE
fix: Always respect loop spec for body-less loops

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -11399,7 +11399,7 @@ namespace Microsoft.Dafny {
     delegate void BodyTranslator(BoogieStmtListBuilder builder, ExpressionTranslator etran);
 
 
-    void TrLoop(LoopStmt s, Expression Guard, BodyTranslator bodyTr,
+    void TrLoop(LoopStmt s, Expression Guard, BodyTranslator/*?*/ bodyTr,
                 BoogieStmtListBuilder builder, List<Variable> locals, ExpressionTranslator etran) {
       Contract.Requires(s != null);
       Contract.Requires(builder != null);
@@ -11517,20 +11517,32 @@ namespace Microsoft.Dafny {
         invariants.Add(TrAssumeCmd(s.Tok, decrCheck));
       }
 
-      BoogieStmtListBuilder loopBodyBuilder = new BoogieStmtListBuilder(this);
+      var loopBodyBuilder = new BoogieStmtListBuilder(this);
       loopBodyBuilder.Add(CaptureState(s.Tok, true, "after some loop iterations"));
-      // as the first thing inside the loop, generate:  if (!w) { CheckWellformed(inv); assume false; }
+
+      // As the first thing inside the loop, generate:  if (!w) { CheckWellformed(inv); assume false; }
       invDefinednessBuilder.Add(TrAssumeCmd(s.Tok, Bpl.Expr.False));
       loopBodyBuilder.Add(new Bpl.IfCmd(s.Tok, Bpl.Expr.Not(w), invDefinednessBuilder.Collect(s.Tok), null, null));
-      // generate:  CheckWellformed(guard); if (!guard) { break; }
+
+      // Generate:  CheckWellformed(guard); if (!guard) { break; }
+      // but if this is a body-less loop, put all of that inside:  if (*) { ... }
+      // Without this, Boogie's abstract interpreter may figure out that the loop guard is always false
+      // on entry to the loop, and then Boogie wouldn't consider this a loop at all. (See also comment
+      // in methods GuardAlwaysHoldsOnEntry_BodyLessLoop and GuardAlwaysHoldsOnEntry_LoopWithBody in
+      // Test/dafny0/DirtyLoops.dfy.)
+      var isBodyLessLoop = s is WhileStmt && ((WhileStmt)s).BodySurrogate != null;
+      var whereToBuildLoopGuard = isBodyLessLoop ? new BoogieStmtListBuilder(this) : loopBodyBuilder;
       Bpl.Expr guard = null;
       if (Guard != null) {
-        TrStmt_CheckWellformed(Guard, loopBodyBuilder, locals, etran, true);
+        TrStmt_CheckWellformed(Guard, whereToBuildLoopGuard, locals, etran, true);
         guard = Bpl.Expr.Not(etran.TrExpr(Guard));
       }
-      BoogieStmtListBuilder guardBreak = new BoogieStmtListBuilder(this);
+      var guardBreak = new BoogieStmtListBuilder(this);
       guardBreak.Add(new Bpl.BreakCmd(s.Tok, null));
-      loopBodyBuilder.Add(new Bpl.IfCmd(s.Tok, guard, guardBreak.Collect(s.Tok), null, null));
+      whereToBuildLoopGuard.Add(new Bpl.IfCmd(s.Tok, guard, guardBreak.Collect(s.Tok), null, null));
+      if (isBodyLessLoop) {
+        loopBodyBuilder.Add(new Bpl.IfCmd(s.Tok, null, whereToBuildLoopGuard.Collect(s.Tok), null, null));
+      }
 
       if (bodyTr != null) {
         // termination checking
@@ -11560,8 +11572,8 @@ namespace Microsoft.Dafny {
           }
           loopBodyBuilder.Add(Assert(s.Tok, decrCheck, msg));
         }
-      } else if (s is WhileStmt && ((WhileStmt)s).BodySurrogate != null) {
-        var bodySurrogate = ((WhileStmt) s).BodySurrogate;
+      } else if (isBodyLessLoop) {
+        var bodySurrogate = ((WhileStmt)s).BodySurrogate;
         // This is a body-less loop. Havoc the targets and then set w to false, to make the loop-invariant
         // maintenance check vaccuous.
         var bplTargets = bodySurrogate.LocalLoopTargets.ConvertAll(v => TrVar(s.Tok, v));

--- a/Test/allocated1/dafny0/DirtyLoops.dfy
+++ b/Test/allocated1/dafny0/DirtyLoops.dfy
@@ -1,4 +1,4 @@
 // RUN: %dafny /verifyAllModules /allocated:1 /compile:0 /dprint:"%t.dprint.dfy" "%s" > "%t"
-// RUN: %dafny /verifyAllModules /allocated:1 /noVerify /compile:1 "%t.dprint.dfy" >> "%t"
+// RUN: %dafny /verifyAllModules /allocated:1 /noVerify "%t.dprint.dfy" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 include "../../dafny0/DirtyLoops.dfy"

--- a/Test/allocated1/dafny0/DirtyLoops.dfy.expect
+++ b/Test/allocated1/dafny0/DirtyLoops.dfy.expect
@@ -36,6 +36,7 @@ DirtyLoops.dfy(504,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy(512,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy(515,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy(515,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy(531,2): Warning: note, this loop has no body (loop frame: x)
 DirtyLoops.dfy(427,4): Warning: note, this loop has no body (loop frame: $Heap)
 DirtyLoops.dfy(436,4): Warning: note, this loop has no body (loop frame: $Heap)
 DirtyLoops.dfy(452,6): Warning: note, this loop has no body (loop frame: i, $Heap)
@@ -45,284 +46,321 @@ DirtyLoops.dfy(515,2): Warning: /!\ No terms found to trigger on.
 DirtyLoops.dfy(30,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(26,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(26,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(26,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(26,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(39,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(35,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(35,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(35,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(35,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(48,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(46,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(46,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(46,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(46,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(57,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(55,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(55,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(55,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(55,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(59,12): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(55,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(55,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(55,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(55,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(70,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(68,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(68,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(68,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(72,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(68,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(68,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(68,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(82,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(80,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(80,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(80,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(80,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(83,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(80,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(80,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(80,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(80,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(90,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(88,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(88,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(88,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(88,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(110,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(106,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(106,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(106,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(106,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(122,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(118,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(118,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(118,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(118,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(136,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(130,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(130,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(130,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(130,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(137,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(130,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(130,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(130,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(130,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(149,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(145,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(145,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(145,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(145,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(151,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(145,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(145,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(145,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(145,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(164,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(159,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(159,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(159,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(159,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(165,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(159,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(159,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(159,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(159,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(180,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(173,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(173,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(173,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(173,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(181,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(173,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(173,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(173,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(173,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(193,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(189,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(189,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(189,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(189,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(195,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(189,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(189,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(189,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(189,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(196,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(189,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(189,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(189,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(189,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(208,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(203,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(203,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(203,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(203,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(221,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(216,3): anon8_LoopHead
-    (0,0): anon8_LoopBody
-    DirtyLoops.dfy(216,3): anon9_Else
-    (0,0): anon11_Then
+    DirtyLoops.dfy(216,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(216,3): anon10_Else
+    (0,0): anon12_Then
+    (0,0): anon13_Then
 DirtyLoops.dfy(234,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(229,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(229,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(229,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(229,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(244,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(242,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(242,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(242,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(242,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(253,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(251,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(251,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(251,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(251,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(261,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(260,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(260,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(260,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(260,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(270,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(268,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(268,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(268,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(268,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(285,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(279,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(279,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(279,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(279,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(297,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(293,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(293,3): anon10_Else
-    (0,0): anon11_Then
+    DirtyLoops.dfy(293,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(293,3): anon11_Else
     (0,0): anon12_Then
-    (0,0): anon8
+    (0,0): anon13_Then
+    (0,0): anon14_Then
+    (0,0): anon9
 DirtyLoops.dfy(298,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(293,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(293,3): anon10_Else
-    (0,0): anon11_Then
-    DirtyLoops.dfy(296,18): anon12_Else
-    (0,0): anon8
+    DirtyLoops.dfy(293,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(293,3): anon11_Else
+    (0,0): anon12_Then
+    (0,0): anon13_Then
+    DirtyLoops.dfy(296,18): anon14_Else
+    (0,0): anon9
 DirtyLoops.dfy(308,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(305,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(305,3): anon10_Else
-    DirtyLoops.dfy(305,15): anon11_Else
-    (0,0): anon5
-    (0,0): anon12_Then
+    DirtyLoops.dfy(305,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(305,3): anon11_Else
+    DirtyLoops.dfy(305,15): anon13_Else
+    (0,0): anon6
+    (0,0): anon14_Then
 DirtyLoops.dfy(309,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(305,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(305,3): anon10_Else
-    DirtyLoops.dfy(305,15): anon11_Else
-    (0,0): anon5
-    (0,0): anon12_Then
+    DirtyLoops.dfy(305,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(305,3): anon11_Else
+    DirtyLoops.dfy(305,15): anon13_Else
+    (0,0): anon6
+    (0,0): anon14_Then
 DirtyLoops.dfy(321,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(319,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(319,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(319,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(319,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(356,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(354,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(354,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(354,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(354,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(369,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(365,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(365,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(365,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(365,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(380,9): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(377,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(377,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(377,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(377,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(401,18): Error BP5004: This loop invariant might not hold on entry.
 DirtyLoops.dfy(401,18): Related message: loop invariant violation
 Execution trace:
@@ -330,43 +368,51 @@ Execution trace:
 DirtyLoops.dfy(414,16): Error: target object may be null
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(413,3): anon6_LoopHead
-    (0,0): anon6_LoopBody
-    (0,0): anon7_Then
+    DirtyLoops.dfy(413,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    (0,0): anon8_Then
 DirtyLoops.dfy(506,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Else
     (0,0): anon7_Then
     (0,0): anon5
+DirtyLoops.dfy(533,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(531,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(531,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(452,6): Error: loop modifies clause may violate context's modifies clause
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(446,5): anon12_LoopHead
-    (0,0): anon12_LoopBody
-    DirtyLoops.dfy(446,5): anon13_Else
+    DirtyLoops.dfy(446,5): anon13_LoopHead
+    (0,0): anon13_LoopBody
     DirtyLoops.dfy(446,5): anon14_Else
+    DirtyLoops.dfy(446,5): anon15_Else
 DirtyLoops.dfy(468,6): Error: loop modifies clause may violate context's modifies clause
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(462,5): anon12_LoopHead
-    (0,0): anon12_LoopBody
-    DirtyLoops.dfy(462,5): anon13_Else
+    DirtyLoops.dfy(462,5): anon13_LoopHead
+    (0,0): anon13_LoopBody
     DirtyLoops.dfy(462,5): anon14_Else
+    DirtyLoops.dfy(462,5): anon15_Else
 DirtyLoops.dfy(485,6): Error: loop modifies clause may violate context's modifies clause
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(480,5): anon12_LoopHead
-    (0,0): anon12_LoopBody
-    DirtyLoops.dfy(480,5): anon13_Else
+    DirtyLoops.dfy(480,5): anon13_LoopHead
+    (0,0): anon13_LoopBody
     DirtyLoops.dfy(480,5): anon14_Else
+    DirtyLoops.dfy(480,5): anon15_Else
 
-Dafny program verifier finished with 21 verified, 45 errors
-DirtyLoops.dfy.tmp.dprint.dfy(426,4): Warning: note, this loop has no body (loop frame: $Heap)
-DirtyLoops.dfy.tmp.dprint.dfy(435,4): Warning: note, this loop has no body (loop frame: $Heap)
-DirtyLoops.dfy.tmp.dprint.dfy(451,6): Warning: note, this loop has no body (loop frame: i, $Heap)
-DirtyLoops.dfy.tmp.dprint.dfy(467,6): Warning: note, this loop has no body (loop frame: i, $Heap)
-DirtyLoops.dfy.tmp.dprint.dfy(484,6): Warning: note, this loop has no body (loop frame: j, $Heap)
+Dafny program verifier finished with 22 verified, 46 errors
+DirtyLoops.dfy.tmp.dprint.dfy(445,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(454,4): Warning: note, this loop has no body (loop frame: $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(470,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(486,6): Warning: note, this loop has no body (loop frame: i, $Heap)
+DirtyLoops.dfy.tmp.dprint.dfy(503,6): Warning: note, this loop has no body (loop frame: j, $Heap)
 DirtyLoops.dfy.tmp.dprint.dfy(8,2): Warning: note, this loop has no body (loop frame: i)
 DirtyLoops.dfy.tmp.dprint.dfy(18,2): Warning: note, this loop has no body (loop frame: i)
 DirtyLoops.dfy.tmp.dprint.dfy(29,2): Warning: note, this loop has no body (loop frame: i)
@@ -405,6 +451,7 @@ DirtyLoops.dfy.tmp.dprint.dfy(398,2): Warning: note, this forall statement has n
 DirtyLoops.dfy.tmp.dprint.dfy(407,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy.tmp.dprint.dfy(415,2): Warning: note, this loop has no body (loop frame: x)
 DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/dafny0/DirtyLoops.dfy.expect
+++ b/Test/dafny0/DirtyLoops.dfy.expect
@@ -41,309 +41,347 @@ DirtyLoops.dfy(504,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy(512,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy(515,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy(515,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy(531,2): Warning: note, this loop has no body (loop frame: x)
 DirtyLoops.dfy(515,2): Warning: /!\ No terms found to trigger on.
 DirtyLoops.dfy(452,6): Error: loop modifies clause may violate context's modifies clause
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(446,5): anon12_LoopHead
-    (0,0): anon12_LoopBody
-    DirtyLoops.dfy(446,5): anon13_Else
+    DirtyLoops.dfy(446,5): anon13_LoopHead
+    (0,0): anon13_LoopBody
     DirtyLoops.dfy(446,5): anon14_Else
+    DirtyLoops.dfy(446,5): anon15_Else
 DirtyLoops.dfy(468,6): Error: loop modifies clause may violate context's modifies clause
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(462,5): anon12_LoopHead
-    (0,0): anon12_LoopBody
-    DirtyLoops.dfy(462,5): anon13_Else
+    DirtyLoops.dfy(462,5): anon13_LoopHead
+    (0,0): anon13_LoopBody
     DirtyLoops.dfy(462,5): anon14_Else
+    DirtyLoops.dfy(462,5): anon15_Else
 DirtyLoops.dfy(485,6): Error: loop modifies clause may violate context's modifies clause
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(480,5): anon12_LoopHead
-    (0,0): anon12_LoopBody
-    DirtyLoops.dfy(480,5): anon13_Else
+    DirtyLoops.dfy(480,5): anon13_LoopHead
+    (0,0): anon13_LoopBody
     DirtyLoops.dfy(480,5): anon14_Else
+    DirtyLoops.dfy(480,5): anon15_Else
 DirtyLoops.dfy(30,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(26,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(26,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(26,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(26,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(39,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(35,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(35,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(35,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(35,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(48,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(46,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(46,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(46,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(46,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(57,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(55,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(55,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(55,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(55,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(59,12): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(55,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(55,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(55,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(55,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(70,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(68,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(68,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(68,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(72,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(68,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(68,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(68,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(82,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(80,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(80,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(80,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(80,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(83,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(80,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(80,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(80,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(80,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(90,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(88,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(88,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(88,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(88,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(110,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(106,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(106,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(106,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(106,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(122,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(118,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(118,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(118,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(118,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(136,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(130,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(130,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(130,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(130,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(137,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(130,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(130,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(130,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(130,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(149,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(145,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(145,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(145,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(145,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(151,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(145,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(145,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(145,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(145,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(164,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(159,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(159,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(159,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(159,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(165,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(159,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(159,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(159,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(159,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(180,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(173,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(173,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(173,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(173,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(181,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(173,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(173,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(173,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(173,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(193,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(189,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(189,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(189,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(189,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(195,14): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(189,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(189,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(189,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(189,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(196,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(189,3): anon11_LoopHead
-    (0,0): anon11_LoopBody
-    DirtyLoops.dfy(189,3): anon12_Else
-    (0,0): anon15_Then
+    DirtyLoops.dfy(189,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(189,3): anon13_Else
+    (0,0): anon16_Then
+    (0,0): anon17_Then
 DirtyLoops.dfy(208,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(203,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(203,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(203,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(203,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(221,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(216,3): anon8_LoopHead
-    (0,0): anon8_LoopBody
-    DirtyLoops.dfy(216,3): anon9_Else
-    (0,0): anon11_Then
+    DirtyLoops.dfy(216,3): anon9_LoopHead
+    (0,0): anon9_LoopBody
+    DirtyLoops.dfy(216,3): anon10_Else
+    (0,0): anon12_Then
+    (0,0): anon13_Then
 DirtyLoops.dfy(234,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(229,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(229,3): anon10_Else
-    (0,0): anon12_Then
+    DirtyLoops.dfy(229,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(229,3): anon11_Else
+    (0,0): anon13_Then
+    (0,0): anon14_Then
 DirtyLoops.dfy(244,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(242,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(242,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(242,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(242,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(253,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(251,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(251,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(251,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(251,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(261,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(260,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(260,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(260,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(260,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(270,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(268,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(268,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(268,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(268,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(285,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(279,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(279,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(279,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(279,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(297,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(293,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(293,3): anon10_Else
-    (0,0): anon11_Then
+    DirtyLoops.dfy(293,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(293,3): anon11_Else
     (0,0): anon12_Then
-    (0,0): anon8
+    (0,0): anon13_Then
+    (0,0): anon14_Then
+    (0,0): anon9
 DirtyLoops.dfy(298,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(293,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(293,3): anon10_Else
-    (0,0): anon11_Then
-    DirtyLoops.dfy(296,18): anon12_Else
-    (0,0): anon8
+    DirtyLoops.dfy(293,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(293,3): anon11_Else
+    (0,0): anon12_Then
+    (0,0): anon13_Then
+    DirtyLoops.dfy(296,18): anon14_Else
+    (0,0): anon9
 DirtyLoops.dfy(308,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(305,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(305,3): anon10_Else
-    DirtyLoops.dfy(305,15): anon11_Else
-    (0,0): anon5
-    (0,0): anon12_Then
+    DirtyLoops.dfy(305,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(305,3): anon11_Else
+    DirtyLoops.dfy(305,15): anon13_Else
+    (0,0): anon6
+    (0,0): anon14_Then
 DirtyLoops.dfy(309,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(305,3): anon9_LoopHead
-    (0,0): anon9_LoopBody
-    DirtyLoops.dfy(305,3): anon10_Else
-    DirtyLoops.dfy(305,15): anon11_Else
-    (0,0): anon5
-    (0,0): anon12_Then
+    DirtyLoops.dfy(305,3): anon10_LoopHead
+    (0,0): anon10_LoopBody
+    DirtyLoops.dfy(305,3): anon11_Else
+    DirtyLoops.dfy(305,15): anon13_Else
+    (0,0): anon6
+    (0,0): anon14_Then
 DirtyLoops.dfy(321,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(319,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(319,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(319,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(319,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(356,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(354,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(354,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(354,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(354,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(369,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(365,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(365,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(365,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(365,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(380,9): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(377,3): anon7_LoopHead
-    (0,0): anon7_LoopBody
-    DirtyLoops.dfy(377,3): anon8_Else
-    (0,0): anon9_Then
+    DirtyLoops.dfy(377,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(377,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 DirtyLoops.dfy(401,18): Error BP5004: This loop invariant might not hold on entry.
 DirtyLoops.dfy(401,18): Related message: loop invariant violation
 Execution trace:
@@ -351,17 +389,25 @@ Execution trace:
 DirtyLoops.dfy(414,16): Error: target object may be null
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(413,3): anon6_LoopHead
-    (0,0): anon6_LoopBody
-    (0,0): anon7_Then
+    DirtyLoops.dfy(413,3): anon7_LoopHead
+    (0,0): anon7_LoopBody
+    (0,0): anon8_Then
 DirtyLoops.dfy(506,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Else
     (0,0): anon7_Then
     (0,0): anon5
+DirtyLoops.dfy(533,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    DirtyLoops.dfy(531,3): anon8_LoopHead
+    (0,0): anon8_LoopBody
+    DirtyLoops.dfy(531,3): anon9_Else
+    (0,0): anon10_Then
+    (0,0): anon11_Then
 
-Dafny program verifier finished with 21 verified, 45 errors
+Dafny program verifier finished with 22 verified, 46 errors
 DirtyLoops.dfy.tmp.dprint.dfy(19,4): Warning: note, this loop has no body (loop frame: $Heap)
 DirtyLoops.dfy.tmp.dprint.dfy(28,4): Warning: note, this loop has no body (loop frame: $Heap)
 DirtyLoops.dfy.tmp.dprint.dfy(44,6): Warning: note, this loop has no body (loop frame: i, $Heap)
@@ -405,6 +451,7 @@ DirtyLoops.dfy.tmp.dprint.dfy(478,2): Warning: note, this forall statement has n
 DirtyLoops.dfy.tmp.dprint.dfy(487,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: note, this forall statement has no body
 DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: the conclusion of the body of this forall statement will not be known outside the forall statement; consider using an 'ensures' clause
+DirtyLoops.dfy.tmp.dprint.dfy(495,2): Warning: note, this loop has no body (loop frame: x)
 DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Without a loop body, we want the effect that the loop specification--that
is, the loop guard, the loop invariant, and the loop frame--says all there
is to say about the loop. Dafny supplies three 3 pieces to Boogie and then
lets Boogie's loop usual processing do the rest. If the guard necessarily
holds initially and this gets noticed by Boogie, then Boogie treats this as
no loop at all. That kind of cleverness is sound, but when demonstrating
the concepts of loop reasoning, it just looks confusing. Therefore, by
this PR, Dafny counteracts this in its Boogie encoding of body-less loop

When the Dafny program supplies a loop body, then Dafny allows Boogie to
be as clever as it wishes, as before PR.