### PR TITLE
#505: Timeouts correctly reported

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2181,7 +2181,7 @@ namespace Microsoft.Dafny
     protected override void EmitConversionExpr(ConversionExpr e, bool inLetExprBody, TargetWriter wr) {
       if (e.E.Type.IsNumericBased(Type.NumericPersuation.Int) || e.E.Type.IsBitVectorType || e.E.Type.IsCharType) {
         if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
-          // (int or bv) -> real
+          // (int or bv or char) -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
           wr.Write("new Dafny.BigRational(");
           if (AsNativeType(e.E.Type) != null) {
@@ -2244,7 +2244,6 @@ namespace Microsoft.Dafny
               // no optimization applies; use the standard translation
               TrParenExpr(e.E, wr, inLetExprBody);
             }
-
           }
         }
       } else if (e.E.Type.IsNumericBased(Type.NumericPersuation.Real)) {
@@ -2254,7 +2253,7 @@ namespace Microsoft.Dafny
           Contract.Assert(AsNativeType(e.ToType) == null);
           TrExpr(e.E, wr, inLetExprBody);
         } else {
-          // real -> (int or bv or char)
+          // real -> (int or bv or char or ordinal)
           if (e.ToType.IsCharType) {
             wr.Write("(char)");
           } else if (AsNativeType(e.ToType) != null) {
@@ -2263,11 +2262,32 @@ namespace Microsoft.Dafny
           TrParenExpr(e.E, wr, inLetExprBody);
           wr.Write(".ToBigInteger()");
         }
+      } else if (e.E.Type.IsBigOrdinalType) {
+        if (e.ToType.IsNumericBased(Type.NumericPersuation.Int) || e.ToType.IsBigOrdinalType) {
+          TrExpr(e.E, wr, inLetExprBody);
+        } else if (e.ToType.IsCharType) {
+          wr.Write("(char)");
+          TrParenExpr(e.E, wr, inLetExprBody);
+        } else if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
+          wr.Write("new Dafny.BigRational(");
+          if (AsNativeType(e.E.Type) != null) {
+            wr.Write("new BigInteger");
+            TrParenExpr(e.E, wr, inLetExprBody);
+            wr.Write(", BigInteger.One)");
+          } else {
+            TrParenExpr(e.E, wr, inLetExprBody);
+            wr.Write(", 1)");
+          }
+        } else if (e.ToType.IsBitVectorType) {
+          // ordinal -> bv
+          var typename = TypeName(e.ToType, wr, null, null);
+          wr.Write($"({typename})");
+          TrParenExpr(e.E, wr, inLetExprBody);
+        } else {
+          Contract.Assert(false, $"not implemented for C#: {e.E.Type} -> {e.ToType}");
+        }
       } else {
-        Contract.Assert(e.E.Type.IsBigOrdinalType);
-        Contract.Assert(e.ToType.IsNumericBased(Type.NumericPersuation.Int));
-        // identity will do
-        TrExpr(e.E, wr, inLetExprBody);
+        Contract.Assert(false, $"not implemented for C#: {e.E.Type} -> {e.ToType}");
       }
     }
 
@@ -2416,6 +2436,7 @@ namespace Microsoft.Dafny
         cp.CompilerOptions += " /optimize";
       }
       cp.CompilerOptions += " /lib:" + crx.libPath;
