### PR TITLE
#356: Implemented all combinations of 'as' conversions among { int, char, bv, real, ordinal}

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2183,7 +2183,6 @@ namespace Microsoft.Dafny
           if (AsNativeType(e.E.Type) != null) {
             wr.Write("new BigInteger");
           }
-
           TrParenExpr(e.E, wr, inLetExprBody);
           wr.Write(", BigInteger.One)");
         } else if (e.ToType.IsCharType) {
@@ -2241,7 +2240,6 @@ namespace Microsoft.Dafny
               // no optimization applies; use the standard translation
               TrParenExpr(e.E, wr, inLetExprBody);
             }
-
           }
         }
       } else if (e.E.Type.IsNumericBased(Type.NumericPersuation.Real)) {
@@ -2250,17 +2248,13 @@ namespace Microsoft.Dafny
           // real -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
           TrExpr(e.E, wr, inLetExprBody);
-        } else if (e.ToType.IsBigOrdinalType) {
-          TrExpr(e.E, wr, inLetExprBody);
-          wr.Write(".ToBigInteger()");
         } else {
-          // real -> (int or bv or char)
+          // real -> (int or bv or char or ordinal)
           if (e.ToType.IsCharType) {
             wr.Write("(char)");
           } else if (AsNativeType(e.ToType) != null) {
             wr.Write("({0})", GetNativeTypeName(AsNativeType(e.ToType)));
           }
-
           TrParenExpr(e.E, wr, inLetExprBody);
           wr.Write(".ToBigInteger()");
         }
@@ -2268,9 +2262,8 @@ namespace Microsoft.Dafny
         if (e.ToType.IsNumericBased(Type.NumericPersuation.Int) || e.ToType.IsBigOrdinalType) {
           TrExpr(e.E, wr, inLetExprBody);
         } else if (e.ToType.IsCharType) {
-          wr.Write("(char)(");
-          TrExpr(e.E, wr, inLetExprBody);
-          wr.Write(")");
+          wr.Write("(char)");
+          TrParenExpr(e.E, wr, inLetExprBody);
         } else if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
           wr.Write("new Dafny.BigRational(");
           if (AsNativeType(e.E.Type) != null) {
@@ -2282,15 +2275,15 @@ namespace Microsoft.Dafny
             wr.Write(", 1)");
           }
         } else if (e.ToType.IsBitVectorType) {
+          // ordinal -> bv
           var typename = TypeName(e.ToType, wr, null, null);
           wr.Write($"({typename})");
           TrParenExpr(e.E, wr, inLetExprBody);
         } else {
-          Contract.Assert(false, $"{0}not implemented for C#: {e.E.Type} -> {e.ToType}");
+          Contract.Assert(false, $"not implemented for C#: {e.E.Type} -> {e.ToType}");
         }
-
       } else {
-        Contract.Assert(false, $"{0}not implemented for C#: {e.E.Type} -> {e.ToType}");
+        Contract.Assert(false, $"not implemented for C#: {e.E.Type} -> {e.ToType}");
       }
     }
 

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -3058,7 +3058,6 @@ namespace Microsoft.Dafny {
             TrExpr(e.E, wr, inLetExprBody);
           } else if (fromNative != null) {
             Contract.Assert(toNative == null); // follows from other checks
-
             // native (int or bv) -> big-integer (int or bv)
             wr.Write("_dafny.IntOf{0}(", Capitalize(GetNativeTypeName(fromNative)));
             TrExpr(e.E, wr, inLetExprBody);
@@ -3087,7 +3086,6 @@ namespace Microsoft.Dafny {
               TrParenExpr(e.E, wr, inLetExprBody);
               wr.Write(".{0}()", Capitalize(GetNativeTypeName(toNative)));
             }
-
           }
         }
       } else if (e.E.Type.IsNumericBased(Type.NumericPersuation.Real)) {
@@ -3109,7 +3107,7 @@ namespace Microsoft.Dafny {
           }
         }
       } else {
-        Contract.Assert(false, $"{0}not implemented for go: {e.E.Type} -> {e.ToType}");
+        Contract.Assert(false, $"not implemented for go: {e.E.Type} -> {e.ToType}");
       }
     }
 

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.Dafny{
           }
           break;
         case SpecialField.ID.Floor:
-          compiledName = "toBigInteger()";
+          compiledName = "ToBigInteger()";
           break;
         case SpecialField.ID.IsLimit:
           preString = "dafny.BigOrdinal.IsLimit(";
