### PR TITLE
#401: Fixes a misleading warning message about z3 binary

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Diagnostics.Contracts;
+using System.IO;
 using Bpl = Microsoft.Boogie;
 
 namespace Microsoft.Dafny
@@ -596,9 +597,9 @@ namespace Microsoft.Dafny
     /// Dafny comes with it's own copy of z3, to save new users the trouble of having to install extra dependency.
     /// For this to work, Dafny makes the Z3ExecutablePath point to the path were Z3 is put by our release script.
     /// For developers though (and people getting this from source), it's convenient to be able to run right away,
-    /// so we vendor a Windows version.
+    /// so we vendor a Windows version.  This is the default value; it may be overwritten by command-line arguments
     /// </summary>
-    private void SetZ3ExecutableName() {
+    public void SetZ3ExecutableName() {
       var platform = (int)System.Environment.OSVersion.Platform;
 
       // http://www.mono-project.com/docs/faq/technical/
@@ -615,13 +616,9 @@ namespace Microsoft.Dafny
         z3BinPath = System.IO.Path.Combine(dafnyBinDir, z3binName);
       }
 
-      if (!System.IO.File.Exists(z3BinPath) && errorReporter != null) {
-        var tok = new Bpl.Token(1, 1) { filename = "*** " };
-        errorReporter.Warning(MessageSource.Other, tok, "Could not find '{0}' in '{1}'.{2}Downloading and extracting a Z3 distribution to Dafny's 'Binaries' folder would solve this issue; for now, we'll rely on Boogie to find Z3.",
-          z3binName, z3BinDir, System.Environment.NewLine);
-      } else {
-        Z3ExecutablePath = z3BinPath;
-      }
+      // Only the default value is set here. Command-line arguments are processed later,
+      // so no checking of whether the path exists is done.
+      Z3ExecutablePath = z3BinPath;
     }
 
     public override void Usage() {

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -660,11 +660,12 @@ namespace Microsoft.Dafny
   /compile:<n>  0 - do not compile Dafny program
                 1 (default) - upon successful verification of the Dafny
                     program, compile it to the designated target language
+                    (/noVerify automatically counts as failed verification)
                 2 - always attempt to compile Dafny program to the target
                     language, regardless of verification outcome
                 3 - if there is a Main method and there are no verification
-                    errors, compiles program in memory (i.e., does not write
-                    an output file) and runs it
+                    errors and /noVerify is not used, compiles program in
+                    memory (i.e., does not write an output file) and runs it
                 4 - like (3), but attempts to compile and run regardless of
                     verification outcome
   /compileTarget:<lang>
@@ -688,8 +689,8 @@ namespace Microsoft.Dafny
                 1 - write the compiled Dafny program in the target language, 
                     if it is being compiled
                 2 - write the compiled Dafny program in the target language, 
-                    provided it passes the verifier, regardless of /compile 
-                    setting
+                    provided it passes the verifier (and /noVerify is NOT used),
+                    regardless of /compile setting
                 3 - write the compiled Dafny program in the target language, 
                     regardless of verification outcome and /compile setting
                 NOTE: If there are .cs or .dll files on the command line, then

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Dafny
         Console.WriteLine();
         Console.Out.Flush();
       } else {
-        // This calls a routine within Boogiemk
+        // This calls a routine within Boogie
         ExecutionEngine.printer.WriteTrailer(stats);
       }
     }

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -371,9 +371,8 @@ namespace Microsoft.Dafny
           TimeSpan ts = watch.Elapsed;
           string elapsedTime = String.Format("{0:00}:{1:00}:{2:00}",
             ts.Hours, ts.Minutes, ts.Seconds);
-
           ExecutionEngine.printer.AdvisoryWriteLine("Elapsed time: {0}", elapsedTime);
-          ExecutionEngine.printer.WriteTrailer(newstats);
+          WriteTrailer(newstats);
         }
 
         statss.Add(prog.Item1, newstats);
@@ -382,6 +381,30 @@ namespace Microsoft.Dafny
       watch.Stop();
 
       return isVerified;