+      cp.CompilerOptions += " /nowarn:1718"; // Comparison to the same variable
       foreach (var filename in crx.immutableDllFileNames) {
         cp.ReferencedAssemblies.Add(filename);
       }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -13076,13 +13076,13 @@ namespace Microsoft.Dafny
           if (e.ToType.IsNumericBased(Type.NumericPersuation.Int)) {
             AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to an int-based type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsNumericBased(Type.NumericPersuation.Real)) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a real-based type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to a real-based type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsBitVectorType) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a bitvector-based type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to a bitvector-based type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsCharType) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to a char type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to a char type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else if (e.ToType.IsBigOrdinalType) {
-            AddXConstraint(expr.tok, "NumericOrBitvector", e.E.Type, "type conversion to an ORDINAL type is allowed only from numeric and bitvector types (got {0})");
+            AddXConstraint(expr.tok, "NumericOrBitvectorOrCharOrORDINAL", e.E.Type, "type conversion to an ORDINAL type is allowed only from numeric and bitvector types, char, and ORDINAL (got {0})");
           } else {
             reporter.Error(MessageSource.Resolver, expr, "type conversions are not supported to this type (got {0})", e.ToType);
           }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8071,76 +8071,132 @@ namespace Microsoft.Dafny {
       Contract.Requires(toType != null);
       toType = toType.NormalizeExpand();
       fromType = fromType.NormalizeExpand();
-      if (fromType.IsBitVectorType) {
+      if (fromType.IsNumericBased(Type.NumericPersuation.Int)) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          // do nothing
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = IntToBV(tok, r, toType);
+        } else if (toType.IsBigOrdinalType) {
+          r = FunctionCall(tok, "ORD#FromNat", predef.BigOrdinalType, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
+      } else if (fromType.IsBitVectorType) {
         var fromWidth = fromType.AsBitVectorType.Width;
         if (toType.IsBitVectorType) {
           // conversion from one bitvector type to another
           var toWidth = toType.AsBitVectorType.Width;
           if (fromWidth == toWidth) {
-            return r;
+            // no conversion
           } else if (fromWidth < toWidth) {
             var zeros = BplBvLiteralExpr(tok, Basetypes.BigNum.ZERO, toWidth - fromWidth);
             if (fromWidth == 0) {
-              return zeros;
+              r = zeros;
             } else {
               var concat = new Bpl.BvConcatExpr(tok, zeros, r);
               // There's a bug in Boogie that causes a warning to be emitted if a BvConcatExpr is passed as the argument
               // to $Box, which takes a type argument.  The bug can apparently be worked around by giving an explicit
               // (and other redudant) type conversion.
-              return Bpl.Expr.CoerceType(tok, concat, BplBvType(toWidth));
+              r = Bpl.Expr.CoerceType(tok, concat, BplBvType(toWidth));
             }
           } else if (toWidth == 0) {
-            return BplBvLiteralExpr(tok, Basetypes.BigNum.ZERO, toWidth);
+            r = BplBvLiteralExpr(tok, Basetypes.BigNum.ZERO, toWidth);
           } else {
-            return new Bpl.BvExtractExpr(tok, r, toWidth, 0);
+            r = new Bpl.BvExtractExpr(tok, r, toWidth, 0);
           }
-        } else {
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
           r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
-          if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
-            r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
-          }
-          return r;
-        }
-      }
-      if (fromType.IsNumericBased(Type.NumericPersuation.Real)) {
-        if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
-          return r;
-        }
-        r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
-        // "r" now denotes an integer
-      } else if (fromType.IsCharType) {
-        Contract.Assert(toType.IsNumericBased(Type.NumericPersuation.Int));
-        return FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
-      } else if (fromType.IsBigOrdinalType) {
-        Contract.Assert(toType.IsNumericBased(Type.NumericPersuation.Int));
-        return FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
-      } else {
-        Contract.Assert(fromType.IsNumericBased(Type.NumericPersuation.Int));
-        if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
-          return FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
         } else if (toType.IsBigOrdinalType) {
-          return FunctionCall(tok, "ORD#FromNat", predef.BigOrdinalType, r);
+          r = FunctionCall(tok, "nat_from_bv" + fromWidth, Bpl.Type.Int, r);
+          r = FunctionCall(tok, "ORD#FromNat", predef.BigOrdinalType, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
         }
-      }
-      if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
         return r;
-      } else if (toType.IsCharType) {
-        Contract.Assert(fromType.IsNumericBased(Type.NumericPersuation.Int));
-        return FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+      } else if (fromType.IsCharType) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+        } else if (toType.IsCharType) {
+          // do nothing
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+          r = IntToBV(tok, r, toType);
+        } else if (toType.IsBigOrdinalType) {
+          r = FunctionCall(tok, BuiltinFunction.CharToInt, null, r);
+          r = FunctionCall(tok, "ORD#FromNat", Bpl.Type.Int, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
+      } else if (fromType.IsNumericBased(Type.NumericPersuation.Real)) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          // do nothing
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+          r = IntToBV(tok, r, toType);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        } else if (toType.IsBigOrdinalType) {
+          r = FunctionCall(tok, BuiltinFunction.RealToInt, null, r);
+          r = FunctionCall(tok, "ORD#FromNat", Bpl.Type.Int, r);
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
+        // "r" now denotes an integer
+      } else if (fromType.IsBigOrdinalType) {
+        if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+        } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.IntToReal, null, r);
+        } else if (toType.IsCharType) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+          r = FunctionCall(tok, BuiltinFunction.CharFromInt, null, r);
+        } else if (toType.IsBitVectorType) {
+          r = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, r);
+          r = IntToBV(tok, r, toType);
+       } else if (toType.IsBigOrdinalType) {
+          // do nothing
+        } else {
+          Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+        }
+        return r;
       } else {
-        Contract.Assert(toType.IsBitVectorType);
-        var toWidth = toType.AsBitVectorType.Width;
-        if (RemoveLit(r) is Bpl.LiteralExpr) {
-          Bpl.LiteralExpr e = (Bpl.LiteralExpr) RemoveLit(r);
-          if (e.isBigNum) {
-            var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth);  // 1 << toWidth
-            if (e.asBigNum <= toBound) {
-              return BplBvLiteralExpr(r.tok, e.asBigNum, toType.AsBitVectorType);
-            }
+        Contract.Assert(false, $"No translation implemented from {fromType} to {toType}");
+      }
+      return r;
+    }
+
+    private Bpl.Expr IntToBV(IToken tok, Bpl.Expr r, Type toType) {
+      var toWidth = toType.AsBitVectorType.Width;
+      if (RemoveLit(r) is Bpl.LiteralExpr) {
+        Bpl.LiteralExpr e = (Bpl.LiteralExpr) RemoveLit(r);
+        if (e.isBigNum) {
+          var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth);  // 1 << toWidth
+          if (e.asBigNum <= toBound) {
+            return BplBvLiteralExpr(r.tok, e.asBigNum, toType.AsBitVectorType);
           }
         }
-        return FunctionCall(tok, "nat_to_bv" + toWidth, BplBvType(toWidth), r);
       }
