### PR TITLE
#258: Fixes the printing of strings through Dafny print statements

### DIFF
--- a/Binaries/DafnyRuntime.go
+++ b/Binaries/DafnyRuntime.go
@@ -68,43 +68,10 @@ func String(x interface{}) string {
 	}
 	return fmt.Sprint(x)
 }
-func StringForChars(x interface{}) string {
-        if x == nil {
-                return "null"
-        }
-        v := refl.ValueOf(x)
-        if isNil(v) {
-                return "null"
-        }
-        if v.Kind() == refl.Func {
-                return v.Type().String()
-        }
-        var vv, ok = x.(Seq)
-        if ok && !vv.isString {
-            s := "";
-            for i := 0; i < vv.LenInt(); i++ { s += fmt.Sprint(vv.contents[i]); }
-            return s;
-        }
-        return fmt.Sprint(x)
-}
-func IsElemChar(x interface{}) bool {
-        var vv, ok = x.(Seq)
-        if ok && !vv.isString && vv.LenInt() > 0 {
-            var _,okchar = vv.contents[0].(Char)
-            if (okchar) {
-                return true
-            }
-        }
-        return false
-}
-
 
 // Print prints the given value using fmt.Print, formatted using String.
 func Print(x interface{}) {
 	fmt.Print(String(x))
-}
-func PrintForChars(x interface{}) {
-	fmt.Print(StringForChars(x))
 }
 
 // SetFinalizer is a re-export of runtime.SetFinalizer.  Included here so that
@@ -432,6 +399,10 @@ func SeqOfString(str string) Seq {
 	return Seq{arr, true}
 }
 
+func (seq Seq) SetString() Seq {
+        return Seq{seq.contents, true}
+}
+
 // Index finds the sequence element at the given index.
 func (seq Seq) Index(i Int) interface{} {
 	return seq.IndexInt(i.Int())
@@ -706,10 +677,15 @@ func (array *Array) RangeToSeq(lo, hi Int) Seq {
 	if len(array.dims) != 1 {
 		panic("Can't take a slice of a multidimensional array")
 	}
+        isString := false;
+        if len(array.contents) > 0 {
+            _, isString = array.contents[0].(Char)
+        }
 
 	// TODO Should set isString to true if this is an array of characters
-	// (need to know it's an array of characters first!).
+	// Do not know if it is an array of characters if the array is empty
 	seq := SeqOf(array.contents...)
+        seq.isString = isString
 
 	return seq.Subseq(lo, hi)
 }

--- a/Binaries/DafnyRuntime.go
+++ b/Binaries/DafnyRuntime.go
@@ -68,10 +68,43 @@ func String(x interface{}) string {
 	}
 	return fmt.Sprint(x)
 }
+func StringForChars(x interface{}) string {
+        if x == nil {
+                return "null"
+        }
+        v := refl.ValueOf(x)
+        if isNil(v) {
+                return "null"
+        }
+        if v.Kind() == refl.Func {
+                return v.Type().String()
+        }
+        var vv, ok = x.(Seq)
+        if ok && !vv.isString {
+            s := "";
+            for i := 0; i < vv.LenInt(); i++ { s += fmt.Sprint(vv.contents[i]); }
+            return s;
+        }
+        return fmt.Sprint(x)
+}
+func IsElemChar(x interface{}) bool {
+        var vv, ok = x.(Seq)
+        if ok && !vv.isString && vv.LenInt() > 0 {
+            var _,okchar = vv.contents[0].(Char)
+            if (okchar) {
+                return true
+            }
+        }
+        return false
+}
+
 
 // Print prints the given value using fmt.Print, formatted using String.
 func Print(x interface{}) {
 	fmt.Print(String(x))
+}
+func PrintForChars(x interface{}) {
+	fmt.Print(StringForChars(x))
 }
 
 // SetFinalizer is a re-export of runtime.SetFinalizer.  Included here so that

--- a/Binaries/DafnyRuntime.js
+++ b/Binaries/DafnyRuntime.js
@@ -527,6 +527,9 @@ let _dafny = (function() {
         return r;
       }
     }
