### PR TITLE
Fixes #351. Already fixed in Boogie 2.4.17. Adding test cases.

### DIFF
--- a/Test/git-issues/git-issue-351.dfy
+++ b/Test/git-issues/git-issue-351.dfy
@@ -3,8 +3,8 @@
 
 
 function method DecodeRecursively(s: seq<int>): (b: seq<int>) {
-    seq(|s|, i requires 0 <= i < |s| =>
-        var d := s[0]; // this line produces the error below
-        s[i]
-    )
+  seq(|s|, i requires 0 <= i < |s| =>
+    var d := s[0]; // this line produced the reported error, prior to the fix
+    s[i]
+  )
 }

--- a/Test/git-issues/git-issue-351.dfy
+++ b/Test/git-issues/git-issue-351.dfy
@@ -1,0 +1,10 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+
+function method DecodeRecursively(s: seq<int>): (b: seq<int>) {
+    seq(|s|, i requires 0 <= i < |s| =>
+        var d := s[0]; // this line produces the error below
+        s[i]
+    )
+}

--- a/Test/git-issues/git-issue-351.dfy.expect
+++ b/Test/git-issues/git-issue-351.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
Fixes #351. Fixed in Boogie 2.4.17, likely by https://github.com/boogie-org/boogie/commit/fd500e1acd56ee390a880f859783c2a7a164d9d2