### PR TITLE
Improve errors for parsing ambiguities of non-associating operators

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -3023,6 +3023,7 @@ ImpliesExpliesExpression<out Expression e0, bool allowSemi, bool allowLambda, bo
                                                                  e0 = new BinaryExpr(x, BinaryExpr.Opcode.Exp, e1, e0);
                                                               .)
       }
+      [ IF(IsImpliesOp()) ImpliesOp (. SemErr(t, "Ambiguous use of ==> and <==. Use parentheses to disambiguate."); .) ]
     )
   ]
   .
@@ -3033,6 +3034,7 @@ ImpliesExpression<out Expression e0, bool allowSemi, bool allowLambda, bool allo
     ImpliesOp                                               (. x = t; .)
     ImpliesExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>       (. e0 = new BinaryExpr(x, BinaryExpr.Opcode.Imp, e0, e1); .)
   ]
+  [ IF(IsExpliesOp()) ExpliesOp (. SemErr(t, "Ambiguous use of ==> and <==. Use parentheses to disambiguate."); .) ]
   .
 /*------------------------------------------------------------------------*/
 LogicalExpression<out Expression e0, bool allowSemi, bool allowLambda, bool allowBitwiseOps>
@@ -3046,6 +3048,7 @@ LogicalExpression<out Expression e0, bool allowSemi, bool allowLambda, bool allo
       AndOp                                                     (. x = t; .)
       RelationalExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>      (. e0 = new BinaryExpr(x, BinaryExpr.Opcode.And, e0, e1); .)
     }
+    [ IF(IsOrOp()) OrOp (. SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); .) ]
     (. if (e0 == first) {
          // There was only one conjunct. To make sure that the type checker still checks it to
          // be a boolean, we conjoin "true" to its left.
@@ -3058,6 +3061,7 @@ LogicalExpression<out Expression e0, bool allowSemi, bool allowLambda, bool allo
       OrOp                                                      (. x = t; .)
       RelationalExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>      (. e0 = new BinaryExpr(x, BinaryExpr.Opcode.Or, e0, e1); .)
     }
+    [ IF(IsAndOp()) AndOp (. SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); .) ]
     (. if (e0 == first) {
          // There was only one disjunct. To make sure that the type checker still checks it to
          // be a boolean, we disjoin [sic] "false" to its left.
@@ -3072,12 +3076,14 @@ LogicalExpression<out Expression e0, bool allowSemi, bool allowLambda, bool allo
           AndOp                                                 (. x = t; .)
           RelationalExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>  (. e0 = new BinaryExpr(x, BinaryExpr.Opcode.And, e0, e1); .)
         }
+        [ IF(IsOrOp()) OrOp (. SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); .) ]
       | OrOp                                                    (. x = t; .)
         RelationalExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>    (. e0 = new BinaryExpr(x, BinaryExpr.Opcode.Or, e0, e1); .)
         { IF(IsOrOp())  /* read a disjunction as far as possible */
           OrOp                                                  (. x = t; .)
           RelationalExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>  (. e0 = new BinaryExpr(x, BinaryExpr.Opcode.Or, e0, e1); .)
         }
+        [ IF(IsAndOp()) AndOp (. SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); .) ]
       )
     ]
   )
@@ -3264,6 +3270,7 @@ BitvectorFactor<out Expression e0, bool allowSemi, bool allowLambda, bool allowB
         "&"                                                           (. x = t; .)
         AsExpression<out e1, allowSemi, allowLambda, allowBitwiseOps> (. e0 = new BinaryExpr(x, op, e0, e1); .)
       }
+      [ IF(IsBitwiseOp()) ( "|" | "^" )  (. SemErr(t, "Ambiguous use of &, |, ^. Use parentheses to disambiguate."); .) ]
     | (. op = BinaryExpr.Opcode.BitwiseOr; .)
       "|"                                                             (. x = t; .)
       AsExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>   (. e0 = new BinaryExpr(x, op, e0, e1); .)
@@ -3271,6 +3278,7 @@ BitvectorFactor<out Expression e0, bool allowSemi, bool allowLambda, bool allowB
         "|"                                                           (. x = t; .)
         AsExpression<out e1, allowSemi, allowLambda, allowBitwiseOps> (. e0 = new BinaryExpr(x, op, e0, e1); .)
       }
+      [ IF(IsBitwiseOp()) ( "^" | "&" )  (. SemErr(t, "Ambiguous use of &, |, ^. Use parentheses to disambiguate."); .) ]
     | (. op = BinaryExpr.Opcode.BitwiseXor; .)
       "^"                                                             (. x = t; .)
       AsExpression<out e1, allowSemi, allowLambda, allowBitwiseOps>   (. e0 = new BinaryExpr(x, op, e0, e1); .)
