### PR TITLE
fix: Verify type members of opaque types

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -1249,7 +1249,7 @@ namespace Microsoft.Dafny {
     public bool IsOrdered {
       get {
         var ct = NormalizeExpand();
-        return !ct.IsTypeParameter && !ct.IsInternalTypeSynonym && !ct.IsCoDatatype && !ct.IsArrowType && !ct.IsIMapType && !ct.IsISetType;
+        return !ct.IsTypeParameter && !ct.IsOpaqueType && !ct.IsInternalTypeSynonym && !ct.IsCoDatatype && !ct.IsArrowType && !ct.IsIMapType && !ct.IsISetType;
       }
     }
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -2525,6 +2525,9 @@ namespace Microsoft.Dafny
               }
             }
             ResolveClassMembers_Pass1(dd);
+          } else if (d is OpaqueTypeDecl) {
+            var dd = (OpaqueTypeDecl)d;
+            ResolveClassMembers_Pass1(dd);
           }
         }
       }

--- a/Test/dafny0/OpaqueTypeWithMembers.dfy
+++ b/Test/dafny0/OpaqueTypeWithMembers.dfy
@@ -97,14 +97,14 @@ type OpaqueErrors {
   }
 
   inductive predicate Q(u: int) {
-    100 / y + z < 20 || Q(u + 1)  // error: index out of bounds
+    100 / y + z < 20 || Q(u + 1)  // error: division by zero
   }
   inductive lemma QL(u: int)
     requires Q(u) && y != 0
     ensures 100 / y + z < 20
   {
     var w := y + 20 / z;
-    var w' := 20 / (y + 1);  // error: index out of bounds
+    var w' := 20 / (y + 1);  // error: division by zero
   }
 }
 

--- a/Test/dafny0/OpaqueTypeWithMembers.dfy
+++ b/Test/dafny0/OpaqueTypeWithMembers.dfy
@@ -1,0 +1,152 @@
+// RUN: %dafny /compile:0 /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Opaque {
+  const y: int
+  const z := 25
+  function F(): int { z }
+  method G(a: int) returns (b: int) { b := a + this.y; }
+
+  lemma LemmaF25(n: nat)
+    ensures z == 25
+  {
+    var zz := z + y;
+    assert zz - y == 25;
+  }
+
+  twostate function H(a: array<int>): int {
+    if a.Length == 100 then old(a[3]) + y + 2 else 0
+  }
+  twostate lemma Two(a: array<int>) returns (u: int)
+    requires a.Length == 100
+    requires old(y + a[3]) == y
+    ensures old(a[3] + y) == y
+  {
+    u := old(y + a[3]);
+    var f := old(F());
+    var u' := y + a[3];
+    var f' := F();
+  }
+
+  inductive predicate Q(u: int) {
+    y + z < 20 || Q(u + 1)
+  }
+  inductive lemma QL(u: int)
+    requires Q(u)
+    ensures y + z < 20
+  {
+    var w := y + z;
+  }
+}
+
+type StaticOpaque {
+  static const y: int
+  static const z := 25
+  static function F(): int { z }
+  static method G(a: int) returns (b: int) { b := a + y; }
+
+  static lemma LemmaF25(n: nat)
+    ensures z == 25
+  {
+    var zz := z + y;
+    assert zz - y == 25;
+  }
+
+  static twostate function H(a: array<int>): int {
+    if a.Length == 100 then old(a[3]) + y + 2 else 0
+  }
+  static twostate lemma Two(a: array<int>) returns (u: int)
+    requires a.Length == 100
+    requires old(y + a[3]) == y
+    ensures old(a[3] + y) == y
+  {
+    u := old(y + a[3]);
+    var f := old(F());
+    var u' := y + a[3];
+    var f' := F();
+  }
+
+  static inductive predicate Q(u: int) {
+    y + z < 20 || Q(u + 1)
+  }
+  static inductive lemma QL(u: int)
+    requires Q(u)
+    ensures y + z < 20
+  {
+    var w := y + z;
+  }
+}
+
+type OpaqueErrors {
+  const y: int
+  const z := 25
+  function F(): int { 100 / z + 100 / y }  // error: division by zero
+  method G(a: int) returns (b: int) { b := a + 100 / this.y; }  // error: division by zero
+
+  twostate function H(a: array<int>): int {
+    old(a[3]) + y + 2  // error: index out of bounds
+  }
+  twostate lemma Two(a: array<int>) returns (u: int)
+    requires old(y + a[3]) == y  // error: index out of bounds
+    ensures old(a[3] + y) == y
+  {
+    u := old(y + a[2]);  // error: index out of bounds
+    var f := old(F());
+    var u' := y + a[2];
+    var f' := F();
+  }
+
+  inductive predicate Q(u: int) {
+    100 / y + z < 20 || Q(u + 1)  // error: index out of bounds
+  }
+  inductive lemma QL(u: int)
+    requires Q(u) && y != 0
+    ensures 100 / y + z < 20
+  {
+    var w := y + 20 / z;
+    var w' := 20 / (y + 1);  // error: index out of bounds
+  }
+}
+
+type FailureCompatible {
+  const c: int
+  predicate method IsFailure() { c < 10 }
+  function method PropagateFailure(): int
+    requires IsFailure()
+  {
+    100 / (c - 10)
+  }
+  function method Extract(): real
+    requires !IsFailure()
+  {
+    100.0 / c as real
+  }
+}
+
+method P(t: FailureCompatible) {
+  var b := t.IsFailure();
+  if t.c < 10 {
+    assert b;
+    var pf := t.PropagateFailure();
+  } else {
+    assert !b;
+    var e := t.Extract();
+  }
+}
+
+method P'(t: FailureCompatible) {
+  if t.c < 10 {
+    var e := t.Extract();  // error: precondition failure
+  } else {
+    var pf := t.PropagateFailure();  // error: precondition failure
+  }
+}
+
+method M() returns (r: FailureCompatible) {
+  r :| true;
+}
+
+method N() returns (x: int) {
+  var s :- M();
+  var t: real := s;
+}

