### PR TITLE
Go traits as just interfaces

### DIFF
--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -174,7 +174,8 @@ namespace Microsoft.Dafny {
 
     protected override IClassWriter CreateClass(string moduleName, string name, bool isExtern, string/*?*/ fullPrintName,
       List<TypeParameter> typeParameters, TopLevelDecl cls, List<Type>/*?*/ superClasses, Bpl.IToken tok, TargetWriter wr) {
-      return CreateClass(name, isExtern, fullPrintName, typeParameters, superClasses, tok, wr, includeRtd: true, includeEquals: true);
+      var isDefaultClass = cls is ClassDecl c && c.IsDefaultClass;
+      return CreateClass(name, isExtern, fullPrintName, typeParameters, superClasses, tok, wr, includeRtd: !isDefaultClass, includeEquals: true);
     }
 
     // TODO Consider splitting this into two functions; most things seem to be

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -178,70 +178,9 @@ namespace Microsoft.Dafny {
       return CreateClass(name, isExtern, fullPrintName, typeParameters, superClasses, tok, wr, includeRtd: !isDefaultClass, includeEquals: true);
     }
 
-    // TODO Consider splitting this into two functions; most things seem to be
-    // passing includeRtd: false and includeEquals: false.
+    // TODO Consider splitting this into two functions; most things seem to bepassing includeRtd: false and includeEquals: false.
     private GoCompiler.ClassWriter CreateClass(string name, bool isExtern, string/*?*/ fullPrintName, List<TypeParameter>/*?*/ typeParameters, List<Type>/*?*/ superClasses, Bpl.IToken tok, TargetWriter wr, bool includeRtd, bool includeEquals) {
-      //
-      // The system for getting traits and inheritance to work is a little
-      // fiddly.  There is no inheritance in Go.  You can, however, *embed* the
-      // trait struct in the class's struct.  This gives you some things---the
-      // class responds to the trait's methods, for instance, and the trait's
-      // fields get added in.  But instead of an upcast, you have to project
-      // the trait struct out, which would lose the ability for a method
-      // invocation to get back the whole object.  (If traits had only methods,
-      // we could use Go interfaces, but fields make life harder.)
-      //
-      // So in order to be able to cast to a trait, whose instance methods
-      // should be invoked with the original object, every trait struct embeds
-      // an interface type with its abstract methods.  Effectively this is a
-      // back pointer to the whole object, imbued with a vtable.  Since the
-      // trait struct embeds the interface, it's a receiver for the interface
-      // (i.e. the methods can be invoked on the trait struct).
-      //
-      // It sounds like the class embeds each trait, each of which embeds the
-      // class!  Crucially, classes all use pointer receivers, so in embedding
-      // an interface, the trait struct actually embeds a pointer, so it all
-      // ends up tied up with a bow.
-      //
-      // There are two sources of complexity here that impact the compiler in
-      // general:
-      //
-      //   1. Upcasts are explicit.  This is why EmitCoercionIfNecessary() came
-      //      to be.  (It would be handy if our IR included upcasts rather than
-      //      leaving the subtyping implicit, but there aren't that many places
-      //      where coercions are necessary---really just function calls and
-      //      assignments to variables.)
-      //   2. We need to wire up the trait structs with their back pointers
-      //      whenever an object is created.  This is taken care of in the
-      //      initializer (New_Class_), so we just need to make sure all object
-      //      creation goes through there.
-      //
-      // type Class struct {
-      //   Trait0
-      //   Trait1
-      //   ...
-      //   Type0 _dafny.Type
-      //   Type1 _dafny.Type
-      //   ...
-      //   Field0 type0
-      //   Field1 type1
-      //   ...
-      // }
-      //
-      // type CompanionStruct_Class_ struct {
-      //   *CompanionStruct_Trait0
-      //   *CompanionStruct_Trait1
-      //   StaticField0 type0
-      //   StaticField1 type1
-      //   ...
-      // }
-      //
-      // var Companion_Class_ = CompanionStruct_Class_{
-      //   &Companion_Trait0,
-      //   &Companion_Trait1,
-      //   StaticField1: ...,
-      //   StaticField2: ...,
-      // }
+      // See docs/Compilation/ReferenceTypes.md for a description of how instance members of classes and traits are compiled into Go.
       //
       // func New_Class_(Type0 Dafny.Type, Type1 Dafny.Type) *Class {
       //   _this := Class{}
@@ -250,21 +189,12 @@ namespace Microsoft.Dafny {
       //   // parameters) assume that _this points to the current value
       //   _this.Type0 = Type0
       //   _this.Type1 = Type1
-      //   _this.Trait0 = New_Trait0_()
-      //   _this.Trait1 = New_Trait1_()
       //   _this.Field0 = ...
       //   _this.Field1 = ...
-      //
-      //   _this.Trait0.Iface_Trait0 = &_this
-      //   _this.Trait1.Iface_Trait1 = &_this
       //   return &_this
       // }
       //
       // func (_this *Class) InstanceMethod(param0 type0, ...) returnType {
-      //   ...
-      //   _this.Trait0.TraitField0 // access field from trait
-      //   var traitVar Trait1 = _this.Trait1 // cast to trait
-      //   _this.TraitMethod0() // can invoke trait method directly
       //   ...
       // }
       //
@@ -340,7 +270,7 @@ namespace Microsoft.Dafny {
 
       if (superClasses != null) {
         foreach (Type typ in superClasses) {
-          cw.AddSuperType(false, typ, tok);
+          w.WriteLine("var _ {0} = &{1}{{}}", TypeName(typ, w, tok), name);
         }
       }
       return cw;
@@ -348,13 +278,7 @@ namespace Microsoft.Dafny {
 
     protected override IClassWriter CreateTrait(string name, bool isExtern, List<TypeParameter>/*?*/ typeParameters, List<Type>/*?*/ superClasses, Bpl.IToken tok, TargetWriter wr) {
       //
-      // type Trait struct {
-      //   Iface_Trait_ // see comments on CreateClass
-      //   InstanceField0 type0
-      //   ...
-      // }
-      //
-      // type Iface_Trait_ interface {
+      // type Trait interface {
       //   AbstractMethod0(param0 type0, ...) returnType0
       //   ...
       // }
@@ -370,35 +294,22 @@ namespace Microsoft.Dafny {
       //   StaticField1: ...,
       // }
       //
-      // func (_this *Trait) ConcreteInstanceMethod(...) ... {
+      // func (_static *companionStruct_Trait) ConcreteInstanceMethod(_this Trait, ...) ... {
       //   ...
       // }
       //
-      // func (_this *companionStruct_Trait) StaticMethod(...) ... {
+      // func (_static *companionStruct_Trait) StaticMethod(...) ... {
       //   ...
       // }
       //
       wr = CreateDescribedSection("trait {0}", wr, name);
-      var instanceFieldWriter = wr.NewNamedBlock("type {0} struct", name);
-      instanceFieldWriter.WriteLine(FormatTraitInterfaceName(name));
-      var abstractMethodWriter = wr.NewNamedBlock("type {0} interface", FormatTraitInterfaceName(name));
+      var abstractMethodWriter = wr.NewNamedBlock("type {0} interface", name);
       var concreteMethodWriter = wr.ForkSection();
-
-      CreateInitializer(name, wr, out var instanceFieldInitWriter, out var traitInitWriter, out var rtdParamWriter);
-
-      if (typeParameters != null) {
-        WriteRuntimeTypeDescriptorsFields(typeParameters, false, instanceFieldWriter, instanceFieldInitWriter, rtdParamWriter);
-      }
 
       var staticFieldWriter = wr.NewNamedBlock("type {0} struct", FormatCompanionTypeName(name));
       var staticFieldInitWriter = wr.NewNamedBlock("var {0} = {1}", FormatCompanionName(name), FormatCompanionTypeName(name));
 
-      var cw = new ClassWriter(this, name, isExtern, abstractMethodWriter, concreteMethodWriter, instanceFieldWriter, instanceFieldInitWriter, traitInitWriter, staticFieldWriter, staticFieldInitWriter);
-      if (superClasses != null) {
-        foreach (Type typ in superClasses) {
-          cw.AddSuperType(true, typ, tok);
-        }
-      }
+      var cw = new ClassWriter(this, name, isExtern, abstractMethodWriter, concreteMethodWriter, null, null, null, staticFieldWriter, staticFieldInitWriter);
       return cw;
     }
 
@@ -1028,7 +939,9 @@ namespace Microsoft.Dafny {
       public readonly TargetWriter/*?*/ AbstractMethodWriter, ConcreteMethodWriter, InstanceFieldWriter, InstanceFieldInitWriter, TraitInitWriter, StaticFieldWriter, StaticFieldInitWriter;
       public bool AnyInstanceFields { get; private set; } = false;
 
-      public ClassWriter(GoCompiler compiler, string className, bool isExtern, TargetWriter abstractMethodWriter, TargetWriter concreteMethodWriter, TargetWriter instanceFieldWriter, TargetWriter instanceFieldInitWriter, TargetWriter traitInitWriter, TargetWriter staticFieldWriter, TargetWriter staticFieldInitWriter) {
+      public ClassWriter(GoCompiler compiler, string className, bool isExtern, TargetWriter abstractMethodWriter, TargetWriter concreteMethodWriter,
+        TargetWriter/*?*/ instanceFieldWriter, TargetWriter/*?*/ instanceFieldInitWriter, TargetWriter/*?*/ traitInitWriter,
+        TargetWriter staticFieldWriter, TargetWriter staticFieldInitWriter) {
         Contract.Requires(compiler != null);
         Contract.Requires(className != null);
         this.Compiler = compiler;
@@ -1083,10 +996,6 @@ namespace Microsoft.Dafny {
       }
 
       public TextWriter/*?*/ ErrorWriter() => ConcreteMethodWriter;
-
-      public void AddSuperType(bool inTrait, Type superType, Bpl.IToken tok) {
-        Compiler.AddSuperType(superType, tok, InstanceFieldWriter, inTrait ? null : InstanceFieldInitWriter, inTrait ? null : TraitInitWriter, StaticFieldWriter, StaticFieldInitWriter);
-      }
 
       public void Finish() {
         Compiler.FinishClass(this);
@@ -1214,16 +1123,17 @@ namespace Microsoft.Dafny {
       }
     }
 
-    void WriteRuntimeTypeDescriptorsFields(List<TypeParameter> typeParams, bool useAllTypeArgs, BlockTargetWriter wr, TargetWriter/*?*/ wInit, TargetWriter/*?*/ wParams) {
+    void WriteRuntimeTypeDescriptorsFields(List<TypeParameter> typeParams, bool useAllTypeArgs, BlockTargetWriter/*?*/ wr, TargetWriter/*?*/ wInit, TargetWriter/*?*/ wParams) {
       Contract.Requires(typeParams != null);
-      Contract.Requires(wr != null);
 
       var sep = "";
       foreach (var tp in typeParams) {
         if (useAllTypeArgs || NeedsTypeDescriptor(tp)) {
           var name = FormatRTDName(tp.CompileName);
 
-          wr.WriteLine("{0} _dafny.Type", name);
+          if (wr != null) {
+            wr.WriteLine("{0} _dafny.Type", name);
+          }
 
           if (wInit != null) {
             wInit.WriteLine("_this.{0} = {0}", name);
@@ -1378,42 +1288,7 @@ namespace Microsoft.Dafny {
     }
 
     protected override bool SupportsStaticsInGenericClasses => false;
-
-    private void AddSuperType(Type superType, Bpl.IToken tok, TargetWriter instanceFieldWriter, TargetWriter/*?*/ instanceFieldInitWriter, TargetWriter/*?*/ traitInitWriter, TargetWriter staticFieldWriter, TargetWriter staticFieldInitWriter) {
-      Contract.Requires(superType != null);
-      Contract.Requires(tok != null);
-      Contract.Requires(instanceFieldWriter != null);
-      Contract.Requires(staticFieldWriter != null);
-      Contract.Requires(staticFieldInitWriter != null);
-
-      instanceFieldWriter.WriteLine("{0}", TypeName(superType, instanceFieldWriter, tok));
-
-      var embed = UnqualifiedClassName(superType, instanceFieldInitWriter, tok);
-
-      if (instanceFieldInitWriter != null) {
-        instanceFieldInitWriter.Write("_this.{0} = {1}(", embed, TypeName_Initializer(superType, instanceFieldInitWriter, tok));
-        if (superType is UserDefinedType udt) {
-          Contract.Assert(udt.ResolvedClass != null);
-          var typeArgs = TypeArgumentInstantiation.ListFromClass(udt.ResolvedClass, superType.TypeArgs);
-          EmitRuntimeTypeDescriptorsActuals(typeArgs, tok, false, instanceFieldInitWriter);
-        }
-        instanceFieldInitWriter.WriteLine(")");
-      }
-      if (traitInitWriter != null && superType.IsTraitType) {
-        traitInitWriter.WriteLine("_this.{0}.{1} = &_this", embed, FormatTraitInterfaceName(embed));
-
-        var trait = (NonNullTypeDecl)((UserDefinedType)superType).ResolvedClass;
-        Contract.Assert(trait != null);
-        foreach (var grandparent in trait.Class.ParentTypeInformation.UniqueParentTraits()) {
-          var grandParentName = UnqualifiedClassName(grandparent, instanceFieldInitWriter, tok);
-          traitInitWriter.WriteLine("_this.{0}.{1} = _this.{1}", embed, grandParentName);
-        }
-      }
-
-      staticFieldWriter.WriteLine("*{0}", TypeName_CompanionType(superType, staticFieldWriter, tok));
-
-      staticFieldInitWriter.WriteLine("{0}: &{1},", FormatCompanionTypeName(embed), TypeName_Companion(superType, staticFieldInitWriter, tok, null));
-    }
+    protected override bool TraitRepeatsInheritedDeclarations => true;
 
     private void FinishClass(GoCompiler.ClassWriter cw) {
       // Go gets weird about zero-length structs.  In particular, it likes to
@@ -1488,11 +1363,7 @@ namespace Microsoft.Dafny {
         } else if (udt.IsTypeParameter) {
           return "interface{}";
         }
-        if (udt.IsDatatype) {
-          // Don't return a pointer to the datatype because the datatype is
-          // already represented using a pointer
-          return IdProtect(s);
-        } else if (udt.IsTraitType && udt.ResolvedClass.IsExtern(out _, out _)) {
+        if (udt.IsTraitType && udt.ResolvedClass.IsExtern(out _, out _)) {
           // To use an external interface, we need to have values of the
           // interface type, so we treat an extern trait as a plain interface
           // value, not a pointer (a Go interface value is basically a typed
@@ -1501,6 +1372,10 @@ namespace Microsoft.Dafny {
           // Also don't use IdProtect so that we can have it be a built-in
           // name like error.
           return s;
+        } else if (udt.IsDatatype || udt.IsTraitType) {
+          // Don't return a pointer to the datatype because the datatype is
+          // already represented using a pointer
+          return IdProtect(s);
         } else {
           return "*" + IdProtect(s);
         }
@@ -1634,8 +1509,6 @@ namespace Microsoft.Dafny {
       string.Format("Iface_{0}_", traitName);
     protected static string FormatRTDName(string formalName) =>
       string.Format("Type_{0}_", formalName);
-    protected static string FormatTraitInterfaceName(string traitName) =>
-      string.Format("Iface_{0}_", traitName);
 
     protected string TypeName_Related(Func<string, string> formatter, Type type, TextWriter wr, Bpl.IToken tok, MemberDecl/*?*/ member = null) {
       Contract.Requires(formatter != null);
@@ -1686,10 +1559,6 @@ namespace Microsoft.Dafny {
 
     protected string TypeName_RTD(Type type, TextWriter wr, Bpl.IToken tok) {
       return TypeName_Related(FormatRTDName, type, wr, tok);
-    }
-
-    protected string TypeName_TraitInterface(Type type, TextWriter wr, Bpl.IToken tok) {
-      return TypeName_Related(FormatTraitInterfaceName, type, wr, tok);
     }
 
     protected string ClassName(Type type, TextWriter wr, Bpl.IToken tok, MemberDecl/*?*/ member = null) {
@@ -2917,7 +2786,7 @@ namespace Microsoft.Dafny {
               postOpString = " == 0";
             } else if (IsComparedByEquals(e0.Type)) {
               callString = "Equals";
-            }else if (IsDirectlyComparable(e0.Type)) {
+            } else if (IsDirectlyComparable(e0.Type)) {
               opString = "==";
             } else {
               staticCallString = "_dafny.AreEqual";
@@ -3314,23 +3183,10 @@ namespace Microsoft.Dafny {
         return wr;
       } else if (from != null && Type.IsSupertype(to, from)) {
         // upcast
-        if (to.IsObjectQ) {
-          // Cast to interface{} is one of the few upcasts we can actually do
-          return wr;
-        } else if (to.IsTraitType && ((UserDefinedType) to).ResolvedClass.IsExtern(out _, out _)) {
-          // An extern trait is a plain interface; no need to project an embedded thing
-          return wr;
-        } else {
-          var w = wr.Fork();
-          wr.Write(".{0}", UnqualifiedClassName(to, wr, tok));
-          return w;
-        }
+        return wr;
       } else if (from == null || from.IsTypeParameter || Type.IsSupertype(from, to)) {
         // downcast (allowed?) or implicit cast from parameter
         var w = wr.Fork();
-        if (from is UserDefinedType fromUdt && fromUdt.ResolvedClass != null && fromUdt.ResolvedClass.ViewAsClass is TraitDecl) {
-          wr.Write(".{0}", TypeName_TraitInterface(from, wr, tok));
-        }
         wr.Write(".({0})", TypeName(to, wr, tok));
         return w;
       } else {

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -4051,7 +4051,7 @@ namespace Microsoft.Dafny {
     public readonly List<MemberDecl> Members;
 
     // The following fields keep track of parent traits
-    public readonly List<MemberDecl> InheritedMembers = new List<MemberDecl>();  // these are instance fields and instance members defined with bodies in traits
+    public readonly List<MemberDecl> InheritedMembers = new List<MemberDecl>();  // these are instance members declared in parent traits
     public readonly List<Type> ParentTraits;  // these are the types that are parsed after the keyword 'extends'; note, for a successfully resolved program, there are UserDefinedType's where .ResolvedClas is NonNullTypeDecl
     public readonly Dictionary<TypeParameter, Type> ParentFormalTypeParametersToActuals = new Dictionary<TypeParameter, Type>();  // maps parent traits' type parameters to actuals
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -7896,7 +7896,7 @@ namespace Microsoft.Dafny
 
       foreach (var member in classMembers[cl].Values) {
         if (member is PrefixPredicate || member is PrefixLemma) {
-          // these are handled with the corresponding extremem predicate/lemma
+          // these are handled with the corresponding extreme predicate/lemma
           continue;
         }
         if (member.EnclosingClass != cl) {
@@ -7906,13 +7906,15 @@ namespace Microsoft.Dafny
           // but that will be checked by the verifier.  And it should also have a body, but that will be checked by the compiler.)
           if (member.IsStatic) {
             // nothing to do
-          } else if (member is Field || (member as Function)?.Body != null || (member as Method)?.Body != null) {
-            // member is a field or a fully defined function or method
-            cl.InheritedMembers.Add(member);
-          } else if (cl is TraitDecl) {
-            // there are no expectations that a field needs to repeat the signature of inherited body-less members
           } else {
-            reporter.Error(MessageSource.Resolver, cl.tok, "{0} '{1}' does not implement trait {2} '{3}.{4}'", cl.WhatKind, cl.Name, member.WhatKind, member.EnclosingClass.Name, member.Name);
+            cl.InheritedMembers.Add(member);
+            if (member is Field || (member as Function)?.Body != null || (member as Method)?.Body != null) {
+              // member is a field or a fully defined function or method
+            } else if (cl is TraitDecl) {
+              // there are no expectations that a field needs to repeat the signature of inherited body-less members
+            } else {
+              reporter.Error(MessageSource.Resolver, cl.tok, "{0} '{1}' does not implement trait {2} '{3}.{4}'", cl.WhatKind, cl.Name, member.WhatKind, member.EnclosingClass.Name, member.Name);
+            }
           }
           continue;
         }

--- a/Test/comp/CovariantCollections.dfy.expect
+++ b/Test/comp/CovariantCollections.dfy.expect
@@ -31,7 +31,15 @@ Dafny program verifier finished with 2 verified, 0 errors
 Sequences: [] [_module.Integer, _module.Integer, _module.Integer, _module.Integer] [_module.Integer, _module.Integer]
   cardinality: 0 4 2
   update: [_module.Integer, _module.Integer, _module.Integer, _module.Integer] [_module.Integer, _module.Integer]
-  index: [Program halted] interface conversion: interface {} is *main.Integer, not *main.Number
+  index: _module.Integer _module.Integer
+  subsequence ([lo..hi]): [_module.Integer, _module.Integer] [_module.Integer]
+  subsequence ([lo..]): [_module.Integer, _module.Integer, _module.Integer] [_module.Integer]
+  subsequence ([..hi]): [_module.Integer, _module.Integer, _module.Integer][_module.Integer]
+  subsequence ([..]): [] [_module.Integer, _module.Integer, _module.Integer, _module.Integer] [_module.Integer, _module.Integer]
+  concatenation: [_module.Integer, _module.Integer, _module.Integer, _module.Integer] [_module.Integer, _module.Integer, _module.Integer, _module.Integer, _module.Integer, _module.Integer]
+  prefix: true false true
+  proper prefix: true false false
+  membership: false true true
 
 Dafny program verifier finished with 2 verified, 0 errors
 CovariantCollections.dfy(34,6): Error: compilation of seq<TRAIT> is not supported; consider introducing a ghost

--- a/Test/traits/TraitCompile.dfy
+++ b/Test/traits/TraitCompile.dfy
@@ -92,6 +92,8 @@ method Main()
 
   NonCapturingFunctionCoercions.Test();
   TailRecursion.Test();
+
+  ObjectEquality.Test();
 }
 
 module OtherModule {
@@ -738,5 +740,61 @@ module TailRecursion {
     var y := c.Compute(15, 1_000_000);
     var z := c.Compute(15, 999_999);
     print x, " ", y, " ", z, "\n";  // 41 15 26
+  }
+}
+
+module ObjectEquality {
+  method Test() {
+    TestReferenceEquality();
+    NotTheSame();
+    TestSequences();
+  }
+
+  trait A { }
+
+  trait B extends A { }
+
+  class C extends B { }
+  class D extends B { }
+
+  method TestReferenceEquality() {
+    var c: C := new C;
+    var b: B := c;
+    var a0: A := c;
+    var a1: A := c;
+
+    print a0 == a1, " ", Eq(a0, a1), "\n";
+    print a0 == c, " ", Eq(a0, c), "\n";
+    print b == c, " ", Eq(b, c), "\n";
+    print b == a0, " ", Eq(b, a0), "\n";
+  }
+
+  predicate method Eq<U(==)>(u: U, v: U) {
+    u == v
+  }
+
+  method NotTheSame() {
+    var c: C, d: D := new C, new D;
+    var oc: object, od: object := c, d;
+
+    print oc != od, " ", !Eq(oc, od), " ", !Eq(c, d), "\n";
+
+    var ac: A, ad: A := c, d;
+    print ac != ad, " ", !Eq(ac, ad), " ", !Eq(ac, ad), "\n";
+  }
+
+  method TestSequences() {
+    /** TODO: Include this when all compilers support seq<TRAIT>
+    var c: C := new C;
+    var b: B := c;
+    var a: A := c;
+
+    var s: seq<A> := [a];
+    var t: seq<B> := [b];
+    var u: seq<C> := [c];
+
+    print s == t, " ", t == u, " ", u == s, "\n";
+    print s[0] == t[0], " ", t[0] == u[0], " ", u[0] == s[0], "\n";
+    **/
   }
 }

--- a/Test/traits/TraitCompile.dfy
+++ b/Test/traits/TraitCompile.dfy
@@ -415,7 +415,7 @@ module TraitsExtendingTraits {
       reads this
   }
   trait B {
-    var bb: bool
+    var b: bool
     method Quantity() returns (x: int)
     method Twice() returns (x: int)
   }
@@ -423,7 +423,7 @@ module TraitsExtendingTraits {
   }
 
   trait K<Y> extends A<Y, Odd> {
-    const kk := y1
+    const k := y1
     function method GetY'(): Y
       reads this
     {
@@ -453,24 +453,24 @@ module TraitsExtendingTraits {
 
   method Test() {
     var g := new G<real>(5.2);
-    print g.y0, " ", g.y1, " ", g.bb, "\n";  // 5.2 9 false
+    print g.y0, " ", g.y1, " ", g.b, "\n";  // 5.2 9 false
 
     var m: M := g;
     var n: N := g;
     var bg: B := g;
     var a: A := g;
-    g.bb := true;
-    assert g.bb && m.bb && n.bb && bg.bb;
-    print g.bb, " ", m.bb, " ", n.bb, " ", bg.bb, "\n";  // true true true true
-    m.bb := false;
-    assert !g.bb && !m.bb && !n.bb && !bg.bb;
-    print g.bb, " ", m.bb, " ", n.bb, " ", bg.bb, "\n";  // false false false false
-    n.bb := true;
-    assert g.bb && m.bb && n.bb && bg.bb;
-    print g.bb, " ", m.bb, " ", n.bb, " ", bg.bb, "\n";  // true true true true
-    bg.bb := false;
-    assert !g.bb && !m.bb && !n.bb && !bg.bb;
-    print g.bb, " ", m.bb, " ", n.bb, " ", bg.bb, "\n";  // false false false false
+    g.b := true;
+    assert g.b && m.b && n.b && bg.b;
+    print g.b, " ", m.b, " ", n.b, " ", bg.b, "\n";  // true true true true
+    m.b := false;
+    assert !g.b && !m.b && !n.b && !bg.b;
+    print g.b, " ", m.b, " ", n.b, " ", bg.b, "\n";  // false false false false
+    n.b := true;
+    assert g.b && m.b && n.b && bg.b;
+    print g.b, " ", m.b, " ", n.b, " ", bg.b, "\n";  // true true true true
+    bg.b := false;
+    assert !g.b && !m.b && !n.b && !bg.b;
+    print g.b, " ", m.b, " ", n.b, " ", bg.b, "\n";  // false false false false
 
     print g.GetY(), " ", g.GetY'(), "\n"; // 5.2 5.2
     g.SetY(1.2);

--- a/Test/traits/TraitCompile.dfy.expect
+++ b/Test/traits/TraitCompile.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 72 verified, 0 errors
+Dafny program verifier finished with 73 verified, 0 errors
 
 Dafny program verifier finished with 0 verified, 0 errors
 y=120
@@ -57,6 +57,12 @@ f(4) = 7
 g(4) = 7
 g(4) = 7
 41 15 26
+true true
+true true
+true true
+true true
+true true true
+true true true
 
 Dafny program verifier finished with 0 verified, 0 errors
 y=120
@@ -114,6 +120,12 @@ f(4) = 7
 g(4) = 7
 g(4) = 7
 41 15 26
+true true
+true true
+true true
+true true
+true true true
+true true true
 
 Dafny program verifier finished with 0 verified, 0 errors
 y=120
@@ -171,6 +183,12 @@ f(4) = 7
 g(4) = 7
 g(4) = 7
 41 15 26
+true true
+true true
+true true
+true true
+true true true
+true true true
 
 Dafny program verifier finished with 0 verified, 0 errors
 y=120
@@ -228,3 +246,9 @@ f(4) = 7
 g(4) = 7
 g(4) = 7
 41 15 26
+true true
+true true
+true true
+true true
+true true true
+true true true

--- a/docs/Compilation/ReferenceTypes.md
+++ b/docs/Compilation/ReferenceTypes.md
@@ -225,10 +225,6 @@ Go has no type parameters, so those are replaced by the empty interface type.
       static method N(rtdV: RTD, rtdU: RTD, _this: Trait, x: X) returns (y: Y) { S }
     }
 
-Note: At the moment, traits are represented using a mix of a "struct" and an "interface" in Go.
-This is about to change. The declarations shown here indicate what will soon be. The previous
-design let field be declared in the "struct" portion of this definition.
-
 Compilation of class members
 ----------------------------
 
@@ -507,9 +503,9 @@ There is no need to say `extends Trait` in Go, because trait membership is not n
 Nevertheless, the compiler generates some code that will cause the Go compiler to
 verify `Class extends Trait` at compile time.
 
-Note: At the moment, traits are represented using a mix of a "struct" and an "interface" in Go.
-This is about to change. The declarations shown here indicate what will soon be. In the
-previous design, the "struct" portion was embedded into the class. This required each Dafny
+Note: Previously, traits were represented using a mix of a "struct" and an "interface" in Go.
+In that design, the "struct" portion was embedded into the class, which allowed fields
+to be inherited using Go's embedding. On the downside, this required each Dafny
 object to be represented as a collection of Go objects, with mutual pointers between them
 This required the compiler to insert upcasts, which became difficult to maintain in the
 implementation. Moreover, the design was problematic for checking equality and became
@@ -668,6 +664,5 @@ parameters and no need for `extends` clauses.
 
 ## Go
 
-Compilation to Go currently uses the "struct"-plus-"interface" design of traits,
-which will soon be changed. Other than that, the compilation follows the general
-form, but without type parameters and no need for `extends` clauses.
+The compilation follows the general form, but without type parameters and no need
+for `extends` clauses.


### PR DESCRIPTION
Traits were previously encoded in Go as a combination of a `struct` plus an `interface`. This led to several complications (see `docs/Compilation/ReferenceTypes.md`). This PR changes the encoding to use just an `interface`. This removes the complications. This change was made easy since the previous PR #694 had already moved fields from the `struct` to become getters/setters in the `interface`.

This change made the `CovarianceCollections.dfy` tests work for Go. They also corrected some issues with equality tests in Go (the new tests for these revealed a problem in Java compilation, which this PR also fixes).