+    }
+
+    private static void WriteTrailer(PipelineStatistics stats) {
+      if (CommandLineOptions.Clo.vcVariety != CommandLineOptions.VCVariety.Doomed && !CommandLineOptions.Clo.Verify && stats.ErrorCount == 0) {
+        Console.WriteLine();
+        Console.Write("{0} finished without attempting verification", CommandLineOptions.Clo.DescriptiveToolName);
+        if (stats.InconclusiveCount != 0) {
+          Console.Write(", {0} inconclusive{1}", stats.InconclusiveCount, stats.InconclusiveCount == 1 ? "" : "s");
+        }
+        if (stats.TimeoutCount != 0) {
+          Console.Write(", {0} time out{1}", stats.TimeoutCount, stats.TimeoutCount == 1 ? "" : "s");
+        }
+        if (stats.OutOfMemoryCount != 0) {
+          Console.Write(", {0} out of memory", stats.OutOfMemoryCount);
+        }
+        if (stats.OutOfResourceCount != 0) {
+          Console.Write(", {0} out of resource", stats.OutOfResourceCount);
+        }
+        Console.WriteLine();
+        Console.Out.Flush();
+      } else {
+        // This calls a routine within Boogiemk
+        ExecutionEngine.printer.WriteTrailer(stats);
+      }
     }
 
     private static void WriteStatss(Dictionary<string, PipelineStatistics> statss) {
@@ -398,7 +421,7 @@ namespace Microsoft.Dafny
         statSum.CachedVerifiedCount += stats.Value.CachedVerifiedCount;
         statSum.InconclusiveCount += stats.Value.InconclusiveCount;
       }
-      ExecutionEngine.printer.WriteTrailer(statSum);
+      WriteTrailer(statSum);
     }
 
 

--- a/Test/allocated1/dafny0/Calculations.dfy.expect
+++ b/Test/allocated1/dafny0/Calculations.dfy.expect
@@ -25,4 +25,4 @@ Execution trace:
 
 Dafny program verifier finished with 3 verified, 6 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/allocated1/dafny0/DirtyLoops.dfy.expect
+++ b/Test/allocated1/dafny0/DirtyLoops.dfy.expect
@@ -454,4 +454,4 @@ DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: the conclusion of the body of thi
 DirtyLoops.dfy.tmp.dprint.dfy(415,2): Warning: note, this loop has no body (loop frame: x)
 DirtyLoops.dfy.tmp.dprint.dfy(409,2): Warning: /!\ No terms found to trigger on.
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/allocated1/dafny0/LetExpr.dfy.expect
+++ b/Test/allocated1/dafny0/LetExpr.dfy.expect
@@ -52,4 +52,4 @@ Dafny program verifier finished with 37 verified, 13 errors
 LetExpr.dfy.tmp.dprint.dfy(281,4): Warning: /!\ No terms found to trigger on.
 LetExpr.dfy.tmp.dprint.dfy(46,2): Warning: /!\ No terms found to trigger on.
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/allocated1/dafny0/Simple.dfy.expect
+++ b/Test/allocated1/dafny0/Simple.dfy.expect
@@ -106,4 +106,4 @@ module B refines A {
   }
 }
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/allocated1/dafny0/SmallTests.dfy.expect
+++ b/Test/allocated1/dafny0/SmallTests.dfy.expect
@@ -226,4 +226,4 @@ Execution trace:
 Dafny program verifier finished with 51 verified, 46 errors
 SmallTests.dfy.tmp.dprint.dfy(451,4): Warning: /!\ No trigger covering all quantified variables found.
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/comp/AutoInit.dfy.expect
+++ b/Test/comp/AutoInit.dfy.expect
@@ -1,7 +1,7 @@
 
 Dafny program verifier finished with 9 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 3 false 0
 Cell.Cell(false) false true
 () (0, false, false, [])
@@ -13,7 +13,7 @@ true false false true
 1 3 9 0 0 ThisOrThat.Or ThisOrThat.Or
 1
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 3 false 0
 Cell.Cell(false) false true
 () (0, false, false, [])
@@ -25,7 +25,7 @@ true false false true
 1 3 9 0 0 ThisOrThat.Or ThisOrThat.Or
 1
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 3 false 0
 Cell.Cell(false) false true
 () (0, false, false, [])
@@ -37,7 +37,7 @@ true false false true
 1 3 9 0 0 ThisOrThat.Or ThisOrThat.Or
 1
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 3 false 0
 Cell.Cell(false) false true
 () (0, false, false, [])

--- a/Test/comp/CovariantCollections.dfy.expect
+++ b/Test/comp/CovariantCollections.dfy.expect
@@ -1,7 +1,7 @@
 
 Dafny program verifier finished with 14 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Sequences: [] [17, 82, 17, 82] [12, 17]
   cardinality: 0 4 2
   update: [42, 82, 17, 82] [42, 17]
