### PR TITLE
#936: Implementing assert and assume in :-

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -647,7 +647,7 @@ namespace Microsoft.Dafny
 
       } else if (stmt is AssignOrReturnStmt) {
         var s = (AssignOrReturnStmt)stmt;
-        r = new AssignOrReturnStmt(Tok(s.Tok), Tok(s.EndTok), s.Lhss.ConvertAll(CloneExpr), CloneExpr(s.Rhs), s.ExpectToken == null ? null : Tok(s.ExpectToken), s.Rhss == null ? null : s.Rhss.ConvertAll(e => CloneRHS(e)));
+        r = new AssignOrReturnStmt(Tok(s.Tok), Tok(s.EndTok), s.Lhss.ConvertAll(CloneExpr), CloneExpr(s.Rhs), s.KeywordToken == null ? null : Tok(s.KeywordToken), s.Rhss == null ? null : s.Rhss.ConvertAll(e => CloneRHS(e)));
 
       } else if (stmt is VarDeclStmt) {
         var s = (VarDeclStmt)stmt;

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -742,6 +742,7 @@ TOKENS
   semicolon = ';'.
   darrow = "=>".
   assume = "assume".
+  assert = "assert".
   calc = "calc".
   case = "case".
   then = "then".
@@ -2183,7 +2184,7 @@ UpdateStmt<out Statement/*!*/ s>
      Attributes attrs = null;
      IToken suchThatAssume = null;
      Expression suchThat = null;
-     IToken exceptionExpect = null;
+     IToken keywordToken = null;
      Expression exceptionExpr = null;
   .)
 ( Lhs<out e>                       (. x = e.tok; .)
@@ -2202,8 +2203,8 @@ UpdateStmt<out Statement/*!*/ s>
       ]
       Expression<out suchThat, false, true>
     | ":-"                         (. x = t; .)
