### PR TITLE
#151, #328: Fixes to ambiguity of imported types

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -839,7 +839,7 @@ namespace Microsoft.Dafny {
     /// Returns whether or not "this" and "that" denote the same type, module proxies and type synonyms and subset types.
     /// </summary>
     [Pure]
-    public abstract bool Equals(Type that);
+    public abstract bool Equals(Type that, bool keepConstraints = false);
 
     public bool IsBoolType { get { return NormalizeExpand() is BoolType; } }
     public bool IsCharType { get { return NormalizeExpand() is CharType; } }
@@ -2135,8 +2135,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "int";
     }
-    public override bool Equals(Type that) {
-      return that is IntVarietiesSupertype;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return keepConstraints ? this.GetType() == that.GetType() : that is IntVarietiesSupertype;
     }
   }
   public class RealVarietiesSupertype : ArtificialType
@@ -2145,8 +2145,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "real";
     }
-    public override bool Equals(Type that) {
-      return that is RealVarietiesSupertype;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return keepConstraints ? this.GetType() == that.GetType() : that is RealVarietiesSupertype;
     }
   }
 
@@ -2166,7 +2166,7 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "bool";
     }
-    public override bool Equals(Type that) {
+    public override bool Equals(Type that, bool keepConstraints = false) {
       return that.IsBoolType;
     }
   }
@@ -2179,7 +2179,7 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "char";
     }
-    public override bool Equals(Type that) {
+    public override bool Equals(Type that, bool keepConstraints = false) {
       return that.IsCharType;
     }
   }
@@ -2190,8 +2190,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "int";
     }