@@ -3611,76 +3611,92 @@ namespace Microsoft.Dafny{
     }
 
     protected override void EmitConversionExpr(ConversionExpr e, bool inLetExprBody, TargetWriter wr) {
-      if (e.E.Type.IsNumericBased(Type.NumericPersuation.Int) || e.E.Type.IsBitVectorType || e.E.Type.IsCharType) {
-        if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
-          // (int or bv) -> real
-          Contract.Assert(AsNativeType(e.ToType) == null);
+      Expression arg = e.E;
+      Type fromType = e.E.Type;
+      Type toType = e.ToType;
+
+      if (fromType.IsNumericBased(Type.NumericPersuation.Int) || fromType.IsBitVectorType || fromType.IsCharType) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          // (int or bv or char) -> real
+          Contract.Assert(AsNativeType(toType) == null);
           wr.Write($"new {DafnyBigRationalClass}(");
-          if (AsNativeType(e.E.Type) != null) {
+          if (AsNativeType(fromType) != null) {
             wr.Write("java.math.BigInteger.valueOf");
-          }
-          TrParenExpr(e.E, wr, inLetExprBody);
-          wr.Write(", java.math.BigInteger.ONE)");
-        } else if (e.ToType.IsCharType) {
-          // Painfully, Java sign-extends bytes when casting to chars ...
-          var fromNative = AsNativeType(e.E.Type);
-          wr.Write("(char)");
-          if (fromNative != null && fromNative.Sel == NativeType.Selection.Byte) {
-            wr.Write("java.lang.Byte.toUnsignedInt");
-            TrParenExpr(e.E, wr, inLetExprBody);
+            TrParenExpr(arg, wr, inLetExprBody);
+            wr.Write(", java.math.BigInteger.ONE)");
+          } else if (fromType.IsCharType) {
+            TrExpr(arg, wr, inLetExprBody);
+            wr.Write(", 1)");
           } else {
-            TrExprAsInt(e.E, wr, inLetExprBody);
+            TrExpr(arg, wr, inLetExprBody);
+            wr.Write(", java.math.BigInteger.ONE)");
+          }
+
+        } else if (toType.IsCharType) {
+          // (int or bv or char) -> char
+          // Painfully, Java sign-extends bytes when casting to chars ...
+          if (fromType.IsCharType) {
+            TrParenExpr(arg, wr, inLetExprBody);
+          } else {
+            var fromNative = AsNativeType(fromType);
+            wr.Write("(char)");
+            if (fromNative != null && fromNative.Sel == NativeType.Selection.Byte) {
+              wr.Write("java.lang.Byte.toUnsignedInt");
+              TrParenExpr(arg, wr, inLetExprBody);
+            } else {
+              TrExprAsInt(arg, wr, inLetExprBody);
+            }
           }
         } else {
           // (int or bv or char) -> (int or bv or ORDINAL)
           var fromNative = AsNativeType(e.E.Type);
           var toNative = AsNativeType(e.ToType);
           if (fromNative == null && toNative == null) {
-            if (e.E.Type.IsCharType) {
+            if (fromType.IsCharType) {
               // char -> big-integer (int or bv or ORDINAL)
               wr.Write("java.math.BigInteger.valueOf");
-              TrParenExpr(e.E, wr, inLetExprBody);
+              TrParenExpr(arg, wr, inLetExprBody);
             } else {
               // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-              TrExpr(e.E, wr, inLetExprBody);
+              TrExpr(arg, wr, inLetExprBody);
             }
           } else if (fromNative != null && toNative == null) {
             // native (int or bv) -> big-integer (int or bv)
             if (fromNative.Sel == NativeType.Selection.ULong) {
               // Can't just use .longValue() because that may return a negative
               wr.Write($"{DafnyHelpersClass}.unsignedLongToBigInteger");
-              TrParenExpr(e.E, wr, inLetExprBody);
+              TrParenExpr(arg, wr, inLetExprBody);
             } else {
               wr.Write("java.math.BigInteger.valueOf(");
               if (fromNative.LowerBound >= 0) {
-                TrParenExpr($"{GetBoxedNativeTypeName(fromNative)}.toUnsignedLong", e.E, wr, inLetExprBody);
+                TrParenExpr($"{GetBoxedNativeTypeName(fromNative)}.toUnsignedLong", arg, wr, inLetExprBody);
               } else {
-                TrParenExpr(e.E, wr, inLetExprBody);
+                TrParenExpr(arg, wr, inLetExprBody);
               }
               wr.Write(")");
             }
           } else if (fromNative != null && NativeTypeSize(toNative) == NativeTypeSize(fromNative)) {
             // native (int or bv) -> native (int or bv)
             // Cast between signed and unsigned, which have the same Java type
-            TrParenExpr(e.E, wr, inLetExprBody);
+            TrParenExpr(arg, wr, inLetExprBody);
           } else {
             GetNativeInfo(toNative.Sel, out var toNativeName, out var toNativeSuffix, out var toNativeNeedsCast);
             // any (int or bv) -> native (int or bv)
             // A cast would do, but we also consider some optimizations
-            var literal = PartiallyEvaluate(e.E);
-            UnaryOpExpr u = e.E.Resolved as UnaryOpExpr;
-            MemberSelectExpr m = e.E.Resolved as MemberSelectExpr;
+            var literal = PartiallyEvaluate(arg);
+            UnaryOpExpr u = arg.Resolved as UnaryOpExpr;
+            MemberSelectExpr m = arg.Resolved as MemberSelectExpr;
             if (literal != null) {
               // Optimize constant to avoid intermediate BigInteger
               EmitNativeIntegerLiteral((BigInteger) literal, toNative, wr);
             } else if (u != null && u.Op == UnaryOpExpr.Opcode.Cardinality) {
               // Optimize || to avoid intermediate BigInteger
-              wr.Write(CastIfSmallNativeType(e.ToType));
+              wr.Write(CastIfSmallNativeType(toType));
               TrParenExpr("", u.E, wr, inLetExprBody);
               wr.Write(".cardinalityInt()");
             } else if (m != null && m.MemberName == "Length" && m.Obj.Type.IsArrayType) {
               // Optimize .length to avoid intermediate BigInteger
-              wr.Write(CastIfSmallNativeType(e.ToType));
+              wr.Write(CastIfSmallNativeType(toType));
               var elmtType = UserDefinedType.ArrayElementType(m.Obj.Type);
               TargetWriter w;
               if (elmtType.IsTypeParameter) {
@@ -3702,46 +3718,77 @@ namespace Microsoft.Dafny{
                 } else {
                   wr.Write(".toUnsignedInt");
                 }
-                TrParenExpr(e.E, wr, inLetExprBody);
+                TrParenExpr(arg, wr, inLetExprBody);
               } else {
-                if (fromNative == null && !e.E.Type.IsCharType) {
-                  TrParenExpr(e.E, wr, inLetExprBody);
+                if (fromNative == null && !fromType.IsCharType) {
+                  TrParenExpr(arg, wr, inLetExprBody);
                   wr.Write($".{toNativeName}Value()");
                 } else {
                   wr.Write($"(({toNativeName}) ");
-                  TrParenExpr(e.E, wr, inLetExprBody);
+                  TrParenExpr(arg, wr, inLetExprBody);
                   wr.Write(")");
                 }
               }
             }
           }
         }
-      } else if (e.E.Type.IsNumericBased(Type.NumericPersuation.Real)) {
-        Contract.Assert(AsNativeType(e.E.Type) == null);
-        if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
+      } else if (fromType.IsNumericBased(Type.NumericPersuation.Real)) {
+        Contract.Assert(AsNativeType(fromType) == null);
+        if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
           // real -> real
-          Contract.Assert(AsNativeType(e.ToType) == null);
-          TrExpr(e.E, wr, inLetExprBody);
-        } else if (e.ToType.IsCharType) {
+          Contract.Assert(AsNativeType(toType) == null);
+          TrExpr(arg, wr, inLetExprBody);
+        } else if (toType.IsCharType) {
           // real -> char
           // Painfully, Java sign-extends bytes when casting to chars ...
           wr.Write("(char)");
-          TrParenExpr(e.E, wr, inLetExprBody);
-          wr.Write(".ToBigInteger().intValue()");
+          TrParenExpr(arg, wr, inLetExprBody);
+          wr.Write(".ToBigInteger().intValue()"); 
+        } else if (toType.IsBigOrdinalType) {
+          TrParenExpr(arg, wr, inLetExprBody);
+          wr.Write(".ToBigInteger()"); 
         } else {
           // real -> (int or bv)
-          TrParenExpr(e.E, wr, inLetExprBody);
+          TrParenExpr(arg, wr, inLetExprBody);
           wr.Write(".ToBigInteger()");
-          if (AsNativeType(e.ToType) != null) {
-            wr.Write($".{GetNativeTypeName(AsNativeType(e.ToType))}Value()");
+          if (AsNativeType(toType) != null) {
+            wr.Write($".{GetNativeTypeName(AsNativeType(toType))}Value()");
           }
         }
-      } else {
-        Contract.Assert(e.E.Type.IsBigOrdinalType);
-        Contract.Assert(e.ToType.IsNumericBased(Type.NumericPersuation.Int));
-        TrParenExpr(e.E, wr, inLetExprBody);
-        if (AsNativeType(e.ToType) != null) {
-          wr.Write($".{GetNativeTypeName(AsNativeType(e.ToType))}Value()");
+      } else if (fromType.IsBigOrdinalType) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int) || toType.IsCharType) {
+          // ordinal -> int, char
+          if (AsNativeType(toType) != null) {
+            TrParenExpr(arg, wr, inLetExprBody);
+            wr.Write($".{GetNativeTypeName(AsNativeType(toType))}Value()");
+          } else if (toType.IsCharType) {
+            wr.Write("(char)");
+            TrParenExpr(arg, wr, inLetExprBody);
+            wr.Write(".intValue()"); 
+
+          } else {
+            TrParenExpr(arg, wr, inLetExprBody);
+          }
+
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          // ordinal -> real
+          wr.Write($"new {DafnyBigRationalClass}(");
+          TrExpr(arg, wr, inLetExprBody);
+          wr.Write(", java.math.BigInteger.ONE)");
+
+        } else if (toType.IsBitVectorType) {
+          // ordinal -> bv
+          if (AsNativeType(toType) != null) {
+            TrParenExpr(arg, wr, inLetExprBody);
+            wr.Write($".{GetNativeTypeName(AsNativeType(toType))}Value()");
+          } else {
+            TrParenExpr(arg, wr, inLetExprBody);
+            Contract.Assert(false,$"not implemented for java: {fromType} -> {toType}");
+          }
+        } else if (toType.IsBigOrdinalType) {
+          TrParenExpr(arg, wr, inLetExprBody);
+        } else {
+          Contract.Assert(false,$"not implemented for java: {fromType} -> {toType}");
         }
       }
     }

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -3614,7 +3614,6 @@ namespace Microsoft.Dafny{
       Expression arg = e.E;
       Type fromType = e.E.Type;
       Type toType = e.ToType;
-
       if (fromType.IsNumericBased(Type.NumericPersuation.Int) || fromType.IsBitVectorType || fromType.IsCharType) {
         if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
           // (int or bv or char) -> real
@@ -3631,7 +3630,6 @@ namespace Microsoft.Dafny{
             TrExpr(arg, wr, inLetExprBody);
             wr.Write(", java.math.BigInteger.ONE)");
           }
-
         } else if (toType.IsCharType) {
           // (int or bv or char) -> char
           // Painfully, Java sign-extends bytes when casting to chars ...
@@ -3764,18 +3762,15 @@ namespace Microsoft.Dafny{
           } else if (toType.IsCharType) {
             wr.Write("(char)");
             TrParenExpr(arg, wr, inLetExprBody);
-            wr.Write(".intValue()"); 
-
+            wr.Write(".intValue()");
           } else {
             TrParenExpr(arg, wr, inLetExprBody);
           }
-
         } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
           // ordinal -> real
           wr.Write($"new {DafnyBigRationalClass}(");
           TrExpr(arg, wr, inLetExprBody);
           wr.Write(", java.math.BigInteger.ONE)");
-
         } else if (toType.IsBitVectorType) {
           // ordinal -> bv
           if (AsNativeType(toType) != null) {
@@ -3783,13 +3778,14 @@ namespace Microsoft.Dafny{
             wr.Write($".{GetNativeTypeName(AsNativeType(toType))}Value()");
           } else {
             TrParenExpr(arg, wr, inLetExprBody);
-            Contract.Assert(false,$"not implemented for java: {fromType} -> {toType}");
           }
         } else if (toType.IsBigOrdinalType) {
           TrParenExpr(arg, wr, inLetExprBody);
         } else {
           Contract.Assert(false,$"not implemented for java: {fromType} -> {toType}");
         }
+      } else {
+        Contract.Assert(false, $"not implemented for java: {fromType} -> {toType}");
       }
     }
 

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -2041,7 +2041,7 @@ namespace Microsoft.Dafny {
           var toNative = AsNativeType(e.ToType);
           if (fromNative != null && toNative != null) {
             // from a native, to a native -- simple!
-           TrExpr(e.E, wr, inLetExprBody);
+            TrExpr(e.E, wr, inLetExprBody);
           } else if (e.E.Type.IsCharType) {
             Contract.Assert(fromNative == null);
             if (toNative == null) {
@@ -2083,7 +2083,6 @@ namespace Microsoft.Dafny {
               TrParenExpr(e.E, wr, inLetExprBody);
               wr.Write(".toNumber()");
             }
-
           }
         }
       } else if (e.E.Type.IsNumericBased(Type.NumericPersuation.Real)) {

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -2014,15 +2014,19 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitConversionExpr(ConversionExpr e, bool inLetExprBody, TargetWriter wr) {
-      if (e.E.Type.IsNumericBased(Type.NumericPersuation.Int) || e.E.Type.IsBitVectorType || e.E.Type.IsCharType) {
-        if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
-          // (int or bv) -> real
+      if (e.E.Type.IsNumericBased(Type.NumericPersuation.Int) || e.E.Type.IsBitVectorType || e.E.Type.IsCharType || e.E.Type.IsBigOrdinalType) {
+        if (e.ToType.Equals(e.E.Type)) {
+          TrParenExpr(e.E, wr, inLetExprBody);
+        } else if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
+          // (int or bv or char) -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
           wr.Write("new _dafny.BigRational(");
-          if (AsNativeType(e.E.Type) != null) {
+          if (AsNativeType(e.E.Type) != null || e.E.Type.IsCharType) {
             wr.Write("new BigNumber");
           }
+          if (e.E.Type.IsCharType) wr.Write("(");
           TrParenExpr(e.E, wr, inLetExprBody);
+          if (e.E.Type.IsCharType) wr.Write(".charCodeAt(0))");
           wr.Write(", new BigNumber(1))");
         } else if (e.ToType.IsCharType) {
           wr.Write("String.fromCharCode(");
@@ -2100,11 +2104,12 @@ namespace Microsoft.Dafny {
             wr.Write(".toNumber()");
           }
         }
-      } else {
-        Contract.Assert(e.E.Type.IsBigOrdinalType);
-        Contract.Assert(e.ToType.IsNumericBased(Type.NumericPersuation.Int));
-        // identity will do
+      } else if (e.E.Type.IsBigOrdinalType) {
+        if (e.ToType.IsCharType) wr.Write("String.fromCharCode((");
         TrExpr(e.E, wr, inLetExprBody);
+        if (e.ToType.IsCharType) wr.Write(").toNumber())");
+      } else {
+        Contract.Assert(false, $"not implemented for javascript: {e.E.Type} -> {e.ToType}");
       }
     }
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -4079,9 +4079,6 @@ namespace Microsoft.Dafny
           case "NumericOrBitvector":
             satisfied = t.IsNumericBased() || t.IsBitVectorType;
             break;
-          case "NumericOrBitvectorOrChar":
-            satisfied = t.IsNumericBased() || t.IsBitVectorType || t.IsCharType;
-            break;
           case "NumericOrBitvectorOrCharOrORDINAL":
             satisfied = t.IsNumericBased() || t.IsBitVectorType || t.IsCharType || t.IsBigOrdinalType;
             break;

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -4079,6 +4079,9 @@ namespace Microsoft.Dafny
           case "NumericOrBitvector":
             satisfied = t.IsNumericBased() || t.IsBitVectorType;
             break;
+          case "NumericOrBitvectorOrChar":
+            satisfied = t.IsNumericBased() || t.IsBitVectorType || t.IsCharType;
+            break;
           case "NumericOrBitvectorOrCharOrORDINAL":
             satisfied = t.IsNumericBased() || t.IsBitVectorType || t.IsCharType || t.IsBigOrdinalType;
             break;
@@ -13107,7 +13110,7 @@ namespace Microsoft.Dafny
           } else if (e.ToType.IsBitVectorType) {
             AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a bitvector-based type is allowed only from numeric and bitvector types (got {0})");
           } else if (e.ToType.IsCharType) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a char type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrChar", e.E.Type, "type conversion to a char type is allowed only from numeric and bitvector types (got {0})");
           } else if (e.ToType.IsBigOrdinalType) {
             AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to an ORDINAL type is allowed only from numeric and bitvector types (got {0})");
           } else {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -13106,13 +13106,13 @@ namespace Microsoft.Dafny
           if (e.ToType.IsNumericBased(Type.NumericPersuation.Int)) {
             AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to an int-based type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a real-based type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to a real-based type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsBitVectorType) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a bitvector-based type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to a bitvector-based type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsCharType) {
-            AddXConstraint(expr.tok, "NumericOrBitvectorOrChar", e.E.Type, "type conversion to a char type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to a char type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsBigOrdinalType) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to an ORDINAL type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to an ORDINAL type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else {
             reporter.Error(MessageSource.Resolver, expr, "type conversions are not supported to this type (got {0})", e.ToType);
           }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8178,28 +8178,6 @@ namespace Microsoft.Dafny {
       return r;
     }
 
-
-    //   if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
-    //     return r;
-    //   } else if (toType.IsCharType) {
-    //     Contract.Assert(fromType.IsNumericBased(Type.NumericPersuation.Int));
-    //     return FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
-    //   } else {
-    //     Contract.Assert(toType.IsBitVectorType);
-    //     var toWidth = toType.AsBitVectorType.Width;
-    //     if (RemoveLit(r) is Bpl.LiteralExpr) {
-    //       Bpl.LiteralExpr e = (Bpl.LiteralExpr) RemoveLit(r);
-    //       if (e.isBigNum) {
-    //         var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth);  // 1 << toWidth
-    //         if (e.asBigNum <= toBound) {
-    //           return BplBvLiteralExpr(r.tok, e.asBigNum, toType.AsBitVectorType);
-    //         }
-    //       }
-    //     }
-    //     return FunctionCall(tok, "nat_to_bv" + toWidth, BplBvType(toWidth), r);
-    //   }
-    // }
-    
     private Bpl.Expr IntToBV(IToken tok, Bpl.Expr r, Type toType) {
       var toWidth = toType.AsBitVectorType.Width;
       if (RemoveLit(r) is Bpl.LiteralExpr) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8307,27 +8307,23 @@ namespace Microsoft.Dafny {
             string.Format("{0}ordinal value to be converted might not fit in {1}", errorMsgPrefix, toType)));
         }
       } else if (toType.IsBigOrdinalType) {
-          if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
-            PutSourceIntoLocal();
-            Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), o);
-            builder.Add(Assert(tok, boundsCheck,
-              string.Format("{0}a negative integer cannot be converted to an {1}", errorMsgPrefix, toType)));
-          }
-
-          if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
-            PutSourceIntoLocal();
-            var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
-            Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), oi);
-            builder.Add(Assert(tok, boundsCheck,
-              string.Format("{0}a negative real cannot be converted to an {1}", errorMsgPrefix, toType)));
-          }
-          
+        if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
+          PutSourceIntoLocal();
+          Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), o);
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}a negative integer cannot be converted to an {1}", errorMsgPrefix, toType)));
+        }
+        if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
+          PutSourceIntoLocal();
+          var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+          Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), oi);
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}a negative real cannot be converted to an {1}", errorMsgPrefix, toType)));
+        }
       } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
         // already checked that BigOrdinal or real inputs are integral