@@ -3278,6 +3286,7 @@ BitvectorFactor<out Expression e0, bool allowSemi, bool allowLambda, bool allowB
         "^"                                                           (. x = t; .)
         AsExpression<out e1, allowSemi, allowLambda, allowBitwiseOps> (. e0 = new BinaryExpr(x, op, e0, e1); .)
       }
+      [ IF(IsBitwiseOp()) ( "&" | "|" )  (. SemErr(t, "Ambiguous use of &, |, ^. Use parentheses to disambiguate."); .) ]
     )
   ]
   .

--- a/Source/Dafny/Parser.cs
+++ b/Source/Dafny/Parser.cs
@@ -4419,6 +4419,10 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 					e0 = new BinaryExpr(x, BinaryExpr.Opcode.Exp, e1, e0);
 					
 				}
+				if (IsImpliesOp()) {
+					ImpliesOp();
+					SemErr(t, "Ambiguous use of ==> and <==. Use parentheses to disambiguate."); 
+				}
 			} else SynErr(265);
 		}
 	}
@@ -4439,6 +4443,10 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				RelationalExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 				e0 = new BinaryExpr(x, BinaryExpr.Opcode.And, e0, e1); 
 			}
+			if (IsOrOp()) {
+				OrOp();
+				SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); 
+			}
 			if (e0 == first) {
 			 // There was only one conjunct. To make sure that the type checker still checks it to
 			 // be a boolean, we conjoin "true" to its left.
@@ -4455,6 +4463,10 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				x = t; 
 				RelationalExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 				e0 = new BinaryExpr(x, BinaryExpr.Opcode.Or, e0, e1); 
+			}
+			if (IsAndOp()) {
+				AndOp();
+				SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); 
 			}
 			if (e0 == first) {
 			 // There was only one disjunct. To make sure that the type checker still checks it to
@@ -4476,6 +4488,10 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 						RelationalExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 						e0 = new BinaryExpr(x, BinaryExpr.Opcode.And, e0, e1); 
 					}
+					if (IsOrOp()) {
+						OrOp();
+						SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); 
+					}
 				} else if (la.kind == 138 || la.kind == 139) {
 					OrOp();
 					x = t; 
@@ -4486,6 +4502,10 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 						x = t; 
 						RelationalExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 						e0 = new BinaryExpr(x, BinaryExpr.Opcode.Or, e0, e1); 
+					}
+					if (IsAndOp()) {
+						AndOp();
+						SemErr(t, "Ambiguous use of && and ||. Use parentheses to disambiguate."); 
 					}
 				} else SynErr(266);
 			}
@@ -4500,6 +4520,10 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			x = t; 
 			ImpliesExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 			e0 = new BinaryExpr(x, BinaryExpr.Opcode.Imp, e0, e1); 
+		}
+		if (IsExpliesOp()) {
+			ExpliesOp();
+			SemErr(t, "Ambiguous use of ==> and <==. Use parentheses to disambiguate."); 
 		}
 	}
 
@@ -4758,6 +4782,14 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 					AsExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 					e0 = new BinaryExpr(x, op, e0, e1); 
 				}
+				if (IsBitwiseOp()) {
+					if (la.kind == 27) {
+						Get();
+					} else if (la.kind == 147) {
+						Get();
+					} else SynErr(271);
+					SemErr(t, "Ambiguous use of &, |, ^. Use parentheses to disambiguate."); 
+				}
 			} else if (la.kind == 27) {
 				op = BinaryExpr.Opcode.BitwiseOr; 
 				Get();
@@ -4769,6 +4801,14 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 					x = t; 
 					AsExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 					e0 = new BinaryExpr(x, op, e0, e1); 
+				}
+				if (IsBitwiseOp()) {
+					if (la.kind == 147) {
+						Get();
+					} else if (la.kind == 146) {
+						Get();
+					} else SynErr(272);
+					SemErr(t, "Ambiguous use of &, |, ^. Use parentheses to disambiguate."); 
 				}
 			} else if (la.kind == 147) {
 				op = BinaryExpr.Opcode.BitwiseXor; 
@@ -4782,7 +4822,15 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 					AsExpression(out e1, allowSemi, allowLambda, allowBitwiseOps);
 					e0 = new BinaryExpr(x, op, e0, e1); 
 				}