-    public override bool Equals(Type that) {
-      return that.IsIntegerType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return keepConstraints ? this.GetType() == that.GetType() : that.IsIntegerType;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
       if (super is IntVarietiesSupertype) {
@@ -2206,8 +2206,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "real";
     }
-    public override bool Equals(Type that) {
-      return that.IsRealType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return keepConstraints ? this.GetType() == that.GetType() : that.IsRealType;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
       if (super is RealVarietiesSupertype) {
@@ -2223,7 +2223,7 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "ORDINAL";
     }
-    public override bool Equals(Type that) {
+    public override bool Equals(Type that, bool keepConstraints = false) {
       return that.IsBigOrdinalType;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
@@ -2254,8 +2254,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "bv" + Width;
     }
-    public override bool Equals(Type that) {
-      var bv = that.NormalizeExpand() as BitvectorType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var bv = that.NormalizeExpand(keepConstraints) as BitvectorType;
       return bv != null && bv.Width == Width;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
@@ -2278,8 +2278,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "selftype";
     }
-    public override bool Equals(Type that) {
-      return that.NormalizeExpand() is SelfType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return that.NormalizeExpand(keepConstraints) is SelfType;
     }
   }
 
@@ -2483,9 +2483,9 @@ namespace Microsoft.Dafny {
     }
     public override string CollectionTypeName { get { return finite ? "set" : "iset"; } }
     [Pure]
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as SetType;
-      return t != null && Finite == t.Finite && Arg.Equals(t.Arg);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as SetType;
+      return t != null && Finite == t.Finite && Arg.Equals(t.Arg, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2500,9 +2500,9 @@ namespace Microsoft.Dafny {
     public MultiSetType(Type arg) : base(arg) {
     }
     public override string CollectionTypeName { get { return "multiset"; } }
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as MultiSetType;
-      return t != null && Arg.Equals(t.Arg);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as MultiSetType;
+      return t != null && Arg.Equals(t.Arg, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2516,9 +2516,9 @@ namespace Microsoft.Dafny {
     public SeqType(Type arg) : base(arg) {
     }
     public override string CollectionTypeName { get { return "seq"; } }
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as SeqType;
-      return t != null && Arg.Equals(t.Arg);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as SeqType;
+      return t != null && Arg.Equals(t.Arg, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2558,9 +2558,9 @@ namespace Microsoft.Dafny {
       var targs = HasTypeArg() ? this.TypeArgsToString(context, parseAble) : "";
       return CollectionTypeName + targs;
     }
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as MapType;
-      return t != null && Finite == t.Finite && Arg.Equals(t.Arg) && Range.Equals(t.Range);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as MapType;
+      return t != null && Finite == t.Finite && Arg.Equals(t.Arg, keepConstraints) && Range.Equals(t.Range, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2779,23 +2779,23 @@ namespace Microsoft.Dafny {
       this.NamePath = ns;
     }
 
-    public override bool Equals(Type that) {
-      var i = NormalizeExpand();
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var i = NormalizeExpand(keepConstraints);
       if (i is UserDefinedType) {
         var ii = (UserDefinedType)i;
-        var t = that.NormalizeExpand() as UserDefinedType;
+        var t = that.NormalizeExpand(keepConstraints) as UserDefinedType;
         if (t == null || ii.ResolvedParam != t.ResolvedParam || ii.ResolvedClass != t.ResolvedClass || ii.TypeArgs.Count != t.TypeArgs.Count) {
           return false;
         } else {
           for (int j = 0; j < ii.TypeArgs.Count; j++) {
-            if (!ii.TypeArgs[j].Equals(t.TypeArgs[j])) {
+            if (!ii.TypeArgs[j].Equals(t.TypeArgs[j],keepConstraints)) {
               return false;
             }
           }
           return true;
         }
       } else {
-        return i.Equals(that);
+        return i.Equals(that,keepConstraints);
       }
     }
 
@@ -3074,13 +3074,13 @@ namespace Microsoft.Dafny {
         }
       }
     }
-    public override bool Equals(Type that) {
-      var i = NormalizeExpand();
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var i = NormalizeExpand(keepConstraints);
       if (i is TypeProxy) {
-        var u = that.NormalizeExpand() as TypeProxy;
+        var u = that.NormalizeExpand(keepConstraints) as TypeProxy;
         return u != null && object.ReferenceEquals(i, u);
       } else {
-        return i.Equals(that);
+        return i.Equals(that,keepConstraints);
       }
     }
 
@@ -4814,8 +4814,8 @@ namespace Microsoft.Dafny {
 
         return "_increasingInt";
       }
-      public override bool Equals(Type that) {
-        return that.NormalizeExpand() is EverIncreasingType;
+      public override bool Equals(Type that, bool keepConstraints = false) {
+        return that.NormalizeExpand(keepConstraints) is EverIncreasingType;
       }
     }
 
@@ -9374,8 +9374,8 @@ namespace Microsoft.Dafny {
         Contract.Assert(parseAble == false);
         return "#module";
       }
-      public override bool Equals(Type that) {
-        return that.NormalizeExpand() is ResolverType_Module;
+      public override bool Equals(Type that, bool keepConstraints = false) {
+        return that.NormalizeExpand(keepConstraints) is ResolverType_Module;
       }
     }
     public class ResolverType_Type : ResolverType {
@@ -9384,8 +9384,8 @@ namespace Microsoft.Dafny {
         Contract.Assert(parseAble == false);
         return "#type";
       }
-      public override bool Equals(Type that) {
-        return that.NormalizeExpand() is ResolverType_Type;
+      public override bool Equals(Type that, bool keepConstraints = false) {
+        return that.NormalizeExpand(keepConstraints) is ResolverType_Type;
       }
     }
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -1599,14 +1599,14 @@ namespace Microsoft.Dafny
                   if (d is TypeSynonymDecl && !(d is SubsetTypeDecl)) {
                     ddd = (d as TypeSynonymDecl).Rhs.NormalizeExpand(true);
                     if (ddd is UserDefinedType) {
-                      dd = (ddd as UserDefinedType).AsRedirectingType as TopLevelDecl;
+                      dd = (ddd as UserDefinedType).AsRevealableType as TopLevelDecl;
                       ddd = null;
                     }
                   }
                   if (kk is TypeSynonymDecl && !(kk is SubsetTypeDecl)) {
                     kkk = (kk as TypeSynonymDecl).Rhs.NormalizeExpand(true);
                     if (kkk is UserDefinedType) {
-                      kk = (kkk as UserDefinedType).AsRedirectingType as TopLevelDecl;
+                      kk = (kkk as UserDefinedType).AsRevealableType as TopLevelDecl;
                       kkk = null;
                     }
                   }

--- a/Test/exports/OpenImportRefined.dfy
+++ b/Test/exports/OpenImportRefined.dfy
@@ -31,7 +31,7 @@ module GiveT2 {
 module Refined2 refines GiveT {
   import opened GiveT2
 
-  function f(x: T): int //error, which T?
+  function f(x: T): int // OK -- GiveT.T takes precedence over GiveT2.T
 }
 
 module GiveF{

--- a/Test/exports/OpenImportRefined.dfy.expect
+++ b/Test/exports/OpenImportRefined.dfy.expect
@@ -1,5 +1,3 @@
 OpenImportRefined.dfy(15,7): Error: Base module Base imports T from an opened import, so it cannot be overridden. Give this declaration a unique name to disambiguate.
-OpenImportRefined.dfy[Refined](11,17): Error: The name T ambiguously refers to a type in one of the modules Refined, GiveT (try qualifying the type name with the module name)
-OpenImportRefined.dfy(34,16): Error: The name T ambiguously refers to a type in one of the modules Refined2, GiveT2 (try qualifying the type name with the module name)
 OpenImportRefined.dfy(51,11): Error: Base module BaseF imports f from an opened import, so it cannot be overridden. Give this declaration a unique name to disambiguate.
-4 resolution/type errors detected in OpenImportRefined.dfy
+2 resolution/type errors detected in OpenImportRefined.dfy

--- a/Test/git-issues/git-issue-151.dfy
+++ b/Test/git-issues/git-issue-151.dfy
@@ -1,0 +1,44 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  type T = int
+  type U = int
+  type V = int
+  type W = int
+  type X = x: int | x > -10
+  type Y = x: int | x > -10
+  newtype Z = int
+  newtype K = int
+}
+
+module B {
+  type U = real
+  type V = int
+  type W = nat
+  type X = x: int | x > -10
+  newtype Z = int
+}
+
+module D {
+  import A
+  type Y = A.Y
+  type K = A.K
+}
+
+module C {
+  import opened A
+  import opened B
+  import opened D
+
+  type T = A.T
+
+  function method Baz(x: T): T { 0 } // OK C.T is local
+  function method Bar(x: U): U { 0 } // Error A.U, B.U conflict
+  function method Bam(x: V): V { 0 } // OK A.V, B.V are the same type
+  function method Baa(x: W): W { 0 } // Error A.W, B.W are different
+  function method Bag(x: X): X { 0 } // Error A.X, B.X are different
+  function method Bay(x: Y): Y { 0 } // OK A.Y, D.Y are the same type
+  function method Bat(x: Z): Z { 0 } // Error: A.Z, B.Z are different newtypes
+  function method Ban(x: K): K { 0 } // OK: A.K, D.K are refer to same decl
+}

--- a/Test/git-issues/git-issue-151.dfy.expect
+++ b/Test/git-issues/git-issue-151.dfy.expect
@@ -1,0 +1,9 @@
+git-issue-151.dfy(37,25): Error: The name U ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(37,29): Error: The name U ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(39,25): Error: The name W ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(39,29): Error: The name W ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(40,25): Error: The name X ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(40,29): Error: The name X ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(42,25): Error: The name Z ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(42,29): Error: The name Z ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+8 resolution/type errors detected in git-issue-151.dfy

--- a/Test/git-issues/git-issue-151b.dfy
+++ b/Test/git-issues/git-issue-151b.dfy
@@ -1,0 +1,29 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  method m() {}
+  method p() {}
+  function f(): int { 0 }
+  function g(): int { 0 }
+}
+
+module B {
+  method m() {}
+  function f(): int { 0 }
+  function g(): int { 0 }
+}
+
+module C {
+  import opened A
+  import opened B
+
+  method p() {}
+  function g(): int { 0 }
+
+  method Bam() { m(); } // Ambiguous
+  method Bay() { p(); } // OK
+  function Baa(): int { f() } // Ambiguous
+  function Bag(): int { g() } // OK
+}
+

--- a/Test/git-issues/git-issue-151b.dfy.expect
+++ b/Test/git-issues/git-issue-151b.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-151b.dfy(24,17): Error: The name m ambiguously refers to a static member in one of the modules A, B (try qualifying the member name with the module name)
+git-issue-151b.dfy(24,18): Error: expected method call, found expression
+git-issue-151b.dfy(26,24): Error: The name f ambiguously refers to a static member in one of the modules A, B (try qualifying the member name with the module name)
+3 resolution/type errors detected in git-issue-151b.dfy

--- a/Test/git-issues/git-issue-328.dfy
+++ b/Test/git-issues/git-issue-328.dfy
@@ -1,0 +1,36 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  datatype T = T(i: int)
+  type X
+}
+
+module B {
+  import A
+  type T = A.T
+  type K
+}
+
+module C {
+  import A
+  type T = A.T
+  type K
+  type X = A.X
+}
+
+module D {
+  import opened B
+  import opened C
+
+  function f(t: T) : T { t } // OK. B.T and C.T are both A.T
+  function g(k: K) : K { k } // Error: ambiguous
+
+}
+
+module E {
+  import opened A
+  import opened C
+
+  function g(x: X) : X { x }  // OK - A.X and C.X are the same
+}

--- a/Test/git-issues/git-issue-328.dfy.expect
+++ b/Test/git-issues/git-issue-328.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-328.dfy(27,16): Error: The name K ambiguously refers to a type in one of the modules B, C (try qualifying the type name with the module name)
+git-issue-328.dfy(27,21): Error: The name K ambiguously refers to a type in one of the modules B, C (try qualifying the type name with the module name)
+2 resolution/type errors detected in git-issue-328.dfy


### PR DESCRIPTION
Allows use of imported types that are imported through multiple paths if they are the "same" type; also gives locally defined types preference over imports.

Fixes #151, #328.