### PR TITLE
fix: Emit compile error for body-less loops

### DIFF
--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -1943,6 +1943,7 @@ namespace Microsoft.Dafny {
         } else if (stmt is WhileStmt) {
           var s = (WhileStmt)stmt;
           if (s.Body == null) {
+            // this checks ghost body-less while statements
             compiler.Error(stmt.Tok, "a while statement without a body cannot be compiled", wr);
           }
         }
@@ -2158,6 +2159,8 @@ namespace Microsoft.Dafny {
       } else if (stmt is WhileStmt) {
         WhileStmt s = (WhileStmt)stmt;
         if (s.Body == null) {
+          // this checks non-ghost body-less while statements
+          Error(stmt.Tok, "a while statement without a body cannot be compiled", wr);
           return;
         }
         if (s.Guard == null) {

--- a/Test/allocated1/dafny0/CompilationErrors.dfy.expect
+++ b/Test/allocated1/dafny0/CompilationErrors.dfy.expect
@@ -1,5 +1,7 @@
+CompilationErrors.dfy(52,2): Warning: note, this loop has no body (loop frame: x)
+CompilationErrors.dfy(62,4): Warning: note, this loop has no body (loop frame: x)
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 4 verified, 0 errors
 CompilationErrors.dfy(3,8): Error: the included file CompilationErrors.dfy contains error(s)
 CompilationErrors.dfy(6,13): Error: Method _module._default.M has no body
 CompilationErrors.dfy(7,7): Error: Method _module._default.P has no body
@@ -9,6 +11,8 @@ CompilationErrors.dfy(22,2): Error: an assume statement cannot be compiled
 CompilationErrors.dfy(25,2): Error: an assume statement cannot be compiled
 CompilationErrors.dfy(30,2): Error: an assume statement cannot be compiled
 CompilationErrors.dfy(39,6): Error: an assume statement cannot be compiled
+CompilationErrors.dfy(52,2): Error: a while statement without a body cannot be compiled
+CompilationErrors.dfy(62,4): Error: a while statement without a body cannot be compiled
 CompilationErrors.dfy(4,5): Error: Opaque type ('_module.MyType') cannot be compiled
 CompilationErrors.dfy(5,9): Error: Iterator _module.Iter has no body
 CompilationErrors.dfy(12,6): Error: an assume statement cannot be compiled

--- a/Test/dafny0/CompilationErrors.dfy
+++ b/Test/dafny0/CompilationErrors.dfy
@@ -41,3 +41,25 @@ function MyCalcFunction(): int
   }
   12
 }
+
+// -------------------------- body-less loops
+
+method BodyLessLoop_NonGhost(y: int)
+  requires y <= 100
+  ensures false
+{
+  var x := y;
+  while true  // error: cannot be compiled
+    invariant x <= 100
+}
+
+method BodyLessLoop_Ghost(ghost y: int)
+  requires y <= 100
+  ensures false
+{
+  if y == y {  // that makes this a ghost statement
+    var x := y;
+    while true  // error: cannot be compiled
+      invariant x <= 100
+  }
+}

--- a/Test/dafny0/CompilationErrors.dfy.expect
+++ b/Test/dafny0/CompilationErrors.dfy.expect
@@ -1,5 +1,7 @@
+CompilationErrors.dfy(52,2): Warning: note, this loop has no body (loop frame: x)
+CompilationErrors.dfy(62,4): Warning: note, this loop has no body (loop frame: x)
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 4 verified, 0 errors
 CompilationErrors.dfy(4,5): Error: Opaque type ('_module.MyType') cannot be compiled
 CompilationErrors.dfy(5,9): Error: Iterator _module.Iter has no body
 CompilationErrors.dfy(12,6): Error: an assume statement cannot be compiled
@@ -11,3 +13,5 @@ CompilationErrors.dfy(22,2): Error: an assume statement cannot be compiled
 CompilationErrors.dfy(25,2): Error: an assume statement cannot be compiled
 CompilationErrors.dfy(30,2): Error: an assume statement cannot be compiled
 CompilationErrors.dfy(39,6): Error: an assume statement cannot be compiled
+CompilationErrors.dfy(52,2): Error: a while statement without a body cannot be compiled
+CompilationErrors.dfy(62,4): Error: a while statement without a body cannot be compiled


### PR DESCRIPTION
Previously, only ghost body-less loops emitted an error. Now, both
compiled and ghost body-less loops do.