@@ -47,7 +47,7 @@ Maps: {} {12 := 17, 17 := 82, 82 := 17} {12 := 17, 17 := 17}
   eq: true true true true true true
   eq: true true true true true true
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Sequences: [] [17, 82, 17, 82] [12, 17]
   cardinality: 0 4 2
   update: [42, 82, 17, 82] [42, 17]
@@ -93,7 +93,7 @@ Maps: {} {12 := 17, 17 := 82, 82 := 17} {12 := 17, 17 := 17}
   eq: true true true true true true
   eq: true true true true true true
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Sequences: [] [17, 82, 17, 82] [12, 17]
   cardinality: 0 4 2
   update: [42, 82, 17, 82] [42, 17]
@@ -139,7 +139,7 @@ Maps: {} {12 := 17, 17 := 82, 82 := 17} {12 := 17, 17 := 17}
   eq: true true true true true true
   eq: true true true true true true
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Sequences: [] [17, 82, 17, 82] [12, 17]
   cardinality: 0 4 2
   update: [42, 82, 17, 82] [42, 17]

--- a/Test/comp/Poly.dfy.expect
+++ b/Test/comp/Poly.dfy.expect
@@ -1,7 +1,7 @@
 
 Dafny program verifier finished with 15 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Center of square: ((1.0 / 2.0), (1.0 / 2.0))
 Center of circle: (1.0, 1.0)
 Center: ((1.0 / 2.0), (1.0 / 2.0))
@@ -15,7 +15,7 @@ Center: (1.0, 1.0)
 Center: ((1.0 / 2.0), (1.0 / 2.0))
 Center: (1.0, 1.0)
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Center of square: ((1.0 / 2.0), (1.0 / 2.0))
 Center of circle: (1.0, 1.0)
 Center: ((1.0 / 2.0), (1.0 / 2.0))
@@ -29,7 +29,7 @@ Center: (1.0, 1.0)
 Center: ((1.0 / 2.0), (1.0 / 2.0))
 Center: (1.0, 1.0)
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Center of square: ((1.0 / 2.0), (1.0 / 2.0))
 Center of circle: (1.0, 1.0)
 Center: ((1.0 / 2.0), (1.0 / 2.0))
@@ -43,7 +43,7 @@ Center: (1.0, 1.0)
 Center: ((1.0 / 2.0), (1.0 / 2.0))
 Center: (1.0, 1.0)
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Center of square: (0.5, 0.5)
 Center of circle: (1.0, 1.0)
 Center: (0.5, 0.5)

--- a/Test/dafny0/Calculations.dfy.expect
+++ b/Test/dafny0/Calculations.dfy.expect
@@ -25,4 +25,4 @@ Execution trace:
 
 Dafny program verifier finished with 3 verified, 6 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/dafny0/DirtyLoops.dfy.expect
+++ b/Test/dafny0/DirtyLoops.dfy.expect
@@ -454,4 +454,4 @@ DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: the conclusion of the body of thi
 DirtyLoops.dfy.tmp.dprint.dfy(495,2): Warning: note, this loop has no body (loop frame: x)
 DirtyLoops.dfy.tmp.dprint.dfy(489,2): Warning: /!\ No terms found to trigger on.
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/dafny0/LetExpr.dfy.expect
+++ b/Test/dafny0/LetExpr.dfy.expect
@@ -52,4 +52,4 @@ Dafny program verifier finished with 37 verified, 13 errors
 LetExpr.dfy.tmp.dprint.dfy(97,4): Warning: /!\ No terms found to trigger on.
 LetExpr.dfy.tmp.dprint.dfy(291,2): Warning: /!\ No terms found to trigger on.
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/dafny0/RuntimeTypeTests0.dfy.expect
+++ b/Test/dafny0/RuntimeTypeTests0.dfy.expect
@@ -1,16 +1,16 @@
 
 Dafny program verifier finished with 4 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 RuntimeTypeTests0.dfy(49,9): Error: compilation does not support trait types as a type parameter; consider introducing a ghost
 RuntimeTypeTests0.dfy(58,9): Error: compilation does not support trait types as a type parameter; consider introducing a ghost
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 RuntimeTypeTests0.dfy(49,9): Error: compilation does not support trait types as a type parameter; consider introducing a ghost
 RuntimeTypeTests0.dfy(58,9): Error: compilation does not support trait types as a type parameter; consider introducing a ghost
 File RuntimeTypeTests0/RuntimeTypeTests0.java contains the partially compiled program
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 {5, 7} and {5, 7}
 Dt.Atom(_module.Class0) and Dt.Atom(_module.Class0)
 Dt.Atom(_module.Class0) and Dt.Atom(_module.Class0)