-      [ IF(la.kind == _expect)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
-        "expect"                   (. exceptionExpect = t; .)
+      [ IF(la.kind == _expect || la.kind == _assert || la.kind == _assume)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
+        ("expect"|"assert"|"assume")    (. keywordToken = t; .)
       ]
       Expression<out exceptionExpr, false, false>
       { "," Rhs<out r>             (. rhss.Add(r); .)
@@ -2213,8 +2214,8 @@ UpdateStmt<out Statement/*!*/ s>
   | ":"                            (. SemErr(t, "invalid statement (did you forget the 'label' keyword?)"); .)
   )
 | ":-"                             (. x = t; .)
-   [ IF(la.kind == _expect)        /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
-     "expect"                      (. exceptionExpect = t; .)
+   [ IF(la.kind == _expect || la.kind == _assert || la.kind == _assume)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
+      ("expect"|"assert"|"assume")    (. keywordToken = t; .)
    ]
    Expression<out exceptionExpr, false, false>
    { "," Rhs<out r>                (. rhss.Add(r); .)
@@ -2224,7 +2225,7 @@ UpdateStmt<out Statement/*!*/ s>
   (. if (suchThat != null) {
        s = new AssignSuchThatStmt(x, endTok, lhss, suchThat, suchThatAssume, null);
      } else if (exceptionExpr != null) {
-       s = new AssignOrReturnStmt(x, endTok, lhss, exceptionExpr, exceptionExpect, rhss);
+       s = new AssignOrReturnStmt(x, endTok, lhss, exceptionExpr, keywordToken, rhss);
      } else {
        if (lhss.Count == 0 && rhss.Count == 0) {
          s = new BlockStmt(x, endTok, new List<Statement>()); // error, give empty statement
@@ -2314,7 +2315,7 @@ VarDeclStatement<.out Statement/*!*/ s.>
      List<AssignmentRhs> rhss = new List<AssignmentRhs>();
      IToken suchThatAssume = null;
      Expression suchThat = null;
-     IToken exceptionExpect = null;
+     IToken keywordToken = null;
      Expression exceptionExpr = null;
      Attributes attrs = null;
      IToken endTok;
@@ -2341,8 +2342,8 @@ VarDeclStatement<.out Statement/*!*/ s.>
       ]
       Expression<out suchThat, false, true>
     | ":-"                           (. assignTok = t; .)
-      [ IF(la.kind == _expect)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
-        "expect"                     (. exceptionExpect = t; .)
+      [ IF(la.kind == _expect  || la.kind == _assert || la.kind == _assume)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
+        ("expect"|"assert"|"assume")    (. keywordToken = t; .)
       ]
       Expression<out exceptionExpr, false, false>
       { "," Rhs<out r>               (. rhss.Add(r); .)
@@ -2363,7 +2364,7 @@ VarDeclStatement<.out Statement/*!*/ s.>
        if (suchThat != null) {
          update = new AssignSuchThatStmt(assignTok, endTok, lhsExprs, suchThat, suchThatAssume, attrs);
        } else if (exceptionExpr != null) {
-         update = new AssignOrReturnStmt(assignTok, endTok, lhsExprs, exceptionExpr, exceptionExpect, rhss);
+         update = new AssignOrReturnStmt(assignTok, endTok, lhsExprs, exceptionExpr, keywordToken, rhss);
        } else if (rhss.Count == 0) {
          update = null;
        } else {

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -102,6 +102,10 @@ void CheckDeclModifiers(DeclModifierData dmod, string declCaption, AllowedDeclMo
   }
 }
 
+bool IsAssumeTypeKeyword(IToken la) {
+  return la.kind == _assume || la.kind == _assert || la.kind == _expect;
+}
+
 ///<summary>
 /// Parses top-level things (modules, classes, datatypes, class members) from "filename"
 /// and appends them in appropriate form to "module".
@@ -2203,7 +2207,7 @@ UpdateStmt<out Statement/*!*/ s>
       ]
       Expression<out suchThat, false, true>
     | ":-"                         (. x = t; .)
-      [ IF(la.kind == _expect || la.kind == _assert || la.kind == _assume)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
+      [ IF(IsAssumeTypeKeyword(la))     /* an Expression can also begin with these keywords, so this says to resolve it to pick up the keyword here */
         ("expect"|"assert"|"assume")    (. keywordToken = t; .)
       ]
       Expression<out exceptionExpr, false, false>
@@ -2214,7 +2218,7 @@ UpdateStmt<out Statement/*!*/ s>
   | ":"                            (. SemErr(t, "invalid statement (did you forget the 'label' keyword?)"); .)
   )
 | ":-"                             (. x = t; .)
-   [ IF(la.kind == _expect || la.kind == _assert || la.kind == _assume)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
+   [ IF(IsAssumeTypeKeyword(la))     /* an Expression can also begin with these keywords, so this says to resolve it to pick up the keyword here */
       ("expect"|"assert"|"assume")    (. keywordToken = t; .)
    ]
    Expression<out exceptionExpr, false, false>
@@ -2342,7 +2346,7 @@ VarDeclStatement<.out Statement/*!*/ s.>
       ]
       Expression<out suchThat, false, true>
     | ":-"                           (. assignTok = t; .)
-      [ IF(la.kind == _expect  || la.kind == _assert || la.kind == _assume)     /* an Expression can also begin with an "expect", so this says to resolve it to pick up any "expect" here */
+      [ IF(IsAssumeTypeKeyword(la))     /* an Expression can also begin with these keywords, so this says to resolve it to pick up the keyword here */
         ("expect"|"assert"|"assume")    (. keywordToken = t; .)
       ]
       Expression<out exceptionExpr, false, false>

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -7273,7 +7273,7 @@ namespace Microsoft.Dafny {
   {
     public readonly Expression Rhs; // this is the unresolved RHS, and thus can also be a method call
     public readonly List<AssignmentRhs> Rhss;
-    public readonly IToken ExpectToken;
+    public readonly IToken KeywordToken;
     public readonly List<Statement> ResolvedStatements = new List<Statement>();  // contents filled in during resolution
     public override IEnumerable<Statement> SubStatements {
       get { return ResolvedStatements; }
@@ -7289,7 +7289,7 @@ namespace Microsoft.Dafny {
       Contract.Invariant(Rhs != null);
     }
 
-    public AssignOrReturnStmt(IToken tok, IToken endTok, List<Expression> lhss, Expression rhs, IToken expectToken, List<AssignmentRhs> rhss = null)
+    public AssignOrReturnStmt(IToken tok, IToken endTok, List<Expression> lhss, Expression rhs, IToken keywordToken, List<AssignmentRhs> rhss = null)
       : base(tok, endTok, lhss)
     {
       Contract.Requires(tok != null);
@@ -7299,7 +7299,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(rhs != null);
       Rhs = rhs;
       Rhss = rhss;
-      ExpectToken = expectToken;
+      KeywordToken = keywordToken;
     }
   }
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -12141,7 +12141,7 @@ namespace Microsoft.Dafny
         } else if (s.KeywordToken.val == "assert") {
           ss = new AssertStmt(s.Tok, s.Tok, notFailureExpr, null, null, null);
         } else {
-          Contract.Assert(false,"Invalid token in :- statement: {s.KeywordToken.val}");
+          Contract.Assert(false,$"Invalid token in :- statement: {s.KeywordToken.val}");
         }
         s.ResolvedStatements.Add(ss);
       } else {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -12013,7 +12013,7 @@ namespace Microsoft.Dafny
         firstType = s.Rhs.Type;
       }
 
-      if ((codeContext as Method).Outs.Count == 0 && s.ExpectToken == null) {
+      if ((codeContext as Method).Outs.Count == 0 && s.KeywordToken == null) {
         reporter.Error(MessageSource.Resolver, s.Tok, "A method containing a :- statement must have an out-parameter ({0})",
           (codeContext as Method).Name);
         return;
@@ -12062,7 +12062,7 @@ namespace Microsoft.Dafny
       Expression lhsExtract = null;
       if (expectExtract) {
         Method caller = codeContext as Method;
-        if (caller != null && caller.Outs.Count == 0 && s.ExpectToken == null) {
+        if (caller != null && caller.Outs.Count == 0 && s.KeywordToken == null) {
           reporter.Error(MessageSource.Resolver, s.Rhs.tok, "Expected {0} to have a Success/Failure output value",
             caller.Name);
           return;
@@ -12130,11 +12130,20 @@ namespace Microsoft.Dafny
       }
       s.ResolvedStatements.Add(up);
 
-      if (s.ExpectToken != null) {
+      if (s.KeywordToken != null) {
         var notFailureExpr = new UnaryOpExpr(s.Tok, UnaryOpExpr.Opcode.Not, VarDotMethod(s.Tok, temp, "IsFailure"));
-        s.ResolvedStatements.Add(
+        Statement ss = null;
+        if (s.KeywordToken.val == "expect") {
           // "expect !temp.IsFailure(), temp"
-          new ExpectStmt(s.Tok, s.Tok, notFailureExpr, new IdentifierExpr(s.Tok, temp), null));
+          ss = new ExpectStmt(s.Tok, s.Tok, notFailureExpr, new IdentifierExpr(s.Tok, temp), null);
+        } else if (s.KeywordToken.val == "assume") {
+          ss = new AssumeStmt(s.Tok, s.Tok, notFailureExpr, null);
+        } else if (s.KeywordToken.val == "assert") {
+          ss = new AssertStmt(s.Tok, s.Tok, notFailureExpr, null, null, null);
+        } else {
+          Contract.Assert(false,"Invalid token in :- statement: {s.KeywordToken.val}");
+        }
+        s.ResolvedStatements.Add(ss);
       } else {
         s.ResolvedStatements.Add(
           // "if temp.IsFailure()"
@@ -12170,23 +12179,34 @@ namespace Microsoft.Dafny
       }
 
       s.ResolvedStatements.ForEach( a => ResolveStatement(a, codeContext) );
-      EnsureSupportsErrorHandling(s.Tok, firstType, expectExtract);
+      EnsureSupportsErrorHandling(s.Tok, firstType, expectExtract, s.KeywordToken != null);
     }
 
-    private void EnsureSupportsErrorHandling(IToken tok, Type tp, bool expectExtract) {
+    private void EnsureSupportsErrorHandling(IToken tok, Type tp, bool expectExtract, bool hasKeywordToken) {
       // The "method not found" errors which will be generated here were already reported while
       // resolving the statement, so we don't want them to reappear and redirect them into a sink.
       var origReporter = this.reporter;
       this.reporter = new ErrorReporterSink();
 
-      if (ResolveMember(tok, tp, "IsFailure", out _) == null ||
-          ResolveMember(tok, tp, "PropagateFailure", out _) == null ||
-          (ResolveMember(tok, tp, "Extract", out _) != null) != expectExtract) {
-        // more details regarding which methods are missing have already been reported by regular resolution
-        origReporter.Error(MessageSource.Resolver, tok,
-          "The right-hand side of ':-', which is of type '{0}', must have members 'IsFailure()', 'PropagateFailure()', {1} 'Extract()'",
-          tp, expectExtract ? "and" : "but not");
+      if (hasKeywordToken) {
+        if (ResolveMember(tok, tp, "IsFailure", out _) == null ||
+            (ResolveMember(tok, tp, "Extract", out _) != null) != expectExtract) {
+          // more details regarding which methods are missing have already been reported by regular resolution
+          origReporter.Error(MessageSource.Resolver, tok,
+            "The right-hand side of ':-', which is of type '{0}', with a keyword token must have members 'IsFailure()', {1} 'Extract()'",
+            tp, expectExtract ? "and" : "but not");
+        }
+      } else {
+        if (ResolveMember(tok, tp, "IsFailure", out _) == null ||
+            ResolveMember(tok, tp, "PropagateFailure", out _) == null ||
+            (ResolveMember(tok, tp, "Extract", out _) != null) != expectExtract) {
+          // more details regarding which methods are missing have already been reported by regular resolution
+          origReporter.Error(MessageSource.Resolver, tok,
+            "The right-hand side of ':-', which is of type '{0}', must have members 'IsFailure()', 'PropagateFailure()', {1} 'Extract()'",
+            tp, expectExtract ? "and" : "but not");
+        }
       }
+
 
       // The following checks are not necessary, because the ghost mismatch is caught later.
       // However the error messages here are much clearer.
@@ -12196,7 +12216,7 @@ namespace Microsoft.Dafny
           $"The IsFailure member may not be ghost (type {tp} used in :- statement)");
       }
       m = ResolveMember(tok, tp, "PropagateFailure", out _);
-      if (m != null && m.IsGhost) {
+      if (!hasKeywordToken && m != null && m.IsGhost) {
         origReporter.Error(MessageSource.Resolver, tok,
           $"The PropagateFailure member may not be ghost (type {tp} used in :- statement)");
       }
@@ -14435,7 +14455,7 @@ namespace Microsoft.Dafny
 
       ResolveExpression(expr.ResolvedExpression, opts);
       bool expectExtract = (expr.Lhs != null);
-      EnsureSupportsErrorHandling(expr.tok, PartiallyResolveTypeForMemberSelection(expr.tok, tempType), expectExtract);
+      EnsureSupportsErrorHandling(expr.tok, PartiallyResolveTypeForMemberSelection(expr.tok, tempType), expectExtract, false);
     }
 
     private Type SelectAppropriateArrowType(IToken tok, List<Type> typeArgs, Type resultType, bool hasReads, bool hasReq) {

--- a/Test/exceptions/VerificationErrors.dfy
+++ b/Test/exceptions/VerificationErrors.dfy
@@ -12,6 +12,6 @@ method CheckThatVerifierRunsInsideDesugaredExprs_Nat(r1: NatOutcome, r2: NatOutc
 method CheckThatVerifierRunsInsideDesugaredExprs_Void(r1: VoidOutcome, r2: VoidOutcome) returns (res: VoidOutcome) {
     var x := assert 2 + 2 == 4; 8;
     assert x == 8;
-    :- assert r1 == r2; r1;
+    :- (assert r1 == r2; r1);
     res := r1;
 }

--- a/Test/exceptions/VerificationErrors.dfy.expect
+++ b/Test/exceptions/VerificationErrors.dfy.expect
@@ -1,7 +1,7 @@
 VerificationErrors.dfy(8,38): Error: assertion violation
 Execution trace:
     (0,0): anon0
-VerificationErrors.dfy(15,17): Error: assertion violation
+VerificationErrors.dfy(15,18): Error: assertion violation
 Execution trace:
     (0,0): anon0
 

--- a/Test/git-issues/git-issue-936.dfy
+++ b/Test/git-issues/git-issue-936.dfy
@@ -1,0 +1,87 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Status = Failure(msg: string) | Success
+{
+  function method IsFailure(): bool ensures IsFailure() == Failure? { Failure? }
+  function method PropagateFailure(): Status requires Failure? ensures PropagateFailure().Failure?  { this }
+}
+
+method q(i: int) returns (r: Status)
+  ensures i == 1 ==> !r.Failure?
+  ensures i == 2 ==> r.Failure?
+{
+  if i == 2 {
+    return Failure("Z");
+  }
+  return Success;
+}
+
+method m() returns (z: int)
+  ensures z == 42
+{
+  z := 0;
+  :- assert q(1);
+  return 42;
+}
+
+method mbad() {
+  :- assert q(0); // error: assert does not necessarily hold
+}
+
+method n() {
+  :- assume q(2);
+  assert false;  // does not fail
+}
+
+method n2() returns (z: int)
+  ensures z == 42
+{
+  z := 0;
+  :- assume q(0);
+  z := 42;
+}
+
+method p() {
+  :- expect q(2);
+  assert false;  // does not fail
+}
+
+method p2() returns (z: int)
+  ensures z == 42
+{
+  z := 0;
+  :- expect q(0);
+  z := 42;
+}
+
+method t() returns (r: Status, z: int)
+  ensures r.Failure? ==> z == 0
+  ensures !r.Failure? ==> z == 42
+{
+  r := Success;
+  z := 0;
+  :- q(0);
+  z := 42;
+}
+
+method t2() returns (r: Status, z: int)
+  ensures !r.Failure?
+  ensures z == 42
+{
+  r := Success;
+  z := 0;
+  :- q(1);
+  z := 42;
+}
+
+method t3() returns (r: Status, z: int)
+  ensures r.Failure?
+  ensures z == 0;
+{
+  r := Success;
+  z := 0;
+  :- q(2);
+  z := 42;
+}
+

--- a/Test/git-issues/git-issue-936.dfy
+++ b/Test/git-issues/git-issue-936.dfy
@@ -3,8 +3,8 @@
 
 datatype Status = Failure(msg: string) | Success
 {
-  function method IsFailure(): bool ensures IsFailure() == Failure? { Failure? }
-  function method PropagateFailure(): Status requires Failure? ensures PropagateFailure().Failure?  { this }
+  function method IsFailure(): bool { Failure? }
+  function method PropagateFailure(): Status { this }
 }
 
 method q(i: int) returns (r: Status)

--- a/Test/git-issues/git-issue-936.dfy.expect
+++ b/Test/git-issues/git-issue-936.dfy.expect
@@ -2,4 +2,4 @@ git-issue-936.dfy(29,2): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 11 verified, 1 error
+Dafny program verifier finished with 9 verified, 1 error

--- a/Test/git-issues/git-issue-936.dfy.expect
+++ b/Test/git-issues/git-issue-936.dfy.expect
@@ -1,0 +1,5 @@
+git-issue-936.dfy(29,2): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 11 verified, 1 error

--- a/docs/_includes/Statements.md
+++ b/docs/_includes/Statements.md
@@ -258,7 +258,7 @@ An update-with-failure statement uses _failure-compatible_ types.
 A failure-compatible type is a type that has the following members (each with no in-parameters and one out-parameter):
 
  * a function method `IsFailure()` that returns a `bool`
- * a function method `PropagateFailure()` that returns a value assignable to the first out-parameter of the caller
+ * an optional function method `PropagateFailure()` that returns a value assignable to the first out-parameter of the caller
  * an optional method or function `Extract()`
 
 A failure-compatible type with an `Extract` member is called _value-carrying_.
@@ -266,7 +266,8 @@ A failure-compatible type with an `Extract` member is called _value-carrying_.
 
 To use this form of update,
 
- * the caller must have a first out-parameter whose type matches the output of `PropagateFailure` applied to the first output of the callee
+ * the caller must have a first out-parameter whose type matches the output of `PropagateFailure` applied to the first output of the callee, unless an
+`expect`, `assume`, or `assert` keyword is used after `:-`
  * if the RHS of the update-with-failure statement is a method call, the first out-parameter of the callee must be failure-compatible
  * if instead the RHS of the update-with-failure statement is one or more expressions, the first of these expressions must be a value with a failure-compatible type
  * if the failure-compatible type of the RHS does not have an `Extract` member,
@@ -477,13 +478,13 @@ s :- M();
 ```
 with the semantics as described above.
 
-### Expect alternative
+### Keyword-enahnced alternative
 
 In any of the above described uses of `:-`, the `:-` token may be followed immediately by the keyword `expect`, `assert` or `assume`.
 
 * `assert` means that the RHS evaluation is expected to be successful, but that
 the verifier should prove that this is so; that is, the verifier should prove
-`assert !r.IsFailure()` (where `r` is te status return from the callee)
+`assert !r.IsFailure()` (where `r` is the status return from the callee)
 * `assume` means that the RHS evaluation should be assumed to be successful,
 as if the statement `assume !r.IsFailure()` followed the evaluation of the RHS
 * `expect` means that the RHS evaluation should be assumed to be successful
@@ -517,9 +518,6 @@ or
 ```dafny
 assume !tmp.IsFailure();
 ```
-
-*Currently, the assert and assume alternatives are not implemented, and the
-expect alternative still requires a PropagateFailure member.*
 
 ### Key points
 


### PR DESCRIPTION
Implemented assert and assume along with expect in :-.
If any of these keywords are present, PropagateFailure is not required and not used.
Instead the desugaring inserts assert !tmp.IsFailure(); etc.