### PR TITLE
fix: Distinguish abstractly imported types only via their type family

### DIFF
--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -78,6 +78,9 @@ axiom (forall t: Ty    :: { TSeq(t) }      Tag(TSeq(t))      == TagSeq);
 axiom (forall t, u: Ty :: { TMap(t,u) }    Tag(TMap(t,u))    == TagMap);
 axiom (forall t, u: Ty :: { TIMap(t,u) }   Tag(TIMap(t,u))   == TagIMap);
 
+type TyTagFamily;
+function TagFamily(Ty): TyTagFamily;
+
 // ---------------------------------------------------------------
 // -- Literals ---------------------------------------------------
 // ---------------------------------------------------------------

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1116,7 +1116,7 @@ DatatypeDecl<DeclModifierData dmod, ModuleDefinition/*!*/ module, out DatatypeDe
      List<DatatypeCtor/*!*/> ctors = new List<DatatypeCtor/*!*/>();
      IToken bodyStart = Token.NoToken;  // dummy assignment
      bool co = false;
-     CheckDeclModifiers(dmod, "datatypes or codatatype", AllowedDeclModifiers.None);
+     CheckDeclModifiers(dmod, "datatype or codatatype", AllowedDeclModifiers.None);
      var members = new List<MemberDecl>();
   .)
   SYNC

--- a/Test/git-issues/git-issue-952.dfy
+++ b/Test/git-issues/git-issue-952.dfy
@@ -1,0 +1,140 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  class Cell {
+    var data: int
+    constructor (data: int) {
+      this.data := data;
+    }
+  }
+
+  class Bell {
+    var data: int
+    constructor (data: int) {
+      this.data := data;
+    }
+  }
+}
+
+abstract module Abstract {
+  // Here are two abstract imports
+  import X: A
+  import Y: A
+  import AA = A
+
+  class Cell {  // local Cell
+    var data: int
+  }
+
+  // X.Cell and Y.Cell may denote the same type
+  method M0(x: X.Cell, y: Y.Cell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // error
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // error
+    }
+  }
+
+  // X.Cell and X.Bell are known to be different
+  method M1(x: X.Cell, y: X.Bell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // fine
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // fine
+    }
+  }
+
+  // X.Cell and Y.Bell are known to be different
+  method M2(x: X.Cell, y: Y.Bell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // fine
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // fine
+    }
+  }
+
+  // X.Cell and AA.Cell may refer to the same type
+  method M3(x: X.Cell, y: AA.Cell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // error
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // error
+    }
+  }
+
+  // X.Bell and AA.Cell are known to be different
+  method M4(x: X.Bell, y: AA.Cell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // fine
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // fine
+    }
+  }
+
+  // X.Cell and Cell always denote different types, because there's no way to
+  // concretize Abstract.X with Abstract. However, these kinds of
+  // cannot-be-concretized-by relations are not encoded in the verifier, so
+  // the verifier generates spurious errors in this method. A workaround is
+  // to name the local class Cell something else; for example, see module
+  // Abstract' below.
+  method M5(x: X.Cell, y: Cell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // error
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // error
+    }
+  }
+}
+
+// This module just goes to show that Abstract's X and Y can indeed be concretized
+// to be the same module.
+module Same refines Abstract {
+  import X = A
+  import Y = A
+}
+
+abstract module Abstract' {
+  // Here are two abstract imports
+  import X: A
+  import Y: A
+
+  // Here, the local class is named Cell', so it couldn't possibly be the same
+  // as the class X.Cell. Even with the local type synonym Cell, the verifier
+  // does not flinch.
+  type Cell = Cell'
+  class Cell' {
+    var data: int
+  }
+
+  // See comment in Abstract.M5 above. Here, X.Cell and Cell are not
+  // to be different (because X.Cell and Cell' are known to be different).
+  method M5(x: X.Cell, y: Cell)
+    modifies x
+  {
+    if * {
+      assert x != var o: object := y; o;  // fine
+    } else {
+      x.data := x.data + 1;
+      assert y.data == old(y.data);  // fine
+    }
+  }
+}

--- a/Test/git-issues/git-issue-952.dfy
+++ b/Test/git-issues/git-issue-952.dfy
@@ -125,7 +125,7 @@ abstract module Abstract' {
     var data: int
   }
 
-  // See comment in Abstract.M5 above. Here, X.Cell and Cell are not
+  // See comment in Abstract.M5 above. Here, X.Cell and Cell are known
   // to be different (because X.Cell and Cell' are known to be different).
   method M5(x: X.Cell, y: Cell)
     modifies x

--- a/Test/git-issues/git-issue-952.dfy.expect
+++ b/Test/git-issues/git-issue-952.dfy.expect
@@ -1,0 +1,26 @@
+git-issue-952.dfy(35,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+git-issue-952.dfy(38,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Else
+git-issue-952.dfy(71,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+git-issue-952.dfy(74,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Else
+git-issue-952.dfy(100,15): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+git-issue-952.dfy(103,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Else
+
+Dafny program verifier finished with 4 verified, 6 errors

--- a/docs/_includes/Modules.md
+++ b/docs/_includes/Modules.md
@@ -105,9 +105,8 @@ of a single implicit unnamed global module.
 ````grammar
 ModuleImport_ = "import" ["opened" ] ModuleName
     [ "=" QualifiedModuleName
-    | "as" QualifiedModuleName ["default" QualifiedModuleName ]
+    | ":" QualifiedModuleName
     ]
-    [ ";" ]
 ````
 
 Sometimes you want to refer to


### PR DESCRIPTION
Fixes #952 

A reference type `X.C` obtained via an abstract import `import X : A` is different from a reference type with a name different than `C`, but it may refer to the a type `C` in some other module. Previously, the verifier treated `X.C` as definitely being different than other reference types, which this PR fixes. Interestingly, the verifier has since the introduction of abstract imports (~9 years ago) had proper verification support for the analogous problem of aliasing field names.