@@ -20,7 +20,7 @@ multiset{_module.Class0} and multiset{_module.Class0}
 map[7 := _module.Class0] and map[7 := _module.Class0]
 [_module.Class0, _module.Class0] and [_module.Class0, _module.Class0]
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 {5, 7} and {5, 7}
 Dt.Atom(_module.Class0) and Dt.Atom(_module.Class0)
 Dt.Atom(_module.Class0) and Dt.Atom(_module.Class0)

--- a/Test/dafny0/Simple.dfy.expect
+++ b/Test/dafny0/Simple.dfy.expect
@@ -106,4 +106,4 @@ colemma M'(x': int)
 {
 }
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/dafny0/SmallTests.dfy.expect
+++ b/Test/dafny0/SmallTests.dfy.expect
@@ -231,4 +231,4 @@ Execution trace:
 Dafny program verifier finished with 56 verified, 47 errors
 SmallTests.dfy.tmp.dprint.dfy(451,4): Warning: /!\ No trigger covering all quantified variables found.
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification

--- a/Test/git-issues/git-issue-179.dfy.expect
+++ b/Test/git-issues/git-issue-179.dfy.expect
@@ -1,25 +1,25 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 {(3, false), (4, true), (5, false)}
 {3, 4, 5}
 {false, true}
 true false true false
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 {(5, false), (4, true), (3, false)}
 {5, 4, 3}
 {false, true}
 true false true false
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 {(5, false), (4, true), (3, false)}
 {5, 4, 3}
 {false, true}
 true false true false
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 {(5, false), (3, false), (4, true)}
 {3, 4, 5}
 {false, true}

--- a/Test/git-issues/git-issue-314.dfy.expect
+++ b/Test/git-issues/git-issue-314.dfy.expect
@@ -1,11 +1,11 @@
 
 Dafny program verifier finished with 1 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 File git-issue-314/git_issue_314.java contains the partially compiled program

--- a/Test/git-issues/git-issue-356.dfy.expect
+++ b/Test/git-issues/git-issue-356.dfy.expect
@@ -1,28 +1,28 @@
 
 Dafny program verifier finished with 7 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Z 90 90.0 90 90
 * 42 42.0 42 42
 F 70 70.0 70 70
 # 35 35.0 35 35
 END
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Z 90 90.0 90 90
 * 42 42.0 42 42
 F 70 70.0 70 70
 # 35 35.0 35 35
 END
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Z 90 90.0 90 90
 * 42 42.0 42 42
 F 70 70.0 70 70
 # 35 35.0 35 35
 END
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 Z 90 90.0 90 90
 * 42 42.0 42 42
 F 70 70.0 70 70

--- a/Test/git-issues/git-issue-374.dfy.expect
+++ b/Test/git-issues/git-issue-374.dfy.expect
@@ -1,11 +1,11 @@
 
 Dafny program verifier finished with 1 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 File git-issue-374/git_issue_374.java contains the partially compiled program

--- a/Test/git-issues/git-issue-401.dfy
+++ b/Test/git-issues/git-issue-401.dfy
@@ -1,0 +1,10 @@
+// RUN: %dafny /compile:0  "%s" > "%t"
+// RUN: %dafny /compile:0 /z3exe:"%S"/../../Binaries/z3/bin/z3 "%s" >> "%t"
+// RUN: cp -r "%S"/../../Binaries/z3/bin "%S"/../../Binaries/z3/binx
+// RUN: %dafny /compile:0 /z3exe:"%S"/../../Binaries/z3/binx/z3 "%s" >> "%t"
+// RUN: rm -rf "%S"/../../Binaries/z3/binx
+// RUN: %diff "%s.expect" "%t"
+
+method m() {
+  assert 1 + 1 == 2;
+}

--- a/Test/git-issues/git-issue-401.dfy.expect
+++ b/Test/git-issues/git-issue-401.dfy.expect
@@ -1,0 +1,6 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue-401a.dfy
+++ b/Test/git-issues/git-issue-401a.dfy
@@ -1,0 +1,6 @@
+// RUN: not %dafny /compile:0 /z3exe:"%S"/../../Binaries/z3/binz/z3 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method m() {
+  assert 1 + 1 == 2;
+}

--- a/Test/git-issues/git-issue-401a.dfy.expect
+++ b/Test/git-issues/git-issue-401a.dfy.expect
@@ -1,0 +1,1 @@
+*** ProverException: Cannot find prover specified with z3exe: /Users/davidcok/yucca/dafny/Test/git-issues/../../Binaries/z3/binz/z3

