### PR TITLE
#181: Documenting type parameter modes and fixing the check of !new

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1463,7 +1463,7 @@ TPCharOption<ref TypeParameter.TypeParameterCharacteristics characteristics>
   | digits     (. if (t.val == "0") {
                     characteristics.MustSupportZeroInitialization = true;
                   } else {
-                    SemErr(t, "unexpected TPCharOption");
+                    SemErr(t, "unexpected type parameter option - should be == or 0 or !new");
                   }
                .)
   | "!" "new"  (. characteristics.DisallowReferenceTypes = true; .)

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -777,7 +777,8 @@ namespace Microsoft.Dafny
 /definiteAssignment:<n>
     0 - ignores definite-assignment rules; this mode is for testing only--it is
         not sound to be used with compilation
-    1 (default) - enforces definite-assignment rules
+    1 (default) - enforces definite-assignment rules for variables and fields
+        of types that do not support auto-initialization
     2 - enforces definite-assignment for all non-ghost non-yield-parameter
         variables and fields, regardless of their types
     3 - like 2, but also performs checks in the compiler that no nondeterministic

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -9213,6 +9213,16 @@ namespace Microsoft.Dafny
       if (f.IsStatic) {
         scope.AllowInstance = false;
       }
+
+      if (f.IsGhost) {
+        foreach (TypeParameter p in f.TypeArgs) {
+          if (p.MustSupportEquality) {
+            reporter.Warning(MessageSource.Resolver, p.tok,
+              $"type parameter {p.Name} of ghost {f.WhatKind} {f.Name} is declared (==), which is unnecessary because the {f.WhatKind} doesn’t contain any compiled code");
+          }
+        }
+      }
+
       foreach (Formal p in f.Formals) {
         scope.Push(p.Name, p);
       }
@@ -9350,6 +9360,15 @@ namespace Microsoft.Dafny
         // take care of the warnShadowing attribute
         if (Attributes.ContainsBool(m.Attributes, "warnShadowing", ref warnShadowing)) {
           DafnyOptions.O.WarnShadowing = warnShadowing;  // set the value according to the attribute
+        }
+
+        if (m.IsGhost) {
+          foreach (TypeParameter p in m.TypeArgs) {
+            if (p.MustSupportEquality) {
+              reporter.Warning(MessageSource.Resolver, p.tok,
+                $"type parameter {p.Name} of ghost {m.WhatKind} {m.Name} is declared (==), which is unnecessary because the {m.WhatKind} doesn’t contain any compiled code");
+            }
+          }
         }
 
         // Add in-parameters to the scope, but don't care about any duplication errors, since they have already been reported

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -7431,6 +7431,11 @@ namespace Microsoft.Dafny
           hint = "";
           return false;
         }
+        if (formal.DisallowReferenceTypes && !actual.IsAllocFree) {
+          whatIsWrong = "no references";
+          hint = "";
+          return false;
+        }
         whatIsWrong = null;
         hint = null;
         return true;

--- a/Test/dafny0/RestrictedBoundedPools.dfy
+++ b/Test/dafny0/RestrictedBoundedPools.dfy
@@ -123,7 +123,7 @@ module Functions_RestrictionsApply {
     forall xs: List<H> :: R(xs)  // error: may involved allocation state
   }
 
-  predicate M5'<H(==)>(S: set<List<H>>)
+  predicate M5'<H>(S: set<List<H>>)
   {
     forall xs: List<H> :: xs in S ==> R(xs)  // fine
   }

--- a/Test/dafny2/MajorityVote.dfy
+++ b/Test/dafny2/MajorityVote.dfy
@@ -69,7 +69,7 @@ function method Count<T(==)>(a: seq<T>, s: int, t: int, x: T): int
   Count(a, s, t-1, x) + if a[t-1] == x then 1 else 0
 }
 
-predicate HasMajority<T(==)>(a: seq<T>, s: int, t: int, x: T)
+predicate HasMajority<T>(a: seq<T>, s: int, t: int, x: T)
   requires 0 <= s <= t <= |a|
 {
   2 * Count(a, s, t, x) > t - s

--- a/Test/dafny4/RollYourOwnArrowType.dfy
+++ b/Test/dafny4/RollYourOwnArrowType.dfy
@@ -74,7 +74,7 @@ predicate Total<A(!new),B>(f: A ~> B)  // (is this (!new) really necessary?)
   forall a :: f.reads(a) == {} && f.requires(a)
 }
 
-type TotalArrow<!A,B> = f: EffectlessArrow<A,B>
+type TotalArrow<!A(!new),B> = f: EffectlessArrow<A,B>
   | Total(f)
   ghost witness TotalWitness<A,B>
 

