### PR TITLE
fix: exit early with exit status 0 on /version and on /help

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -114,6 +114,11 @@ namespace Microsoft.Dafny
         return CommandLineArgumentsResult.OK_EXIT_EARLY;
       }
 
+      if (CommandLineOptions.Clo.HelpRequested)
+      {
+        return CommandLineArgumentsResult.OK_EXIT_EARLY;
+      }
+
       if (CommandLineOptions.Clo.Files.Count == 0)
       {
         ExecutionEngine.printer.ErrorWriteLine(Console.Out, "*** Error: No input files were specified.");


### PR DESCRIPTION
Before:
```bash
$ ./Binaries/dafny /version; echo $?
Dafny 2.3.0.10506
5
$ ./Binaries/dafny /help; echo $?
  ---- Dafny options ---------------------------------------------------------

  Multiple .dfy files supplied on the command line are concatenated into one
  Dafny program.
<snip>
  Yices2 specific options:
  /yices2exe:<path>
                path to Yices2 executable

*** Error: No input files were specified.
1
```

After:
```bash
$ ./Binaries/dafny /version; echo $?
Dafny 2.3.0.10506
0
$ ./Binaries/dafny /help; echo $?
  ---- Dafny options ---------------------------------------------------------

  Multiple .dfy files supplied on the command line are concatenated into one
  Dafny program.
<snip>
  Yices2 specific options:
  /yices2exe:<path>
                path to Yices2 executable

0
```

To accomplish the above, this PR refactors `DafnyDriver.ProcessCommandLineArguments` to return its own specialized type, in order to avoid overloading the`ExitValue` type returned by `DafnyDriver.ProcessFiles`.

Addresses feedback on merged PR #627.
Resolves #628.