--- a/Test/git-issues/git-issue-442.dfy
+++ b/Test/git-issues/git-issue-442.dfy
@@ -1,0 +1,7 @@
+// RUN: %dafny /noVerify /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method m() 
+  ensures false
+{
+}

--- a/Test/git-issues/git-issue-442.dfy.expect
+++ b/Test/git-issues/git-issue-442.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished without attempting verification

--- a/Test/git-issues/git-issue-532.dfy.expect
+++ b/Test/git-issues/git-issue-532.dfy.expect
@@ -1,22 +1,22 @@
 
 Dafny program verifier finished with 2 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 t.x=5  The given Tr is a C, and c.y=6
 t.x=100  The given Tr is not a C
 t.x=5  The given Tr is a C, and c.y=16
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 t.x=5  The given Tr is a C, and c.y=6
 t.x=100  The given Tr is not a C
 t.x=5  The given Tr is a C, and c.y=16
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 t.x=5  The given Tr is a C, and c.y=6
 t.x=100  The given Tr is not a C
 t.x=5  The given Tr is a C, and c.y=16
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 t.x=5  The given Tr is a C, and c.y=6
 t.x=100  The given Tr is not a C
 t.x=5  The given Tr is a C, and c.y=16

--- a/Test/git-issues/git-issue-643.dfy.expect
+++ b/Test/git-issues/git-issue-643.dfy.expect
@@ -1,14 +1,14 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643.dfy(9,3): expectation violation
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643.dfy(9,3): expectation violation
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643.dfy(9,3): expectation violation
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643.dfy(9,3): expectation violation

--- a/Test/git-issues/git-issue-643a.dfy.expect
+++ b/Test/git-issues/git-issue-643a.dfy.expect
@@ -1,14 +1,14 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643a.dfy(9,3): fails
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643a.dfy(9,3): fails
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643a.dfy(9,3): fails
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 [Program halted] git-issue-643a.dfy(9,3): fails

--- a/Test/git-issues/git-issue-684.dfy.expect
+++ b/Test/git-issues/git-issue-684.dfy.expect
@@ -1,11 +1,11 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 File git-issue-684/git_issue_684.java contains the partially compiled program

--- a/Test/git-issues/git-issue-701.dfy.expect
+++ b/Test/git-issues/git-issue-701.dfy.expect
@@ -1,22 +1,22 @@
 
 Dafny program verifier finished with 1 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0
 [] [] []
 C.Nothing C.Nothing C.Nothing
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0
 [] [] []
 C.Nothing C.Nothing C.Nothing
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0
 [] [] []
 C.Nothing C.Nothing C.Nothing
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0
 [] [] []
 C.Nothing C.Nothing C.Nothing

--- a/Test/git-issues/git-issue-731.dfy.expect
+++ b/Test/git-issues/git-issue-731.dfy.expect
@@ -1,18 +1,18 @@
 
 Dafny program verifier finished with 3 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0 42
 0 0 0 9
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0 42
 0 0 0 9
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0 42
 0 0 0 9
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 0 0 42
 0 0 0 9

--- a/Test/git-issues/git-issue-731b.dfy.expect
+++ b/Test/git-issues/git-issue-731b.dfy.expect
@@ -1,14 +1,14 @@
 
 Dafny program verifier finished with 2 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 42
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 42
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 42
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 0 42

--- a/Test/git-issues/git-issue-784.dfy.expect
+++ b/Test/git-issues/git-issue-784.dfy.expect
@@ -1,11 +1,11 @@
 
 Dafny program verifier finished with 4 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 File git-issue-784/git_issue_784.java contains the partially compiled program

--- a/Test/traits/TraitCompile.dfy.expect
+++ b/Test/traits/TraitCompile.dfy.expect
@@ -1,7 +1,7 @@
 
 Dafny program verifier finished with 73 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 y=120
 x=12
 d=800
@@ -64,7 +64,7 @@ true true
 true true true
 true true true
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 y=120
 x=12
 d=800
@@ -127,7 +127,7 @@ true true
 true true true
 true true true
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 y=120
 x=12
 d=800
@@ -190,7 +190,7 @@ true true
 true true true
 true true true
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished without attempting verification
 y=120
 x=12
 d=800


### PR DESCRIPTION
Fixes #401.

The existence of the z3 binary was being checked on the default location, before processing the command-line arguments. That check is removed, relying on boogie's check. Slightly better diagnostics could be produced by modifying boogie -- which is not currently an option.