### PR TITLE
#551: Check for a (previously missing) error message

### DIFF
--- a/Test/git-issues/git-issue-551.dfy
+++ b/Test/git-issues/git-issue-551.dfy
@@ -1,0 +1,26 @@
+datatype VoidOutcome =
+| VoidSuccess
+| VoidFailure(error: string)
+{
+    predicate method IsFailure() {
+        this.VoidFailure?
+    }
+    function method PropagateFailure(): VoidOutcome requires IsFailure() {
+        this
+    }
+}
+
+function method Require(b: bool): (r: VoidOutcome) ensures r.VoidSuccess? ==> b
+{
+  if b then VoidSuccess else VoidFailure("failed")
+}
+
+predicate MyPredicate() {
+  true
+}
+
+method Main() returns (r: VoidOutcome) {
+  // Verifies, but then fails to compile because MyPredicate isn't compiled
+  r := Require(MyPredicate()); 
+}
+

--- a/Test/git-issues/git-issue-551.dfy.expect
+++ b/Test/git-issues/git-issue-551.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-551.dfy(27,15): Error: function calls are allowed only in specification contexts (consider declaring the function a 'function method')
+1 resolution/type errors detected in git-issue-551.dfy


### PR DESCRIPTION
Fixes #551. The issue was apparently corrected by other fixes. Adding the issue as a test.