### PR TITLE
#425: adding AutoGhostIdentifierExpr branch in Cloner.CloneExpr

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -294,6 +294,10 @@ namespace Microsoft.Dafny
           return new ThisExpr(Tok(expr.tok));
         }
 
+      } else if (expr is AutoGhostIdentifierExpr) {
+        var e = (AutoGhostIdentifierExpr)expr;
+        return new AutoGhostIdentifierExpr(Tok(e.tok), e.Name);
+
       } else if (expr is IdentifierExpr) {
         var e = (IdentifierExpr)expr;
         return new IdentifierExpr(Tok(e.tok), e.Name);

--- a/Test/git-issues/git-issue-425.dfy
+++ b/Test/git-issues/git-issue-425.dfy
@@ -14,7 +14,7 @@ datatype Color = Red | Blue
 method Main() {
   var x0, y0 := M();  // this is fine: x0 is compiled, y0 is ghost
   print x0, "\n";
-  var c: Color;
+  var c := Red;
   match c
   case Red =>
     var x1, y1 := M();  // this used to generate an error, saying y1 is not ghost :(

--- a/Test/git-issues/git-issue-425.dfy
+++ b/Test/git-issues/git-issue-425.dfy
@@ -1,0 +1,12 @@
+method M() returns (x: int, ghost y: int)
+
+datatype Color = Red | Blue
+  
+method Main() {
+  var x0, y0 := M();  // this is fine: x0 is compiled, y0 is ghost
+  var c: Color;
+  match c
+  case Red =>
+    var x1, y1 := M();  // this used to generate an error, saying y1 is not ghost :(
+  case Blue =>
+}

--- a/Test/git-issues/git-issue-425.dfy
+++ b/Test/git-issues/git-issue-425.dfy
@@ -1,12 +1,23 @@
-method M() returns (x: int, ghost y: int)
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method M() returns (x: int, ghost y: int) {
+  return 42, 43;
+}
 
 datatype Color = Red | Blue
   
 method Main() {
   var x0, y0 := M();  // this is fine: x0 is compiled, y0 is ghost
+  print x0, "\n";
   var c: Color;
   match c
   case Red =>
     var x1, y1 := M();  // this used to generate an error, saying y1 is not ghost :(
+    print x1, "\n";
   case Blue =>
 }

--- a/Test/git-issues/git-issue-425.dfy.expect
+++ b/Test/git-issues/git-issue-425.dfy.expect
@@ -1,0 +1,18 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+42
+42
+
+Dafny program verifier finished with 0 verified, 0 errors
+42
+42
+
+Dafny program verifier finished with 0 verified, 0 errors
+42
+42
+
+Dafny program verifier finished with 0 verified, 0 errors
+42
+42


### PR DESCRIPTION
Auto detection of ghost was missing because Cloner.CloneExpr was missing a case for AutoGhostIdentifierExpr.

Fixes #425.