### PR TITLE
fix: Fix Code Contracts

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -3861,7 +3861,6 @@ namespace Microsoft.Dafny{
     }
 
     public override string TransformToClassName(string baseName) {
-      Contract.Requires(baseName != null);
       return System.Text.RegularExpressions.Regex.Replace(baseName, "[^_A-Za-z0-9\\$]", "_");
     }
   }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -10515,7 +10515,7 @@ namespace Microsoft.Dafny
       Expression expr = genExpr;
       if (genExpr is IdentifierExpr idExpr) {
         if (idExpr.Name.StartsWith("_")) {
-          expr = new IdentifierExpr(var.Tok, idExpr.Var) {Type = idExpr.Type};
+          expr = new IdentifierExpr(var.Tok, idExpr.Var);
         }
       }
       if (branch is RBranchStmt branchStmt) {
@@ -10793,7 +10793,7 @@ namespace Microsoft.Dafny
           }
         }
         // Add variables corresponding to the arguments of the current constructor (ctor) to the matchees
-        List<IdentifierExpr> freshMatchees = freshPatBV.ConvertAll(x => new IdentifierExpr(x.tok, x) { Var = x, Type = x.Type });
+        List<IdentifierExpr> freshMatchees = freshPatBV.ConvertAll(x => new IdentifierExpr(x.tok, x));
         List<Expression> cmatchees = matchees.Select(x => x).ToList();
         cmatchees.InsertRange(0, freshMatchees);
         // Update the current context

--- a/Source/Dafny/SccGraph.cs
+++ b/Source/Dafny/SccGraph.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Dafny {
     {
     }
 
+    [Pure]
     public IEnumerable<Vertex> GetVertices() {
       return vertices.Values;
     }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -12150,7 +12150,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(etran != null);
       Contract.Requires(tySubst != null);
       Contract.Requires(tyArgs != null);
-      Contract.Requires(tySubst.Count == tyArgs.Count);
+      Contract.Requires(tyArgs.Count <= tySubst.Count);  // more precisely, the members of tyArgs are required to be keys of tySubst, but this is a cheap sanity test
 
       // Figure out if the call is recursive or not, which will be used below to determine the need for a
       // termination check and the need to include an implicit _k-1 argument.


### PR DESCRIPTION
The full run-time CodeContract checking works only on Windows machines, and only if one goes through some steps to install the CodeContract tools. These checks and the code had drift apart. This PR mends that in most places.

Note, CodeContract.Assert and CodeContract.Assume are available on all platforms, but Requires, Ensures, Invariant, and some well-formedness checks are not engaged unless the CodeContract tool is run.