--- a/Test/git-issues/git-issue-181.dfy
+++ b/Test/git-issues/git-issue-181.dfy
@@ -15,4 +15,46 @@ method m() {
   var x6: ResultN<array<int>>; // error
 }
 
+class D<T(==)> {}
+codatatype E = Nil
+
+method n(d: D<int>) {}
+method n2(d: D<int->int>) {} // error: function types are not (==)
+method n3(d: D<E>) {} // error: codataypes are not (==)
+ghost method g2(d: D<int->int>) {}
+ghost method g3(d: D<E>) {}
+
+function g<T(==)>(t: T): T {
+  t
+}
+
+function gx<T>(t: T): T {
+  t
+}
+
+function method gg<T(==)>(t: T): T {
+  t
+}
+
+function method ggx<T>(t: T): T {
+  t
+}
+
+method mm<T(==)>(t: T) {
+  ghost var x := g(t);
+  ghost var xx := gx(t);
+  var y := gg(t);
+  var yy := ggx(t);
+}
+
+method mx<T>(t: T) {
+  ghost var x := g(t); // OK - g wants (==) but is ghost
+  ghost var xx := gx(t); // OK ghost
+  var y := gg(t); // error: gg wants (==)
+  var yy := ggx(t);
+}
+
+ghost method mg<T(==)>(t: T) {
+}
+
 

--- a/Test/git-issues/git-issue-181.dfy
+++ b/Test/git-issues/git-issue-181.dfy
@@ -24,7 +24,7 @@ method n3(d: D<E>) {} // error: codataypes are not (==)
 ghost method g2(d: D<int->int>) {}
 ghost method g3(d: D<E>) {}
 