+    static JoinIfPossible(x) {
+      try { return x.join(""); } catch(_error) { return x; }
+    }
     static IsPrefixOf(a, b) {
       if (b.length < a.length) {
         return false;

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Dafny {
       ModuleName = MainModuleName = HasMain(program, out _) ? "main" : Path.GetFileNameWithoutExtension(program.Name);
 
       wr.WriteLine("package {0}", ModuleName);
-      //wr.WriteLine("import \"strings\"");
       wr.WriteLine();
       // Keep the import writers so that we can import subsequent modules into the main one
       EmitImports(wr, out RootImportWriter, out RootImportDummyWriter);
@@ -1832,6 +1831,8 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitPrintStmt(TargetWriter wr, Expression arg) {
+      bool isSeq = arg.Type.AsCollectionType != null &&
+                   arg.Type.AsCollectionType.AsSeqType != null;
       bool isString = arg.Type.AsCollectionType != null &&
                       arg.Type.AsCollectionType.AsSeqType != null &&
                       arg.Type.AsCollectionType.AsSeqType.Arg.IsCharType;
@@ -1839,23 +1840,11 @@ namespace Microsoft.Dafny {
       bool isGeneric = arg.Type.AsCollectionType != null &&
                        arg.Type.AsCollectionType.AsSeqType != null &&
                        arg.Type.AsCollectionType.AsSeqType.Arg.IsTypeParameter;
-      // if (!isStringLiteral) {
-      //   wr.Write("_dafny.Print((");
-      //   TrExpr(arg, wr, false);
-      //   wr.WriteLine(").isString)");
-      // }
       if (isString && !isStringLiteral) {
-        wr.Write("_dafny.PrintForChars(");
+        wr.Write("_dafny.Print(");
+        wr.Write("(");
         TrExpr(arg, wr, false);
-        wr.WriteLine(")");
-      } else if (isGeneric) {
-        wr.Write("if _dafny.IsElemChar(");
-        TrExpr(arg, wr, false);
-        wr.Write(") { _dafny.PrintForChars(");
-        TrExpr(arg, wr, false);
-        wr.Write(") } else { _dafny.Print(");
-        TrExpr(arg, wr, false);
-        wr.WriteLine(") }");
+        wr.WriteLine(").SetString())");
       } else {
         wr.Write("_dafny.Print(");
         TrExpr(arg, wr, false);

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1831,26 +1831,18 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitPrintStmt(TargetWriter wr, Expression arg) {
-      bool isString = arg.Type.AsCollectionType != null &&
-                      arg.Type.AsCollectionType.AsSeqType != null &&
-                      arg.Type.AsCollectionType.AsSeqType.Arg.IsCharType;
-      if (isString) {
-        // needed for empty sequences known to be strings
-        if (arg.Resolved is MemberSelectExpr &&
-            (arg.Resolved as MemberSelectExpr).Member.IsExtern(out _, out _)) {
-          wr.Write("_dafny.Print((");
-          TrExpr(arg, wr, false);
-          wr.WriteLine("))");
-        } else {
-          wr.Write("_dafny.Print((");
-          TrExpr(arg, wr, false);
-          wr.WriteLine(").SetString())");
-        }
-
-      } else {
+      bool isString = arg.Type.AsSeqType != null &&
+                      arg.Type.AsSeqType.Arg.IsCharType;
+      if (!isString || 
+          (arg.Resolved is MemberSelectExpr mse &&
+            mse.Member.IsExtern(out _, out _))) {
         wr.Write("_dafny.Print(");
         TrExpr(arg, wr, false);
-        wr.WriteLine(")");
+        wr.WriteLine(")"); 
+      } else {
+        wr.Write("_dafny.Print((");
+        TrExpr(arg, wr, false);
+        wr.WriteLine(").SetString())");
       }
     }
 

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1831,16 +1831,10 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitPrintStmt(TargetWriter wr, Expression arg) {
-      bool isSeq = arg.Type.AsCollectionType != null &&
-                   arg.Type.AsCollectionType.AsSeqType != null;
       bool isString = arg.Type.AsCollectionType != null &&
                       arg.Type.AsCollectionType.AsSeqType != null &&
                       arg.Type.AsCollectionType.AsSeqType.Arg.IsCharType;
-      bool isStringLiteral = arg is StringLiteralExpr;
-      bool isGeneric = arg.Type.AsCollectionType != null &&
-                       arg.Type.AsCollectionType.AsSeqType != null &&
-                       arg.Type.AsCollectionType.AsSeqType.Arg.IsTypeParameter;
-      if (isString && !isStringLiteral) {
+      if (isString) { // needed for empty sequences known to be strings
         wr.Write("_dafny.Print(");
         wr.Write("(");
         TrExpr(arg, wr, false);

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1834,11 +1834,19 @@ namespace Microsoft.Dafny {
       bool isString = arg.Type.AsCollectionType != null &&
                       arg.Type.AsCollectionType.AsSeqType != null &&
                       arg.Type.AsCollectionType.AsSeqType.Arg.IsCharType;
-      if (isString) { // needed for empty sequences known to be strings
-        wr.Write("_dafny.Print(");
-        wr.Write("(");
-        TrExpr(arg, wr, false);
-        wr.WriteLine(").SetString())");
+      if (isString) {
+        // needed for empty sequences known to be strings
+        if (arg.Resolved is MemberSelectExpr &&
+            (arg.Resolved as MemberSelectExpr).Member.IsExtern(out _, out _)) {
+          wr.Write("_dafny.Print((");
+          TrExpr(arg, wr, false);
+          wr.WriteLine("))");
+        } else {
+          wr.Write("_dafny.Print((");
+          TrExpr(arg, wr, false);
+          wr.WriteLine(").SetString())");
+        }
+
       } else {
         wr.Write("_dafny.Print(");
         TrExpr(arg, wr, false);

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -2048,12 +2048,10 @@ namespace Microsoft.Dafny{
         }
       } else {
         // TODO-RS: This doesn't handle strings printed out as part of datatypes
-        bool isString = arg.Type.AsCollectionType != null &&
-                        arg.Type.AsCollectionType.AsSeqType != null &&
-                        arg.Type.AsCollectionType.AsSeqType.Arg.IsCharType;
-        bool isGeneric = arg.Type.AsCollectionType != null &&
-                         arg.Type.AsCollectionType.AsSeqType != null &&
-                         arg.Type.AsCollectionType.AsSeqType.Arg.IsTypeParameter;
+        bool isString = arg.Type.AsSeqType != null &&
+                        arg.Type.AsSeqType.Arg.IsCharType;
+        bool isGeneric = arg.Type.AsSeqType != null &&
+                         arg.Type.AsSeqType.Arg.IsTypeParameter;
         if (isString) {
           TrExpr(arg, wr, false);
           wr.Write(".verbatimString()");

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -2050,14 +2050,25 @@ namespace Microsoft.Dafny{
         // TODO-RS: This doesn't handle strings printed out as part of datatypes
         bool isString = arg.Type.AsCollectionType != null &&
                         arg.Type.AsCollectionType.AsSeqType != null &&
-                        arg.Type.AsCollectionType.AsSeqType.Arg is CharType;
-        if (!isString) {
-          wr.Write("String.valueOf(");
-        }
-        TrExpr(arg, wr, false);
+                        arg.Type.AsCollectionType.AsSeqType.Arg.IsCharType;
+        bool isGeneric = arg.Type.AsCollectionType != null &&
+                         arg.Type.AsCollectionType.AsSeqType != null &&
+                         arg.Type.AsCollectionType.AsSeqType.Arg.IsTypeParameter;
         if (isString) {
+          TrExpr(arg, wr, false);
           wr.Write(".verbatimString()");
+        } else if (isGeneric) {
+          wr.Write("((java.util.function.Function<dafny.DafnySequence<?>,String>)(_s -> (_td___T.defaultValue().getClass() == java.lang.Character.class ? _s.verbatimString() : String.valueOf(_s)))).apply(");
+          TrExpr(arg, wr, false);
+          wr.Write(")");
+          // wr.Write("(td___T.defaultValue().getClass() == java.lang.Character.class ? (");
+          // TrExpr(arg, wr, false);
+          // wr.Write(") : String.valueOf(");
+          // TrExpr(arg, wr, false);
+          // wr.Write(")).verbatimString()");
         } else {
+          wr.Write("String.valueOf(");
+          TrExpr(arg, wr, false);
           wr.Write(")");
         }
       }

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -2058,14 +2058,9 @@ namespace Microsoft.Dafny{
           TrExpr(arg, wr, false);
           wr.Write(".verbatimString()");
         } else if (isGeneric) {
-          wr.Write("((java.util.function.Function<dafny.DafnySequence<?>,String>)(_s -> (_td___T.defaultValue().getClass() == java.lang.Character.class ? _s.verbatimString() : String.valueOf(_s)))).apply(");
+          wr.Write("((java.util.function.Function<dafny.DafnySequence<?>,String>)(_s -> (_s.elementType().defaultValue().getClass() == java.lang.Character.class ? _s.verbatimString() : String.valueOf(_s)))).apply(");
           TrExpr(arg, wr, false);
           wr.Write(")");
-          // wr.Write("(td___T.defaultValue().getClass() == java.lang.Character.class ? (");
-          // TrExpr(arg, wr, false);
-          // wr.Write(") : String.valueOf(");
-          // TrExpr(arg, wr, false);
-          // wr.Write(")).verbatimString()");
         } else {
           wr.Write("String.valueOf(");
           TrExpr(arg, wr, false);

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -1050,21 +1050,25 @@ namespace Microsoft.Dafny {
                        arg.Type.AsCollectionType.AsSeqType != null &&
                        arg.Type.AsCollectionType.AsSeqType.Arg.IsTypeParameter;
       if (isString && isStringLiteral) {
+        // process.stdout.write(_dafny.toString(x));
         wr.Write("process.stdout.write(_dafny.toString(");
         TrExpr(arg, wr, false);
         wr.WriteLine("));");
       } else if (isString && !isStringLiteral) {
-        wr.Write("try { process.stdout.write(_dafny.toString(");
+        // try { process.stdout.write(_dafny.toString((x).join(""))); } catch (_error) { process.stdout.write(_dafny.toString(x)); }
+        wr.Write("try { process.stdout.write(_dafny.toString((");
         TrExpr(arg, wr, false);
-        wr.WriteLine(".join(\"\")));");
+        wr.WriteLine(").join(\"\")));");
         wr.Write(" } catch (_error) { process.stdout.write(_dafny.toString(");
         TrExpr(arg, wr, false);
-        wr.WriteLine("));}");
+        wr.WriteLine(")); }");
       } else if (!isString && !isGeneric) {
+        // process.stdout.write(_dafny.toString(x));
         wr.Write("process.stdout.write(_dafny.toString(");
         TrExpr(arg, wr, false);
         wr.WriteLine("));");
-      } else {//if (!isString && isGeneric) {
+      } else { // isGeneric
+        // try { process.stdout.write(_dafny.toString(((x) instanceof Array && typeof((x)[0]) == \"string\") ? (x).join("") : (x))); } catch (_error) { process.stdout.write(_dafny.toString(x)); }
         wr.Write("try { process.stdout.write(_dafny.toString(");
         wr.Write("(");
         wr.Write("(");

--- a/Test/comp/Collections.dfy
+++ b/Test/comp/Collections.dfy
@@ -116,7 +116,7 @@ module BoundedIntegerParameters {
   {
     var data := "Bounded";
 
-    print data[..u0], " ";  // it is unfortunate how these get printed in Java
+    print data[..u0], " ";
     print data[..u1], " ";
     print data[..u2], " ";
     print data[..u3], " ";

--- a/Test/comp/Collections.dfy.expect
+++ b/Test/comp/Collections.dfy.expect
@@ -242,20 +242,20 @@ Sequences: [] [17, 82, 17, 82] [12, 17]
   prefix: true false true
   proper prefix: true false false
   membership: false true true
-[B, o, u, n, d] [B, o, u, n, d] [B, o, u, n, d] [B, o, u, n, d] [B, o, u, n, d] [B, o, u, n, d]
-[e, d] [e, d] [e, d] [e, d] [e, d] [e, d]
+Bound Bound Bound Bound Bound Bound
+ed ed ed ed ed ed
 e e e e e e
 hello
 hEllo
 [2, 4, 6, 8, 10]
 [2, 0, 6, 8, 10]
-Strings: [] [u, R, u, R] [g, u]
+Strings:  uRuR gu
   cardinality: 0 4 2
-  concatenation: [u, R, u, R] [u, R, u, R, g, u]
+  concatenation: uRuR uRuRgu
   prefix: true false true
   proper prefix: true false false
   membership: false true true
-  constructed as sequence: [g, u, r, u]
+  constructed as sequence: guru
   mix: hello-d ddd-hello
 Maps: map[] map[17 := 2, 82 := 2] map[17 := 0, 12 := 26]
   cardinality: 0 2 2

--- a/Test/comp/GoModule.dfy.expect
+++ b/Test/comp/GoModule.dfy.expect
@@ -5,4 +5,4 @@ has the following parts:
 host: localhost:8080
 pathname: /default.htm
 search: year=1915&month=august&day=29
-Parse error: parse http://localhost:8080/default.htm%: invalid URL escape "%"
+Parse error: parse "http://localhost:8080/default.htm%": invalid URL escape "%"

--- a/Test/comp/GoModule.dfy.expect
+++ b/Test/comp/GoModule.dfy.expect
@@ -5,4 +5,4 @@ has the following parts:
 host: localhost:8080
 pathname: /default.htm
 search: year=1915&month=august&day=29
-Parse error: parse "http://localhost:8080/default.htm%": invalid URL escape "%"
+Parse error: parse http://localhost:8080/default.htm%: invalid URL escape "%"

--- a/Test/git-issues/git-issue-258.dfy
+++ b/Test/git-issues/git-issue-258.dfy
@@ -1,0 +1,7 @@
+method Main() {
+  var a := new char[2];
+  a[0] := 'h';
+  a[1] := 'i';
+  print a[..], "\n";
+  print (a[..]) as string, "\n";
+}

--- a/Test/git-issues/git-issue-258.dfy
+++ b/Test/git-issues/git-issue-258.dfy
@@ -1,7 +1,33 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /compile:3 /spillTargetCode:3 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /compile:3 /spillTargetCode:3 /compileTarget:java "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method pr<T>(s: seq<T>) {
+  print s, "\n";
+}
+
 method Main() {
   var a := new char[2];
   a[0] := 'h';
   a[1] := 'i';
   print a[..], "\n";
-  print (a[..]) as string, "\n";
+  print (a[..]), "\n";
+  var b := new char[0];
+  print b[..], "\n";
+  print "", "\n";
+  print "HI!", "\n";
+
+  pr(a[..]);
+  pr(b[..]);
+  pr("HI!");
+  pr("");
+
+  var d:= new int[2];
+  d[0] := 23;
+  d[1] := 45;
+  print d[..], "\n";
+  pr(d[..]);
 }
+
+

--- a/Test/git-issues/git-issue-258.dfy
+++ b/Test/git-issues/git-issue-258.dfy
@@ -1,6 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %dafny /compile:3 /spillTargetCode:3 /compileTarget:cs "%s" >> "%t"
 // RUN: %dafny /compile:3 /spillTargetCode:3 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /compile:3 /spillTargetCode:3 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /compile:3 /spillTargetCode:3 /compileTarget:go "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 method pr<T>(s: seq<T>) {
@@ -11,23 +13,39 @@ method Main() {
   var a := new char[2];
   a[0] := 'h';
   a[1] := 'i';
-  print a[..], "\n";
-  print (a[..]), "\n";
+  print a[..], "\n";   // hi
+  print (a[..]), "\n"; // hi
   var b := new char[0];
-  print b[..], "\n";
-  print "", "\n";
-  print "HI!", "\n";
+  print b[..], "\n";   //    -- empty line
+  print "", "\n";      //    -- empty line
+  print "HI!", "\n";   // HI!
 
-  pr(a[..]);
-  pr(b[..]);
-  pr("HI!");
-  pr("");
+  pr(a[..]);           // hi
+  pr(b[..]);           //    -- empty line  // JS and GO unavoidably produce [] -- as a generic object cannot distinguish empty char sequence and empty other sequence
+  pr("HI!");           // HI!
+  pr("");              //    -- empty line
 
   var d:= new int[2];
   d[0] := 23;
   d[1] := 45;
-  print d[..], "\n";
-  pr(d[..]);
+  print d[..], "\n";   // [23,45]
+  pr(d[..]);           // [23,45]
+  d := new int[0];
+  print d[..], "\n";   // []
+  pr(d[..]);           // []
+
+  var s: string := "abc";
+  print (s+s), "\n";   // abcabc
+  pr(s+s);             // abcabc
+  print ("abc"+"def"), "\n"; // abcdef
+  pr("abc"+"def");           // abcdef
+  print ""+"", "\n";         //    -- empty line
+  pr(""+"");                 //    -- empty line
+  print [1,2]+[3,4], "\n";   // [1,2,3,4]
+  pr([1,2]+[3,4]);           // [1,2,3,4]
+
+  // print []+[], "\n"; // not legal Dafny
+  // pr([]+[]);         // not legal Dafny
 }
 
 

--- a/Test/git-issues/git-issue-258.dfy.expect
+++ b/Test/git-issues/git-issue-258.dfy.expect
@@ -1,0 +1,28 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors
+hi
+hi
+
+
+HI!
+hi
+
+HI!
+
+[23, 45]
+[23, 45]
+
+Dafny program verifier finished with 1 verified, 0 errors
+hi
+hi
+
+
+HI!
+hi
+
+HI!
+
+[23, 45]
+[23, 45]

--- a/Test/git-issues/git-issue-258.dfy.expect
+++ b/Test/git-issues/git-issue-258.dfy.expect
@@ -13,6 +13,16 @@ HI!
 
 [23, 45]
 [23, 45]
+[]
+[]
+abcabc
+abcabc
+abcdef
+abcdef
+
+
+[1, 2, 3, 4]
+[1, 2, 3, 4]
 
 Dafny program verifier finished with 1 verified, 0 errors
 hi
@@ -26,3 +36,59 @@ HI!
 
 [23, 45]
 [23, 45]
+[]
+[]
+abcabc
+abcabc
+abcdef
+abcdef
+
+
+[1, 2, 3, 4]
+[1, 2, 3, 4]
+
+Dafny program verifier finished with 1 verified, 0 errors
+hi
+hi
+
+
+HI!
+hi
+[]
+HI!
+
+[23, 45]
+[23, 45]
+[]
+[]
+abcabc
+abcabc
+abcdef
+abcdef
+
+
+[1, 2, 3, 4]
+[1, 2, 3, 4]
+
+Dafny program verifier finished with 1 verified, 0 errors
+hi
+hi
+
+
+HI!
+hi
+[]
+HI!
+
+[23, 45]
+[23, 45]
+[]
+[]
+abcabc
+abcabc
+abcdef
+abcdef
+
+
+[1, 2, 3, 4]
+[1, 2, 3, 4]


### PR DESCRIPTION
Fixes #258. One remaining infelicity: when Dafny sequences are passed through a generic interface as in method pr<T>(s: seq<T>), then JS and GO cannot tell the element type of an empty string, so empty sequences passed through such an interface will print as [] instead of just nothing, as C# and Java will do.