### PR TITLE
refactor: Rename "fixpoint" to "extreme" for -predicate and -lemma

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1491,7 +1491,7 @@ MethodDecl<DeclModifierData dmod, bool allowConstructor, bool isWithinAbstractMo
      IToken bodyEnd = Token.NoToken;
      AllowedDeclModifiers allowed = AllowedDeclModifiers.None;
      string caption = "";
-     FixpointPredicate.KType kType = FixpointPredicate.KType.Unspecified;
+     ExtremePredicate.KType kType = ExtremePredicate.KType.Unspecified;
   .)
   SYNC
   ( "method"                        (. isPlainOlMethod = true; caption = "Methods";
@@ -1575,10 +1575,10 @@ MethodDecl<DeclModifierData dmod, bool allowConstructor, bool isWithinAbstractMo
      m.BodyEndTok = bodyEnd;
  .)
   .
-KType<ref FixpointPredicate.KType kType>
+KType<ref ExtremePredicate.KType kType>
 = "["
-  ( "nat"       (. kType = FixpointPredicate.KType.Nat; .)
-  | "ORDINAL"   (. kType = FixpointPredicate.KType.ORDINAL; .)
+  ( "nat"       (. kType = ExtremePredicate.KType.Nat; .)
+  | "ORDINAL"   (. kType = ExtremePredicate.KType.ORDINAL; .)
   )
   "]"
   .
@@ -1850,7 +1850,7 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
      IToken signatureEllipsis = null;
      bool missingOpenParen;
      bool isTwoState = false;
-     FixpointPredicate.KType kType = FixpointPredicate.KType.Unspecified;
+     ExtremePredicate.KType kType = ExtremePredicate.KType.Unspecified;
   .)
   /* ----- function ----- */
   [ "twostate"               (. isTwoState = true; .)

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -3976,12 +3976,12 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public static IEnumerable<FixpointLemma> AllFixpointLemmas(List<TopLevelDecl> declarations) {
+    public static IEnumerable<ExtremeLemma> AllExtremeLemmas(List<TopLevelDecl> declarations) {
       foreach (var d in declarations) {
         var cl = d as TopLevelDeclWithMembers;
         if (cl != null) {
           foreach (var member in cl.Members) {
-            var m = member as FixpointLemma;
+            var m = member as ExtremeLemma;
             if (m != null) {
               yield return m;
             }
@@ -5951,7 +5951,7 @@ namespace Microsoft.Dafny {
     }
 
     /// <summary>
-    /// The "AllCalls" field is used for non-FixpointPredicate, non-PrefixPredicate functions only (so its value should not be relied upon for FixpointPredicate and PrefixPredicate functions).
+    /// The "AllCalls" field is used for non-ExtremePredicate, non-PrefixPredicate functions only (so its value should not be relied upon for ExtremePredicate and PrefixPredicate functions).
     /// It records all function calls made by the Function, including calls made in the body as well as in the specification.
     /// The field is filled in during resolution (and used toward the end of resolution, to attach a helpful "decreases" prefix to functions in clusters
     /// with co-recursive calls.
@@ -6074,27 +6074,27 @@ namespace Microsoft.Dafny {
   }
 
   /// <summary>
-  /// An PrefixPredicate is the inductive unrolling P# implicitly declared for every fixpoint-predicate P.
+  /// An PrefixPredicate is the inductive unrolling P# implicitly declared for every extreme predicate P.
   /// </summary>
   public class PrefixPredicate : Function
   {
     public override string WhatKind { get { return "prefix predicate"; } }
     public readonly Formal K;
-    public readonly FixpointPredicate FixpointPred;
+    public readonly ExtremePredicate ExtremePred;
     public PrefixPredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected,
                      List<TypeParameter> typeArgs, Formal k, List<Formal> formals,
                      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
-                     Expression body, Attributes attributes, FixpointPredicate fixpointPred)
+                     Expression body, Attributes attributes, ExtremePredicate extremePred)
       : base(tok, name, hasStaticKeyword, isProtected, true, typeArgs, formals, null, Type.Bool, req, reads, ens, decreases, body, attributes, null) {
       Contract.Requires(k != null);
-      Contract.Requires(fixpointPred != null);
+      Contract.Requires(extremePred != null);
       Contract.Requires(formals != null && 1 <= formals.Count && formals[0] == k);
       K = k;
-      FixpointPred = fixpointPred;
+      ExtremePred = extremePred;
     }
   }
 
-  public abstract class FixpointPredicate : Function
+  public abstract class ExtremePredicate : Function
   {
     public enum KType { Unspecified, Nat, ORDINAL }
     public readonly KType TypeOfK;
@@ -6106,7 +6106,7 @@ namespace Microsoft.Dafny {
     public readonly List<FunctionCallExpr> Uses = new List<FunctionCallExpr>();  // filled in during resolution, used by verifier
     public PrefixPredicate PrefixPredicate;  // filled in during resolution (name registration)
 
-    public FixpointPredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
+    public ExtremePredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
                              List<TypeParameter> typeArgs, List<Formal> formals,
                              List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
                              Expression body, Attributes attributes, IToken signatureEllipsis)
@@ -6137,7 +6137,7 @@ namespace Microsoft.Dafny {
     }
   }
 
-  public class InductivePredicate : FixpointPredicate
+  public class InductivePredicate : ExtremePredicate
   {
     public override string WhatKind { get { return "inductive predicate"; } }
     public InductivePredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
@@ -6149,7 +6149,7 @@ namespace Microsoft.Dafny {
     }
   }
 
-  public class CoPredicate : FixpointPredicate
+  public class CoPredicate : ExtremePredicate
   {
     public override string WhatKind { get { return "copredicate"; } }
     public CoPredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
@@ -6454,32 +6454,32 @@ namespace Microsoft.Dafny {
   {
     public override string WhatKind { get { return "prefix lemma"; } }
     public readonly Formal K;
-    public readonly FixpointLemma FixpointLemma;
+    public readonly ExtremeLemma ExtremeLemma;
     public PrefixLemma(IToken tok, string name, bool hasStaticKeyword,
                        List<TypeParameter> typeArgs, Formal k, List<Formal> ins, List<Formal> outs,
                        List<AttributedExpression> req, Specification<FrameExpression> mod, List<AttributedExpression> ens, Specification<Expression> decreases,
-                       BlockStmt body, Attributes attributes, FixpointLemma fixpointLemma)
+                       BlockStmt body, Attributes attributes, ExtremeLemma extremeLemma)
       : base(tok, name, hasStaticKeyword, true, typeArgs, ins, outs, req, mod, ens, decreases, body, attributes, null) {
       Contract.Requires(k != null);
       Contract.Requires(ins != null && 1 <= ins.Count && ins[0] == k);
-      Contract.Requires(fixpointLemma != null);
+      Contract.Requires(extremeLemma != null);
       K = k;
-      FixpointLemma = fixpointLemma;
+      ExtremeLemma = extremeLemma;
     }
   }
 
-  public abstract class FixpointLemma : Method
+  public abstract class ExtremeLemma : Method
   {
-    public readonly FixpointPredicate.KType TypeOfK;
+    public readonly ExtremePredicate.KType TypeOfK;
     public bool KNat {
       get {
-        return TypeOfK == FixpointPredicate.KType.Nat;
+        return TypeOfK == ExtremePredicate.KType.Nat;
       }
     }
     public PrefixLemma PrefixLemma;  // filled in during resolution (name registration)
 
-    public FixpointLemma(IToken tok, string name,
-                         bool hasStaticKeyword, FixpointPredicate.KType typeOfK,
+    public ExtremeLemma(IToken tok, string name,
+                         bool hasStaticKeyword, ExtremePredicate.KType typeOfK,
                          List<TypeParameter> typeArgs,
                          List<Formal> ins, [Captured] List<Formal> outs,
                          List<AttributedExpression> req, [Captured] Specification<FrameExpression> mod,
@@ -6501,12 +6501,12 @@ namespace Microsoft.Dafny {
     }
   }
 
-  public class InductiveLemma : FixpointLemma
+  public class InductiveLemma : ExtremeLemma
   {
     public override string WhatKind { get { return "inductive lemma"; } }
 
     public InductiveLemma(IToken tok, string name,
-                          bool hasStaticKeyword, FixpointPredicate.KType typeOfK,
+                          bool hasStaticKeyword, ExtremePredicate.KType typeOfK,
                           List<TypeParameter> typeArgs,
                           List<Formal> ins, [Captured] List<Formal> outs,
                           List<AttributedExpression> req, [Captured] Specification<FrameExpression> mod,
@@ -6527,12 +6527,12 @@ namespace Microsoft.Dafny {
     }
   }
 
-  public class CoLemma : FixpointLemma
+  public class CoLemma : ExtremeLemma
   {
     public override string WhatKind { get { return "colemma"; } }
 
     public CoLemma(IToken tok, string name,
-                   bool hasStaticKeyword, FixpointPredicate.KType typeOfK,
+                   bool hasStaticKeyword, ExtremePredicate.KType typeOfK,
                    List<TypeParameter> typeArgs,
                    List<Formal> ins, [Captured] List<Formal> outs,
                    List<AttributedExpression> req, [Captured] Specification<FrameExpression> mod,

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -617,7 +617,7 @@ namespace Microsoft.Dafny {
         } else if (m is Method) {
           if (state != 0) { wr.WriteLine(); }
           PrintMethod((Method)m, indent, false);
-          var com = m as FixpointLemma;
+          var com = m as ExtremeLemma;
           if (com != null && com.PrefixLemma != null) {
             Indent(indent); wr.WriteLine("/***");
             PrintMethod(com.PrefixLemma, indent, false);
@@ -631,7 +631,7 @@ namespace Microsoft.Dafny {
         } else if (m is Function) {
           if (state != 0) { wr.WriteLine(); }
           PrintFunction((Function)m, indent, false);
-          var fixp = m as FixpointPredicate;
+          var fixp = m as ExtremePredicate;
           if (fixp != null && fixp.PrefixPredicate != null) {
             Indent(indent); wr.WriteLine("/*** (note, what is printed here does not show substitutions of calls to prefix predicates)");
             PrintFunction(fixp.PrefixPredicate, indent, false);
@@ -835,11 +835,11 @@ namespace Microsoft.Dafny {
       if (f.SignatureIsOmitted) {
         wr.WriteLine(" ...");
       } else {
-        if (f is FixpointPredicate) {
-          PrintKTypeIndication(((FixpointPredicate)f).TypeOfK);
+        if (f is ExtremePredicate) {
+          PrintKTypeIndication(((ExtremePredicate)f).TypeOfK);
         }
         PrintFormals(f.Formals, f, f.Name);
-        if (!isPredicate && !(f is FixpointPredicate) && !(f is TwoStatePredicate)) {
+        if (!isPredicate && !(f is ExtremePredicate) && !(f is TwoStatePredicate)) {
           wr.Write(": ");
           if (f.Result != null) {
             wr.Write("(");
@@ -908,7 +908,7 @@ namespace Microsoft.Dafny {
         method is TwoStateLemma ? "twostate lemma" :
         "method";
       if (method.HasStaticKeyword) { k = "static " + k; }
-      if (method.IsGhost && !(method is Lemma) && !(method is PrefixLemma) && !(method is TwoStateLemma) && !(method is FixpointLemma)) {
+      if (method.IsGhost && !(method is Lemma) && !(method is PrefixLemma) && !(method is TwoStateLemma) && !(method is ExtremeLemma)) {
         k = "ghost " + k;
       }
       string nm = method is Constructor && !((Constructor)method).HasName ? "" : method.Name;
@@ -916,8 +916,8 @@ namespace Microsoft.Dafny {
       if (method.SignatureIsOmitted) {
         wr.WriteLine(" ...");
       } else {
-        if (method is FixpointLemma) {
-          PrintKTypeIndication(((FixpointLemma)method).TypeOfK);
+        if (method is ExtremeLemma) {
+          PrintKTypeIndication(((ExtremeLemma)method).TypeOfK);
         }
         PrintFormals(method.Ins, method, method.Name);
         if (method.Outs.Count != 0) {
@@ -948,15 +948,15 @@ namespace Microsoft.Dafny {
       }
     }
 
-    void PrintKTypeIndication(FixpointPredicate.KType kType) {
+    void PrintKTypeIndication(ExtremePredicate.KType kType) {
       switch (kType) {
-        case FixpointPredicate.KType.Nat:
+        case ExtremePredicate.KType.Nat:
           wr.Write("[nat]");
           break;
-        case FixpointPredicate.KType.ORDINAL:
+        case ExtremePredicate.KType.ORDINAL:
           wr.Write("[ORDINAL]");
           break;
-        case FixpointPredicate.KType.Unspecified:
+        case ExtremePredicate.KType.Unspecified:
           break;
         default:
           Contract.Assume(false);  // unexpected KType value

--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Dafny
       var forallvisiter = new ForAllStmtVisitor(reporter);
       foreach (var decl in ModuleDefinition.AllCallables(m.TopLevelDecls)) {
         forallvisiter.Visit(decl, true);
-        if (decl is FixpointLemma) {
-          var prefixLemma = ((FixpointLemma)decl).PrefixLemma;
+        if (decl is ExtremeLemma) {
+          var prefixLemma = ((ExtremeLemma)decl).PrefixLemma;
           if (prefixLemma != null) {
             forallvisiter.Visit(prefixLemma, true);
           }
@@ -217,7 +217,7 @@ namespace Microsoft.Dafny
             // Strengthen the range of the "forall" statement with the precondition of the call, suitably substituted with the actual parameters.
             if (Attributes.Contains(s.Attributes, "_autorequires")) {
               var range = s.Range;
-              foreach (var req in s0.Method.Req) { 
+              foreach (var req in s0.Method.Req) {
                 var p = substituter.Substitute(req.E);  // substitute the call's actuals for the method's formals
                 range = Expression.CreateAnd(range, p);
               }
@@ -1648,8 +1648,8 @@ namespace Microsoft.Dafny
           if (decl is TopLevelDeclWithMembers) {
             var cl = (TopLevelDeclWithMembers)decl;
             foreach (var member in cl.Members) {
-              if (member is FixpointLemma) {
-                var method = (FixpointLemma)member;
+              if (member is ExtremeLemma) {
+                var method = (ExtremeLemma)member;
                 ProcessMethodExpressions(method);
                 ComputeLemmaInduction(method.PrefixLemma);
                 ProcessMethodExpressions(method.PrefixLemma);
@@ -1657,8 +1657,8 @@ namespace Microsoft.Dafny
                 var method = (Method)member;
                 ComputeLemmaInduction(method);
                 ProcessMethodExpressions(method);
-              } else if (member is FixpointPredicate) {
-                var function = (FixpointPredicate)member;
+              } else if (member is ExtremePredicate) {
+                var function = (ExtremePredicate)member;
                 ProcessFunctionExpressions(function);
                 ProcessFunctionExpressions(function.PrefixPredicate);
               } else if (member is Function) {
@@ -1700,7 +1700,7 @@ namespace Microsoft.Dafny
 
     void ComputeLemmaInduction(Method method) {
       Contract.Requires(method != null);
-      if (method.Body != null && method.IsGhost && method.Mod.Expressions.Count == 0 && method.Outs.Count == 0 && !(method is FixpointLemma)) {
+      if (method.Body != null && method.IsGhost && method.Mod.Expressions.Count == 0 && method.Outs.Count == 0 && !(method is ExtremeLemma)) {
         var specs = new List<Expression>();
         method.Req.ForEach(mfe => specs.Add(mfe.E));
         method.Ens.ForEach(mfe => specs.Add(mfe.E));

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -2285,10 +2285,10 @@ namespace Microsoft.Dafny {
           AddFunctionOverrideCheckImpl(f);
         }
       }
-      var cop = f as FixpointPredicate;
+      var cop = f as ExtremePredicate;
       if (cop != null) {
         AddClassMember_Function(cop.PrefixPredicate);
-        // skip the well-formedness check, because it has already been done for the fixpoint-predicate
+        // skip the well-formedness check, because it has already been done for the extreme predicate
       }
       this.fuelContext = oldFuelContext;
       isAllocContext = null;
@@ -2316,10 +2316,10 @@ namespace Microsoft.Dafny {
       }
       // the method spec itself
       sink.AddTopLevelDeclaration(AddMethod(m, MethodTranslationKind.Call));
-      if (m is FixpointLemma) {
+      if (m is ExtremeLemma) {
         // Let the CoCall and Impl forms to use m.PrefixLemma signature and specification (and
         // note that m.PrefixLemma.Body == m.Body.
-        m = ((FixpointLemma)m).PrefixLemma;
+        m = ((ExtremeLemma)m).PrefixLemma;
         sink.AddTopLevelDeclaration(AddMethod(m, MethodTranslationKind.CoCall));
       }
       if (m.Body != null && InVerificationScope(m)) {
@@ -2389,8 +2389,8 @@ namespace Microsoft.Dafny {
       }
 
       // supply the connection between inductive/coinductive predicates and prefix predicates
-      if (f is FixpointPredicate) {
-        AddPrefixPredicateAxioms(((FixpointPredicate)f).PrefixPredicate);
+      if (f is ExtremePredicate) {
+        AddPrefixPredicateAxioms(((ExtremePredicate)f).PrefixPredicate);
       }
 
       Reset();
@@ -2795,7 +2795,7 @@ namespace Microsoft.Dafny {
       sink.AddTopLevelDeclaration(ax);
       // TODO(namin) Is checking f.Reads.Count==0 excluding Valid() of BinaryTree in the right way?
       //             I don't see how this in the decreasing clause would help there.
-      if (!(f is FixpointPredicate) && f.CoClusterTarget == Function.CoCallClusterInvolvement.None &&
+      if (!(f is ExtremePredicate) && f.CoClusterTarget == Function.CoCallClusterInvolvement.None &&
         f.Reads.Count == 0 &&
         !DafnyOptions.O.Dafnycc) {
         var FVs = new HashSet<IVariable>();
@@ -3545,7 +3545,7 @@ namespace Microsoft.Dafny {
     }
 
     /// <summary>
-    /// For a fixpoint-predicate P, "pp" is the prefix predicate for P (such that P = pp.FixpointPred) and
+    /// For an extreme predicate P, "pp" is the prefix predicate for P (such that P = pp.ExtremePred) and
     /// "body" is the body of P.  Return what would be the body of the prefix predicate pp.
     /// In particular, return
     /// #if _k has type nat:
@@ -3563,15 +3563,15 @@ namespace Microsoft.Dafny {
     Expression PrefixSubstitution(PrefixPredicate pp, Expression body) {
       Contract.Requires(pp != null);
 
-      var typeMap = Util.Dict<TypeParameter,Type>(pp.FixpointPred.TypeArgs, Map(pp.TypeArgs, x => new UserDefinedType(x)));
+      var typeMap = Util.Dict<TypeParameter,Type>(pp.ExtremePred.TypeArgs, Map(pp.TypeArgs, x => new UserDefinedType(x)));
 
       var paramMap = new Dictionary<IVariable, Expression>();
-      for (int i = 0; i < pp.FixpointPred.Formals.Count; i++) {
+      for (int i = 0; i < pp.ExtremePred.Formals.Count; i++) {
         var replacement = pp.Formals[i + 1];  // the +1 is to skip pp's _k parameter
         var param = new IdentifierExpr(replacement.tok, replacement.Name);
         param.Var = replacement;  // resolve here
         param.Type = replacement.Type;  // resolve here
-        paramMap.Add(pp.FixpointPred.Formals[i], param);
+        paramMap.Add(pp.ExtremePred.Formals[i], param);
       }
 
       var k = new IdentifierExpr(pp.tok, pp.K.Name);
@@ -3579,7 +3579,7 @@ namespace Microsoft.Dafny {
       k.Type = pp.K.Type;  // resolve here
       Expression kMinusOne = Expression.CreateSubtract(k, Expression.CreateNatLiteral(pp.tok, 1, pp.K.Type));
 
-      var s = new PrefixCallSubstituter(null, paramMap, typeMap, pp.FixpointPred, kMinusOne);
+      var s = new PrefixCallSubstituter(null, paramMap, typeMap, pp.ExtremePred, kMinusOne);
       body = s.Substitute(body);
 
       if (pp.K.Type.IsBigOrdinalType) {
@@ -3604,7 +3604,7 @@ namespace Microsoft.Dafny {
 
         Attributes triggerAttr = new Attributes("trigger", new List<Expression> { ppCall }, null);
         Expression limitCalls;
-        if (pp.FixpointPred is CoPredicate) {
+        if (pp.ExtremePred is CoPredicate) {
           // forall k':ORDINAL | _k' LESS _k :: pp(_k', args)
           var smaller = Expression.CreateLess(kprime, k);
           limitCalls = new ForallExpr(pp.tok, new List<BoundVar> { kprimeVar }, smaller, ppCall, triggerAttr);
@@ -3627,7 +3627,7 @@ namespace Microsoft.Dafny {
       } else {
         // 0 < k
         var kIsPositive = Expression.CreateLess(Expression.CreateIntLiteral(pp.tok, 0), k);
-        if (pp.FixpointPred is CoPredicate) {
+        if (pp.ExtremePred is CoPredicate) {
           // add antecedent "0 < _k ==>"
           return Expression.CreateImplies(kIsPositive, body);
         } else {
@@ -3819,7 +3819,7 @@ namespace Microsoft.Dafny {
     void AddPrefixPredicateAxioms(PrefixPredicate pp) {
       Contract.Requires(pp != null);
       Contract.Requires(predef != null);
-      var co = pp.FixpointPred;
+      var co = pp.ExtremePred;
       var tok = pp.tok;
       var etran = new ExpressionTranslator(this, predef, tok);
 
@@ -3920,7 +3920,7 @@ namespace Microsoft.Dafny {
 
       // forall args :: { P(args) } args-have-appropriate-values && P(args) ==> QQQ k { P#[k](args) } :: 0 ATMOST k HHH P#[k](args)
       var tr = BplTrigger(prefixAppl);
-      var qqqK = pp.FixpointPred is CoPredicate ?
+      var qqqK = pp.ExtremePred is CoPredicate ?
         (Bpl.Expr)new Bpl.ForallExpr(tok, new List<Variable> { k }, tr, kWhere == null ? prefixAppl : BplImp(kWhere, prefixAppl)) :
         (Bpl.Expr)new Bpl.ExistsExpr(tok, new List<Variable> { k }, tr, kWhere == null ? prefixAppl : BplAnd(kWhere, prefixAppl));
       tr = BplTriggerHeap(this, tok, coAppl, AlwaysUseHeap || pp.ReadsHeap ? null : h);
@@ -3942,7 +3942,7 @@ namespace Microsoft.Dafny {
         Bpl.Expr.Literal(0));
       funcID = new Bpl.IdentifierExpr(tok, pp.FullSanitizedName, TrType(pp.ResultType));
       Bpl.Expr prefixLimitedBody = new Bpl.NAryExpr(tok, new Bpl.FunctionCall(funcID), prefixArgsLimited);
-      Bpl.Expr prefixLimited = pp.FixpointPred is InductivePredicate ? Bpl.Expr.Not(prefixLimitedBody) : prefixLimitedBody;
+      Bpl.Expr prefixLimited = pp.ExtremePred is InductivePredicate ? Bpl.Expr.Not(prefixLimitedBody) : prefixLimitedBody;
 
       var trigger = BplTriggerHeap(this, prefixLimitedBody.tok, prefixLimitedBody, AlwaysUseHeap || pp.ReadsHeap ? null : h);
       var trueAtZero = new Bpl.ForallExpr(tok, moreBvs, trigger, BplImp(BplAnd(ante, z), prefixLimited));
@@ -3964,7 +3964,7 @@ namespace Microsoft.Dafny {
       funcID = new Bpl.IdentifierExpr(tok, pp.FullSanitizedName, TrType(pp.ResultType));
       var prefixPred_K = new Bpl.NAryExpr(tok, new Bpl.FunctionCall(funcID), prefixArgsLimited);
       var prefixPred_M = new Bpl.NAryExpr(tok, new Bpl.FunctionCall(funcID), prefixArgsLimitedM);
-      var direction = pp.FixpointPred is InductivePredicate ? BplImp(prefixPred_K, prefixPred_M) : BplImp(prefixPred_M, prefixPred_K);
+      var direction = pp.ExtremePred is InductivePredicate ? BplImp(prefixPred_K, prefixPred_M) : BplImp(prefixPred_M, prefixPred_K);
 
       var trigger2 = new Bpl.Trigger(tok, true, new List<Bpl.Expr> { prefixPred_K, prefixPred_M });
       var monotonicity = new Bpl.ForallExpr(tok, moreBvs, trigger2, BplImp(smaller, direction));
@@ -3973,7 +3973,7 @@ namespace Microsoft.Dafny {
 #endif
       // A more targeted monotonicity axiom used to increase the power of automation for proving the limit case for
       // inductive predicates that have more than one focal-predicate term.
-      if (pp.FixpointPred is InductivePredicate && pp.Formals[0].Type.IsBigOrdinalType) {
+      if (pp.ExtremePred is InductivePredicate && pp.Formals[0].Type.IsBigOrdinalType) {
         // forall args,k,m,limit ::
         //   { P#[k](args), ORD#LessThanLimit(k,limit), ORD#LessThanLimit(m,limit) }
         //   args-have-appropriate-values && k < m && P#[k](args) ==> P#[m](args))
@@ -7542,7 +7542,7 @@ namespace Microsoft.Dafny {
           }
 
           Bpl.Expr allowance = null;
-          if (codeContext != null && e.CoCall != FunctionCallExpr.CoCallResolution.Yes && !(e.Function is FixpointPredicate)) {
+          if (codeContext != null && e.CoCall != FunctionCallExpr.CoCallResolution.Yes && !(e.Function is ExtremePredicate)) {
             // check that the decreases measure goes down
             if (ModuleDefinition.InSameSCC(e.Function, codeContext)) {
               List<Expression> contextDecreases = codeContext.Decreases.Expressions;
@@ -12156,7 +12156,7 @@ namespace Microsoft.Dafny {
         // Note, prefix lemmas are not recorded in the call graph, but their corresponding colemmas are.
         // Similarly, an iterator is not recorded in the call graph, but its MoveNext method is.
         ICallable cllr =
-          codeContext is PrefixLemma ? ((PrefixLemma)codeContext).FixpointLemma :
+          codeContext is PrefixLemma ? ((PrefixLemma)codeContext).ExtremeLemma :
           codeContext is IteratorDecl ? ((IteratorDecl)codeContext).Member_MoveNext :
           codeContext;
         if (ModuleDefinition.InSameSCC(method, cllr)) {
@@ -12166,9 +12166,9 @@ namespace Microsoft.Dafny {
 
       MethodTranslationKind kind;
       var callee = method;
-      if (method is FixpointLemma && isRecursiveCall) {
+      if (method is ExtremeLemma && isRecursiveCall) {
         kind = MethodTranslationKind.CoCall;
-        callee = ((FixpointLemma)method).PrefixLemma;
+        callee = ((ExtremeLemma)method).PrefixLemma;
       } else if (method is PrefixLemma) {
         // an explicit call to a prefix lemma is allowed only inside the SCC of the corresponding colemma,
         // so we consider this to be a co-call
@@ -12218,7 +12218,7 @@ namespace Microsoft.Dafny {
 
         var param = (Bpl.IdentifierExpr)etran.TrExpr(ie);  // TODO: is this cast always justified?
         Bpl.Expr bActual;
-        if (i == 0 && method is FixpointLemma && isRecursiveCall) {
+        if (i == 0 && method is ExtremeLemma && isRecursiveCall) {
           // Treat this call to M(args) as a call to the corresponding prefix lemma M#(_k - 1, args), so insert an argument here.
           var k = ((PrefixLemma)callee).K;
           var bplK = new Bpl.IdentifierExpr(k.tok, k.AssignUniqueName(currentDeclaration.IdGenerator), TrType(k.Type));
@@ -12231,7 +12231,7 @@ namespace Microsoft.Dafny {
           }
         } else {
           Expression actual;
-          if (method is FixpointLemma && isRecursiveCall) {
+          if (method is ExtremeLemma && isRecursiveCall) {
             actual = Args[i - 1];
           } else {
             actual = Args[i];
@@ -17944,22 +17944,22 @@ namespace Microsoft.Dafny {
     }
     public class PrefixCallSubstituter : Substituter
     {
-      readonly FixpointPredicate fixpointPred;
+      readonly ExtremePredicate extremePred;
       readonly Expression unrollDepth;
       readonly ModuleDefinition module;
-      public PrefixCallSubstituter(Expression receiverReplacement, Dictionary<IVariable, Expression/*!*/>/*!*/ substMap, Dictionary<TypeParameter, Type> tySubstMap, FixpointPredicate fixpointpred, Expression depth)
+      public PrefixCallSubstituter(Expression receiverReplacement, Dictionary<IVariable, Expression/*!*/>/*!*/ substMap, Dictionary<TypeParameter, Type> tySubstMap, ExtremePredicate extremePredicate, Expression depth)
         : base(receiverReplacement, substMap, tySubstMap) {
-        Contract.Requires(fixpointpred != null);
+        Contract.Requires(extremePredicate != null);
         Contract.Requires(depth != null);
-        fixpointPred = fixpointpred;
+        extremePred = extremePredicate;
         unrollDepth = depth;
-        module = fixpointpred.EnclosingClass.Module;
+        module = extremePredicate.EnclosingClass.Module;
       }
       public override Expression Substitute(Expression expr) {
         if (expr is FunctionCallExpr) {
           var e = (FunctionCallExpr)expr;
-          var cof = e.Function as FixpointPredicate;
-          if (cof != null && ModuleDefinition.InSameSCC(cof, fixpointPred)) {
+          var cof = e.Function as ExtremePredicate;
+          if (cof != null && ModuleDefinition.InSameSCC(cof, extremePred)) {
             expr = cof.CreatePrefixPredicateCall(e, unrollDepth);
           }
         }


### PR DESCRIPTION
Internally, `inductive predicate` and `copredicate` were called "fixpoint predicates",
and `inductive lemma` and `colemma` were called "fixpoint lemmas". This terminology
was inconsistent (sometimes called "extreme predicate/lemma") and can be confusing.
This PR consistently renames all occurrences of such "fixpoint" names to "extreme".

All of the changes in this PR are renamings. There are no logical changes.