-function g<T(==)>(t: T): T {
+function g<T(==)>(t: T): T { // Warning: unnecessary (==)
   t
 }
 
@@ -54,7 +54,7 @@ method mx<T>(t: T) {
   var yy := ggx(t);
 }
 
-ghost method mg<T(==)>(t: T) {
+ghost method mg<T(==)>(t: T) { // warning: unneccessary (==)
 }
 
 

--- a/Test/git-issues/git-issue-181.dfy
+++ b/Test/git-issues/git-issue-181.dfy
@@ -1,0 +1,18 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Result<T> = Failure(error: string) | Success(value: T)
+datatype ResultN<T(!new)> = Failure(error: string) | Success(value: T)
+
+class C {}
+
+method m() {
+  var x1: Result<int>;
+  var x2: ResultN<int>;
+  var x3: Result<C>;
+  var x4: ResultN<C>; // error
+  var x5: Result<array<int>>;
+  var x6: ResultN<array<int>>; // error
+}
+
+

--- a/Test/git-issues/git-issue-181.dfy.expect
+++ b/Test/git-issues/git-issue-181.dfy.expect
@@ -1,3 +1,8 @@
+git-issue-181.dfy(27,11): Warning: type parameter T of ghost function g is declared (==), which is unnecessary because the function doesn’t contain any compiled code
+git-issue-181.dfy(57,16): Warning: type parameter T of ghost method mg is declared (==), which is unnecessary because the method doesn’t contain any compiled code
 git-issue-181.dfy(13,10): Error: type parameter (T) passed to type ResultN must support no references (got C)
 git-issue-181.dfy(15,10): Error: type parameter (T) passed to type ResultN must support no references (got array<int>)
-2 resolution/type errors detected in git-issue-181.dfy
+git-issue-181.dfy(22,13): Error: type parameter (T) passed to type D must support equality (got int -> int)
+git-issue-181.dfy(23,13): Error: type parameter (T) passed to type D must support equality (got E)
+git-issue-181.dfy(53,11): Error: type parameter (T) passed to function gg must support equality (got T) (perhaps try declaring type parameter 'T' on line 50 as 'T(==)', which says it can only be instantiated with a type that supports equality)
+5 resolution/type errors detected in git-issue-181.dfy

--- a/Test/git-issues/git-issue-181.dfy.expect
+++ b/Test/git-issues/git-issue-181.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-181.dfy(13,10): Error: type parameter (T) passed to type ResultN must support no references (got C)
+git-issue-181.dfy(15,10): Error: type parameter (T) passed to type ResultN must support no references (got array<int>)
+2 resolution/type errors detected in git-issue-181.dfy

--- a/Test/refman/Example-TP.dfy
+++ b/Test/refman/Example-TP.dfy
@@ -1,0 +1,4 @@
+// RUN: %dafny /verifyAllModules /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+include "../../docs/_includes/Example-TP.dfy"

--- a/Test/refman/Example-TP.dfy.expect
+++ b/Test/refman/Example-TP.dfy.expect
@@ -1,0 +1,4 @@
+Example-TP.dfy(4,8): Error: the included file Example-TP.dfy contains error(s)
+Example-TP.dfy(13,10): Error: type parameter (T) passed to type ResultN must support no references (got C)
+Example-TP.dfy(15,10): Error: type parameter (T) passed to type ResultN must support no references (got array<int>)
+3 resolution/type errors detected in Example-TP.dfy

--- a/docs/_includes/Example-TP.dfy
+++ b/docs/_includes/Example-TP.dfy
@@ -1,8 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-datatype Result<T> = Failure(error: string) | Success(value: T)
-datatype ResultN<T(!new)> = Failure(error: string) | Success(value: T)
+datatype Result<T> = Failure(error: string) | Success(v: T)
+datatype ResultN<T(!new)> = Failure(error: string) | Success(v: T)
 
 class C {}
 

--- a/docs/_includes/Example-TP.dfy
+++ b/docs/_includes/Example-TP.dfy
@@ -1,0 +1,18 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Result<T> = Failure(error: string) | Success(value: T)
+datatype ResultN<T(!new)> = Failure(error: string) | Success(value: T)
+
+class C {}
+
+method m() {
+  var x1: Result<int>;
+  var x2: ResultN<int>;
+  var x3: Result<C>;
+  var x4: ResultN<C>; // error
+  var x5: Result<array<int>>;
+  var x6: ResultN<array<int>>; // error
+}
+
+

--- a/docs/_includes/Topics.md
+++ b/docs/_includes/Topics.md
@@ -786,7 +786,7 @@ each lemma, the bodies of the given extreme lemmas `EvenNat` and
 `Always` can be empty and Dafny still completes the proofs.
 Folks, it doesn't get any simpler than that!
 
-## Variable Initialization and Definite Assignment
+## Variable Initialization and Definite Assignment {#sec-definite-assignment}
 
 TO BE WRITTEN -- rules for default initialization; resulting rules for constructors; definite assignment rules
 

--- a/docs/_includes/Types.md
+++ b/docs/_includes/Types.md
@@ -456,7 +456,7 @@ GenericParameters =
   "<" TypeVariableName [ "(" "==" ")" ]
   { "," TypeVariableName [ "(" "==" ")" ] } ">"
 ````
-Many of the types, functions and methods in Dafny can be
+Many of the types, functions, and methods in Dafny can be
 parameterized by types.  These _type parameters_ are typically
 declared inside angle brackets and can stand for any type.
 
@@ -516,10 +516,12 @@ method m() {
 }
 ```
 
-However, by default, non-ghost computations must follow definite-assignment
-rules, in which case local variables must be assigned a value before use.
 For some types, the compiler can choose an initial value, but for others
-it does not; for more details see the section describing [Definite Assignment](#sec-definite-assignment) and the `-definiteAssignment` command-line option.
+it does not.
+Variables and fields of a type that the compiler does not auto-initialize
+are subject to _definite-assignment_ rules. These ensure that the program
+explicitly assigns a value to a variable before it is used.
+For more details see the section describing [Definite Assignment](#sec-definite-assignment) and the `-definiteAssignment` command-line option.
 
 The `(0)` suffix indicates that the type must be one that the compiler knows
 how to auto-initialize, if the type is used to declare a non-ghost variable.
@@ -537,7 +539,7 @@ Thus it can be relevant to know whether the values of a type parameter
 are heap-based or not. This is indicated by the mode suffix `(!new)`.
 
 A type parameter characterized by `(!new)` is _recursively_ independent
-of the allocation state. For example a datatype is not a reference, but for
+of the allocation state. For example, a datatype is not a reference, but for
 a parameterized data type such as
 ```dafny
 dataype Result<T> = Failure(error: string) | Success(value: T)

--- a/docs/_includes/Types.md
+++ b/docs/_includes/Types.md
@@ -460,18 +460,21 @@ Many of the types (as well as functions and methods) in Dafny can be
 parameterized by types.  These _type parameters_ are typically
 declared inside angle brackets and can stand for any type.
 
-It is sometimes necessary to restrict these type parameters so that
+Dafny has some inference support that makes certain signatures less
+cluttered (described in Section [Type Inference](#sec-type-inference)).
+
+## Declaring restrictions on type parameters
+
+It is sometimes necessary to restrict type parameters so that
 they can only be instantiated by certain families of types, that is,
 by types that have certain properties. The following subsections
 describe the restrictions Dafny supports.
 
-Dafny has some inference support that makes certain signatures less
-cluttered (described in Section [Type Inference](#sec-type-inference)).
-In some cases, this support will infer that a type-parameter
+In some cases, type inference will infer that a type-parameter
 must be restricted in a particular way, in which case Dafny
 will add the appropriate suffix, such as `(==)`, automatically.
 
-## Equality-supporting type parameters: `T(==)`
+### Equality-supporting type parameters: `T(==)`
 
 Designating a type parameter with the `(==)` suffix indicates that
 the parameter may only be replaced with types that are known to
@@ -493,11 +496,11 @@ code.  Co-inductive datatypes, function types, as well as inductive
 datatypes with ghost parameters are examples of types that are not
 equality supporting.
 
-## Auto-initializable types: `T(0)`
+### Auto-initializable types: `T(0)`
 
 All Dafny variables of a given type hold a legal value of that type;
 if no explicit initialization is given, then an arbitrary value is
-assumed.
+assumedi, that is, the variable is _auto-innitialized_..
 During verification, this means that any subsequent uses of that
 variable must hold for any value.
 For example,
@@ -518,7 +521,7 @@ it does not; for more details see the section describing [Definite Assignment](#
 The `(0)` suffix indicates that the type must be one that the compiler knows
 how to auto-initialize.
 
-## Non-heap based: `T(!new)`
+### Non-heap based: `T(!new)`
 
 Dafny makes a distinction between types whose values are on the heap,
 i.e. references, like
@@ -547,6 +550,9 @@ Here are some examples:
 ```dafny
 {% include Example-TP.dfy %}
 ```
+
+## Type parameter variance
+
 TO BE WRITTEN: Type parameter variance
 
 # Generic Instantiation

--- a/docs/_includes/Types.md
+++ b/docs/_includes/Types.md
@@ -456,7 +456,7 @@ GenericParameters =
   "<" TypeVariableName [ "(" "==" ")" ]
   { "," TypeVariableName [ "(" "==" ")" ] } ">"
 ````
-Many of the types (as well as functions and methods) in Dafny can be
+Many of the types, functions and methods in Dafny can be
 parameterized by types.  These _type parameters_ are typically
 declared inside angle brackets and can stand for any type.
 
@@ -477,10 +477,11 @@ will add the appropriate suffix, such as `(==)`, automatically.
 ### Equality-supporting type parameters: `T(==)`
 
 Designating a type parameter with the `(==)` suffix indicates that
-the parameter may only be replaced with types that are known to
-support equality comparisons (`==` and `!=`).
-This restriction only applies during compilation; for verification
-the `(==)` suffix does not restrict the substituted type.
+the parameter may only be replaced in non-ghost contexts
+with types that are known to
+support run-time equality comparisons (`==` and `!=`).
+All types support equality in ghost contexts,
+as if, for some types, the equality function is ghost.
 
 For example,
 ```dafny
@@ -490,9 +491,10 @@ method Compare<T(==)>(a: T, b: T) returns (eq: bool)
 }
 ```
 is a method whose type parameter is restricted to equality-supporting
-types.  Again, note that _all_ types support equality in _ghost_
+types when used in a non-ghost context.
+Again, note that _all_ types support equality in _ghost_
 contexts; the difference is only for non-ghost (that is, compiled)
-code.  Co-inductive datatypes, function types, as well as inductive
+code.  Co-inductive datatypes, function types, and inductive
 datatypes with ghost parameters are examples of types that are not
 equality supporting.
 
@@ -500,7 +502,8 @@ equality supporting.
 
 All Dafny variables of a given type hold a legal value of that type;
 if no explicit initialization is given, then an arbitrary value is
-assumedi, that is, the variable is _auto-innitialized_..
+assumed by the verifier and supplied by the compiler,
+ that is, the variable is _auto-initialized_.
 During verification, this means that any subsequent uses of that
 variable must hold for any value.
 For example,
@@ -514,12 +517,12 @@ method m() {
 ```
 
 However, by default, non-ghost computations must follow definite-assignment
-rules, in which case local variables must be initialized.
+rules, in which case local variables must be assigned a value before use.
 For some types, the compiler can choose an initial value, but for others
 it does not; for more details see the section describing [Definite Assignment](#sec-definite-assignment) and the `-definiteAssignment` command-line option.
 
 The `(0)` suffix indicates that the type must be one that the compiler knows
-how to auto-initialize.
+how to auto-initialize, if the type is used to declare a non-ghost variable.
 
 ### Non-heap based: `T(!new)`
 

--- a/docs/_includes/Types.md
+++ b/docs/_includes/Types.md
@@ -541,6 +541,7 @@ the instantiation `Result<int>` satisifies `(!new)`, whereas
 
 Note that this characteristic of a type parameter is operative for both
 verification and compilation.
+Also, opaque types at the topmost scope are always implicitly `(!new)`.
 
 Here are some examples:
 ```dafny


### PR DESCRIPTION
Fixes #181. 

Also it appeared that there was no compiler check for !new uses, so added that.