### PR TITLE
#664: perform wellformedness checks on expressions that are static receivers

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -8934,6 +8934,7 @@ namespace Microsoft.Dafny {
   {
     public readonly Type UnresolvedType;
     private bool Implicit;
+    public Expression OriginalResolved;
 
     public StaticReceiverExpr(IToken tok, Type t, bool isImplicit)
       : base(tok) {
@@ -8941,6 +8942,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(t != null);
       UnresolvedType = t;
       Implicit = isImplicit;
+      OriginalResolved = null;
     }
 
     /// <summary>
@@ -8971,7 +8973,7 @@ namespace Microsoft.Dafny {
     ///   a trait that in turn extends trait "W(g(Y))".  If "t" denotes type "C(G)" and "cl" denotes "W",
     ///   then type of the StaticReceiverExpr will be "T(g(f(G)))".
     /// </summary>
-    public StaticReceiverExpr(IToken tok, UserDefinedType t, TopLevelDeclWithMembers cl, bool isImplicit)
+    public StaticReceiverExpr(IToken tok, UserDefinedType t, TopLevelDeclWithMembers cl, bool isImplicit, Expression lhs = null)
       : base(tok) {
       Contract.Requires(tok != null);
       Contract.Requires(t.ResolvedClass != null);
@@ -8990,6 +8992,7 @@ namespace Microsoft.Dafny {
       }
       UnresolvedType = Type;
       Implicit = isImplicit;
+      OriginalResolved = lhs;
     }
 
     public override bool IsImplicit {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -5577,6 +5577,13 @@ namespace Microsoft.Dafny
               resolver.reporter.Error(MessageSource.Resolver, e.tok, "bitvector literal ({0}) is too large for the type {1}", e.Value, t);
             }
           }
+
+          if (expr is StaticReceiverExpr stexpr) {
+            if (stexpr.OriginalResolved != null) {
+              Visit(stexpr.OriginalResolved);
+            }
+          }
+
         } else if (expr is ComprehensionExpr) {
           var e = (ComprehensionExpr)expr;
           foreach (var bv in e.BoundVars) {
@@ -14429,7 +14436,7 @@ namespace Microsoft.Dafny
             receiver = expr.Lhs;
             r = ResolveExprDotCall(expr.tok, receiver, tentativeReceiverType, member, args, expr.OptTypeArguments, opts, allowMethodCall);
           } else {
-            receiver = new StaticReceiverExpr(expr.tok, (UserDefinedType)tentativeReceiverType, (TopLevelDeclWithMembers)member.EnclosingClass, false);
+            receiver = new StaticReceiverExpr(expr.tok, (UserDefinedType)tentativeReceiverType, (TopLevelDeclWithMembers)member.EnclosingClass, false, lhs);
             r = ResolveExprDotCall(expr.tok, receiver, null, member, args, expr.OptTypeArguments, opts, allowMethodCall);
           }
         }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -7163,8 +7163,10 @@ namespace Microsoft.Dafny {
         options = new WFOptions(false, options);
       }
 
-      if (expr is StaticReceiverExpr) {
-        // yeah, it's okay
+      if (expr is StaticReceiverExpr stexpr) {
+        if (stexpr.OriginalResolved != null) {
+          CheckWellformedWithResult(stexpr.OriginalResolved, options, null, null, locals, builder, etran);
+        }
       } else if (expr is LiteralExpr) {
         CheckResultToBeInType(expr.tok, expr, expr.Type, locals, builder, etran);
       } else if (expr is ThisExpr || expr is WildcardExpr || expr is BoogieWrapper) {
@@ -12205,6 +12207,10 @@ namespace Microsoft.Dafny {
           }
         }
         ins.Add(etran.TrExpr(receiver));
+      } else if (receiver is StaticReceiverExpr stexpr) {
+        if (stexpr.OriginalResolved != null) {
+          TrStmt_CheckWellformed(stexpr.OriginalResolved, builder, locals, etran, true);
+        }
       }
 
       // Ideally, the modifies and decreases checks would be done after the precondition check,

--- a/Test/allocated1/dafny0/Basics.dfy.expect
+++ b/Test/allocated1/dafny0/Basics.dfy.expect
@@ -123,5 +123,9 @@ Execution trace:
     (0,0): anon0
     (0,0): anon4_Then
     (0,0): anon3
+Basics.dfy(13,13): Error: variable 'g', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon7_Then
 
-Dafny program verifier finished with 46 verified, 18 errors
+Dafny program verifier finished with 45 verified, 19 errors

--- a/Test/dafny0/Basics.dfy.expect
+++ b/Test/dafny0/Basics.dfy.expect
@@ -1,3 +1,7 @@
+Basics.dfy(13,13): Error: variable 'g', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon7_Then
 Basics.dfy(45,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
@@ -124,4 +128,4 @@ Execution trace:
     (0,0): anon4_Then
     (0,0): anon3
 
-Dafny program verifier finished with 46 verified, 18 errors
+Dafny program verifier finished with 45 verified, 19 errors

--- a/Test/git-issues/git-issue-664.dfy
+++ b/Test/git-issues/git-issue-664.dfy
@@ -1,0 +1,20 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class C {
+  static const X: int
+  static method M() { }
+  static function method F(): int { 5 }
+}
+
+method TestClass(c: C) {
+  if
+  case true =>
+    var x := (if 5/0 == 1 then c else c).X;  // error: receiver is not well-formed
+  case true =>
+    (if 5/0 == 2 then c else c).M();  // error: receiver is not well-formed
+  case true =>
+    var x := (if 5/0 == 3 then c else c).F();  // error: receiver is not well-formed
+  case true =>
+    var f := (if 5/0 == 4 then c else c).F;  // error: receiver is not well-formed
+}

--- a/Test/git-issues/git-issue-664.dfy.expect
+++ b/Test/git-issues/git-issue-664.dfy.expect
@@ -1,0 +1,18 @@
+git-issue-664.dfy(13,18): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon18_Then
+git-issue-664.dfy(15,9): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon20_Then
+git-issue-664.dfy(17,18): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon22_Then
+git-issue-664.dfy(19,18): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon24_Then
+
+Dafny program verifier finished with 0 verified, 4 errors


### PR DESCRIPTION
Fixes #664.