### PR TITLE
Set up Dafny 3.0.0 pre-release 0

### DIFF
--- a/Source/version.cs
+++ b/Source/version.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
-// Version 2.3.0, year 2018+1 month 05 day 06
-[assembly: AssemblyVersion("2.3.0.10506")]
-[assembly: AssemblyFileVersion("2.3.0.10506")]
+// Version 3.0.0 pre-release 0, year 2018+2 month 08 day 17
+[assembly: AssemblyVersion("3.0.0.20817")]
+[assembly: AssemblyFileVersion("3.0.0.20817")]

--- a/package.py
+++ b/package.py
@@ -56,9 +56,10 @@ DLLs = ["BoogieAbsInt",
         "BoogieParserHelper",
         "Provers.SMTLib",
         "BoogieVCExpr",
-        "BoogieVCGeneration"]
+        "BoogieVCGeneration",
+        "Mono.Cecil"]
 EXEs = ["Dafny", "DafnyServer"]
-ETCs = UNIX_EXECUTABLES + ["DafnyPrelude.bpl", "DafnyRuntime.cs", "DafnyRuntime.js", "DafnyRuntime.go", "DafnyLanguageService.vsix"]
+ETCs = UNIX_EXECUTABLES + ["DafnyPrelude.bpl", "DafnyRuntime.cs", "DafnyRuntime.js", "DafnyRuntime.go"]
 
 # Constants
 


### PR DESCRIPTION
Change version to 3.0.0.20817.
Remove DafnyLanguageService.vsix (which had been the Dafny extension for Microsoft Visual Studio).
Bundle Mono.Cecil (also under MIT License).