### PR TITLE
Add boogie as a git submodule

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -31,9 +31,9 @@ jobs:
         submodules: recursive
         path: dafny
     - name: Nuget Restore Boogie
-      run: nuget restore dafny/Source/boogie/Boogie.sln
+      run: nuget restore dafny/Source/boogie/Source/Boogie.sln
     - name: Build Boogie
-      run: msbuild dafny/Source/boogie/Boogie.sln
+      run: msbuild dafny/Source/boogie/Source/Boogie.sln
     - name: Get Z3
       if: matrix.os != 'windows-latest'
       run: |

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -25,20 +25,14 @@ jobs:
     - name: Add msbuild to PATH
       if: matrix.os == 'windows-latest'
       uses: microsoft/setup-msbuild@v1.0.0
-    - name: Checkout Boogie
-      uses: actions/checkout@v2
-      with:
-        repository: boogie-org/boogie
-        ref: v2.4.21
-        path: boogie
-    - name: Nuget Restore Boogie
-      run: nuget restore boogie/Source/Boogie.sln
-    - name: Build Boogie
-      run: msbuild boogie/Source/Boogie.sln
     - name: Checkout Dafny
       uses: actions/checkout@v2
       with:
         path: dafny
+    - name: Nuget Restore Boogie
+      run: nuget restore dafny/Source/boogie/Boogie.sln
+    - name: Build Boogie
+      run: msbuild dafny/Source/boogie/Boogie.sln
     - name: Get Z3
       if: matrix.os != 'windows-latest'
       run: |

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Checkout Dafny
       uses: actions/checkout@v2
       with:
+        submodules: recursive
         path: dafny
     - name: Nuget Restore Boogie
       run: nuget restore dafny/Source/boogie/Boogie.sln

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Source/boogie"]
+	path = Source/boogie
+	url = https://github.com/boogie-org/boogie.git

--- a/Source/Dafny/DafnyPipeline.csproj
+++ b/Source/Dafny/DafnyPipeline.csproj
@@ -131,13 +131,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BoogieBasetypes">
-      <HintPath>..\..\..\boogie\Binaries\BoogieBasetypes.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieBasetypes.dll</HintPath>
     </Reference>
     <Reference Include="BoogieCore">
-      <HintPath>..\..\..\boogie\Binaries\BoogieCore.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieCore.dll</HintPath>
     </Reference>
     <Reference Include="BoogieParserHelper">
-      <HintPath>..\..\..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
     </Reference>
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <Reference Include="System" />

--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -129,26 +129,26 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BoogieAbsInt">
-      <HintPath>..\..\..\boogie\Binaries\BoogieAbsInt.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieAbsInt.dll</HintPath>
     </Reference>
     <Reference Include="BoogieConcurrency">
-      <HintPath>..\..\..\boogie\Binaries\BoogieConcurrency.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieConcurrency.dll</HintPath>
     </Reference>
     <Reference Include="BoogieCore">
-      <HintPath>..\..\..\boogie\Binaries\BoogieCore.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieCore.dll</HintPath>
     </Reference>
     <Reference Include="BoogieExecutionEngine">
-      <HintPath>..\..\..\boogie\Binaries\BoogieExecutionEngine.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieExecutionEngine.dll</HintPath>
     </Reference>
     <Reference Include="BoogieParserHelper">
-      <HintPath>..\..\..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
     </Reference>
     <Reference Include="Provers.SMTLib">
-      <HintPath>..\..\..\boogie\Binaries\Provers.SMTLib.dll</HintPath>
+      <HintPath>..\boogie\Binaries\Provers.SMTLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="BoogieVCGeneration">
-      <HintPath>..\..\..\boogie\Binaries\BoogieVCGeneration.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieVCGeneration.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/DafnyExtension/DafnyExtension.csproj
+++ b/Source/DafnyExtension/DafnyExtension.csproj
@@ -95,16 +95,16 @@
       <HintPath>..\..\Binaries\DafnyPipeline.dll</HintPath>
     </Reference>
     <Reference Include="BoogieDoomed">
-      <HintPath>..\..\..\boogie\Binaries\BoogieDoomed.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieDoomed.dll</HintPath>
     </Reference>
     <Reference Include="BoogieExecutionEngine">
