### PR TITLE
Datatype default via values

### DIFF
--- a/Binaries/DafnyRuntime.js
+++ b/Binaries/DafnyRuntime.js
@@ -71,6 +71,9 @@ let _dafny = (function() {
       }
       return true;
     }
+    static Default(...values) {
+      return Tuple.of(...values);
+    }
     static Rtd(...rtdArgs) {
       return {
         Default: Tuple.from(rtdArgs, rtd => rtd.Default)

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Dafny
       wDefault.Write(DtCreateName(groundingCtor));
       wDefault.Write("(");
       var nonGhostFormals = groundingCtor.Formals.Where(f => !f.IsGhost);
-      wDefault.Write(Util.Comma(nonGhostFormals, f => DefaultValue(f.Type, wDefault, f.tok, false, false)));
+      wDefault.Write(Util.Comma(nonGhostFormals, f => DefaultValue(f.Type, wDefault, f.tok)));
       wDefault.Write(")");
 
       EmitTypeDescriptorMethod(dt, wr);

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1099,7 +1099,7 @@ namespace Microsoft.Dafny
       return "object";
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
 
       if (inAutoInitContext) {

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1191,7 +1191,7 @@ namespace Microsoft.Dafny
           s += "<" + TypeNames(udt.TypeArgs, wr, udt.tok) + ">";
         }
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors))})");
+        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})");
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1099,10 +1099,10 @@ namespace Microsoft.Dafny
       return "object";
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
+    public override string TypeInitializationValue(Type type, TextWriter wr /*?*/, Bpl.IToken tok /*?*/, bool usePlaceboValue, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
 
-      if (inAutoInitContext) {
+      if (usePlaceboValue) {
         return $"default({TypeName(type, wr, tok)})";
       }
 
@@ -1138,7 +1138,7 @@ namespace Microsoft.Dafny
         } else if (td.NativeType != null) {
           return "0";
         } else {
-          return TypeInitializationValue(td.BaseType, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+          return TypeInitializationValue(td.BaseType, wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
@@ -1150,7 +1150,7 @@ namespace Microsoft.Dafny
           if (ArrowType.IsPartialArrowTypeName(td.Name)) {
             return string.Format("(({0})null)", TypeName(xType, wr, udt.tok));
           } else if (ArrowType.IsTotalArrowTypeName(td.Name)) {
-            var rangeDefaultValue = TypeInitializationValue(udt.TypeArgs.Last(), wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+            var rangeDefaultValue = TypeInitializationValue(udt.TypeArgs.Last(), wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
             // return the lambda expression ((Ty0 x0, Ty1 x1, Ty2 x2) => rangeDefaultValue)
             return string.Format("(({0}) => {1})",
               Util.Comma(udt.TypeArgs.Count - 1, i => string.Format("{0} x{1}", TypeName(udt.TypeArgs[i], wr, udt.tok), i)),
@@ -1168,7 +1168,7 @@ namespace Microsoft.Dafny
             return string.Format("default({0})", TypeName(xType, wr, udt.tok));
           }
         } else {
-          return TypeInitializationValue(td.RhsWithArgument(udt.TypeArgs), wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+          return TypeInitializationValue(td.RhsWithArgument(udt.TypeArgs), wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
         }
       } else if (cl is ClassDecl) {
         bool isHandle = true;

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -390,12 +390,7 @@ namespace Microsoft.Dafny
           w.WriteLine(";");
         }
       }
-      DatatypeCtor groundingCtor;
-      if (dt is IndDatatypeDecl) {
-        groundingCtor = ((IndDatatypeDecl)dt).GroundingCtor;
-      } else {
-        groundingCtor = ((CoDatatypeDecl)dt).Ctors[0];  // pick any one of them (but pick must be the same as in InitializerIsKnown and HasZeroInitializer)
-      }
+      var groundingCtor = dt.GetGroundingCtor();
       if (dt is CoDatatypeDecl) {
         var wCo = wDefault;
         wCo.Write("new {0}__Lazy{1}(", dt.CompileName, DtT_TypeArgs);

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Dafny
       foreach (var member in iter.Members) {
         var f = member as Field;
         if (f != null && !f.IsGhost) {
-          cw.DeclareField(IdName(f), iter, false, false, f.Type, f.tok, DefaultValue(f.Type, w, f.tok, false, true), f);
+          cw.DeclareField(IdName(f), iter, false, false, f.Type, f.tok, DefaultValue(f.Type, w, f.tok, true), f);
         } else if (member is Constructor) {
           Contract.Assert(ct == null);  // we're expecting just one constructor
           ct = (Constructor)member;
@@ -1191,7 +1191,7 @@ namespace Microsoft.Dafny
           s += "<" + TypeNames(udt.TypeArgs, wr, udt.tok) + ">";
         }
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})");
+        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})");
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }
@@ -1593,7 +1593,7 @@ namespace Microsoft.Dafny
       } else {
         wr.Write("Dafny.ArrayHelpers.InitNewArray{0}<{1}>", dimCount, TypeName(elmtType, wr, tok));
         wr.Write("(");
-        wr.Write(DefaultValue(elmtType, wr, tok, false, true));
+        wr.Write(DefaultValue(elmtType, wr, tok, true));
         for (var d = 0; d < dimCount; d++) {
           wr.Write(", ");
           var w = wr.Fork();

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1142,7 +1142,7 @@ namespace Microsoft.Dafny
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
-        if (td.Witness != null) {
+        if (td.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           return TypeName_UDT(FullTypeName(udt), udt, wr, udt.tok) + ".Default()";
         } else if (td.WitnessKind == SubsetTypeDecl.WKind.Special) {
           // WKind.Special is only used with -->, ->, and non-null types:

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -997,7 +997,7 @@ namespace Microsoft.Dafny {
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
-        if (td.Witness != null) {
+        if (td.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           return td.Module.CompileName + "::class_" + td.CompileName + "::Witness";
         } else if (td.WitnessKind == SubsetTypeDecl.WKind.Special) {
           // WKind.Special is only used with -->, ->, and non-null types:

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -941,7 +941,7 @@ namespace Microsoft.Dafny {
       return TypeName(type, wr, tok, member, false);
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter /*?*/ wr, Bpl.IToken /*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
+    public override string TypeInitializationValue(Type type, TextWriter wr /*?*/, Bpl.IToken tok /*?*/, bool usePlaceboValue, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
       if (xType is BoolType) {
         return "false";
@@ -978,7 +978,7 @@ namespace Microsoft.Dafny {
         if (udt.ResolvedClass != null && Attributes.Contains(udt.ResolvedClass.Attributes, "extern")) {
           // Assume the external definition includes a default value
           return String.Format("{1}::get_{0}_default()", IdProtect(udt.Name), udt.ResolvedClass.Module.CompileName);
-        } else if (inAutoInitContext && !udt.ResolvedParam.Characteristics.MustSupportZeroInitialization) {
+        } else if (usePlaceboValue && !udt.ResolvedParam.Characteristics.MustSupportZeroInitialization) {
           return String.Format("get_default<{0}>::call()", IdProtect(udt.Name));
         } else {
           return String.Format("get_default<{0}>::call()", IdProtect(udt.Name));
@@ -993,7 +993,7 @@ namespace Microsoft.Dafny {
         } else if (td.NativeType != null) {
           return "0";
         } else {
-          return TypeInitializationValue(td.BaseType, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+          return TypeInitializationValue(td.BaseType, wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
@@ -1005,7 +1005,7 @@ namespace Microsoft.Dafny {
           if (ArrowType.IsPartialArrowTypeName(td.Name)) {
             return "nullptr";
           } else if (ArrowType.IsTotalArrowTypeName(td.Name)) {
-            var rangeDefaultValue = TypeInitializationValue(udt.TypeArgs.Last(), wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+            var rangeDefaultValue = TypeInitializationValue(udt.TypeArgs.Last(), wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
             // return the lambda expression ((Ty0 x0, Ty1 x1, Ty2 x2) => rangeDefaultValue)
             return string.Format("function () {{ return {0}; }}", rangeDefaultValue);
           } else if (((NonNullTypeDecl)td).Class is ArrayClassDecl) {
@@ -1024,7 +1024,7 @@ namespace Microsoft.Dafny {
             return "nullptr";
           }
         } else {
-          return TypeInitializationValue(td.RhsWithArgument(udt.TypeArgs), wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+          return TypeInitializationValue(td.RhsWithArgument(udt.TypeArgs), wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
         }
       } else if (cl is ClassDecl) {
         bool isHandle = true;

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -941,7 +941,7 @@ namespace Microsoft.Dafny {
       return TypeName(type, wr, tok, member, false);
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+    public override string TypeInitializationValue(Type type, TextWriter /*?*/ wr, Bpl.IToken /*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
       if (xType is BoolType) {
         return "false";

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1454,7 +1454,7 @@ namespace Microsoft.Dafny {
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
-        if (td.Witness != null) {
+        if (td.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           return TypeName_Companion(cl, wr, tok) + ".Witness()";
         } else if (td.WitnessKind == SubsetTypeDecl.WKind.Special) {
           // WKind.Special is only used with -->, ->, and non-null types:

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1492,7 +1492,7 @@ namespace Microsoft.Dafny {
         }
         var n = dt is TupleTypeDecl ? "_dafny.TupleOf" : $"{TypeName_Companion(dt, wr, tok)}.Default";
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return $"{n}({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors))})";
+        return $"{n}({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})";
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.Dafny {
         new List<TypeArgumentInstantiation>(), enclosingClass.ParentFormalTypeParametersToActuals, instantiatedFieldType);
         var wRHS = lvalue.EmitWrite(FieldInitWriter(false));
         Compiler.EmitCoercionIfNecessary(instantiatedFieldType, field.Type, tok, wRHS);
-        wRHS.Write(Compiler.DefaultValue(instantiatedFieldType, ErrorWriter(), tok, true));
+        wRHS.Write(Compiler.PlaceboValue(instantiatedFieldType, ErrorWriter(), tok));
       }
 
       public TextWriter/*?*/ ErrorWriter() => ConcreteMethodWriter;
@@ -1630,7 +1630,7 @@ namespace Microsoft.Dafny {
         wr.WriteLine("{0} {1}", name, TypeName(type, initWriter, tok));
 
         if (isStatic) {
-          initWriter.WriteLine("{0}: {1},", name, rhs ?? DefaultValue(type, initWriter, tok, true));
+          initWriter.WriteLine("{0}: {1},", name, rhs ?? PlaceboValue(type, initWriter, tok));
         } else if (rhs != null) {
           initWriter.WriteLine("_this.{0} = {1}", name, rhs);
         }

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -827,13 +827,7 @@ namespace Microsoft.Dafny {
         WriteRuntimeTypeDescriptorsLocals(usedTypeParams, true, wDefault);
 
         wDefault.Write("return ");
-        DatatypeCtor groundingCtor;
-        if (dt is IndDatatypeDecl idd) {
-          groundingCtor = idd.GroundingCtor;
-        } else {
-          groundingCtor = dt.Ctors[0];
-        }
-
+        var groundingCtor = dt.GetGroundingCtor();
         var arguments = new TargetWriter();
         string sep = "";
         foreach (var f in groundingCtor.Formals) {

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -1399,7 +1399,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       // When returning nil, explicitly cast the nil so that type assertions work
       string nil() {
         return string.Format("({0})(nil)", TypeName(type, wr, tok));

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Dafny {
       Constructor ct = null;
       foreach (var member in iter.Members) {
         if (member is Field f && !f.IsGhost) {
-          cw.DeclareField(IdName(f), iter, false, false, f.Type, f.tok, DefaultValue(f.Type, wr, f.tok, false, true), f);
+          cw.DeclareField(IdName(f), iter, false, false, f.Type, f.tok, DefaultValue(f.Type, wr, f.tok, true), f);
         } else if (member is Constructor c) {
           Contract.Assert(ct == null);
           ct = c;
@@ -843,7 +843,7 @@ namespace Microsoft.Dafny {
 
         WriteRuntimeTypeDescriptorsLocals(usedTypeParams, true, wDefault);
 
-        var arguments = Util.Comma(UsedTypeParameters(dt), tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, false, true));
+        var arguments = Util.Comma(UsedTypeParameters(dt), tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
         wDefault.WriteLine($"return {TypeName_Companion(dt, wr, dt.tok)}.Default({arguments});");
       }
 
@@ -1492,7 +1492,7 @@ namespace Microsoft.Dafny {
         }
         var n = dt is TupleTypeDecl ? "_dafny.TupleOf" : $"{TypeName_Companion(dt, wr, tok)}.Default";
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return $"{n}({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})";
+        return $"{n}({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})";
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }
@@ -1906,7 +1906,7 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitNewArray(Type elmtType, Bpl.IToken tok, List<Expression> dimensions, bool mustInitialize, TargetWriter wr) {
-      var initValue = DefaultValue(elmtType, wr, tok, false, true);
+      var initValue = DefaultValue(elmtType, wr, tok, true);
 
       string sep;
       if (!mustInitialize) {

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -3008,7 +3008,7 @@ namespace Microsoft.Dafny{
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
-        if (td.Witness != null) {
+        if (td.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           return FullTypeName(udt) + ".defaultValue()";
         } else if (td.WitnessKind == SubsetTypeDecl.WKind.Special) {
           // WKind.Special is only used with -->, ->, and non-null types:

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -3070,7 +3070,7 @@ namespace Microsoft.Dafny{
           return $"({s}{typeargs})null";
         }
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return $"{s}.{typeargs}Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors))})";
+        return $"{s}.{typeargs}Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})";
       } else {
         Contract.Assert(false);
         throw new cce.UnreachableException(); // unexpected type

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1717,12 +1717,7 @@ namespace Microsoft.Dafny{
         wDefault = w.Fork();
         w.WriteLine(";");
       }
-      DatatypeCtor groundingCtor;
-      if (dt is IndDatatypeDecl) {
-        groundingCtor = ((IndDatatypeDecl)dt).GroundingCtor;
-      } else {
-        groundingCtor = ((CoDatatypeDecl) dt).Ctors[0];
-      }
+      var groundingCtor = dt.GetGroundingCtor();
       string arguments = "";
       string sep = "";
       foreach (Formal f in groundingCtor.Formals) {

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1725,7 +1725,7 @@ namespace Microsoft.Dafny{
       EmitDatatypeValue(dt, groundingCtor, null, dt is CoDatatypeDecl, arguments, wDefault);
 
       var targetTypeName = BoxedTypeName(UserDefinedType.FromTopLevelDecl(dt.tok, dt, null), wr, dt.tok);
-      arguments = Util.Comma(usedTypeArgs, tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, false, true));
+      arguments = Util.Comma(usedTypeArgs, tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
       EmitTypeMethod(dt, IdName(dt), dt.TypeArgs, usedTypeArgs, targetTypeName, $"Default({arguments})", wr);
 
       // create methods
@@ -3070,7 +3070,7 @@ namespace Microsoft.Dafny{
           return $"({s}{typeargs})null";
         }
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return $"{s}.{typeargs}Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})";
+        return $"{s}.{typeargs}Default({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})";
       } else {
         Contract.Assert(false);
         throw new cce.UnreachableException(); // unexpected type
@@ -3445,7 +3445,7 @@ namespace Microsoft.Dafny{
         wBareArray = wr.Fork();
         wr.Write(")");
         if (mustInitialize) {
-          wr.Write($".fillThenReturn({DefaultValue(elmtType, wr, tok, false, true)})");
+          wr.Write($".fillThenReturn({DefaultValue(elmtType, wr, tok, true)})");
         }
       } else {
         if (!elmtType.IsTypeParameter) {
@@ -3456,7 +3456,7 @@ namespace Microsoft.Dafny{
         }
         wBareArray = wr.Fork();
         if (mustInitialize) {
-          wr.Write($", {DefaultValue(elmtType, wr, tok, false, true)})");
+          wr.Write($", {DefaultValue(elmtType, wr, tok, true)})");
         }
       }
 

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -2959,7 +2959,7 @@ namespace Microsoft.Dafny{
       }
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter wr, Bpl.IToken tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+    public override string TypeInitializationValue(Type type, TextWriter wr, Bpl.IToken tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
       if (xType is BoolType) {
         return "false";

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Dafny{
       } else {
         Contract.Assert(cw.CtorBodyWriter != null, "Unexpected instance field");
         cw.InstanceMemberWriter.WriteLine("public {0} {1};", TypeName(type, cw.InstanceMemberWriter, tok), name);
-        cw.CtorBodyWriter.WriteLine("this.{0} = {1};", name, rhs ?? DefaultValue(type, cw.CtorBodyWriter, tok, inAutoInitContext: true));
+        cw.CtorBodyWriter.WriteLine("this.{0} = {1};", name, rhs ?? PlaceboValue(type, cw.CtorBodyWriter, tok));
       }
     }
 

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -478,12 +478,7 @@ namespace Microsoft.Dafny {
         using (var wClass = wRtd.NewBlock("return class", ";")) {
           using (var wDefault = wClass.NewBlock("static get Default()")) {
             wDefault.Write("return ");
-            DatatypeCtor groundingCtor;
-            if (dt is IndDatatypeDecl) {
-              groundingCtor = ((IndDatatypeDecl)dt).GroundingCtor;
-            } else {
-              groundingCtor = ((CoDatatypeDecl)dt).Ctors[0];  // pick any one of them (but pick must be the same as in InitializerIsKnown and HasZeroInitializer)
-            }
+            var groundingCtor = dt.GetGroundingCtor();
             var arguments = new TargetWriter();
             string sep = "";
             foreach (var f in groundingCtor.Formals) {

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -905,7 +905,7 @@ namespace Microsoft.Dafny {
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
-        if (td.Witness != null) {
+        if (td.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           return TypeName_UDT(FullTypeName(udt), udt, wr, udt.tok) + ".Default";
         } else if (td.WitnessKind == SubsetTypeDecl.WKind.Special) {
           // WKind.Special is only used with -->, ->, and non-null types:

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -682,10 +682,6 @@ namespace Microsoft.Dafny {
     }
 
     protected override string TypeDescriptor(Type type, TextWriter wr, Bpl.IToken tok) {
-      return TypeDescriptor(type, wr, tok, false);
-    }
-
-    string TypeDescriptor(Type type, TextWriter wr, Bpl.IToken tok, bool inAutoInitContext) {
       Contract.Requires(type != null);
       Contract.Requires(tok != null);
       Contract.Requires(wr != null);
@@ -860,10 +856,10 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
+    public override string TypeInitializationValue(Type type, TextWriter wr /*?*/, Bpl.IToken tok /*?*/, bool usePlaceboValue, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
 
-      if (inAutoInitContext) {
+      if (usePlaceboValue) {
         return "undefined";
       }
 
@@ -891,7 +887,7 @@ namespace Microsoft.Dafny {
       var udt = (UserDefinedType)xType;
       if (udt.ResolvedParam != null) {
         if (constructTypeParameterDefaultsFromTypeDescriptors) {
-          return string.Format("{0}.Default", TypeDescriptor(udt, wr, udt.tok, inAutoInitContext));
+          return string.Format("{0}.Default", TypeDescriptor(udt, wr, udt.tok));
         } else {
           return FormatDefaultTypeParameterValue(udt.ResolvedParam);
         }
@@ -905,7 +901,7 @@ namespace Microsoft.Dafny {
         } else if (td.NativeType != null) {
           return "0";
         } else {
-          return TypeInitializationValue(td.BaseType, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+          return TypeInitializationValue(td.BaseType, wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
         }
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
@@ -917,7 +913,7 @@ namespace Microsoft.Dafny {
           if (ArrowType.IsPartialArrowTypeName(td.Name)) {
             return "null";
           } else if (ArrowType.IsTotalArrowTypeName(td.Name)) {
-            var rangeDefaultValue = TypeInitializationValue(udt.TypeArgs.Last(), wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+            var rangeDefaultValue = TypeInitializationValue(udt.TypeArgs.Last(), wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
             // return the lambda expression ((Ty0 x0, Ty1 x1, Ty2 x2) => rangeDefaultValue)
             return string.Format("function () {{ return {0}; }}", rangeDefaultValue);
           } else if (((NonNullTypeDecl)td).Class is ArrayClassDecl) {
@@ -935,7 +931,7 @@ namespace Microsoft.Dafny {
             return "null";
           }
         } else {
-          return TypeInitializationValue(td.RhsWithArgument(udt.TypeArgs), wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors);
+          return TypeInitializationValue(td.RhsWithArgument(udt.TypeArgs), wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
         }
       } else if (cl is ClassDecl) {
         bool isHandle = true;

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -948,7 +948,7 @@ namespace Microsoft.Dafny {
         var dt = (DatatypeDecl)cl;
         var s = dt is TupleTypeDecl ? "_dafny.Tuple" : FullTypeName(udt);
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs).ConvertAll(ta => ta.Actual);
-        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, arg => DefaultValue(arg, wr, tok, inAutoInitContext, constructTypeParameterDefaultsFromTypeDescriptors))})");
+        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, arg => DefaultValue(arg, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})");
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Dafny {
       foreach (var member in iter.Members) {
         var f = member as Field;
         if (f != null && !f.IsGhost) {
-          DeclareField(IdName(f), false, false, f.Type, f.tok, DefaultValue(f.Type, instanceFieldsWriter, f.tok, false, true), instanceFieldsWriter);
+          DeclareField(IdName(f), false, false, f.Type, f.tok, DefaultValue(f.Type, instanceFieldsWriter, f.tok, true), instanceFieldsWriter);
         } else if (member is Constructor) {
           Contract.Assert(ct == null);  // we're expecting just one constructor
           ct = (Constructor)member;
@@ -493,7 +493,7 @@ namespace Microsoft.Dafny {
       using (var wRtd = wr.NewBlock(")")) {
         using (var wClass = wRtd.NewBlock("return class", ";")) {
           using (var wDefault = wClass.NewBlock("static get Default()")) {
-            var arguments = Util.Comma(UsedTypeParameters(dt), tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, false, true));
+            var arguments = Util.Comma(UsedTypeParameters(dt), tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
             wDefault.WriteLine($"return {DtT_protected}.Default({arguments});");
           }
         }
@@ -948,7 +948,7 @@ namespace Microsoft.Dafny {
         var dt = (DatatypeDecl)cl;
         var s = dt is TupleTypeDecl ? "_dafny.Tuple" : FullTypeName(udt);
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs).ConvertAll(ta => ta.Actual);
-        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, arg => DefaultValue(arg, wr, tok, false, constructTypeParameterDefaultsFromTypeDescriptors))})");
+        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, arg => DefaultValue(arg, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})");
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }
@@ -1187,7 +1187,7 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitNewArray(Type elmtType, Bpl.IToken tok, List<Expression> dimensions, bool mustInitialize, TargetWriter wr) {
-      var initValue = mustInitialize ? DefaultValue(elmtType, wr, tok, false, true) : null;
+      var initValue = mustInitialize ? DefaultValue(elmtType, wr, tok, true) : null;
       if (dimensions.Count == 1) {
         // handle the common case of 1-dimensional arrays separately
         wr.Write("Array(");

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -860,7 +860,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+    public override string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool inAutoInitContext, bool constructTypeParameterDefaultsFromTypeDescriptors) {
       var xType = type.NormalizeExpandKeepConstraints();
 
       if (inAutoInitContext) {

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -1445,7 +1445,7 @@ namespace Microsoft.Dafny {
             var cfType = Resolver.SubstType(cf.Type, c.ParentFormalTypeParametersToActuals);
             if (cf.Rhs == null) {
               Contract.Assert(!cf.IsStatic); // as checked above, only instance members can be inherited
-              classWriter.DeclareField("_" + cf.CompileName, c, false, false, cfType, cf.tok, DefaultValue(cfType, errorWr, cf.tok, true, true), cf);
+              classWriter.DeclareField("_" + cf.CompileName, c, false, false, cfType, cf.tok, PlaceboValue(cfType, errorWr, cf.tok, true), cf);
             }
             var w = CreateFunctionOrGetter(cf, IdName(cf), c, false, true, true, classWriter);
             Contract.Assert(w != null);  // since the previous line asked for a body
@@ -1461,7 +1461,7 @@ namespace Microsoft.Dafny {
           } else if (member is Field f) {
             var fType = Resolver.SubstType(f.Type, c.ParentFormalTypeParametersToActuals);
             // every field is inherited
-            classWriter.DeclareField("_" + f.CompileName, c, false, false, fType, f.tok, DefaultValue(fType, errorWr, f.tok, true, true), f);
+            classWriter.DeclareField("_" + f.CompileName, c, false, false, fType, f.tok, PlaceboValue(fType, errorWr, f.tok, true), f);
             TargetWriter wSet;
             var wGet = classWriter.CreateGetterSetter(IdName(f), f.Type, f.tok, false, true, member, out wSet, true);
             {
@@ -1518,7 +1518,7 @@ namespace Microsoft.Dafny {
               if (cf.Rhs != null) {
                 CompileReturnBody(cf.Rhs, f.Type, wBody, null);
               } else {
-                EmitReturnExpr(DefaultValue(cf.Type, wBody, cf.tok, true, true), wBody);
+                EmitReturnExpr(PlaceboValue(cf.Type, wBody, cf.tok, true), wBody);
               }
             } else {
               BlockTargetWriter wBody;
@@ -1542,7 +1542,7 @@ namespace Microsoft.Dafny {
                 Contract.Assert(wBody == null);  // since the previous line said not to create a body
               } else if (cf.Rhs == null && c is ClassDecl) {
                 // create a backing field, since this constant field may be assigned in constructors
-                classWriter.DeclareField("_" + f.CompileName, c, false, false, f.Type, f.tok, DefaultValue(f.Type, errorWr, f.tok, true, true), f);
+                classWriter.DeclareField("_" + f.CompileName, c, false, false, f.Type, f.tok, PlaceboValue(f.Type, errorWr, f.tok, true), f);
                 wBody = CreateFunctionOrGetter(cf, IdName(cf), c, false, true, false, classWriter);
                 Contract.Assert(wBody != null);  // since the previous line asked for a body
               } else {
@@ -1560,7 +1560,7 @@ namespace Microsoft.Dafny {
                   EmitMemberSelect(EmitThis, UserDefinedType.FromTopLevelDecl(c.tok, c), cf,
                     typeArgs, typeSubst, f.Type, internalAccess: true).EmitRead(sw);
                 } else {
-                  EmitReturnExpr(DefaultValue(cf.Type, wBody, cf.tok, true, true), wBody);
+                  EmitReturnExpr(PlaceboValue(cf.Type, wBody, cf.tok, true), wBody);
                 }
               }
             }
@@ -1569,7 +1569,7 @@ namespace Microsoft.Dafny {
             var wGet = classWriter.CreateGetterSetter(IdName(f), f.Type, f.tok, f.IsStatic, false, member, out wSet, false);
             Contract.Assert(wSet == null && wGet == null);  // since the previous line specified no body
           } else {
-            var rhs = c is TraitDecl ? null : DefaultValue(f.Type, errorWr, f.tok, true, true);
+            var rhs = c is TraitDecl ? null : PlaceboValue(f.Type, errorWr, f.tok, true);
             classWriter.DeclareField(IdName(f), c, f.IsStatic, false, f.Type, f.tok, rhs, f);
           }
           if (f is ConstantField && ((ConstantField)f).Rhs != null) {
@@ -2057,7 +2057,7 @@ namespace Microsoft.Dafny {
         var useReturnStyleOuts = UseReturnStyleOuts(m, nonGhostOutsCount);
         foreach (var p in m.Outs) {
           if (!p.IsGhost) {
-            DeclareLocalOutVar(IdName(p), p.Type, p.tok, DefaultValue(p.Type, w, p.tok, true, true), useReturnStyleOuts, w);
+            DeclareLocalOutVar(IdName(p), p.Type, p.tok, PlaceboValue(p.Type, w, p.tok, true), useReturnStyleOuts, w);
           }
         }
 
@@ -2439,6 +2439,19 @@ namespace Microsoft.Dafny {
       string dv;
       TypeInitialization(type, null, null, null, out hs, out hz, out ik, out dv);
       return ik;
+    }
+
+    protected string PlaceboValue(Type type, TextWriter wr, Bpl.IToken tok, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+      Contract.Requires(type != null);
+      Contract.Requires(wr != null);
+      Contract.Requires(tok != null);
+      Contract.Ensures(Contract.Result<string>() != null);
+
+      bool valueSkeletonOnly = !InitializerIsKnown(type);
+      bool hs, hz, ik;
+      string dv;
+      TypeInitialization(type, this, wr, tok, out hs, out hz, out ik, out dv, valueSkeletonOnly, constructTypeParameterDefaultsFromTypeDescriptors);
+      return dv;
     }
 
     protected string DefaultValue(Type type, TextWriter wr, Bpl.IToken tok, bool inAutoInitContext = false, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Dafny {
     protected virtual string TypeArgumentName(Type type, TextWriter wr, Bpl.IToken tok) {
       return TypeName(type, wr, tok);
     }
-    public abstract string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool valueSkeletonOnly, bool constructTypeParameterDefaultsFromTypeDescriptors);
+    public abstract string TypeInitializationValue(Type type, TextWriter wr /*?*/, Bpl.IToken tok /*?*/, bool usePlaceboValue, bool constructTypeParameterDefaultsFromTypeDescriptors);
 
     protected string TypeName_UDT(string fullCompileName, UserDefinedType udt, TextWriter wr, Bpl.IToken tok) {
       Contract.Requires(fullCompileName != null);
@@ -2447,10 +2447,10 @@ namespace Microsoft.Dafny {
       Contract.Requires(tok != null);
       Contract.Ensures(Contract.Result<string>() != null);
 
-      bool valueSkeletonOnly = !InitializerIsKnown(type);
+      bool usePlaceboValue = !InitializerIsKnown(type);
       bool hs, hz, ik;
       string dv;
-      TypeInitialization(type, this, wr, tok, out hs, out hz, out ik, out dv, valueSkeletonOnly, constructTypeParameterDefaultsFromTypeDescriptors);
+      TypeInitialization(type, this, wr, tok, out hs, out hz, out ik, out dv, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
       return dv;
     }
 
@@ -2476,14 +2476,14 @@ namespace Microsoft.Dafny {
     ///   defaultValue - If "compiler" is non-null, "defaultValue" is the C# representation of one possible value of the
     ///                  type (not necessarily the same value as the zero initializer, if any, may give).
     ///                  If "compiler" is null, then "defaultValue" can return as anything.
-    ///   valueSkeletonOnly - If "true", the default value produced is one that the target language accepts as a value
+    ///   usePlaceboValue - If "true", the default value produced is one that the target language accepts as a value
     ///                  of the type, but which may not correspond to a Dafny value. This option is used when it is known
-    ///                  that the Dafny program will not use the value (for example, when a field is automatically nitialized
+    ///                  that the Dafny program will not use the value (for example, when a field is automatically initialized
     ///                  but the Dafny program will soon assign a new value)
     /// </summary>
     static void TypeInitialization(Type type, Compiler/*?*/ compiler, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok,
         out bool hasSimpleZeroInitializer, out bool hasZeroInitializer, out bool initializerIsKnown, out string defaultValue,
-        bool valueSkeletonOnly = false, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+        bool usePlaceboValue = false, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
       Contract.Requires(type != null);
       Contract.Requires(compiler == null || (wr != null && tok != null));
       Contract.Ensures(!Contract.ValueAtReturn(out hasSimpleZeroInitializer) || Contract.ValueAtReturn(out hasZeroInitializer));  // hasSimpleZeroInitializer ==> hasZeroInitializer
@@ -2496,7 +2496,7 @@ namespace Microsoft.Dafny {
         xType = new BoolType();
       }
 
-      defaultValue = compiler?.TypeInitializationValue(xType, wr, tok, valueSkeletonOnly, constructTypeParameterDefaultsFromTypeDescriptors);
+      defaultValue = compiler?.TypeInitializationValue(xType, wr, tok, usePlaceboValue, constructTypeParameterDefaultsFromTypeDescriptors);
       if (xType is BoolType) {
         hasSimpleZeroInitializer = true;
         hasZeroInitializer = true;

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -2454,16 +2454,15 @@ namespace Microsoft.Dafny {
       return dv;
     }
 
-    protected string DefaultValue(Type type, TextWriter wr, Bpl.IToken tok, bool inAutoInitContext = false, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
+    protected string DefaultValue(Type type, TextWriter wr, Bpl.IToken tok, bool constructTypeParameterDefaultsFromTypeDescriptors = false) {
       Contract.Requires(type != null);
       Contract.Requires(wr != null);
       Contract.Requires(tok != null);
       Contract.Ensures(Contract.Result<string>() != null);
 
-      bool valueSkeletonOnly = inAutoInitContext && !InitializerIsKnown(type);
       bool hs, hz, ik;
       string dv;
-      TypeInitialization(type, this, wr, tok, out hs, out hz, out ik, out dv, valueSkeletonOnly, constructTypeParameterDefaultsFromTypeDescriptors);
+      TypeInitialization(type, this, wr, tok, out hs, out hz, out ik, out dv, false, constructTypeParameterDefaultsFromTypeDescriptors);
       return dv;
     }
 
@@ -4136,7 +4135,7 @@ namespace Microsoft.Dafny {
         // only emit non-ghosts (we get here only for local variables introduced implicitly by call statements)
         return;
       }
-      DeclareLocalVar(IdName(v), v.Type, v.Tok, false, alwaysInitialize ? DefaultValue(v.Type, wr, v.Tok, false, true) : null, wr);
+      DeclareLocalVar(IdName(v), v.Type, v.Tok, false, alwaysInitialize ? DefaultValue(v.Type, wr, v.Tok, true) : null, wr);
     }
 
     TargetWriter MatchCasePrelude(string source, UserDefinedType sourceType, DatatypeCtor ctor, List<BoundVar> arguments, int caseIndex, int caseCount, TargetWriter wr) {
@@ -4541,7 +4540,7 @@ namespace Microsoft.Dafny {
           } else {
             var w = CreateIIFE1(0, e.Body.Type, e.Body.tok, "_let_dummy_" + GetUniqueAstNumber(e), wr);
             foreach (var bv in e.BoundVars) {
-              DeclareLocalVar(IdName(bv), bv.Type, bv.tok, false, DefaultValue(bv.Type, wr, bv.tok, false, true), w);
+              DeclareLocalVar(IdName(bv), bv.Type, bv.tok, false, DefaultValue(bv.Type, wr, bv.tok, true), w);
             }
             TrAssignSuchThat(new List<IVariable>(e.BoundVars).ConvertAll(bv => (IVariable)bv), e.RHSs[0], e.Constraint_Bounds, e.tok.line, w, inLetExprBody);
             EmitReturnExpr(e.Body, e.Body.Type, true, w);

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Dafny {
     protected virtual string TypeArgumentName(Type type, TextWriter wr, Bpl.IToken tok) {
       return TypeName(type, wr, tok);
     }
-    public abstract string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool valueSkeletonOnly, bool constructTypeParameterDefaultsFromTypeDescriptors = false);
+    public abstract string TypeInitializationValue(Type type, TextWriter/*?*/ wr, Bpl.IToken/*?*/ tok, bool valueSkeletonOnly, bool constructTypeParameterDefaultsFromTypeDescriptors);
 
     protected string TypeName_UDT(string fullCompileName, UserDefinedType udt, TextWriter wr, Bpl.IToken tok) {
       Contract.Requires(fullCompileName != null);

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1853,7 +1853,6 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
      IToken bodyStart = Token.NoToken;
      IToken bodyEnd = Token.NoToken;
      IToken signatureEllipsis = null;
-     bool missingOpenParen;
      bool isTwoState = false;
      ExtremePredicate.KType kType = ExtremePredicate.KType.Unspecified;
   .)
@@ -1914,8 +1913,8 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
     { Attribute<ref attrs> }
     NoUSIdent<out id>
     (
-      [ GenericParameters<typeArgs, false> ]                 (. missingOpenParen = true; .)
-      [ Formals<true, isFunctionMethod, isTwoState, formals> (. missingOpenParen = false; .)
+      [ GenericParameters<typeArgs, false> ]
+      [ Formals<true, isFunctionMethod, isTwoState, formals>
       ]
       [ ":"                    (. SemErr(t, "predicates do not have an explicitly declared return type; it is always bool"); .)
       ]

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -4422,12 +4422,19 @@ namespace Microsoft.Dafny {
       get { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
       set { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
     }
+
+    public abstract DatatypeCtor GetGroundingCtor();
   }
 
   public class IndDatatypeDecl : DatatypeDecl, RevealableTypeDecl
   {
     public override string WhatKind { get { return "datatype"; } }
     public DatatypeCtor GroundingCtor;  // set during resolution
+
+    public override DatatypeCtor GetGroundingCtor() {
+      return GroundingCtor;
+    }
+
     public bool[] TypeParametersUsedInConstructionByGroundingCtor;  // set during resolution; has same length as the number of type arguments
 
     public enum ES { NotYetComputed, Never, ConsultTypeArguments }
@@ -4525,6 +4532,10 @@ namespace Microsoft.Dafny {
       Contract.Requires(cce.NonNullElements(ctors));
       Contract.Requires(cce.NonNullElements(members));
       Contract.Requires(1 <= ctors.Count);
+    }
+
+    public override DatatypeCtor GetGroundingCtor() {
+      return Ctors[0];
     }
   }
 

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/Tuple2.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/Tuple2.java
@@ -9,12 +9,17 @@ public class Tuple2<T0, T1> {
     this._0 = _0;
     this._1 = _1;
   }
-  public static <T0, T1> dafny.TypeDescriptor<Tuple2<T0, T1> > _typeDescriptor(dafny.TypeDescriptor<T0> _td_T0, dafny.TypeDescriptor<T1> _td_T1) {
-    return (dafny.TypeDescriptor<Tuple2<T0, T1> >) (dafny.TypeDescriptor<?>) dafny.TypeDescriptor.referenceWithInitializer(Tuple2.class, () -> Default(_td_T0, _td_T1));
+
+  public static <T0, T1> dafny.TypeDescriptor<Tuple2<T0, T1>> _typeDescriptor(dafny.TypeDescriptor<T0> _td_T0, dafny.TypeDescriptor<T1> _td_T1) {
+    return (dafny.TypeDescriptor<Tuple2<T0, T1>>) (dafny.TypeDescriptor<?>) dafny.TypeDescriptor.referenceWithInitializer(Tuple2.class, () -> Default(_td_T0.defaultValue(), _td_T1.defaultValue()));
   }
 
-  public static <T0, T1> Tuple2<T0, T1> Default(dafny.TypeDescriptor<T0> _td_T0, dafny.TypeDescriptor<T1> _td_T1) {
-    return new Tuple2<>(_td_T0.defaultValue(), _td_T1.defaultValue());
+  public static <T0, T1> Tuple2<T0, T1> Default(T0 _default_T0, T1 _default_T1) {
+    return create(_default_T0, _default_T1);
+  }
+
+  public static <T0, T1> Tuple2<T0, T1> create(T0 _0, T1 _1) {
+    return new Tuple2(_0, _1);
   }
 
   @Override

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/Tuple3.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/Tuple3.java
@@ -11,12 +11,17 @@ public class Tuple3<T0, T1, T2> {
     this._1 = _1;
     this._2 = _2;
   }
-  public static <T0, T1, T2> dafny.TypeDescriptor<Tuple3<T0, T1, T2> > _typeDescriptor(dafny.TypeDescriptor<T0> _td_T0, dafny.TypeDescriptor<T1> _td_T1, dafny.TypeDescriptor<T2> _td_T2) {
-    return (dafny.TypeDescriptor<Tuple3<T0, T1, T2> >) (dafny.TypeDescriptor<?>) dafny.TypeDescriptor.referenceWithInitializer(Tuple3.class, () -> Default(_td_T0, _td_T1, _td_T2));
+
+  public static <T0, T1, T2> dafny.TypeDescriptor<Tuple3<T0, T1, T2>> _typeDescriptor(dafny.TypeDescriptor<T0> _td_T0, dafny.TypeDescriptor<T1> _td_T1, dafny.TypeDescriptor<T2> _td_T2) {
+    return (dafny.TypeDescriptor<Tuple3<T0, T1, T2>>) (dafny.TypeDescriptor<?>) dafny.TypeDescriptor.referenceWithInitializer(Tuple3.class, () -> Default(_td_T0.defaultValue(), _td_T1.defaultValue(), _td_T2.defaultValue()));
   }
 
-  public static <T0, T1, T2> Tuple3<T0, T1, T2> Default(dafny.TypeDescriptor<T0> _td_T0, dafny.TypeDescriptor<T1> _td_T1, dafny.TypeDescriptor<T2> _td_T2) {
-    return new Tuple3<>(_td_T0.defaultValue(), _td_T1.defaultValue(), _td_T2.defaultValue());
+  public static <T0, T1, T2> Tuple3<T0, T1, T2> Default(T0 _default_T0, T1 _default_T1, T2 _default_T2) {
+    return create(_default_T0, _default_T1, _default_T2);
+  }
+
+  public static <T0, T1, T2> Tuple3<T0, T1, T2> create(T0 _0, T1 _1, T2 _2) {
+    return new Tuple3(_0, _1, _2);
   }
 
   @Override

--- a/Test/comp/AutoInit.dfy
+++ b/Test/comp/AutoInit.dfy
@@ -66,6 +66,7 @@ method Main() {
   Arrows();
   NilRegression.Test();
   DatatypeDefaultValues.Test();
+  ImportedTypes.Test();
 }
 
 datatype ThisOrThat<A,B> = This(A) | Or | That(B)
@@ -257,5 +258,32 @@ module DatatypeDefaultValues {
     var g: Difficult;
     var h: GenDifficult<int>;
     print g, "\n  ", h, "\n";
+  }
+}
+
+module ImportedTypes {
+  module Library {
+    datatype Color = Red(int) | Green(real) | Blue(bv30)
+    codatatype CoColor = Yellow(int)
+    codatatype MoColor = MoYellow(int, MoColor)
+    newtype Nt = r | -1.0 <= r <= 1.0
+  }
+
+  method Test() {
+    var c: Library.Color;
+    Try(c);
+    /** TODO: include these tests once the new (0) semantics allows them
+    var co: Library.CoColor;
+    Try(co);
+    var mo: Library.MoColor;
+    Try(mo);
+    **/
+    var nt: Library.Nt;
+    Try(nt);
+  }
+
+  method Try<A(0)>(a: A) {
+    var x: A;
+    print a, " and ", x, "\n";
   }
 }

--- a/Test/comp/AutoInit.dfy
+++ b/Test/comp/AutoInit.dfy
@@ -290,11 +290,11 @@ module ImportedTypes {
 }
 
 module GhostWitness {
-  type EffectlessArrow<!A(!new),B> = f: A ~> B
+  type EffectlessArrow<!A(!new), B> = f: A ~> B
     | forall a :: f.reads(a) == {}
-    ghost witness GhostEffectlessArrowWitness<A,B>
+    ghost witness GhostEffectlessArrowWitness<A, B>
 
-  function GhostEffectlessArrowWitness<A,B>(a: A): B
+  function GhostEffectlessArrowWitness<A, B>(a: A): B
   {
     var b: B :| true; b
   }
@@ -303,17 +303,17 @@ module GhostWitness {
 
   class MyClass { }
 
-  predicate Total<A(!new),B>(f: A ~> B)  // (is this (!new) really necessary?)
+  predicate Total<A(!new), B>(f: A ~> B)  // (is this (!new) really necessary?)
     reads f.reads
   {
     forall a :: f.reads(a) == {} && f.requires(a)
   }
 
-  type TotalArrow<!A,B> = f: EffectlessArrow<A,B>
+  type TotalArrow<!A(!new), B> = f: EffectlessArrow<A, B>
     | Total(f)
-    ghost witness TotalWitness<A,B>
+    ghost witness TotalWitness<A, B>
 
-  function TotalWitness<A,B>(a: A): B
+  function TotalWitness<A, B>(a: A): B
   {
     var b: B :| true; b
   }

--- a/Test/comp/AutoInit.dfy.expect
+++ b/Test/comp/AutoInit.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 16 verified, 0 errors
+Dafny program verifier finished with 22 verified, 0 errors
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -36,6 +36,7 @@ DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
 ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
 0.0 and 0.0
+13
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -72,6 +73,7 @@ DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
 ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
 0.0 and 0.0
+13
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -108,6 +110,7 @@ DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
 ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
 0.0 and 0.0
+13
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -144,3 +147,4 @@ DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
 ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
 0.0 and 0.0
+13

--- a/Test/comp/AutoInit.dfy.expect
+++ b/Test/comp/AutoInit.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 14 verified, 0 errors
+Dafny program verifier finished with 16 verified, 0 errors
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -34,6 +34,8 @@ DatatypeDefaultValues_Compile.GenericTree.Leaf
   DatatypeDefaultValues_Compile.CellCell.MakeCellCell(DatatypeDefaultValues_Compile.Cell.MakeCell(0))
 DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
+ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
+0.0 and 0.0
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -68,6 +70,8 @@ DatatypeDefaultValues_Compile.GenericTree.Leaf
   DatatypeDefaultValues_Compile.CellCell.MakeCellCell(DatatypeDefaultValues_Compile.Cell.MakeCell(0))
 DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
+ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
+0.0 and 0.0
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -102,6 +106,8 @@ DatatypeDefaultValues_Compile.GenericTree.Leaf
   DatatypeDefaultValues_Compile.CellCell.MakeCellCell(DatatypeDefaultValues_Compile.Cell.MakeCell(0))
 DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
+ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
+0.0 and 0.0
 
 Dafny program verifier did not attempt verification
 3 false 0
@@ -136,3 +142,5 @@ DatatypeDefaultValues_Compile.GenericTree.Leaf
   DatatypeDefaultValues_Compile.CellCell.MakeCellCell(DatatypeDefaultValues_Compile.Cell.MakeCell(0))
 DatatypeDefaultValues_Compile.Difficult.MakeDifficult(null)
   DatatypeDefaultValues_Compile.GenDifficult.MakeGenDifficult(null)
+ImportedTypes_mLibrary_Compile.Color.Red(0) and ImportedTypes_mLibrary_Compile.Color.Red(0)
+0.0 and 0.0

--- a/docs/Compilation/AutoInitialization.md
+++ b/docs/Compilation/AutoInitialization.md
@@ -138,8 +138,7 @@ type `char`. In fact, the compiler is free to emit code that chooses a different
 initial value each time this program snippet is encountered at run time. In other words,
 the language allows the selection of the values to be nondeterministic.
 
-The purpose of this document is to describe how the compiler (in particular, the
-Dafny-to-C# compiler in `Compiler-CSharp.cs`, though the other targets are similar) implements
+The purpose of this document is to describe how the common compilers implement
 the auto-init feature. It will be convenient (and, for this particular compiler, accurate)
 to speak of each type as having a _default value_. However, please note that this
 terminology is specific to an implementation of a compiler--the Dafny _language_ itself


### PR DESCRIPTION
Previously, the `Default` method in the C# target code for a `datatype` took default (sub-)values as parameters, whereas the other compilers took type descriptors as parameters. This PR changes the other compilers to also pass default values, like the C# compiler had done. This PR also introduces `create_Ctor` methods for `datatype` constructors in Java, which previously had been omitted. All in all, this PR thus makes the compilation of defaults and auto-initialization more uniform across the compilers.