+      return FunctionCall(tok, "nat_to_bv" + toWidth, BplBvType(toWidth), r);
     }
 
     /// <summary>
@@ -8174,10 +8230,16 @@ namespace Microsoft.Dafny {
         // this operation is well-formed only if the real-based number represents an integer
         //   assert Real(Int(o)) == o;
         PutSourceIntoLocal();
-        var from = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+        Bpl.Expr from = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
         Bpl.Expr e = FunctionCall(tok, BuiltinFunction.IntToReal, null, from);
         e = Bpl.Expr.Binary(tok, Bpl.BinaryOperator.Opcode.Eq, e, o);
         builder.Add(Assert(tok, e, errorMsgPrefix + "the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)"));
+      }
+
+      if (expr.Type.IsBigOrdinalType && !toType.IsBigOrdinalType) {
+        PutSourceIntoLocal();
+        Bpl.Expr boundsCheck = FunctionCall(tok, "ORD#IsNat", Bpl.Type.Bool, o);
+        builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might be bigger than every natural number", errorMsgPrefix)));
       }
 
       if (toType.IsBitVectorType) {
@@ -8192,19 +8254,23 @@ namespace Microsoft.Dafny {
             var bound = BplBvLiteralExpr(tok, toBound, expr.Type.AsBitVectorType);
             boundsCheck = FunctionCall(expr.tok, "lt_bv" + fromWidth, Bpl.Type.Bool, o, bound);
           }
-        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
+        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Int) || expr.Type.IsCharType) {
           // Check "expr < (1 << toWdith)" in type "int"
           PutSourceIntoLocal();
           var bound = Bpl.Expr.Literal(toBound);
           boundsCheck = Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), o), Bpl.Expr.Lt(o, bound));
-        } else {
-          Contract.Assert(expr.Type.IsNumericBased(Type.NumericPersuation.Real));
+        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
           // Check "Int(expr) < (1 << toWdith)" in type "int"
           PutSourceIntoLocal();
           var bound = Bpl.Expr.Literal(toBound);
           var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
           boundsCheck = Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), oi), Bpl.Expr.Lt(oi, bound));
+        } else if (expr.Type.IsBigOrdinalType) {
+          var bound = Bpl.Expr.Literal(toBound);
+          var oi = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, o);
+          boundsCheck = Bpl.Expr.Lt(oi, bound);
         }
+
         if (boundsCheck != null) {
           builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might not fit in {1}", errorMsgPrefix, toType)));
         }
@@ -8213,17 +8279,58 @@ namespace Microsoft.Dafny {
       if (toType.IsCharType) {
         if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
           PutSourceIntoLocal();
-          Bpl.Expr boundsCheck = Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), o), Bpl.Expr.Lt(o, Bpl.Expr.Literal(65536)));
-          builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+          Bpl.Expr boundsCheck =
+            Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), o), Bpl.Expr.Lt(o, Bpl.Expr.Literal(65536)));
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+        } else if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
+          PutSourceIntoLocal();
+          var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+          var boundsCheck =
+            Bpl.Expr.And(Bpl.Expr.Le(Bpl.Expr.Literal(0), oi), Bpl.Expr.Lt(oi, Bpl.Expr.Literal(65536)));
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}real value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+        } else if (expr.Type.IsBitVectorType) {
+          PutSourceIntoLocal();
+          var fromWidth = expr.Type.AsBitVectorType.Width;
+          var toWidth = 16;
+          if (toWidth < fromWidth) {
+            // Check "expr < (1 << toWidth)" in type "fromType" (note that "1 << toWidth" is indeed a value in "fromType")
+            PutSourceIntoLocal();
+            var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth); // 1 << toWidth
+            var bound = BplBvLiteralExpr(tok, toBound, expr.Type.AsBitVectorType);
+            var boundsCheck = FunctionCall(expr.tok, "lt_bv" + fromWidth, Bpl.Type.Bool, o, bound);
+            builder.Add(Assert(tok, boundsCheck,
+              string.Format("{0}bit-vector value to be converted might not fit in {1}", errorMsgPrefix, toType)));
+          }
+        } else if (expr.Type.IsBigOrdinalType) {
+          PutSourceIntoLocal();
+          var oi = FunctionCall(tok, "ORD#Offset", Bpl.Type.Int, o);
+          int toWidth = 16;
+          var toBound = Basetypes.BigNum.FromBigInt(BigInteger.One << toWidth); // 1 << toWidth
+          var bound = Bpl.Expr.Literal(toBound);
+          var boundsCheck = Bpl.Expr.Lt(oi, bound);
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}ordinal value to be converted might not fit in {1}", errorMsgPrefix, toType)));
         }