-        // FIXME - are there subset range checks to make?}
       } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
         // already checked that BigOrdinal is integral
-        // FIXME - are there subset range checks to make?
       }
 
       if (toType.NormalizeExpandKeepConstraints().AsRedirectingType != null) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8331,8 +8331,11 @@ namespace Microsoft.Dafny {
         Bpl.Expr be;
         if (expr.Type.IsNumericBased() || expr.Type.IsBitVectorType) {
           be = ConvertExpression(expr.tok, o, expr.Type, toType);
+        } else if (expr.Type.IsCharType) {
+          be = ConvertExpression(expr.tok, o, Dafny.Type.Int, toType);
         } else if (expr.Type.IsBigOrdinalType) {
           be = FunctionCall(expr.tok, "ORD#Offset", Bpl.Type.Int, o);
+          be = ConvertExpression(expr.tok, be, Dafny.Type.Int, toType);
         } else {
           be = o;
         }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8064,6 +8064,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(toType != null);
       toType = toType.NormalizeExpand();
       fromType = fromType.NormalizeExpand();
+      if (fromType.Equals(toType)) return r;
       if (fromType.IsBitVectorType) {
         var fromWidth = fromType.AsBitVectorType.Width;
         if (toType.IsBitVectorType) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8091,12 +8091,18 @@ namespace Microsoft.Dafny {
           r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
           if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
             r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+          } else if (toType.IsCharType) {
+            r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
           }
           return r;
         }
       }
       if (fromType.IsNumericBased(Type.NumericPersuation.Real)) {
         if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          return r;
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
           return r;
         }
         r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8064,83 +8064,154 @@ namespace Microsoft.Dafny {
       Contract.Requires(toType != null);
       toType = toType.NormalizeExpand();
       fromType = fromType.NormalizeExpand();
-      if (fromType.Equals(toType)) return r;
-      if (fromType.IsBitVectorType) {
+      if (fromType.IsNumericBased(Type.NumericPersuation.Int)) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          // do nothing
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = IntToBV(tok, r, toType);
+        } else if (toType.IsBigOrdinalType) {
+          r = FunctionCall(tok, "ORD#FromNat", predef.BigOrdinalType, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
+      } else if (fromType.IsBitVectorType) {
         var fromWidth = fromType.AsBitVectorType.Width;
         if (toType.IsBitVectorType) {
           // conversion from one bitvector type to another
           var toWidth = toType.AsBitVectorType.Width;
           if (fromWidth == toWidth) {
-            return r;
+            // no conversion
           } else if (fromWidth < toWidth) {
             var zeros = BplBvLiteralExpr(tok, Basetypes.BigNum.ZERO, toWidth - fromWidth);
             if (fromWidth == 0) {
-              return zeros;
+              r = zeros;
             } else {
               var concat = new Bpl.BvConcatExpr(tok, zeros, r);
               // There's a bug in Boogie that causes a warning to be emitted if a BvConcatExpr is passed as the argument
               // to $Box, which takes a type argument.  The bug can apparently be worked around by giving an explicit
               // (and other redudant) type conversion.
-              return Bpl.Expr.CoerceType(tok, concat, BplBvType(toWidth));
+              r = Bpl.Expr.CoerceType(tok, concat, BplBvType(toWidth));
             }
           } else if (toWidth == 0) {
-            return BplBvLiteralExpr(tok, Basetypes.BigNum.ZERO, toWidth);
+            r = BplBvLiteralExpr(tok, Basetypes.BigNum.ZERO, toWidth);
           } else {
-            return new Bpl.BvExtractExpr(tok, r, toWidth, 0);
+            r = new Bpl.BvExtractExpr(tok, r, toWidth, 0);
           }
-        } else {
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
           r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
-          if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
-            r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
-          } else if (toType.IsCharType) {
-            r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
-          }
-          return r;
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        } else if (toType.IsBigOrdinalType) {
+          r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
+          r = FunctionCall(tok, "ORD#FromNat", predef.BigOrdinalType, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
         }
-      }
-      if (fromType.IsNumericBased(Type.NumericPersuation.Real)) {
+        return r;
+      } else if (fromType.IsCharType) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+        } else if (toType.IsCharType) {
+          // do nothing
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+          r = IntToBV(tok, r, toType);
+        } else if (toType.IsBigOrdinalType) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+          r = FunctionCall(tok, "ORD#FromNat", Bpl.Type.Int, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
+      } else if (fromType.IsNumericBased(Type.NumericPersuation.Real)) {
         if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
-          return r;
+          // do nothing
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+          r = IntToBV(tok, r, toType);
         } else if (toType.IsCharType) {
           r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
           r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
-          return r;
-        }
-        r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
-        // "r" now denotes an integer
-      } else if (fromType.IsCharType) {
-        Contract.Assert(toType.IsNumericBased(Type.NumericPersuation.Int));
-        return FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
-      } else if (fromType.IsBigOrdinalType) {
-        Contract.Assert(toType.IsNumericBased(Type.NumericPersuation.Int));
-        return FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
-      } else {
-        Contract.Assert(fromType.IsNumericBased(Type.NumericPersuation.Int));
-        if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
-          return FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
         } else if (toType.IsBigOrdinalType) {
-          return FunctionCall(tok, "ORD#FromNat", predef.BigOrdinalType, r);
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+          r = FunctionCall(tok, "ORD#FromNat", Bpl.Type.Int, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
         }
-      }
-      if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
         return r;
