### PR TITLE
Confirm cyclic-dependency fix and correct Java name issues

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1678,8 +1678,8 @@ namespace Microsoft.Dafny{
       var DtT_TypeArgs = TypeParameters(dt.TypeArgs);
       var justTypeArgs = dt.TypeArgs.Count == 0 ? "" : " " + DtT_TypeArgs;
       var DtT_protected = IdName(dt) + DtT_TypeArgs;
-      var filename = $"{ModulePath}/{dt}.java";
-      wr = wr.NewFile(filename);
+      var filename = $"{ModulePath}/{IdName(dt)}.java";
+       wr = wr.NewFile(filename);
       FileCount += 1;
       wr.WriteLine($"// Class {DtT_protected}");
       wr.WriteLine($"// Dafny class {DtT_protected} compiled into Java");
@@ -2520,7 +2520,7 @@ namespace Microsoft.Dafny{
     }
 
     void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, List<Type>/*?*/ typeArgs, bool isCoCall, string arguments, TargetWriter wr) {
-      var dtName = dt is TupleTypeDecl tupleDecl ? DafnyTupleClass(tupleDecl.TypeArgs.Count) : dt.CompileName;
+      var dtName = dt is TupleTypeDecl tupleDecl ? DafnyTupleClass(tupleDecl.TypeArgs.Count) : dt.FullCompileName;
       var typeParams = typeArgs == null || typeArgs.Count == 0 ? "" : $"<{BoxedTypeNames(typeArgs, wr, dt.tok)}>";
       if (!isCoCall) {
         // For an ordinary constructor (that is, one that does not guard any co-recursive calls), generate:
@@ -3089,7 +3089,7 @@ namespace Microsoft.Dafny{
     }
 
     protected override IClassWriter CreateTrait(string name, bool isExtern, List<TypeParameter>/*?*/ typeParameters, List<Type> superClasses, Bpl.IToken tok, TargetWriter wr) {
-      var filename = $"{ModulePath}/{name}.java";
+      var filename = $"{ModulePath}/{IdProtect(name)}.java";
       var w = wr.NewFile(filename);
       FileCount += 1;
       w.WriteLine($"// Interface {name}");

--- a/Test/git-issues/git-issue-953.dfy
+++ b/Test/git-issues/git-issue-953.dfy
@@ -1,0 +1,48 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module P {
+  datatype T_ = T()  // the underscore in this name once caused a problem in Java compilation
+  type T = t:T_ | true ghost witness T()
+}
+
+module C refines P {
+  datatype C = C(t: T)  // this had once caused a bogus error about cyclic dependencies
+}
+
+module OtherNamesWithSpecialCharacters?_ {
+  datatype A?_ = A?_
+  codatatype B?_ = B?_
+  trait Tr?_ { var data: int }
+  class Cl?_ extends Tr?_ { }
+  type Threes?_ = x: int | x % 3 == 0
+  newtype Fives?_ = x: int | x % 5 == 0
+
+  method Test() {
+    var a: A?_;
+    var b: B?_ := B?_;
+    print a, " ", b, "\n";
+
+    var c: Cl?_ := new Cl?_;
+    var t: Tr?_ := c;
+    c.data := 17;
+    var x3: Threes?_;
+    var x5: Fives?_;
+    print c.data, " ", t.data, " ", x3, " ", x5, "\n";
+  }
+}
+
+method Main() {
+  var t: C.T := C.T;  // this had once caused malformed Java, because of a missing qualified name
+  var c := C.C(t);
+  print c, "\n";
+
+  var pt: P.T := P.T;
+  print pt, "\n";
+
+  OtherNamesWithSpecialCharacters?_.Test();
+}

--- a/Test/git-issues/git-issue-953.dfy.expect
+++ b/Test/git-issues/git-issue-953.dfy.expect
@@ -1,0 +1,26 @@
+
+Dafny program verifier finished with 5 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+C_Compile.C.C(C_Compile.T_.T)
+P_Compile.T_.T
+OtherNamesWithSpecialCharacters_q___Compile.A?_.A?_ OtherNamesWithSpecialCharacters_q___Compile.B?_.B?_
+17 17 0 0
+
+Dafny program verifier did not attempt verification
+C_Compile.C.C(C_Compile.T_.T)
+P_Compile.T_.T
+OtherNamesWithSpecialCharacters_q___Compile.A?_.A?_ OtherNamesWithSpecialCharacters_q___Compile.B?_.B?_
+17 17 0 0
+
+Dafny program verifier did not attempt verification
+C_Compile.C.C(C_Compile.T_.T)
+P_Compile.T_.T
+OtherNamesWithSpecialCharacters_q___Compile.A?_.A?_ OtherNamesWithSpecialCharacters_q___Compile.B?_.B?_
+17 17 0 0
+
+Dafny program verifier did not attempt verification
+C_Compile.C.C(C_Compile.T_.T)
+P_Compile.T_.T
+OtherNamesWithSpecialCharacters_q___Compile.A?_.A?_ OtherNamesWithSpecialCharacters_q___Compile.B?_.B?_
+17 17 0 0


### PR DESCRIPTION
This PR confirms that Issue 953 has been fixed. In doing so, some bugs in the generation of filenames and qualified names in the Java compiler were detected; this PR fixes them.

Closes #953 