-			} else SynErr(271);
+				if (IsBitwiseOp()) {
+					if (la.kind == 146) {
+						Get();
+					} else if (la.kind == 27) {
+						Get();
+					} else SynErr(273);
+					SemErr(t, "Ambiguous use of &, |, ^. Use parentheses to disambiguate."); 
+				}
+			} else SynErr(274);
 		}
 	}
 
@@ -4797,7 +4845,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		} else if (la.kind == 145) {
 			Get();
 			x = t;  op = BinaryExpr.Opcode.Mod; 
-		} else SynErr(272);
+		} else SynErr(275);
 	}
 
 	void AsExpression(out Expression e, bool allowSemi, bool allowLambda, bool allowBitwiseOps) {
@@ -4873,7 +4921,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			while (IsSuffix()) {
 				Suffix(ref e);
 			}
-		} else SynErr(273);
+		} else SynErr(276);
 	}
 
 	void MapDisplayExpr(IToken/*!*/ mapToken, bool finite, out Expression e) {
@@ -4927,13 +4975,13 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				} else if (la.kind == 125) {
 					HashCall(id, out openParen, out typeArgs, out args);
 				} else if (StartOf(37)) {
-				} else SynErr(274);
+				} else SynErr(277);
 				e = new ExprDotName(id, e, id.val, typeArgs);
 				if (openParen != null) {
 				 e = new ApplySuffix(openParen, e, args);
 				}
 				
-			} else SynErr(275);
+			} else SynErr(278);
 		} else if (la.kind == 77) {
 			Get();
 			x = t; 
@@ -4981,7 +5029,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 						multipleIndices.Add(ee);
 						
 					}
-				} else SynErr(276);
+				} else SynErr(279);
 			} else if (la.kind == 157) {
 				Get();
 				anyDots = true; 
@@ -4989,7 +5037,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 					Expression(out ee, true, true);
 					e1 = ee; 
 				}
-			} else SynErr(277);
+			} else SynErr(280);
 			if (multipleIndices != null) {
 			 e = new MultiSelectExpr(x, e, multipleIndices);
 			 // make sure an array class with this dimensionality exists
@@ -5033,7 +5081,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			}
 			Expect(80);
 			e = new ApplySuffix(openParen, e, args); 
-		} else SynErr(278);
+		} else SynErr(281);
 	}
 
 	void ISetDisplayExpr(IToken/*!*/ setToken, bool finite, out Expression e) {
@@ -5074,7 +5122,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				}
 			}
 			Expect(80);
-		} else SynErr(279);
+		} else SynErr(282);
 		while (la.kind == 69 || la.kind == 70) {
 			if (la.kind == 69) {
 				Get();
@@ -5114,7 +5162,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				isExistentialGuard = true; 
 			} else if (StartOf(8)) {
 				Expression(out e, true, true);
-			} else SynErr(280);
+			} else SynErr(283);
 			Expect(39);
 			Expression(out e0, true, true, true);
 			Expect(40);
@@ -5177,7 +5225,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			NamedExpr(out e, allowSemi, allowLambda, allowBitwiseOps);
 			break;
 		}
-		default: SynErr(281); break;
+		default: SynErr(284); break;
 		}
 	}
 
@@ -5192,7 +5240,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		} else if (la.kind == 125) {
 			HashCall(id, out openParen, out typeArgs, out args);
 		} else if (StartOf(37)) {
-		} else SynErr(282);
+		} else SynErr(285);
 		e = new NameSegment(id, id.val, typeArgs);
 		if (openParen != null) {
 		 e = new ApplySuffix(openParen, e, args);
@@ -5221,7 +5269,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			}
 			e = new SeqDisplayExpr(x, elements); 
 			Expect(78);
-		} else SynErr(283);
+		} else SynErr(286);
 	}
 
 	void MultiSetExpr(out Expression e) {
@@ -5245,7 +5293,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			Expression(out e, true, true);
 			e = new MultiSetFormingExpr(x, e); 
 			Expect(80);
-		} else SynErr(284);
+		} else SynErr(287);
 	}
 
 	void SeqConstructionExpr(out Expression e) {
@@ -5300,7 +5348,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			 n = BigInteger.Zero;
 			}
 			
-		} else SynErr(285);
+		} else SynErr(288);
 	}
 
 	void Dec(out Basetypes.BigDec d) {
@@ -5416,7 +5464,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				NestedCaseExpression(out c, allowSemi, allowLambda, allowBitwiseOps);
 				cases.Add(c); 
 			}
-		} else SynErr(286);
+		} else SynErr(289);
 		e = new NestedMatchExpr(x, e, cases, usesOptionalBraces); 
 	}
 