-      } else if (toType.IsCharType) {
-        Contract.Assert(fromType.IsNumericBased(Type.NumericPersuation.Int));
-        return FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        // "r" now denotes an integer
+      } else if (fromType.IsBigOrdinalType) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+          r = IntToBV(tok, r, toType);
+       } else if (toType.IsBigOrdinalType) {
+          // do nothing
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
       } else {
-        Contract.Assert(toType.IsBitVectorType);
-        var toWidth = toType.AsBitVectorType.Width;
-        if (RemoveLit(r) is Bpl.LiteralExpr) {
-          Bpl.LiteralExpr e = (Bpl.LiteralExpr) RemoveLit(r);
-          if (e.isBigNum) {
-            var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth);  // 1 << toWidth
-            if (e.asBigNum <= toBound) {
-              return BplBvLiteralExpr(r.tok, e.asBigNum, toType.AsBitVectorType);
-            }
+        Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+      }
+      return r;
+    }
+
+
+    //   if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+    //     return r;
+    //   } else if (toType.IsCharType) {
+    //     Contract.Assert(fromType.IsNumericBased(Type.NumericPersuation.Int));
+    //     return FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+    //   } else {
+    //     Contract.Assert(toType.IsBitVectorType);
+    //     var toWidth = toType.AsBitVectorType.Width;
+    //     if (RemoveLit(r) is Bpl.LiteralExpr) {
+    //       Bpl.LiteralExpr e = (Bpl.LiteralExpr) RemoveLit(r);
+    //       if (e.isBigNum) {
+    //         var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth);  // 1 << toWidth
+    //         if (e.asBigNum <= toBound) {
+    //           return BplBvLiteralExpr(r.tok, e.asBigNum, toType.AsBitVectorType);
+    //         }
+    //       }
+    //     }
+    //     return FunctionCall(tok, "nat_to_bv" + toWidth, BplBvType(toWidth), r);
+    //   }
+    // }
+    
+    private Bpl.Expr IntToBV(IToken tok, Bpl.Expr r, Type toType) {
+      var toWidth = toType.AsBitVectorType.Width;
+      if (RemoveLit(r) is Bpl.LiteralExpr) {
+        Bpl.LiteralExpr e = (Bpl.LiteralExpr) RemoveLit(r);
+        if (e.isBigNum) {
+          var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth);  // 1 << toWidth
+          if (e.asBigNum <= toBound) {
+            return BplBvLiteralExpr(r.tok, e.asBigNum, toType.AsBitVectorType);
           }
         }
-        return FunctionCall(tok, "nat_to_bv" + toWidth, BplBvType(toWidth), r);
       }
+      return FunctionCall(tok, "nat_to_bv" + toWidth, BplBvType(toWidth), r);
     }
 
     /// <summary>
@@ -8174,10 +8245,16 @@ namespace Microsoft.Dafny {
         // this operation is well-formed only if the real-based number represents an integer
         //   assert Real(Int(o)) == o;
         PutSourceIntoLocal();
-        var from = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+        Bpl.Expr from = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
         Bpl.Expr e = FunctionCall(tok, BuiltinFunction.IntToReal, null, from);
         e = Bpl.Expr.Binary(tok, Bpl.BinaryOperator.Opcode.Eq, e, o);
         builder.Add(Assert(tok, e, errorMsgPrefix + "the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)"));
+      }
+
+      if (expr.Type.IsBigOrdinalType && !toType.IsBigOrdinalType) {
+        PutSourceIntoLocal();
+        Bpl.Expr boundsCheck = FunctionCall(tok, "ORD#IsNat", Bpl.Type.Bool, o);
+        builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might be bigger than every natural number", errorMsgPrefix)));
       }
 
       if (toType.IsBitVectorType) {
@@ -8192,19 +8269,23 @@ namespace Microsoft.Dafny {
             var bound = BplBvLiteralExpr(tok, toBound, expr.Type.AsBitVectorType);
             boundsCheck = FunctionCall(expr.tok, "lt_bv" + fromWidth, Bpl.Type.Bool, o, bound);
           }
-        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
+        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Int) || expr.Type.IsCharType) {
           // Check "expr < (1 << toWdith)" in type "int"
           PutSourceIntoLocal();
           var bound = Bpl.Expr.Literal(toBound);
           boundsCheck = Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), o), Bpl.Expr.Lt(o, bound));
-        } else {
-          Contract.Assert(expr.Type.IsNumericBased(Type.NumericPersuation.Real));
+        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
           // Check "Int(expr) < (1 << toWdith)" in type "int"
           PutSourceIntoLocal();
           var bound = Bpl.Expr.Literal(toBound);
           var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
           boundsCheck = Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), oi), Bpl.Expr.Lt(oi, bound));
+        } else if (expr.Type.IsBigOrdinalType) {
+          var bound = Bpl.Expr.Literal(toBound);
+          var oi = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, o);
+          boundsCheck = Bpl.Expr.Lt(oi, bound);
         }
+
         if (boundsCheck != null) {
           builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might not fit in {1}", errorMsgPrefix, toType)));
         }
@@ -8213,17 +8294,62 @@ namespace Microsoft.Dafny {
       if (toType.IsCharType) {
         if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
           PutSourceIntoLocal();
-          Bpl.Expr boundsCheck = Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), o), Bpl.Expr.Lt(o, Bpl.Expr.Literal(65536)));
-          builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+          Bpl.Expr boundsCheck =
+            Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), o), Bpl.Expr.Lt(o, Bpl.Expr.Literal(65536)));
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
+          PutSourceIntoLocal();
+          var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+          var boundsCheck =
+            Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), oi), Bpl.Expr.Lt(oi, Bpl.Expr.Literal(65536)));
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}real value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+        } else if (expr.Type.IsBitVectorType) {
+          PutSourceIntoLocal();
+          var fromWidth = expr.Type.AsBitVectorType.Width;
+          var toWidth = 16;
+          if (toWidth < fromWidth) {
+            // Check "expr < (1 << toWidth)" in type "fromType" (note that "1 << toWidth" is indeed a value in "fromType")
+            PutSourceIntoLocal();
+            var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth); // 1 << toWidth
+            var bound = BplBvLiteralExpr(tok, toBound, expr.Type.AsBitVectorType);
+            var boundsCheck = FunctionCall(expr.tok, "lt_bv" + fromWidth, Bpl.Type.Bool, o, bound);
+            builder.Add(Assert(tok, boundsCheck,
+              string.Format("{0}bit-vector value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+          }
+        } else if (expr.Type.IsBigOrdinalType) {
+          PutSourceIntoLocal();
+          var oi = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, o);
+          int toWidth = 16;
+          var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth); // 1 << toWidth
+          var bound = Bpl.Expr.Literal(toBound);
+          var boundsCheck = Bpl.Expr.Lt(oi, bound);
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}ordinal value to be converted might not fit in {1}", errorMsgPrefix, toType)));
         }