-      <HintPath>..\..\..\boogie\Binaries\BoogieExecutionEngine.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieExecutionEngine.dll</HintPath>
     </Reference>
     <Reference Include="BoogieGraph">
-      <HintPath>..\..\..\boogie\Binaries\BoogieGraph.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieGraph.dll</HintPath>
     </Reference>
     <Reference Include="BoogieHoudini">
-      <HintPath>..\..\..\boogie\Binaries\BoogieHoudini.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieHoudini.dll</HintPath>
     </Reference>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -113,19 +113,19 @@
       <HintPath>..\packages\VSSDK.Language.11.0.4\lib\net45\Microsoft.VisualStudio.Language.Intellisense.dll</HintPath>
     </Reference>
     <Reference Include="BoogieModel">
-      <HintPath>..\..\..\boogie\Binaries\BoogieModel.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieModel.dll</HintPath>
     </Reference>
     <Reference Include="BoogieParserHelper">
-      <HintPath>..\..\..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
     </Reference>
     <Reference Include="Provers.SMTLib">
-      <HintPath>..\..\..\boogie\Binaries\Provers.SMTLib.dll</HintPath>
+      <HintPath>..\boogie\Binaries\Provers.SMTLib.dll</HintPath>
     </Reference>
     <Reference Include="BoogieVCExpr">
-      <HintPath>..\..\..\boogie\Binaries\BoogieVCExpr.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieVCExpr.dll</HintPath>
     </Reference>
     <Reference Include="BoogieVCGeneration">
-      <HintPath>..\..\..\boogie\Binaries\BoogieVCGeneration.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieVCGeneration.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/DafnyMenu/DafnyMenu.csproj
+++ b/Source/DafnyMenu/DafnyMenu.csproj
@@ -69,10 +69,10 @@
       <HintPath>..\..\Binaries\DafnyPipeline.dll</HintPath>
     </Reference>
     <Reference Include="BoogieModel">
-      <HintPath>..\..\..\boogie\Binaries\BoogieModel.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieModel.dll</HintPath>
     </Reference>
     <Reference Include="BoogieModelViewer">
-      <HintPath>..\..\..\boogie\Binaries\BoogieModelViewer.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieModelViewer.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -112,25 +112,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BoogieCore">
-      <HintPath>..\..\..\boogie\Binaries\BoogieCore.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieCore.dll</HintPath>
     </Reference>
     <Reference Include="BoogieExecutionEngine">
-      <HintPath>..\..\..\boogie\Binaries\BoogieExecutionEngine.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieExecutionEngine.dll</HintPath>
     </Reference>
     <Reference Include="BoogieGraph">
-		<HintPath>..\..\..\boogie\Binaries\BoogieGraph.dll</HintPath>
+		<HintPath>..\boogie\Binaries\BoogieGraph.dll</HintPath>
 	</Reference>
     <Reference Include="BoogieParserHelper">
-      <HintPath>..\..\..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieParserHelper.dll</HintPath>
     </Reference>
     <Reference Include="Provers.SMTLib">
-      <HintPath>..\..\..\boogie\Binaries\Provers.SMTLib.dll</HintPath>
+      <HintPath>..\boogie\Binaries\Provers.SMTLib.dll</HintPath>
     </Reference>
     <Reference Include="BoogieModelViewer">
-      <HintPath>..\..\..\boogie\Binaries\BoogieModelViewer.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieModelViewer.dll</HintPath>
     </Reference>
     <Reference Include="BoogieModel">
-      <HintPath>..\..\..\boogie\Binaries\BoogieModel.dll</HintPath>
+      <HintPath>..\boogie\Binaries\BoogieModel.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
### Changes
- Add Boogie as a git submodule, as suggested in [this issue](https://github.com/dafny-lang/dafny/issues/625). Note that this makes cloning Dafny less straightforward, since you need to pass `--recurse-submodules` to `git clone` to immediately get the submodule checked out as well.
- The submodule is nested in the `Source` directory, since it also contains boogie source. I don't have a strong opinion on this so I'll gladly move it up if that's preferred.

### Out of scope
- The Dafny install wiki should be updated [here](https://github.com/dafny-lang/dafny/wiki/INSTALL#windows-1), but I don't think I can do that in this PR.

### Testing
Cleaning and rebuilding the solution on Visual Studio for Windows succeeds.