### PR TITLE
Fix for issue #590

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -200,6 +200,9 @@ namespace Microsoft.Dafny
           }
         }
       }
+      if (dafnyFiles.Count == 0) { ExecutionEngine.printer.ErrorWriteLine(Console.Out, "*** Error: The command-line contains no .dfy files");
+        return CommandLineArgumentsResult.PREPROCESSING_ERROR;
+      }
       return CommandLineArgumentsResult.OK;
     }
 

--- a/Test/git-issues/git-issue-590.dfy
+++ b/Test/git-issues/git-issue-590.dfy
@@ -1,0 +1,3 @@
+// RUN: %dafny /compile:3 x.cs > "%t"
+// RUN: %diff "%s.expect" "%t"
+// XFAIL: *

--- a/Test/git-issues/git-issue-590.dfy.expect
+++ b/Test/git-issues/git-issue-590.dfy.expect
@@ -1,0 +1,1 @@
+*** Error: The command-line contains no .dfy files


### PR DESCRIPTION
In several places there are Contracts or code that presume that some dafny file is on the command-line. The simplest fix is to have an early check that this is indeed the case.