-      } else if (toType.IsBigOrdinalType && expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
-        PutSourceIntoLocal();
-        Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), o);
-        builder.Add(Assert(tok, boundsCheck, string.Format("{0}a negative integer cannot be converted to an {1}", errorMsgPrefix, toType)));
-      } else if (expr.Type.IsBigOrdinalType && toType.IsNumericBased(Type.NumericPersuation.Int)) {
-        PutSourceIntoLocal();
-        Bpl.Expr boundsCheck = FunctionCall(tok, "ORD#IsNat", Bpl.Type.Bool, o);
-        builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might be bigger than every natural number", errorMsgPrefix)));
+      } else if (toType.IsBigOrdinalType) {
+          if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
+            PutSourceIntoLocal();
+            Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), o);
+            builder.Add(Assert(tok, boundsCheck,
+              string.Format("{0}a negative integer cannot be converted to an {1}", errorMsgPrefix, toType)));
+          }
+
+          if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
+            PutSourceIntoLocal();
+            var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+            Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), oi);
+            builder.Add(Assert(tok, boundsCheck,
+              string.Format("{0}a negative real cannot be converted to an {1}", errorMsgPrefix, toType)));
+          }
+          
+      } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+        // already checked that BigOrdinal or real inputs are integral
+        // FIXME - are there subset range checks to make?}
+      } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+        // already checked that BigOrdinal is integral
+        // FIXME - are there subset range checks to make?
       }
 
       if (toType.NormalizeExpandKeepConstraints().AsRedirectingType != null) {
@@ -8240,6 +8366,7 @@ namespace Microsoft.Dafny {
         CheckResultToBeInType_Aux(tok, new BoogieWrapper(be, dafnyType), toType.NormalizeExpandKeepConstraints(), builder, etran, errorMsgPrefix);
       }
     }