-      } else if (toType.IsBigOrdinalType && expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
-        PutSourceIntoLocal();
-        Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), o);
-        builder.Add(Assert(tok, boundsCheck, string.Format("{0}a negative integer cannot be converted to an {1}", errorMsgPrefix, toType)));
-      } else if (expr.Type.IsBigOrdinalType && toType.IsNumericBased(Type.NumericPersuation.Int)) {
-        PutSourceIntoLocal();
-        Bpl.Expr boundsCheck = FunctionCall(tok, "ORD#IsNat", Bpl.Type.Bool, o);
-        builder.Add(Assert(tok, boundsCheck, string.Format("{0}value to be converted might be bigger than every natural number", errorMsgPrefix)));
+      } else if (toType.IsBigOrdinalType) {
+        if (expr.Type.IsNumericBased(Type.NumericPersuation.Int)) {
+          PutSourceIntoLocal();
+          Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), o);
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}a negative integer cannot be converted to an {1}", errorMsgPrefix, toType)));
+        }
+        if (expr.Type.IsNumericBased(Type.NumericPersuation.Real)) {
+          PutSourceIntoLocal();
+          var oi = FunctionCall(tok, BuiltinFunction.RealToInt, null, o);
+          Bpl.Expr boundsCheck = Bpl.Expr.Le(Bpl.Expr.Literal(0), oi);
+          builder.Add(Assert(tok, boundsCheck,
+            string.Format("{0}a negative real cannot be converted to an {1}", errorMsgPrefix, toType)));
+        }
+      } else if (toType.IsNumericBased(Type.NumericPersuation.Int)) {
+        // already checked that BigOrdinal or real inputs are integral
+      } else if (toType.IsNumericBased(Type.NumericPersuation.Real)) {
+        // already checked that BigOrdinal is integral
       }
 
       if (toType.NormalizeExpandKeepConstraints().AsRedirectingType != null) {
@@ -8231,8 +8338,11 @@ namespace Microsoft.Dafny {
         Bpl.Expr be;
         if (expr.Type.IsNumericBased() || expr.Type.IsBitVectorType) {
           be = ConvertExpression(expr.tok, o, expr.Type, toType);
+        } else if (expr.Type.IsCharType) {
+          be = ConvertExpression(expr.tok, o, Dafny.Type.Int, toType);
         } else if (expr.Type.IsBigOrdinalType) {
           be = FunctionCall(expr.tok, "ORD#Offset", Bpl.Type.Int, o);
+          be = ConvertExpression(expr.tok, be, Dafny.Type.Int, toType);
         } else {
           be = o;
         }
@@ -8240,6 +8350,7 @@ namespace Microsoft.Dafny {
         CheckResultToBeInType_Aux(tok, new BoogieWrapper(be, dafnyType), toType.NormalizeExpandKeepConstraints(), builder, etran, errorMsgPrefix);
       }
     }
+      
     void CheckResultToBeInType_Aux(IToken tok, Expression expr, Type toType, BoogieStmtListBuilder builder, ExpressionTranslator etran, string errorMsgPrefix) {
       Contract.Requires(tok != null);
       Contract.Requires(expr != null);

--- a/Test/git-issues/git-issue-289.dfy
+++ b/Test/git-issues/git-issue-289.dfy
@@ -1,0 +1,6 @@
+// RUN: %dafny /compile:1 "%s"                      > "%t"
+// RUN: %dafny /compile:1 "%s" "git-issue-289b.dfy" >> "%t"
+// RUN: %dafny /compile:1      "git-issue-289b.dfy" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+include "git-issue-289b.dfy"

--- a/Test/git-issues/git-issue-289.dfy.expect
+++ b/Test/git-issues/git-issue-289.dfy.expect
@@ -1,0 +1,6 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue-289b.dfy
+++ b/Test/git-issues/git-issue-289b.dfy
@@ -1,0 +1,27 @@
+// RUN: echo ""
+// This is just an auxiliary file, with no tests by itself
+
+abstract module Foo {
+  type Value
+
+  datatype Message =
+    | M(value: Value)
+
+  lemma someLemma(a: Message, b: Message, c: Message)
+  {
+    match (a, b, c) {
+      case (M(x), M(y), M(z)) => { }
+    }
+  }
+}
+
+module ByteDefinition {
+  newtype byte = i:int | 0 <= i < 0x100
+  type Byte = byte
+}
+
+module ConcreteFoo refines Foo {
+  import ByteDefinition
+
+  type Value = ByteDefinition.Byte
+}

--- a/Test/git-issues/git-issue-356-errors.dfy
+++ b/Test/git-issues/git-issue-356-errors.dfy
@@ -1,0 +1,222 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+
+// Check every possible conversion range error among int,char,bv,real,ORDINAL
+
+// int to char
+method Test1(n: int)
+{
+  var ch := n as char;  // ERROR
+}
+
+method Test1b(n: int)
+  requires n < 65536
+{
+  var ch := n as char;  // ERROR
+}
+
+method Test1c(n: int)
+  requires 0 <= n
+{
+  var ch := n as char;  // ERROR
+}
+
+method Test1OK(n: int)
+  requires 0 <= n < 65536
+{
+  var ch := n as char;
+}
+
+
+// int to ORDINAL
+method Test2(n: int) {
+  var o: ORDINAL := n as ORDINAL;  // ERROR
+}
+  
+method Test2OK(n: int)
+  requires n >= 0
+{
+  var o: ORDINAL := n as ORDINAL;
+}
+
+// real to ORDINAL  
+method Test3(r: real)
+  requires r.Floor as real == r
+{
+  var o: ORDINAL := r as ORDINAL;  // ERROR
+}
+
+method Test3b(r: real)
+  requires r >= 0.0  // ERROR
+{
+  var o: ORDINAL := r as ORDINAL;
+}
+
+method Test3OK(r: real)
+  requires r.Floor as real == r
+  requires r >= 0.0
+{
+  var o: ORDINAL := r as ORDINAL;
+}
+
+// real to int
+method Test4(r: real)
+{
+  var n: int := r as int;  // ERROR
+}
+
+method Test4OK(r: real)
+  requires r.Floor as real == r
+{
+  var n: int := r as int;
+}
+
+// real to char
+method Test5(r:real)
+  requires 0.0 <= r
+  requires r == r.Floor as real
+{
+  var ch := r as char;  // ERROR
+}
+
+method Test5b(r:real)
+  requires r <= 65535.0
+  requires r == r.Floor as real
+{
+  var ch := r as char;  // ERROR
+}
+
+method Test5c(r:real)
+  requires 0.0 <= r <= 65535.0
+{
+  var ch := r as char;  // ERROR
+}
+
+method Test5OK(r: real)
+  requires 0.0 <= r < 65536.0
+  requires r == r.Floor as real
+{
+  var ch := r as char;
+}
+
+// real to bv
+method Test6(r: real)
+  requires 0.0 <= r
+  requires r == r.Floor as real
+{
+  var bv := r as bv8;  // ERROR
+}
+
+method Test6b(r: real)
+  requires r <= 255.0
+  requires r == r.Floor as real
+{
+  var bv := r as bv8;  // ERROR
+}
+
+method Test6c(r: real)
+  requires 0.0 <= r <= 255.0
+{
+  var bv := r as bv8;  // ERROR
+}
+
+method Test6OK(r: real)
+  requires 0.0 < r <= 255.0
+  requires r == r.Floor as real
+{
+  var bv := r as bv8;
+}
+
+// int to bv
+method Test7(n: int)
+  requires 0 <= n
+{
+  var bv := n as bv8;  // ERROR
+}
+
+method Test7b(n: int)
+  requires n <= 255
+{
+  var bv := n as bv8;  // ERROR
+}
+
+method Test7OK(n: int)
+  requires 0 <= n <= 255
+{
+  var bv := n as bv8;
+}
+
+// char to bv
+method Test8(n: char)
+{
+  var bv := n as bv8;  // ERROR
+}
+
+method Test8OK(n: char)
+  requires n as int <= 255
+{
+  var bv := n as bv8;
+}
+
+method Test8OKb(n: char)
+{
+  var bv := n as bv16;
+}
+
+// ordinal to char
+method TestA(o: ORDINAL)
+{
+  var ch := o as char;  // ERROR
+}
+
+method TestAb(o: ORDINAL)
+  requires o.IsNat
+{
+  var ch := o as char;  // ERROR
+}
+
+method TestAOK(o: ORDINAL)
+  requires o.IsNat && o as int < 65536
+{
+  var ch := o as char;
+}
+
+
+// ordinal to bv
+method TestB(o: ORDINAL)
+{
+  var b := o as bv8;  // ERROR
+}
+
+method TestBb(o: ORDINAL)
+  requires o.IsNat
+{
+  var b := o as bv8;  // ERROR
+}
+
+method TestBOK(o: ORDINAL)
+  requires o.IsNat && o as int < 256
+{
+  var b := o as bv8;
+}
+
+// bv to char
+method TestC(b: bv32)
+{
+  var ch := b as char;  // ERROR
+}
+
+method TestCOK(b: bv32)
+  requires b as int < 65536
+{
+  var ch := b as char;
+}
+method TestCOKb(b: bv16)
+{
+  var ch := b as char;
+}
+method TestCOKc(b: bv8)
+{
+  var ch := b as char;
+}

--- a/Test/git-issues/git-issue-356-errors.dfy.expect
+++ b/Test/git-issues/git-issue-356-errors.dfy.expect
@@ -1,0 +1,71 @@
+git-issue-356-errors.dfy(10,14): Error: value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(16,14): Error: value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(22,14): Error: value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(34,22): Error: a negative integer cannot be converted to an ORDINAL
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(47,22): Error: a negative real cannot be converted to an ORDINAL
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(53,22): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(66,18): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(80,14): Error: real value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(87,14): Error: real value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(93,14): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(108,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(115,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(121,14): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(135,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(141,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(153,14): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(170,14): Error: ordinal value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(170,14): Error: value to be converted might be bigger than every natural number
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(176,14): Error: ordinal value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(189,13): Error: value to be converted might be bigger than every natural number
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(189,13): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(195,13): Error: value to be converted might not fit in bv8
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors.dfy(207,14): Error: bit-vector value to be converted might not fit in char
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 14 verified, 23 errors

--- a/Test/git-issues/git-issue-356-errors2.dfy
+++ b/Test/git-issues/git-issue-356-errors2.dfy
@@ -1,0 +1,25 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Subset tsype conversions
+
+type Tx = x | 0 <= x <= 100
+method TestD(x: Tx) {
+  var z := x as Tx;
+  var c := x as char;
+  var n := x as int;
+  var r := x as real;
+  var b := x as bv8;
+  var o := x as ORDINAL;
+}
+method TestF(cc: char, nn: int, rr: real, bb: bv8, oo: ORDINAL) {
+  var xx: Tx;
+  xx := oo as Tx; // ERROR
+  xx := cc as Tx; // ERROR
+  xx := nn as Tx; // ERROR
+}
+method TestG(cc: char, nn: int, rr: real, bb: bv8, oo: ORDINAL) {
+  var xx: Tx;
+  xx := rr as Tx; // ERROR
+  xx := bb as Tx; // ERROR
+}

--- a/Test/git-issues/git-issue-356-errors2.dfy.expect
+++ b/Test/git-issues/git-issue-356-errors2.dfy.expect
@@ -1,0 +1,23 @@
+git-issue-356-errors2.dfy(17,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(17,11): Error: value to be converted might be bigger than every natural number
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(18,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(19,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(23,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(23,11): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
+Execution trace:
+    (0,0): anon0
+git-issue-356-errors2.dfy(24,11): Error: result of operation might violate subset type constraint for 'Tx'
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 2 verified, 7 errors

--- a/Test/git-issues/git-issue-356.dfy
+++ b/Test/git-issues/git-issue-356.dfy
@@ -1,0 +1,212 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module M {
+  type Tx = i: int | 0 <= i <= 100
+  newtype Tr = r: real | r == r.Floor as real && 0.0 <= r <= 100.0
+
+  method Main() {
+    Test(0xDEAD, 100, 'a');
+    Test2(0x40, 42, 'Z', 70.0, 35, 50, 61.0);
+    Test3(0x0, 50, '*', 50.0, 30);
+    print "END\n";
+  }
+
+  type bv = bv8
+  const mx: int := 256; // limit for the chosen bit-vector type
+  const mxch: int := 0x1_0000;
+  
+  method Test(b: bv32, n: nat, c: char)
+    requires b < mxch as bv32  // in range of char
+    requires n < mxch
+  {
+    var r: real := 42.0;
+    var o: ORDINAL := 42 as ORDINAL;
+    var ch: char;
+    
+    ch := c as char;
+    ch := n as char;
+    ch := b as char;
+    ch := r as char;
+    ch := o as char;
+  
+    var nn: int;
+    var nnn: int;
+    nn := c as int;
+    nn := r as int;
+    nn := b as int;
+    nn := nnn as int;
+    nn := o as int;
+  
+    var rr: real;
+    rr := c as real;
+    rr := n as real;
+    rr := b as real;
+    rr := r as real;
+    rr := o as real;
+  
+    var bb: bv32;
+    bb := c as bv32;
+    bb := n as bv32;
+    bb := r as bv32;
+    bb := b as bv32;
+    bb := o as bv32;
+  
+    var oo: ORDINAL;
+    oo := c as ORDINAL;
+    oo := n as ORDINAL;
+    oo := r as ORDINAL;
+    oo := b as ORDINAL;
+    oo := o as ORDINAL;
+    
+  }
+
+  method Test2(b: bv, n: int, c: char, r: real, o: ORDINAL, x: Tx, h: Tr) {
+  
+    assert c == c as char;
+    expect c == c as char;
+    assert c == c as int as char;
+    expect c == c as int as char;
+    assert c == c as real as char;
+    expect c == c as real as char;
+    // assert c == c as bv as char; // in Test3
+    // expect c == c as bv as char; // in Test3
+    assert c == c as ORDINAL as char;
+    expect c == c as ORDINAL as char;
+    if c as int < mx { print c as char, " ", c as int, " ", c as real, " ", c as bv, " ", c as ORDINAL, "\n"; }
+  
+    // assert b == b as bv; // in Test3
+    // expect b == b as bv; // in Test3
+    // assert b == b as char as bv; // in Test3
+    // expect b == b as char as bv; // in Test3
+    // assert b == b as int as bv; // in Test3
+    // expect b == b as int as bv; // in Test3
+    // assert b == b as real as bv; // in Test3
+    // expect b == b as real as bv; // in Test3
+    // assert b == b as ORDINAL as bv; // in Test3
+    // expect b == b as ORDINAL as bv; // in Test3
+    
+    assert n == n as int;
+    expect n == n as int;
+    assert 0 <= n < mxch ==> n == n as char as int;
+    expect 0 <= n < mxch ==> n == n as char as int;
+    // assert 0 <= n < mx ==> n == n as bv as int; // in Test3
+    // expect 0 <= n < mx ==> n == n as bv as int; // in Test3
+    assert n == n as real as int;
+    expect n == n as real as int;
+    assert 0 <= n ==> n == n as ORDINAL as int;
+    expect 0 <= n ==> n == n as ORDINAL as int;
+    if 0 <= n < mx && n < mxch { print n as char, " ", n as int, " ", n as real, " ", n as bv, " ", n as ORDINAL, "\n"; }
+    
+    assert r == r as real;
+    expect r == r as real;
+    assert r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
+    expect r == r.Floor as real  ==> 0.0 <= r < (mxch as real) ==> r == r as char as real;
+    assert r == r.Floor as real  ==> r == r as int as real;
+    expect r == r.Floor as real  ==> r == r as int as real;
+    // assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
+    // expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real; // in Test3
+    assert r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
+    expect r == r.Floor as real  ==> 0.0 <= r ==> r == r as ORDINAL as real;
+    if r == r.Floor as real && 0.0 <= r < (mx as real) && r < (mxch as real) { print r as char, " ", r as int, " ", r as real, " ", r as bv, " ", r as ORDINAL, "\n"; }
+ 
+    assert o == o as ORDINAL;
+    expect o == o as ORDINAL;
+    assert o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
+    expect o.IsNat && o as int < mxch ==> o == o as char as ORDINAL;
+    assert o.IsNat ==> o == o as int as ORDINAL;
+    expect o.IsNat ==> o == o as int as ORDINAL;
+    assert o.IsNat ==> o == o as real as ORDINAL;
+    expect o.IsNat ==> o == o as real as ORDINAL;
+    // assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+    // expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL; // in Test3
+    if o.IsNat && o as int < mx && o as int < mxch { print o as char, " ", o as int, " ", o as real, " ", o as bv, " ", o as ORDINAL, "\n"; }
+
+    // subset type
+    var nnn: int := x; // Implicit conversion allowed
+    assert x == x as Tx;
+    expect x == x as Tx;
+    assert x == x as char as Tx;
+    expect x == x as char as Tx;
+    assert x == x as int as Tx;
+    expect x == x as int as Tx;
+    assert x == x as real as Tx;
+    expect x == x as real as Tx;
+    assert x == x as bv as Tx;
+    expect x == x as bv as Tx;
+    assert x == x as ORDINAL as Tx;
+    expect x == x as ORDINAL as Tx;
+    assert c as int <= 100 ==> c == c as Tx as char;
+    expect c as int <= 100 ==> c == c as Tx as char;
+    assert 0 <= n as int <= 100 ==> n == n as Tx as int;
+    expect 0 <= n as int <= 100 ==> n == n as Tx as int;
+    assert r == r.Floor as real &&  0.0 <= r <= 100.0 ==> r == r as Tx as real;
+    expect r == r.Floor as real &&  0.0 <= r <= 100.0 ==> r == r as Tx as real;
+    assert b as int <= 100 ==> b == b as Tx as bv;
+    expect b as int <= 100 ==> b == b as Tx as bv;
+    assert o.IsNat && o as int <= 100 ==> o == o as Tx as ORDINAL;
+    expect o.IsNat && o as int <= 100 ==> o == o as Tx as ORDINAL;
+
+    assert h == h as Tr;
+    expect h == h as Tr;
+    assert h == h as Tx as Tr;
+    expect h == h as Tx as Tr;
+    assert h == h as char as Tr;
+    expect h == h as char as Tr;
+    assert h == h as int as Tr;
+    expect h == h as int as Tr;
+    assert h == h as real as Tr;
+    expect h == h as real as Tr;
+    assert h == h as bv8 as Tr;
+    expect h == h as bv8 as Tr;
+    assert h == h as ORDINAL as Tr;
+    expect h == h as ORDINAL as Tr;
+    assert x == x as Tr as Tx;
+    expect x == x as Tr as Tx;
+    assert c as int <= 100 ==> c == c as Tr as char;
+    expect c as int <= 100 ==> c == c as Tr as char;
+    assert 0 <= n as int <= 100 ==> n == n as Tr as int;
+    expect 0 <= n as int <= 100 ==> n == n as Tr as int;
+    assert r == r.Floor as real && 0 <= r as int <= 100 ==> r == r as Tr as real;
+    expect r == r.Floor as real && 0 <= r as int <= 100 ==> r == r as Tr as real;
+    assert b as int <= 100 ==> b == b as Tr as bv8;
+    expect b as int <= 100 ==> b == b as Tr as bv8;
+    assert o.IsNat && o as int <= 100 ==> o == o as Tr as ORDINAL;
+    expect o.IsNat && o as int <= 100 ==> o == o as Tr as ORDINAL;
+
+  }
+  
+  // These take a while depending on the width of the bit-vector type
+  // About 25 sec on my machine for bv8; longer than I wanted to wait (>10s min) for bv16
+  method Test3(b: bv, n: int, c: char, r: real, o: ORDINAL) {
+  
+    assert c as int < mx ==> c == c as bv as char;
+    expect c as int < mx ==> c == c as bv as char;
+      
+    assert b == b as bv;
+    expect b == b as bv;
+    assert b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
+    expect b == b as bv32 as bv; // assumes bv32 is at least as wide as bv
+    assert b as int < mxch ==> b == b as char as bv;
+    expect b as int < mxch ==> b == b as char as bv;
+    assert b == b as int as bv;
+    expect b == b as int as bv;
+    assert b == b as real as bv;
+    expect b == b as real as bv;
+    assert b == b as ORDINAL as bv;
+    expect b == b as ORDINAL as bv;
+    
+    assert 0 <= n < mx ==> n == n as bv as int;
+    expect 0 <= n < mx ==> n == n as bv as int;
+    
+    assert r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
+    expect r == r.Floor as real ==> 0.0 <= r < (mx as real) ==> r == r as bv as real;
+
+    assert o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
+    expect o.IsNat && o as int < mx ==> o == o as bv as ORDINAL;
+  }
+}

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -1,0 +1,30 @@
+
+Dafny program verifier finished with 7 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
+END
+
+Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
+END
+
+Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
+END
+
+Dafny program verifier finished with 0 verified, 0 errors
+Z 90 90.0 90 90
+* 42 42.0 42 42
+F 70 70.0 70 70
+# 35 35.0 35 35
+END

--- a/Test/git-issues/git-issue-505.dfy
+++ b/Test/git-issues/git-issue-505.dfy
@@ -1,0 +1,45 @@
+// RUN: %dafny /compile:0 /timeLimit:20 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+lemma a()
+{
+  var a: int := 0x0000_0000_DEAD_BEEF;
+  var testbv: bv64 := a as bv64;
+  var testval: int := testbv as int;
+
+  assert testval == a; // "Timed out on: assertion violation"
+}
+lemma b()
+{
+  var a: int := 0x0000_0010_DEAD_BEEF;
+  var testbv: bv64 := a as bv64;
+  var testval: int := testbv as int;
+
+  assert testval == a; // "Timed out on: assertion violation"
+}
+lemma c()
+{
+  var a: int := 0x0000_0000_DEAD_BEEF;
+  var testbv: bv32 := a as bv32;
+  var testval: int := testbv as int;
+
+  assert testval == a; // "Timed out on: assertion violation"
+}
+lemma d()
+{
+  var a: int := 0x0000_0000_0000_BEEF;
+  var testbv: bv16 := a as bv16;
+  var testval: int := testbv as int;
+
+  assert testval == a; // "Timed out on: assertion violation"
+}
+lemma e()
+{
+  var a: int := 0x0000_0000_0000_00EF;
+  var testbv: bv8 := a as bv8;
+  var testval: int := testbv as int;
+
+  assert testval == a; // "Timed out on: assertion violation"
+}
+
+// The longer bit vector operations are likely to timeout, but none should error

--- a/Test/git-issues/git-issue-505.dfy
+++ b/Test/git-issues/git-issue-505.dfy
@@ -31,7 +31,7 @@ lemma d()
   var testbv: bv16 := a as bv16;
   var testval: int := testbv as int;
 
-  assert testval == a; // "Timed out on: assertion violation"
+  assert testval == a; // OK
 }
 lemma e()
 {
@@ -39,7 +39,8 @@ lemma e()
   var testbv: bv8 := a as bv8;
   var testval: int := testbv as int;
 
-  assert testval == a; // "Timed out on: assertion violation"
+  assert testval == a; // OK
 }
 
-// The longer bit vector operations are likely to timeout, but none should error
+// The longer bit vector operations currently timeout (because of Z3's inefficient support for bit-vector/int conversions), 
+// but the shorter bit width attempts should verify OK

--- a/Test/git-issues/git-issue-505.dfy.expect
+++ b/Test/git-issues/git-issue-505.dfy.expect
@@ -1,0 +1,14 @@
+git-issue-505.dfy(4,6): Verification of 'Impl$$_module.__default.a' timed out after 20 seconds
+git-issue-505.dfy(10,17): Timed out on: assertion violation
+Execution trace:
+    (0,0): anon0
+git-issue-505.dfy(12,6): Verification of 'Impl$$_module.__default.b' timed out after 20 seconds
+git-issue-505.dfy(18,17): Timed out on: assertion violation
+Execution trace:
+    (0,0): anon0
+git-issue-505.dfy(20,6): Verification of 'Impl$$_module.__default.c' timed out after 20 seconds
+git-issue-505.dfy(26,17): Timed out on: assertion violation
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 2 verified, 0 errors, 3 time outs


### PR DESCRIPTION
Fixes #505. Not changes to dafny. Current dafny correctly reports timeouts, with a non-zero exit code. Added a test. If the test is found to be non-deterministic, it can be disabled.