@@ -5434,7 +5482,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		} else if (la.kind == 142 || la.kind == 143) {
 			Exists();
 			x = t; 
-		} else SynErr(287);
+		} else SynErr(290);
 		QuantifierDomain(out bvars, out attrs, out range);
 		QSep();
 		Expression(out body, allowSemi, allowLambda);
@@ -5491,7 +5539,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			RevealStmt(out s);
 		} else if (la.kind == 37) {
 			CalcStmt(out s);
-		} else SynErr(288);
+		} else SynErr(291);
 	}
 
 	void LetExpr(out Expression e, bool allowSemi, bool allowLambda, bool allowBitwiseOps) {
@@ -5500,7 +5548,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			LetExprWithLHS(out e, allowSemi, allowLambda, allowBitwiseOps);
 		} else if (la.kind == 116) {
 			LetExprWithoutLHS(out e, allowSemi, allowLambda, allowBitwiseOps);
-		} else SynErr(289);
+		} else SynErr(292);
 	}
 
 	void NamedExpr(out Expression e, bool allowSemi, bool allowLambda, bool allowBitwiseOps) {
@@ -5562,7 +5610,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		} else if (la.kind == 116) {
 			Get();
 			isLetOrFail = true; 
-		} else SynErr(290);
+		} else SynErr(293);
 		Expression(out e, false, true);
 		letRHSs.Add(e); 
 		while (la.kind == 26) {
@@ -5650,7 +5698,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			IdentTypeOptional(out bv);
 			pat = new CasePattern<BoundVar>(bv.tok, bv);
 			
-		} else SynErr(291);
+		} else SynErr(294);
 		if (pat == null) {
 		 pat = new CasePattern<BoundVar>(t, "_ParseError", new List<CasePattern<BoundVar>>());
 		}
@@ -5699,7 +5747,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		} else if (la.kind == 2) {
 			Get();
 			id = t; 
-		} else SynErr(292);
+		} else SynErr(295);
 		Expect(29);
 		Expression(out e, true, true);
 	}
@@ -5742,7 +5790,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		} else if (la.kind == 69) {
 			Get();
 			x = t; 
-		} else SynErr(293);
+		} else SynErr(296);
 	}
 
 
@@ -6095,28 +6143,31 @@ public class Errors {
 			case 269: s = "invalid RelOp"; break;
 			case 270: s = "invalid AddOp"; break;
 			case 271: s = "invalid BitvectorFactor"; break;
-			case 272: s = "invalid MulOp"; break;
-			case 273: s = "invalid UnaryExpression"; break;
-			case 274: s = "invalid Suffix"; break;
-			case 275: s = "invalid Suffix"; break;
-			case 276: s = "invalid Suffix"; break;
+			case 272: s = "invalid BitvectorFactor"; break;
+			case 273: s = "invalid BitvectorFactor"; break;
+			case 274: s = "invalid BitvectorFactor"; break;
+			case 275: s = "invalid MulOp"; break;
+			case 276: s = "invalid UnaryExpression"; break;
 			case 277: s = "invalid Suffix"; break;
 			case 278: s = "invalid Suffix"; break;
-			case 279: s = "invalid LambdaExpression"; break;
-			case 280: s = "invalid EndlessExpression"; break;
-			case 281: s = "invalid EndlessExpression"; break;
-			case 282: s = "invalid NameSegment"; break;
-			case 283: s = "invalid DisplayExpr"; break;
-			case 284: s = "invalid MultiSetExpr"; break;
-			case 285: s = "invalid Nat"; break;
-			case 286: s = "invalid NestedMatchExpression"; break;
-			case 287: s = "invalid QuantifierGuts"; break;
-			case 288: s = "invalid StmtInExpr"; break;
-			case 289: s = "invalid LetExpr"; break;
-			case 290: s = "invalid LetExprWithLHS"; break;
-			case 291: s = "invalid CasePattern"; break;
-			case 292: s = "invalid MemberBindingUpdate"; break;
-			case 293: s = "invalid DotSuffix"; break;
+			case 279: s = "invalid Suffix"; break;
+			case 280: s = "invalid Suffix"; break;
+			case 281: s = "invalid Suffix"; break;
+			case 282: s = "invalid LambdaExpression"; break;
+			case 283: s = "invalid EndlessExpression"; break;
+			case 284: s = "invalid EndlessExpression"; break;
+			case 285: s = "invalid NameSegment"; break;
+			case 286: s = "invalid DisplayExpr"; break;
+			case 287: s = "invalid MultiSetExpr"; break;
+			case 288: s = "invalid Nat"; break;
+			case 289: s = "invalid NestedMatchExpression"; break;
+			case 290: s = "invalid QuantifierGuts"; break;
+			case 291: s = "invalid StmtInExpr"; break;
+			case 292: s = "invalid LetExpr"; break;
+			case 293: s = "invalid LetExprWithLHS"; break;
+			case 294: s = "invalid CasePattern"; break;
+			case 295: s = "invalid MemberBindingUpdate"; break;
+			case 296: s = "invalid DotSuffix"; break;
 
       default: s = "error " + n; break;
     }