+      
     void CheckResultToBeInType_Aux(IToken tok, Expression expr, Type toType, BoogieStmtListBuilder builder, ExpressionTranslator etran, string errorMsgPrefix) {
       Contract.Requires(tok != null);
       Contract.Requires(expr != null);

--- a/Test/git-issues/git-issue-356-errors.dfy
+++ b/Test/git-issues/git-issue-356-errors.dfy
@@ -220,7 +220,3 @@ method TestCOKc(b: bv8)
 {
   var ch := b as char;
 }
-
-
-// check everything to/from subset int or newtype
-// check everything to/from subset real or newtype

--- a/Test/git-issues/git-issue-356-errors.dfy
+++ b/Test/git-issues/git-issue-356-errors.dfy
@@ -7,19 +7,19 @@
 // int to char
 method Test1(n: int)
 {
-  var ch := n as char;
+  var ch := n as char;  // ERROR
 }
 
 method Test1b(n: int)
   requires n < 65536
 {
-  var ch := n as char;
+  var ch := n as char;  // ERROR
 }
 
 method Test1c(n: int)
   requires 0 <= n
 {
-  var ch := n as char;
+  var ch := n as char;  // ERROR
 }
 
 method Test1OK(n: int)
@@ -31,7 +31,7 @@ method Test1OK(n: int)
 
 // int to ORDINAL
 method Test2(n: int) {
-  var o: ORDINAL := n as ORDINAL; // must be non-negative // NO ERROR
+  var o: ORDINAL := n as ORDINAL;  // ERROR
 }
   
 method Test2OK(n: int)
@@ -44,11 +44,11 @@ method Test2OK(n: int)
 method Test3(r: real)
   requires r.Floor as real == r
 {
-  var o: ORDINAL := r as ORDINAL;
+  var o: ORDINAL := r as ORDINAL;  // ERROR
 }
 
 method Test3b(r: real)
-  requires r >= 0.0
+  requires r >= 0.0  // ERROR
 {
   var o: ORDINAL := r as ORDINAL;
 }
@@ -63,7 +63,7 @@ method Test3OK(r: real)
 // real to int
 method Test4(r: real)
 {
-  var n: int := r as int;
+  var n: int := r as int;  // ERROR
 }
 
 method Test4OK(r: real)
@@ -77,24 +77,24 @@ method Test5(r:real)
   requires 0.0 <= r
   requires r == r.Floor as real
 {
-  var ch := r as char;
+  var ch := r as char;  // ERROR
 }
 
 method Test5b(r:real)
   requires r <= 65535.0
   requires r == r.Floor as real
 {
-  var ch := r as char;
+  var ch := r as char;  // ERROR
 }
 
 method Test5c(r:real)
   requires 0.0 <= r <= 65535.0
 {
-  var ch := r as char;
+  var ch := r as char;  // ERROR
 }
 
 method Test5OK(r: real)
-  requires 0.0 < r <= 65535.0
+  requires 0.0 <= r < 65536.0
   requires r == r.Floor as real
 {
   var ch := r as char;
@@ -105,20 +105,20 @@ method Test6(r: real)
   requires 0.0 <= r
   requires r == r.Floor as real
 {
-  var bv := r as bv8;
+  var bv := r as bv8;  // ERROR
 }
 
 method Test6b(r: real)
   requires r <= 255.0
   requires r == r.Floor as real
 {
-  var bv := r as bv8;
+  var bv := r as bv8;  // ERROR
 }
 
 method Test6c(r: real)
   requires 0.0 <= r <= 255.0
 {
-  var bv := r as bv8;
+  var bv := r as bv8;  // ERROR
 }
 
 method Test6OK(r: real)
@@ -132,13 +132,13 @@ method Test6OK(r: real)
 method Test7(n: int)
   requires 0 <= n
 {
-  var bv := n as bv8;
+  var bv := n as bv8;  // ERROR
 }
 
 method Test7b(n: int)
   requires n <= 255
 {
-  var bv := n as bv8;
+  var bv := n as bv8;  // ERROR
 }
 
 method Test7OK(n: int)
@@ -150,7 +150,7 @@ method Test7OK(n: int)
 // char to bv
 method Test8(n: char)
 {
-  var bv := n as bv8;
+  var bv := n as bv8;  // ERROR
 }
 
 method Test8OK(n: char)
@@ -167,13 +167,13 @@ method Test8OKb(n: char)
 // ordinal to char
 method TestA(o: ORDINAL)
 {
-  var ch := o as char;
+  var ch := o as char;  // ERROR
 }
 
 method TestAb(o: ORDINAL)
   requires o.IsNat
 {
-  var ch := o as char;
+  var ch := o as char;  // ERROR
 }
 
 method TestAOK(o: ORDINAL)
@@ -186,13 +186,13 @@ method TestAOK(o: ORDINAL)
 // ordinal to bv
 method TestB(o: ORDINAL)
 {
-  var b := o as bv8;
+  var b := o as bv8;  // ERROR
 }
 
 method TestBb(o: ORDINAL)
   requires o.IsNat
 {
-  var b := o as bv8;
+  var b := o as bv8;  // ERROR
 }
 
 method TestBOK(o: ORDINAL)
@@ -204,7 +204,7 @@ method TestBOK(o: ORDINAL)
 // bv to char
 method TestC(b: bv32)
 {
-  var ch := b as char;
+  var ch := b as char;  // ERROR
 }
 
 method TestCOK(b: bv32)

--- a/Test/git-issues/git-issue-356-errors.dfy
+++ b/Test/git-issues/git-issue-356-errors.dfy
@@ -1,11 +1,226 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-method Test(b: bv32, n: nat, r: real, c: char)
-  requires b < 0x1_0000
-  requires n < 0x1_0000
+
+// Check every possible conversion range error among int,char,bv,real,ORDINAL
+
+// int to char
+method Test1(n: int)
 {
-  var ch: char;
-  ch := r as char;
-  assert true;
+  var ch := n as char;
 }
+
+method Test1b(n: int)
+  requires n < 65536
+{
+  var ch := n as char;
+}
+
+method Test1c(n: int)
+  requires 0 <= n
+{
+  var ch := n as char;
+}
+
+method Test1OK(n: int)
+  requires 0 <= n < 65536
+{
+  var ch := n as char;
+}
+
+
+// int to ORDINAL
+method Test2(n: int) {
+  var o: ORDINAL := n as ORDINAL; // must be non-negative // NO ERROR
+}
+  
+method Test2OK(n: int)
+  requires n >= 0
+{
+  var o: ORDINAL := n as ORDINAL;
+}
+
+// real to ORDINAL  
+method Test3(r: real)
+  requires r.Floor as real == r
+{
+  var o: ORDINAL := r as ORDINAL;
+}
+
+method Test3b(r: real)
+  requires r >= 0.0
+{
+  var o: ORDINAL := r as ORDINAL;
+}
+
+method Test3OK(r: real)
+  requires r.Floor as real == r
+  requires r >= 0.0
+{
+  var o: ORDINAL := r as ORDINAL;
+}
+
+// real to int
+method Test4(r: real)
+{
+  var n: int := r as int;
+}
+
+method Test4OK(r: real)
+  requires r.Floor as real == r
+{
+  var n: int := r as int;
+}
+
+// real to char
+method Test5(r:real)
+  requires 0.0 <= r
+  requires r == r.Floor as real
+{
+  var ch := r as char;
+}
+
+method Test5b(r:real)
+  requires r <= 65535.0
+  requires r == r.Floor as real
+{
+  var ch := r as char;
+}
+
+method Test5c(r:real)
+  requires 0.0 <= r <= 65535.0
+{
+  var ch := r as char;
+}
+
+method Test5OK(r: real)
+  requires 0.0 < r <= 65535.0
+  requires r == r.Floor as real
+{
+  var ch := r as char;
+}
+
+// real to bv
+method Test6(r: real)
+  requires 0.0 <= r
+  requires r == r.Floor as real
+{
+  var bv := r as bv8;
+}
+
+method Test6b(r: real)
+  requires r <= 255.0
+  requires r == r.Floor as real
+{
+  var bv := r as bv8;
+}
+
+method Test6c(r: real)
+  requires 0.0 <= r <= 255.0
+{
+  var bv := r as bv8;
+}
+
+method Test6OK(r: real)
+  requires 0.0 < r <= 255.0
+  requires r == r.Floor as real
+{
+  var bv := r as bv8;
+}
+
+// int to bv
+method Test7(n: int)
+  requires 0 <= n
+{
+  var bv := n as bv8;
+}
+
+method Test7b(n: int)
+  requires n <= 255
+{
+  var bv := n as bv8;
+}
+
+method Test7OK(n: int)
+  requires 0 <= n <= 255
+{
+  var bv := n as bv8;
+}
+
+// char to bv
+method Test8(n: char)
+{
+  var bv := n as bv8;
+}
+
+method Test8OK(n: char)
+  requires n as int <= 255
+{
+  var bv := n as bv8;
+}
+
+method Test8OKb(n: char)
+{
+  var bv := n as bv16;
+}
+
+// ordinal to char
+method TestA(o: ORDINAL)
+{
+  var ch := o as char;
+}
+
+method TestAb(o: ORDINAL)
+  requires o.IsNat
+{
+  var ch := o as char;
+}
+
+method TestAOK(o: ORDINAL)
+  requires o.IsNat && o as int < 65536
+{
+  var ch := o as char;
+}
+
+
+// ordinal to bv
+method TestB(o: ORDINAL)
+{
+  var b := o as bv8;
+}
+
+method TestBb(o: ORDINAL)
+  requires o.IsNat
+{
+  var b := o as bv8;
+}
+
+method TestBOK(o: ORDINAL)
+  requires o.IsNat && o as int < 256
+{
+  var b := o as bv8;
+}
+
+// bv to char
+method TestC(b: bv32)
+{
+  var ch := b as char;
+}
+
+method TestCOK(b: bv32)
+  requires b as int < 65536
+{
+  var ch := b as char;
+}
+method TestCOKb(b: bv16)
+{
+  var ch := b as char;
+}
+method TestCOKc(b: bv8)
+{
+  var ch := b as char;
+}
+
+
+// check everything to/from subset int or newtype
+// check everything to/from subset real or newtype

--- a/Test/git-issues/git-issue-356-errors.dfy
+++ b/Test/git-issues/git-issue-356-errors.dfy
@@ -1,0 +1,11 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Test(b: bv32, n: nat, r: real, c: char)
+  requires b < 0x1_0000
+  requires n < 0x1_0000
+{
+  var ch: char;
+  ch := r as char;
+  assert true;
+}

--- a/Test/git-issues/git-issue-356-errors.dfy.expect
+++ b/Test/git-issues/git-issue-356-errors.dfy.expect
@@ -1,5 +1,71 @@
-git-issue-356-errors.dfy(9,10): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+git-issue-356-errors.dfy(10,14): Error: value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(16,14): Error: value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(22,14): Error: value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(34,22): Error: a negative integer cannot be converted to an ORDINAL
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(47,22): Error: a negative real cannot be converted to an ORDINAL
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(53,22): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(66,18): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(80,14): Error: real value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(87,14): Error: real value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(93,14): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(108,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(115,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(121,14): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(135,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(141,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(153,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(170,14): Error: ordinal value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(170,14): Error: value to be converted might be bigger than every natural number
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(176,14): Error: ordinal value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(189,13): Error: value to be converted might be bigger than every natural number
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(189,13): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(195,13): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(207,14): Error: bit-vector value to be converted might not fit in char
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 0 verified, 1 error
+Dafny program verifier finished with 14 verified, 23 errors

--- a/Test/git-issues/git-issue-356-errors.dfy.expect
+++ b/Test/git-issues/git-issue-356-errors.dfy.expect
@@ -1,0 +1,5 @@
+git-issue-356-errors.dfy(9,10): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 0 verified, 1 error

--- a/Test/git-issues/git-issue-356-errors2.dfy
+++ b/Test/git-issues/git-issue-356-errors2.dfy
@@ -1,0 +1,25 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Subset tsype conversions
+
+type Tx = x | 0 <= x <= 100
+method TestD(x: Tx) {
+  var z := x as Tx;
+  var c := x as char;
+  var n := x as int;
+  var r := x as real;
+  var b := x as bv8;
+  var o := x as ORDINAL;
+}
+method TestF(cc: char, nn: int, rr: real, bb: bv8, oo: ORDINAL) {
+  var xx: Tx;
+  xx := oo as Tx; // ERROR
+  xx := cc as Tx; // ERROR
+  xx := nn as Tx; // ERROR
+}
+method TestG(cc: char, nn: int, rr: real, bb: bv8, oo: ORDINAL) {
+  var xx: Tx;
+  xx := rr as Tx; // ERROR
+  xx := bb as Tx; // ERROR
+}

--- a/Test/git-issues/git-issue-356-errors2.dfy.expect
+++ b/Test/git-issues/git-issue-356-errors2.dfy.expect
@@ -1,0 +1,23 @@
+git-issue-356-errors2.dfy(17,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(17,11): Error: value to be converted might be bigger than every natural number
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(18,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(19,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(23,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(23,11): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(24,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 2 verified, 7 errors

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -6,9 +6,11 @@
 // RUN: %diff "%s.expect" "%t"
 
 module M {
+  type Tx = i: int | 0 <= i <= 100
+
   method Main() {
     Test(0xDEAD, 100, 'a');
-    Test2(0x40, 42, 'Z', 70.0, 35);
+    Test2(0x40, 42, 'Z', 70.0, 35, 50);
     Test3(0x0, 50, '*', 50.0, 30);
     print "END\n";
   }
@@ -60,11 +62,9 @@ module M {
     oo := b as ORDINAL;
     oo := o as ORDINAL;
     
-    assert true;
-  
   }
 
-  method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL) {
+  method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL, x: Tx) {
   
     assert c == c as char;
     expect c == c as char;
@@ -124,6 +124,31 @@ module M {
     // assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
     // expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
     if o.IsNat && o as int < mx && o as int < mxch { print o as char, " ", o as int, " ", o as real, " ", o as bv, " ", o as ORDINAL, "\n"; }
+
+    // subset type
+    var nnn: int := x; // Implicit conversion allowed
+    assert x == x as Tx;
+    expect x == x as Tx;
+    assert x == x as char as Tx;
+    expect x == x as char as Tx;
+    assert x == x as int as Tx;
+    expect x == x as int as Tx;
+    assert x == x as real as Tx;
+    expect x == x as real as Tx;
+    assert x == x as bv as Tx;
+    expect x == x as bv as Tx;
+    assert x == x as ORDINAL as Tx;
+    expect x == x as ORDINAL as Tx;
+    assert c as int <= 100 ==> c == c as Tx as char;
+    expect c as int <= 100 ==> c == c as Tx as char;
+    assert 0 <= n as int <= 100 ==> n == n as Tx as int;
+    expect 0 <= n as int <= 100 ==> n == n as Tx as int;
+    assert r == r.Floor as real &&  0.0 <= r <= 100.0 ==> r == r as Tx as real;
+    expect r == r.Floor as real &&  0.0 <= r <= 100.0 ==> r == r as Tx as real;
+    assert b as int <= 100 ==> b == b as Tx as bv;
+    expect b as int <= 100 ==> b == b as Tx as bv;
+    assert o.IsNat && o as int <= 100 ==> o == o as Tx as ORDINAL;
+    expect o.IsNat && o as int <= 100 ==> o == o as Tx as ORDINAL;
 
   }
   

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -7,10 +7,11 @@
 
 module M {
   type Tx = i: int | 0 <= i <= 100
+  newtype Tr = r: real | r == r.Floor as real && 0.0 <= r <= 100.0
 
   method Main() {
     Test(0xDEAD, 100, 'a');
-    Test2(0x40, 42, 'Z', 70.0, 35, 50);
+    Test2(0x40, 42, 'Z', 70.0, 35, 50, 61.0);
     Test3(0x0, 50, '*', 50.0, 30);
     print "END\n";
   }
@@ -64,7 +65,7 @@ module M {
     
   }
 
-  method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL, x: Tx) {
+  method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL, x: Tx, h: Tr) {
   
     assert c == c as char;
     expect c == c as char;
@@ -149,6 +150,33 @@ module M {
     expect b as int <= 100 ==> b == b as Tx as bv;
     assert o.IsNat && o as int <= 100 ==> o == o as Tx as ORDINAL;
     expect o.IsNat && o as int <= 100 ==> o == o as Tx as ORDINAL;
+
+    assert h == h as Tr;
+    expect h == h as Tr;
+    assert h == h as Tx as Tr;
+    expect h == h as Tx as Tr;
+    assert h == h as char as Tr;
+    expect h == h as char as Tr;
+    assert h == h as int as Tr;
+    expect h == h as int as Tr;
+    assert h == h as real as Tr;
+    expect h == h as real as Tr;
+    assert h == h as bv8 as Tr;
+    expect h == h as bv8 as Tr;
+    assert h == h as ORDINAL as Tr;
+    expect h == h as ORDINAL as Tr;
+    assert x == x as Tr as Tx;
+    expect x == x as Tr as Tx;
+    assert c as int <= 100 ==> c == c as Tr as char;
+    expect c as int <= 100 ==> c == c as Tr as char;
+    assert 0 <= n as int <= 100 ==> n == n as Tr as int;
+    expect 0 <= n as int <= 100 ==> n == n as Tr as int;
+    assert r == r.Floor as real && 0 <= r as int <= 100 ==> r == r as Tr as real;
+    expect r == r.Floor as real && 0 <= r as int <= 100 ==> r == r as Tr as real;
+    assert b as int <= 100 ==> b == b as Tr as bv8;
+    expect b as int <= 100 ==> b == b as Tr as bv8;
+    assert o.IsNat && o as int <= 100 ==> o == o as Tr as ORDINAL;
+    expect o.IsNat && o as int <= 100 ==> o == o as Tr as ORDINAL;
 
   }
   

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -8,7 +8,7 @@
 module M {
   method Main() {
     Test(0xDEAD, 100, 'a');
-    Test2(0x40, 42, 'Z', 70.0, 20);
+    Test2(0x40, 42, 'Z', 70.0, 35);
     Test3(0x0, 50, '*', 50.0, 30);
     print "END\n";
   }
@@ -66,90 +66,94 @@ module M {
 
   method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL) {
   
-      assert c == c as char;
-      expect c == c as char;
-      assert c == c as int as char;
-      expect c == c as int as char;
-      assert c == c as real as char;
-      expect c == c as real as char;
-      // assert c == c as bv as char; // in Test3
-      // expect c == c as bv as char; // in Test3
-      assert c == c as ORDINAL as char;
-      expect c == c as ORDINAL as char;
-   
-      // assert b == b as bv; // in Test3
-      // expect b == b as bv; // in Test3
-      // assert b == b as char as bv; // in Test3
-      // expect b == b as char as bv; // in Test3
-      // assert b == b as int as bv; // in Test3
-      // expect b == b as int as bv; // in Test3
-      // assert b == b as real as bv; // in Test3
-      // expect b == b as real as bv; // in Test3
-      // assert b == b as ORDINAL as bv; // in Test3
-      // expect b == b as ORDINAL as bv; // in Test3
-      
-      assert n == n as int;
-      expect n == n as int;
-      assert 0 <= n < mxch ==> n == n as char as int;
-      expect 0 <= n < mxch ==> n == n as char as int;
-      // assert 0 <= n < mx ==> n == n as bv as int; // in Test3
-      // expect 0 <= n < mx ==> n == n as bv as int; // in Test3
-      assert n == n as real as int;
-      expect n == n as real as int;
-      assert 0 <= n ==> n == n as ORDINAL as int;
-      expect 0 <= n ==> n == n as ORDINAL as int;
-      
-      assert r == r as real;
-      expect r == r as real;
-      assert r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
-      expect r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
-      assert r == r.Floor as real  ==> r == r as int as real;
-      expect r == r.Floor as real  ==> r == r as int as real;
-      // assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
-      // expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
-      assert r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
-      expect r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
-   
-      assert o == o as ORDINAL;
-      expect o == o as ORDINAL;
-      assert o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
-      expect o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
-      assert o.IsNat ==> o == o as int as ORDINAL;
-      expect o.IsNat ==> o == o as int as ORDINAL;
-      assert o.IsNat ==> o == o as real as ORDINAL;
-      expect o.IsNat ==> o == o as real as ORDINAL;
-      // assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
-      // expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+    assert c == c as char;
+    expect c == c as char;
+    assert c == c as int as char;
+    expect c == c as int as char;
+    assert c == c as real as char;
+    expect c == c as real as char;
+    // assert c == c as bv as char; // in Test3
+    // expect c == c as bv as char; // in Test3
+    assert c == c as ORDINAL as char;
+    expect c == c as ORDINAL as char;
+    if c as int < mx { print c as char, " ", c as int, " ", c as real, " ", c as bv, " ", c as ORDINAL, "\n"; }
   
+    // assert b == b as bv; // in Test3
+    // expect b == b as bv; // in Test3
+    // assert b == b as char as bv; // in Test3
+    // expect b == b as char as bv; // in Test3
+    // assert b == b as int as bv; // in Test3
+    // expect b == b as int as bv; // in Test3
+    // assert b == b as real as bv; // in Test3
+    // expect b == b as real as bv; // in Test3
+    // assert b == b as ORDINAL as bv; // in Test3
+    // expect b == b as ORDINAL as bv; // in Test3
+    
+    assert n == n as int;
+    expect n == n as int;
+    assert 0 <= n < mxch ==> n == n as char as int;
+    expect 0 <= n < mxch ==> n == n as char as int;
+    // assert 0 <= n < mx ==> n == n as bv as int; // in Test3
+    // expect 0 <= n < mx ==> n == n as bv as int; // in Test3
+    assert n == n as real as int;
+    expect n == n as real as int;
+    assert 0 <= n ==> n == n as ORDINAL as int;
+    expect 0 <= n ==> n == n as ORDINAL as int;
+    if 0 <= n < mx && n < mxch { print n as char, " ", n as int, " ", n as real, " ", n as bv, " ", n as ORDINAL, "\n"; }
+    
+    assert r == r as real;
+    expect r == r as real;
+    assert r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
+    expect r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
+    assert r == r.Floor as real  ==> r == r as int as real;
+    expect r == r.Floor as real  ==> r == r as int as real;
+    // assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
+    // expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
+    assert r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
+    expect r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
+    if r == r.Floor as real && 0.0 <= r < (mx as real) && r < (mxch as real) { print r as char, " ", r as int, " ", r as real, " ", r as bv, " ", r as ORDINAL, "\n"; }
+ 
+    assert o == o as ORDINAL;
+    expect o == o as ORDINAL;
+    assert o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
+    expect o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
+    assert o.IsNat ==> o == o as int as ORDINAL;
+    expect o.IsNat ==> o == o as int as ORDINAL;
+    assert o.IsNat ==> o == o as real as ORDINAL;
+    expect o.IsNat ==> o == o as real as ORDINAL;
+    // assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+    // expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+    if o.IsNat && o as int < mx && o as int < mxch { print o as char, " ", o as int, " ", o as real, " ", o as bv, " ", o as ORDINAL, "\n"; }
+
   }
   
   // These take a while depending on the width of the bit-vector type
   // About 25 sec on my machine for bv8; longer than I wanted to wait (>10s min) for bv16
   method Test3(b: bv, n: int, c: char, r: real, o: ORDINAL) {
   
-      assert c as int < mx ==> c == c as bv as char;
-      expect c as int < mx ==> c == c as bv as char;
+    assert c as int < mx ==> c == c as bv as char;
+    expect c as int < mx ==> c == c as bv as char;
       
-      assert b == b as bv;
-      expect b == b as bv;
-      assert b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
-      expect b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
-      assert b as int < mxch ==> b == b as char as bv;
-      expect b as int < mxch ==> b == b as char as bv;
-      assert b == b as int as bv;
-      expect b == b as int as bv;
-      assert b == b as real as bv;
-      expect b == b as real as bv;
-      assert b == b as ORDINAL as bv;
-      expect b == b as ORDINAL as bv;
-      
-      assert 0 <= n < mx ==> n == n as bv as int;
-      expect 0 <= n < mx ==> n == n as bv as int;
-      
-      assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
-      expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
-  
-      assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
-      expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
+    assert b == b as bv;
+    expect b == b as bv;
+    assert b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
+    expect b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
+    assert b as int < mxch ==> b == b as char as bv;
+    expect b as int < mxch ==> b == b as char as bv;
+    assert b == b as int as bv;
+    expect b == b as int as bv;
+    assert b == b as real as bv;
+    expect b == b as real as bv;
+    assert b == b as ORDINAL as bv;
+    expect b == b as ORDINAL as bv;
+    
+    assert 0 <= n < mx ==> n == n as bv as int;
+    expect 0 <= n < mx ==> n == n as bv as int;
+    
+    assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
+    expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
+
+    assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
+    expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
   }
 }

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -1,4 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /compole:3 /compileTarget:cs "%s" >> %t"
+// RUN: %dafny /compole:3 /compileTarget:js "%s" >> %t"
+// RUN: %dafny /compole:3 /compileTarget:go "%s" >> %t"
+// RUN: %dafny /compole:3 /compileTarget:java "%s" >> %t"
 // RUN: %diff "%s.expect" "%t"
 
 module M {

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -1,36 +1,151 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-method Test(b: bv32, n: nat, c: char)
-  requires b < 0x1_0000
-  requires n < 0x1_0000
-{
-  var r: real := 42.0;
-  var ch: char;
-  ch := c as char;
-  ch := n as char;  // translates into char#FromInt(n), which is good
-  ch := b as char;  // translates into nat_from_bv32(b), which crashes; should be char#FromInt(nat_from_bv32(b))
-  ch := r as char;
+module M {
+  method Main() {
+    Test(0xDEAD, 100, 'a');
+    Test2(0x40, 42, 'Z', 70.0, 20);
+    Test3(0x0, 50, '*', 50.0, 30);
+    print "END\n";
+  }
 
-  var nn: int;
-  var nnn: int;
-  nn := c as int;
-  nn := r as int;
-  nn := b as int;
-  nn := nnn as int;
+  type bv = bv8
+  const mx: int := 256; // limit for the chosen bit-vector type
+  const mxch: int := 0x1_0000;
+  
+  method Test(b: bv32, n: nat, c: char)
+    requires b < mxch as bv32  // in range of char
+    requires n < mxch
+  {
+    var r: real := 42.0;
+    var o: ORDINAL := 42 as ORDINAL;
+    var ch: char;
+    
+    ch := c as char;
+    ch := n as char;
+    ch := b as char;
+    ch := r as char;
+    ch := o as char;
+  
+    var nn: int;
+    var nnn: int;
+    nn := c as int;
+    nn := r as int;
+    nn := b as int;
+    nn := nnn as int;
+    nn := o as int;
+  
+    var rr: real;
+    rr := c as real;
+    rr := n as real;
+    rr := b as real;
+    rr := r as real;
+    rr := o as real;
+  
+    var bb: bv32;
+    bb := c as bv32;
+    bb := n as bv32;
+    bb := r as bv32;
+    bb := b as bv32;
+    bb := o as bv32;
+  
+    var oo: ORDINAL;
+    oo := c as ORDINAL;
+    oo := n as ORDINAL;
+    oo := r as ORDINAL;
+    oo := b as ORDINAL;
+    oo := o as ORDINAL;
+    
+    assert true;
+  
+  }
 
-  var rr: real;
-  //rr := c as real;
-  rr := c as int as real;
-  rr := n as real;
-  rr := b as real;
-  rr := r as real;
-
-  var bb: bv32;
-  //bb := c as bv32;
-  bb := c as int as bv32;
-  bb := n as bv32;
-  bb := r as bv32;
-  bb := b as bv32;
-  assert true;
+  method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL) {
+  
+      assert c == c as char;
+      expect c == c as char;
+      assert c == c as int as char;
+      expect c == c as int as char;
+      assert c == c as real as char;
+      expect c == c as real as char;
+      // assert c == c as bv as char; // in Test3
+      // expect c == c as bv as char; // in Test3
+      assert c == c as ORDINAL as char;
+      expect c == c as ORDINAL as char;
+   
+      // assert b == b as bv;
+      // expect b == b as bv;
+      // assert b == b as char as bv; // in Test3
+      // expect b == b as char as bv; // in Test3
+      // assert b == b as int as bv; // in Test3
+      // expect b == b as int as bv; // in Test3
+      // assert b == b as real as bv; // in Test3
+      // expect b == b as real as bv; // in Test3
+      // assert b == b as ORDINAL as bv; // in Test3
+      // expect b == b as ORDINAL as bv; // in Test3
+      
+      assert n == n as int;
+      expect n == n as int;
+      assert 0 <= n < mxch ==> n == n as char as int;
+      expect 0 <= n < mxch ==> n == n as char as int;
+      // assert 0 <= n < mx ==> n == n as bv as int; // in Test3
+      // expect 0 <= n < mx ==> n == n as bv as int; // in Test3
+      assert n == n as real as int;
+      expect n == n as real as int;
+      assert 0 <= n ==> n == n as ORDINAL as int;
+      expect 0 <= n ==> n == n as ORDINAL as int;
+      
+      assert r == r as real;
+      expect r == r as real;
+      assert r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
+      expect r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
+      assert r == r.Floor as real  ==> r == r as int as real;
+      expect r == r.Floor as real  ==> r == r as int as real;
+      // assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
+      // expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
+      assert r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
+      expect r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
+   
+      assert o == o as ORDINAL;
+      expect o == o as ORDINAL;
+      assert o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
+      expect o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
+      assert o.IsNat ==> o == o as int as ORDINAL;
+      expect o.IsNat ==> o == o as int as ORDINAL;
+      assert o.IsNat ==> o == o as real as ORDINAL;
+      expect o.IsNat ==> o == o as real as ORDINAL;
+      // assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+      // expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+  
+  }
+  
+  // These take a while depending on the width of the bit-vector type
+  // About 25 sec on my machine for bv8; longer than I wanted to wait (>10s min) for bv16
+  method Test3(b: bv, n: int, c: char, r: real, o: ORDINAL) {
+  
+      assert c as int < mx ==> c == c as bv as char;
+      expect c as int < mx ==> c == c as bv as char;
+      
+      assert b == b as bv;
+      expect b == b as bv;
+      assert b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
+      expect b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
+      assert b as int < mxch ==> b == b as char as bv;
+      expect b as int < mxch ==> b == b as char as bv;
+      assert b == b as int as bv;
+      expect b == b as int as bv;
+      assert b == b as real as bv;
+      expect b == b as real as bv;
+      assert b == b as ORDINAL as bv;
+      expect b == b as ORDINAL as bv;
+      
+      assert 0 <= n < mx ==> n == n as bv as int;
+      expect 0 <= n < mx ==> n == n as bv as int;
+      
+      assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
+      expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
+  
+      assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
+      expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
+  }
 }

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -1,14 +1,36 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-method Test(b: bv32, n: nat, r: real, c: char)
+method Test(b: bv32, n: nat, c: char)
   requires b < 0x1_0000
   requires n < 0x1_0000
 {
-  var rr: real := 42.0;
+  var r: real := 42.0;
   var ch: char;
+  ch := c as char;
   ch := n as char;  // translates into char#FromInt(n), which is good
   ch := b as char;  // translates into nat_from_bv32(b), which crashes; should be char#FromInt(nat_from_bv32(b))
-  ch := rr as char;
+  ch := r as char;
+
+  var nn: int;
+  var nnn: int;
+  nn := c as int;
+  nn := r as int;
+  nn := b as int;
+  nn := nnn as int;
+
+  var rr: real;
+  //rr := c as real;
+  rr := c as int as real;
+  rr := n as real;
+  rr := b as real;
+  rr := r as real;
+
+  var bb: bv32;
+  //bb := c as bv32;
+  bb := c as int as bv32;
+  bb := n as bv32;
+  bb := r as bv32;
+  bb := b as bv32;
   assert true;
 }

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -1,0 +1,14 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Test(b: bv32, n: nat, r: real, c: char)
+  requires b < 0x1_0000
+  requires n < 0x1_0000
+{
+  var rr: real := 42.0;
+  var ch: char;
+  ch := n as char;  // translates into char#FromInt(n), which is good
+  ch := b as char;  // translates into nat_from_bv32(b), which crashes; should be char#FromInt(nat_from_bv32(b))
+  ch := rr as char;
+  assert true;
+}

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -1,8 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
-// RUN: %dafny /compole:3 /compileTarget:cs "%s" >> %t"
-// RUN: %dafny /compole:3 /compileTarget:js "%s" >> %t"
-// RUN: %dafny /compole:3 /compileTarget:go "%s" >> %t"
-// RUN: %dafny /compole:3 /compileTarget:java "%s" >> %t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module M {
@@ -77,8 +77,8 @@ module M {
       assert c == c as ORDINAL as char;
       expect c == c as ORDINAL as char;
    
-      // assert b == b as bv;
-      // expect b == b as bv;
+      // assert b == b as bv; // in Test3
+      // expect b == b as bv; // in Test3
       // assert b == b as char as bv; // in Test3
       // expect b == b as char as bv; // in Test3
       // assert b == b as int as bv; // in Test3

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 6 verified, 0 errors
+Dafny program verifier finished with 7 verified, 0 errors
 
 Dafny program verifier finished with 0 verified, 0 errors
 Z 90 90.0 90 90

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -2,13 +2,29 @@
 Dafny program verifier finished with 5 verified, 0 errors
 
 Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
 END
 
 Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
 END
 
 Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
 END
 
 Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
 END

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 5 verified, 0 errors
+Dafny program verifier finished with 6 verified, 0 errors
 
 Dafny program verifier finished with 0 verified, 0 errors
 Z 90 90.0 90 90

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -1,2 +1,14 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 5 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+END
+
+Dafny program verifier finished with 0 verified, 0 errors
+END
+
+Dafny program verifier finished with 0 verified, 0 errors
+END
+
+Dafny program verifier finished with 0 verified, 0 errors
+END


### PR DESCRIPTION
Fixes #356. Implemented all combinations of 'as' conversions among { int, char, bv, real, ordinal} in verification and all four compilers, with corresponding verification and run-time tests.