--- a/Test/dafny0/OpaqueTypeWithMembers.dfy.expect
+++ b/Test/dafny0/OpaqueTypeWithMembers.dfy.expect
@@ -1,0 +1,38 @@
+OpaqueTypeWithMembers.dfy(83,36): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+OpaqueTypeWithMembers.dfy(84,51): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+OpaqueTypeWithMembers.dfy(87,9): Error: index out of range
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+OpaqueTypeWithMembers.dfy(90,22): Error: index out of range
+Execution trace:
+    (0,0): anon0
+OpaqueTypeWithMembers.dfy(93,18): Error: index out of range
+Execution trace:
+    (0,0): anon0
+OpaqueTypeWithMembers.dfy(100,8): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Else
+OpaqueTypeWithMembers.dfy(107,17): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+OpaqueTypeWithMembers.dfy(139,15): Error: possible violation of function precondition
+OpaqueTypeWithMembers.dfy(120,13): Related location
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+OpaqueTypeWithMembers.dfy(141,16): Error: possible violation of function precondition
+OpaqueTypeWithMembers.dfy(115,13): Related location
+OpaqueTypeWithMembers.dfy(113,35): Related location
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Else
+
+Dafny program verifier finished with 18 verified, 9 errors

--- a/Test/dafny0/ParseErrors.dfy
+++ b/Test/dafny0/ParseErrors.dfy
@@ -166,3 +166,6 @@ newtype Pos = x | 0 < x witness 1
 {
   var x: int  // error: mutable fields not allowed in newtypes
 }
+type Opaque {
+  var x: int  // error: mutable field not allowed in opaque type
+}

--- a/Test/dafny0/ParseErrors.dfy.expect
+++ b/Test/dafny0/ParseErrors.dfy.expect
@@ -40,4 +40,5 @@ ParseErrors.dfy(155,18): Error: a set comprehension with more than one bound var
 ParseErrors.dfy(156,22): Error: a set comprehension with more than one bound variable must have a term expression
 ParseErrors.dfy(163,2): Error: mutable fields are not allowed in value types
 ParseErrors.dfy(167,2): Error: mutable fields are not allowed in value types
-42 parse errors detected in ParseErrors.dfy
+ParseErrors.dfy(170,2): Error: mutable fields are not allowed in value types
+43 parse errors detected in ParseErrors.dfy


### PR DESCRIPTION
Previously, the translation to Boogie of opaque-type members was broken. This PR fixes that.

This address the malformed Boogie shown as an example in #858. However, the main bug reported in that issue (namely, printing "Dafny internal error" when a bug in Dafny causes it to generate malformed Boogie) still needs to be fixed.