### PR TITLE
feat: add /version CLI flag

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Dafny
       false
 #endif
     ;
+    public bool PrintVersionAndExit = false;
 
     protected override bool ParseOption(string name, Bpl.CommandLineOptionEngine.CommandLineParseState ps) {
       var args = ps.args;  // convenient synonym
@@ -411,6 +412,10 @@ namespace Microsoft.Dafny
               DafnyVerify = false;
             }
           }
+          return true;
+
+        case "version":
+          PrintVersionAndExit = true;
           return true;
 
         default:
@@ -819,6 +824,7 @@ namespace Microsoft.Dafny
   /disableScopes
                 Treat all export sets as 'export reveal *'. i.e. don't hide function bodies
                 or type definitions during translation.
+  /version      Print the Dafny version number and exit.
 ");
       base.Usage();  // also print the Boogie options
     }

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Dafny
 
   public class DafnyDriver
   {
-    public enum ExitValue { VERIFIED = 0, PREPROCESSING_ERROR, DAFNY_ERROR, COMPILE_ERROR, NOT_VERIFIED }
+    public enum ExitValue { VERIFIED = 0, PREPROCESSING_ERROR, DAFNY_ERROR, COMPILE_ERROR, NOT_VERIFIED, DONT_PROCESS_FILES }
 
     public static int Main(string[] args)
     {
@@ -85,6 +85,12 @@ namespace Microsoft.Dafny
       } catch (ProverException pe) {
         ExecutionEngine.printer.ErrorWriteLine(Console.Out, "*** ProverException: {0}", pe.Message);
         return ExitValue.PREPROCESSING_ERROR;
+      }
+
+      if (DafnyOptions.O.PrintVersionAndExit)
+      {
+        Console.WriteLine(CommandLineOptions.Clo.Version);
+        return ExitValue.DONT_PROCESS_FILES;
       }
 
       if (CommandLineOptions.Clo.Files.Count == 0)

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Dafny
 
   public class DafnyDriver
   {
+    // TODO: Refactor so that non-errors (NOT_VERIFIED, DONT_PROCESS_FILES) don't result in non-zero exit codes
     public enum ExitValue { VERIFIED = 0, PREPROCESSING_ERROR, DAFNY_ERROR, COMPILE_ERROR, NOT_VERIFIED, DONT_PROCESS_FILES }
 
     public static int Main(string[] args)


### PR DESCRIPTION
This PR exposes the Dafny version number via a CLI flag:
```bash
$ ./Binaries/dafny /version
Dafny 2.3.0.10506
```

Resolves #624.