--- a/Test/dafny0/AndOrAmbiguity.dfy
+++ b/Test/dafny0/AndOrAmbiguity.dfy
@@ -1,0 +1,66 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// && and || have the same binding power and do not associate with each other.
+// The same goes for ==> and <==, and for &, |, and ^.
+// The tests below check that these ambiguities result in understandable error message.
+
+method M0() returns (A: bool, B: bool)
+  ensures A && B ||  // error: and-or ambiguity
+
+method M1() returns (A: bool, B: bool)
+  ensures A || B &&  // error: and-or ambiguity
+
+method M2() returns (A: bool, B: bool)
+  ensures && B ||  // error: and-or ambiguity
+
+method M3() returns (A: bool, B: bool)
+  ensures || B &&  // error: and-or ambiguity
+
+method M4() returns (A: bool, B: bool)
+  ensures && A && B ||  // error: and-or ambiguity
+
+method M5() returns (A: bool, B: bool)
+  ensures || A || B &&  // error: and-or ambiguity
+
+// ---
+
+method N0() returns (A: bool, B: bool, C: bool)
+  ensures A ==> B <==  // error: plication ambiguity
+
+method N1() returns (A: bool, B: bool, C: bool)
+  ensures A ==> B ==> C <==  // error: plication ambiguity
+
+method N2() returns (A: bool, B: bool, C: bool)
+  ensures A <== B ==>  // error: plication ambiguity
+
+method N3() returns (A: bool, B: bool, C: bool)
+  ensures A <== B <== C ==>  // error: plication ambiguity
+
+// ---
+
+method P0() returns (a: bv8, b: bv8)
+  ensures a & b |  // error: bitwise-op ambiguity
+
+method P1() returns (a: bv8, b: bv8)
+  ensures a & b ^  // error: bitwise-op ambiguity
+
+method P2() returns (a: bv8, b: bv8)
+  ensures a | b ^  // error: bitwise-op ambiguity
+
+method P3() returns (a: bv8, b: bv8)
+  ensures a | b &  // error: bitwise-op ambiguity
+
+method P4() returns (a: bv8, b: bv8)
+  ensures a ^ b &  // error: bitwise-op ambiguity
+
+method P5() returns (a: bv8, b: bv8)
+  ensures a ^ b |  // error: bitwise-op ambiguity
+
+// ---
+
+method SwanSong() returns (A: bool, B: bool, C: bool)
+  ensures A || B && C  // error: and-or ambiguity (this also gives an EOF error message for the C)
+
+method PostSwanSong() returns (A: bool, B: bool, C: bool)
+  ensures A || B && C  // since the parser already expected an EOF above, it doesn't even get here

--- a/Test/dafny0/AndOrAmbiguity.dfy.expect
+++ b/Test/dafny0/AndOrAmbiguity.dfy.expect
@@ -1,0 +1,19 @@
+AndOrAmbiguity.dfy(9,17): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(12,17): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(15,15): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(18,15): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(21,20): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(24,20): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(29,18): Error: Ambiguous use of ==> and <==. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(32,24): Error: Ambiguous use of ==> and <==. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(35,18): Error: Ambiguous use of ==> and <==. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(38,24): Error: Ambiguous use of ==> and <==. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(43,16): Error: Ambiguous use of &, |, ^. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(46,16): Error: Ambiguous use of &, |, ^. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(49,16): Error: Ambiguous use of &, |, ^. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(52,16): Error: Ambiguous use of &, |, ^. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(55,16): Error: Ambiguous use of &, |, ^. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(58,16): Error: Ambiguous use of &, |, ^. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(63,17): Error: Ambiguous use of && and ||. Use parentheses to disambiguate.
+AndOrAmbiguity.dfy(63,20): Error: EOF expected
+18 parse errors detected in AndOrAmbiguity.dfy

--- a/Test/traits/TraitOverride2.dfy.expect
+++ b/Test/traits/TraitOverride2.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 25 verified, 0 errors
+Dafny program verifier finished with 20 verified, 0 errors


### PR DESCRIPTION
The operators && and || have the same binding power, but do not associate with other.
The same goes for ==> and <==, and also for &, |, and ^.
Parsing-error messages for these have now been improved.