### PR TITLE
feat!: Stop supporting "protected" keyword

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Dafny
       if (m is DefaultModuleDecl) {
         nw = new DefaultModuleDecl();
       } else {
-        nw = new ModuleDefinition(Tok(m.tok), name, m.PrefixIds, m.IsAbstract, m.IsProtected, m.IsFacade, m.RefinementBaseName, m.Module, CloneAttributes(m.Attributes),
+        nw = new ModuleDefinition(Tok(m.tok), name, m.PrefixIds, m.IsAbstract, m.IsFacade, m.RefinementBaseName, m.Module, CloneAttributes(m.Attributes),
                                   true, m.IsToBeVerified, m.IsToBeCompiled);
       }
       foreach (var d in m.TopLevelDecls) {
@@ -755,13 +755,13 @@ namespace Microsoft.Dafny
       }
 
       if (f is Predicate) {
-        return new Predicate(Tok(f.tok), newName, f.HasStaticKeyword, f.IsProtected, f.IsGhost, tps, formals,
+        return new Predicate(Tok(f.tok), newName, f.HasStaticKeyword, f.IsGhost, tps, formals,
           req, reads, ens, decreases, body, Predicate.BodyOriginKind.OriginalOrInherited, CloneAttributes(f.Attributes), null);
       } else if (f is LeastPredicate) {
-        return new LeastPredicate(Tok(f.tok), newName, f.HasStaticKeyword, f.IsProtected, ((LeastPredicate)f).TypeOfK, tps, formals,
+        return new LeastPredicate(Tok(f.tok), newName, f.HasStaticKeyword, ((LeastPredicate)f).TypeOfK, tps, formals,
           req, reads, ens, body, CloneAttributes(f.Attributes), null);
       } else if (f is GreatestPredicate) {
-        return new GreatestPredicate(Tok(f.tok), newName, f.HasStaticKeyword, f.IsProtected, ((GreatestPredicate)f).TypeOfK, tps, formals,
+        return new GreatestPredicate(Tok(f.tok), newName, f.HasStaticKeyword, ((GreatestPredicate)f).TypeOfK, tps, formals,
           req, reads, ens, body, CloneAttributes(f.Attributes), null);
       } else if (f is TwoStatePredicate) {
         return new TwoStatePredicate(Tok(f.tok), newName, f.HasStaticKeyword, tps, formals,
@@ -770,7 +770,7 @@ namespace Microsoft.Dafny
         return new TwoStateFunction(Tok(f.tok), newName, f.HasStaticKeyword, tps, formals, f.Result == null ? null : CloneFormal(f.Result), CloneType(f.ResultType),
           req, reads, ens, decreases, body, CloneAttributes(f.Attributes), null);
       } else {
-        return new Function(Tok(f.tok), newName, f.HasStaticKeyword, f.IsProtected, f.IsGhost, tps, formals, f.Result == null ? null : CloneFormal(f.Result), CloneType(f.ResultType),
+        return new Function(Tok(f.tok), newName, f.HasStaticKeyword, f.IsGhost, tps, formals, f.Result == null ? null : CloneFormal(f.Result), CloneType(f.ResultType),
           req, reads, ens, decreases, body, CloneAttributes(f.Attributes), null);
       }
     }

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -855,6 +855,14 @@ DeclModifier<ref DeclModifierData dmod>
 = ( "abstract"                             (. dmod.IsAbstract = true;  CheckAndSetToken(ref dmod.AbstractToken); .)
   | "ghost"                                (. dmod.IsGhost = true;  CheckAndSetToken(ref dmod.GhostToken); .)
   | "static"                               (. dmod.IsStatic = true; CheckAndSetToken(ref dmod.StaticToken); .)
+  | "protected"
+    (. errors.Deprecated(t,
+         "the 'protected' modifier is no longer supported; " +
+         "to restrict access from outside the module, use a 'provides' clause in the module's export set; " +
+         "if you're trying to add conjuncts to a predicate in a refinement module, see " +
+         "Test/dafny3/CachedContainer.dfy, Test/dafny2/StoreAndRetrieve.dfy, and Test/dafny2/MonotonicHeapstate.dfy " +
+         "in the Dafny test suite on github");
+    .)
   )
   .
 

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -41,8 +41,6 @@ struct DeclModifierData {
   public IToken GhostToken;
   public bool IsStatic;
   public IToken StaticToken;
-  public bool IsProtected;
-  public IToken ProtectedToken;
 }
 
 // Check that token has not been set, then set it.
@@ -66,7 +64,6 @@ enum AllowedDeclModifiers {
   // Means ghost not allowed because already implicitly ghost.
   AlreadyGhost = 4,
   Static = 8,
-  Protected = 16,
 };
 
 /// <summary>
@@ -96,10 +93,6 @@ void CheckDeclModifiers(DeclModifierData dmod, string declCaption, AllowedDeclMo
   if (dmod.IsStatic && ((allowed & AllowedDeclModifiers.Static) == 0)) {
     SemErr(dmod.StaticToken, $"{declCaption} cannot be declared 'static'.");
     dmod.IsStatic = false;
-  }
-  if (dmod.IsProtected && ((allowed & AllowedDeclModifiers.Protected) == 0)) {
-    SemErr(dmod.ProtectedToken, $"{declCaption} cannot be declared 'protected'.");
-    dmod.IsProtected = false;
   }
 }
 
@@ -510,7 +503,6 @@ bool IsGenericInstantiation(bool inExpressionContext) {
     case _copredicate:
     case _ghost:
     case _static:
-    case _protected:
     case _import:
     case _export:
     case _class:
@@ -777,7 +769,6 @@ TOKENS
   copredicate = "copredicate".
   lemma = "lemma".
   static = "static".
-  protected = "protected".
   import = "import".
   export = "export".
   class = "class".
@@ -864,7 +855,6 @@ DeclModifier<ref DeclModifierData dmod>
 = ( "abstract"                             (. dmod.IsAbstract = true;  CheckAndSetToken(ref dmod.AbstractToken); .)
   | "ghost"                                (. dmod.IsGhost = true;  CheckAndSetToken(ref dmod.GhostToken); .)
   | "static"                               (. dmod.IsStatic = true; CheckAndSetToken(ref dmod.StaticToken); .)
-  | "protected"                            (. dmod.IsProtected = true; CheckAndSetToken(ref dmod.ProtectedToken); .)
   )
   .
 
@@ -899,9 +889,8 @@ SubModuleDecl<DeclModifierData dmod, ModuleDefinition parent, out ModuleDecl sub
      ModuleDefinition module;
      submodule = null; // appease compiler
      bool isAbstract = dmod.IsAbstract;
-     bool isProtected = dmod.IsProtected;
      bool opened = false;
-     CheckDeclModifiers(dmod, "module", AllowedDeclModifiers.Abstract | AllowedDeclModifiers.Protected);
+     CheckDeclModifiers(dmod, "module", AllowedDeclModifiers.Abstract);
   .)
   ( "module"
     { Attribute<ref attrs> }
@@ -910,7 +899,7 @@ SubModuleDecl<DeclModifierData dmod, ModuleDefinition parent, out ModuleDecl sub
       "." NoUSIdent<out id>
     }
     [ "refines" ModuleName<out idRefined> ]
-    (. module = new ModuleDefinition(id, id.val, prefixIds, isAbstract, isProtected, false, idRefined, parent, attrs,
+    (. module = new ModuleDefinition(id, id.val, prefixIds, isAbstract, false, idRefined, parent, attrs,
                                       false, theVerifyThisFile, theCompileThisFile);
     .)
     "{"                                 (. module.BodyStartTok = t; .)
@@ -1514,14 +1503,12 @@ MethodDecl<DeclModifierData dmod, bool allowConstructor, bool isWithinAbstractMo
   ( "method"                        (. isPlainOlMethod = true; caption = "method";
                                        allowed = AllowedDeclModifiers.Ghost | AllowedDeclModifiers.Static; .)
   | "lemma"                         (. isLemma = true; caption = "lemma";
-                                       allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static
-                                         | AllowedDeclModifiers.Protected; .)
+                                       allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static; .)
   | ( "greatest" "lemma"
     | "colemma"                     (. errors.Deprecated(t, "the old keyword 'colemma' has been renamed to the keyword phrase 'greatest lemma'"); .)
     )
                                     (. isGreatestLemma = true; caption = "greatest lemma";
-                                       allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static
-                                         | AllowedDeclModifiers.Protected; .)
+                                       allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static; .)
   | ( "least"
     | "inductive"                   (. errors.Deprecated(t, "the old keyword phrase 'inductive lemma' has been renamed to 'least lemma'"); .)
     )
@@ -1529,8 +1516,7 @@ MethodDecl<DeclModifierData dmod, bool allowConstructor, bool isWithinAbstractMo
                                     (. isLeastLemma = true;  caption = "least lemma";
                                        allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static;.)
   | "twostate" "lemma"              (. isTwoStateLemma = true; caption = "two-state lemma";
-                                       allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static
-                                         | AllowedDeclModifiers.Protected; .)
+                                       allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static; .)
   | "constructor"                   (. if (allowConstructor) {
                                          isConstructor = true;
                                        } else {
@@ -1884,7 +1870,6 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
                                .)
     ]
     (. AllowedDeclModifiers allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static;
-       if (!isTwoState) { allowed |= AllowedDeclModifiers.Protected; }
        string caption = "function";
        if (isFunctionMethod) {
          caption = "function method";
@@ -1922,7 +1907,6 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
                                .)
     ]
     (. AllowedDeclModifiers allowed = AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static;
-       if (!isTwoState) { allowed |= AllowedDeclModifiers.Protected; }
        string caption = "predicate";
        if (isFunctionMethod) {
          caption = "predicate method";
@@ -1949,7 +1933,7 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
     "predicate"
     (. isLeastPredicate = true;
        CheckDeclModifiers(dmod, "least predicate",
-         AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static | AllowedDeclModifiers.Protected);
+         AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static);
     .)
     { Attribute<ref attrs> }
     FuMe_Ident<out id>
@@ -1970,7 +1954,7 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
     )
     (. isGreatestPredicate = true;
        CheckDeclModifiers(dmod, "greatest predicate",
-         AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static | AllowedDeclModifiers.Protected);
+         AllowedDeclModifiers.AlreadyGhost | AllowedDeclModifiers.Static);
     .)
     { Attribute<ref attrs> }
     NoUSIdent<out id>
@@ -2000,16 +1984,16 @@ FunctionDecl<DeclModifierData dmod, bool isWithinAbstractModule, out Function/*!
         f = new TwoStateFunction(tok, id.val, dmod.IsStatic, typeArgs, formals, result, returnType,
                                  reqs, reads, ens, new Specification<Expression>(decreases, null), body, attrs, signatureEllipsis);
      } else if (isPredicate) {
-        f = new Predicate(tok, id.val, dmod.IsStatic, dmod.IsProtected, !isFunctionMethod, typeArgs, formals,
+        f = new Predicate(tok, id.val, dmod.IsStatic, !isFunctionMethod, typeArgs, formals,
                           reqs, reads, ens, new Specification<Expression>(decreases, null), body, Predicate.BodyOriginKind.OriginalOrInherited, attrs, signatureEllipsis);
      } else if (isLeastPredicate) {
-        f = new LeastPredicate(tok, id.val, dmod.IsStatic, dmod.IsProtected, kType, typeArgs, formals,
+        f = new LeastPredicate(tok, id.val, dmod.IsStatic, kType, typeArgs, formals,
                                reqs, reads, ens, body, attrs, signatureEllipsis);
      } else if (isGreatestPredicate) {
-        f = new GreatestPredicate(tok, id.val, dmod.IsStatic, dmod.IsProtected, kType, typeArgs, formals,
+        f = new GreatestPredicate(tok, id.val, dmod.IsStatic, kType, typeArgs, formals,
                                   reqs, reads, ens, body, attrs, signatureEllipsis);
      } else {
-        f = new Function(tok, id.val, dmod.IsStatic, dmod.IsProtected, !isFunctionMethod, typeArgs, formals, result, returnType,
+        f = new Function(tok, id.val, dmod.IsStatic, !isFunctionMethod, typeArgs, formals, result, returnType,
                          reqs, reads, ens, new Specification<Expression>(decreases, null), body, attrs, signatureEllipsis);
      }
      f.BodyStartTok = bodyStart;

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Dafny {
 
   public class BuiltIns
   {
-    public readonly ModuleDefinition SystemModule = new ModuleDefinition(Token.NoToken, "_System", new List<IToken>(), false, false, false, null, null, null, true, true, true);
+    public readonly ModuleDefinition SystemModule = new ModuleDefinition(Token.NoToken, "_System", new List<IToken>(), false, false, null, null, null, true, true, true);
     readonly Dictionary<int, ClassDecl> arrayTypeDecls = new Dictionary<int, ClassDecl>();
     public readonly Dictionary<int, ArrowTypeDecl> ArrowTypeDecls = new Dictionary<int, ArrowTypeDecl>();
     public readonly Dictionary<int, SubsetTypeDecl> PartialArrowTypeDecls = new Dictionary<int, SubsetTypeDecl>();  // same keys as arrowTypeDecl
@@ -215,12 +215,12 @@ namespace Microsoft.Dafny {
           Type = new SetType(true, ObjectQ()),
         };
         var readsFrame = new List<FrameExpression> { new FrameExpression(tok, readsIS, null) };
-        var req = new Function(tok, "requires", false, false, true,
+        var req = new Function(tok, "requires", false, true,
           new List<TypeParameter>(), args, null, Type.Bool,
           new List<AttributedExpression>(), readsFrame, new List<AttributedExpression>(),
           new Specification<Expression>(new List<Expression>(), null),
           null, null, null);
-        var reads = new Function(tok, "reads", false, false, true,
+        var reads = new Function(tok, "reads", false, true,
           new List<TypeParameter>(), args, null, new SetType(true, ObjectQ()),
           new List<AttributedExpression>(), readsFrame, new List<AttributedExpression>(),
           new Specification<Expression>(new List<Expression>(), null),
@@ -3724,7 +3724,6 @@ namespace Microsoft.Dafny {
     public readonly Graph<ICallable> CallGraph = new Graph<ICallable>();  // filled in during resolution
     public int Height;  // height in the topological sorting of modules; filled in during resolution
     public readonly bool IsAbstract;
-    public readonly bool IsProtected;
     public readonly bool IsFacade; // True iff this module represents a module facade (that is, an abstract interface)
     private readonly bool IsBuiltinName; // true if this is something like _System that shouldn't have it's name mangled.
     public readonly bool IsToBeVerified;
@@ -3769,7 +3768,8 @@ namespace Microsoft.Dafny {
       Contract.Invariant(CallGraph != null);
     }
 
-    public ModuleDefinition(IToken tok, string name, List<IToken> prefixIds, bool isAbstract, bool isProtected, bool isFacade, IToken refinementBase, ModuleDefinition parent, Attributes attributes, bool isBuiltinName, bool isToBeVerified, bool isToBeCompiled)
+    public ModuleDefinition(IToken tok, string name, List<IToken> prefixIds, bool isAbstract, bool isFacade, IToken refinementBase, ModuleDefinition parent, Attributes attributes, bool isBuiltinName,
+      bool isToBeVerified, bool isToBeCompiled)
     {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
@@ -3780,7 +3780,6 @@ namespace Microsoft.Dafny {
       this.Module = parent;
       RefinementBaseName = refinementBase;
       IsAbstract = isAbstract;
-      IsProtected = isProtected;
       IsFacade = isFacade;
       RefinementBaseRoot = null;
       this.refinementBase = null;
@@ -4010,7 +4009,7 @@ namespace Microsoft.Dafny {
 
   public class DefaultModuleDecl : ModuleDefinition {
     public DefaultModuleDecl()
-      : base(Token.NoToken, "_module", new List<IToken>(), false, false, false, null, null, null, true, true, true) {
+      : base(Token.NoToken, "_module", new List<IToken>(), false, false, null, null, null, true, true, true) {
     }
     public override bool IsDefaultModule {
       get {
@@ -4997,11 +4996,11 @@ namespace Microsoft.Dafny {
   public class SpecialFunction : Function, ICodeContext, ICallable
   {
     readonly ModuleDefinition Module;
-    public SpecialFunction(IToken tok, string name, ModuleDefinition module, bool hasStaticKeyword, bool isProtected, bool isGhost,
-                    List<TypeParameter> typeArgs, List<Formal> formals, Type resultType,
-                    List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
-                    Expression body, Attributes attributes, IToken signatureEllipsis)
-      : base(tok, name, hasStaticKeyword, isProtected, isGhost, typeArgs, formals, null, resultType, req, reads, ens, decreases, body, attributes, signatureEllipsis)
+    public SpecialFunction(IToken tok, string name, ModuleDefinition module, bool hasStaticKeyword, bool isGhost,
+      List<TypeParameter> typeArgs, List<Formal> formals, Type resultType,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
+      Expression body, Attributes attributes, IToken signatureEllipsis)
+      : base(tok, name, hasStaticKeyword, isGhost, typeArgs, formals, null, resultType, req, reads, ens, decreases, body, attributes, signatureEllipsis)
     {
       Module = module;
     }
@@ -5882,7 +5881,6 @@ namespace Microsoft.Dafny {
   public class Function : MemberDecl, TypeParameter.ParentType, ICallable {
     public override string WhatKind { get { return "function"; } }
     public override bool CanBeRevealed() { return true; }
-    public readonly bool IsProtected;
     public bool IsRecursive;  // filled in during resolution
     public TailStatus TailRecursion = TailStatus.NotTailRecursive;  // filled in during resolution; NotTailRecursive = no tail recursion; TriviallyTailRecursive is never used here
     public bool IsTailRecursive => TailRecursion != TailStatus.NotTailRecursive;
@@ -5989,10 +5987,10 @@ namespace Microsoft.Dafny {
     /// <summary>
     /// Note, functions are "ghost" by default; a non-ghost function is called a "function method".
     /// </summary>
-    public Function(IToken tok, string name, bool hasStaticKeyword, bool isProtected, bool isGhost,
-                    List<TypeParameter> typeArgs, List<Formal> formals, Formal result, Type resultType,
-                    List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
-                    Expression body, Attributes attributes, IToken signatureEllipsis)
+    public Function(IToken tok, string name, bool hasStaticKeyword, bool isGhost,
+      List<TypeParameter> typeArgs, List<Formal> formals, Formal result, Type resultType,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
+      Expression body, Attributes attributes, IToken signatureEllipsis)
       : base(tok, name, hasStaticKeyword, isGhost, attributes) {
 
       Contract.Requires(tok != null);
@@ -6004,7 +6002,6 @@ namespace Microsoft.Dafny {
       Contract.Requires(cce.NonNullElements(reads));
       Contract.Requires(cce.NonNullElements(ens));
       Contract.Requires(decreases != null);
-      this.IsProtected = isProtected;
       this.IsFueled = false;  // Defaults to false.  Only set to true if someone mentions this function in a fuel annotation
       this.TypeArgs = typeArgs;
       this.Formals = formals;
@@ -6074,11 +6071,11 @@ namespace Microsoft.Dafny {
       Extension  // this predicate extends the definition of a predicate with a body in a module being refined
     }
     public readonly BodyOriginKind BodyOrigin;
-    public Predicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, bool isGhost,
-                     List<TypeParameter> typeArgs, List<Formal> formals,
-                     List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
-                     Expression body, BodyOriginKind bodyOrigin, Attributes attributes, IToken signatureEllipsis)
-      : base(tok, name, hasStaticKeyword, isProtected, isGhost, typeArgs, formals, null, Type.Bool, req, reads, ens, decreases, body, attributes, signatureEllipsis) {
+    public Predicate(IToken tok, string name, bool hasStaticKeyword, bool isGhost,
+      List<TypeParameter> typeArgs, List<Formal> formals,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
+      Expression body, BodyOriginKind bodyOrigin, Attributes attributes, IToken signatureEllipsis)
+      : base(tok, name, hasStaticKeyword, isGhost, typeArgs, formals, null, Type.Bool, req, reads, ens, decreases, body, attributes, signatureEllipsis) {
       Contract.Requires(bodyOrigin == Predicate.BodyOriginKind.OriginalOrInherited || body != null);
       BodyOrigin = bodyOrigin;
     }
@@ -6092,11 +6089,11 @@ namespace Microsoft.Dafny {
     public override string WhatKind { get { return "prefix predicate"; } }
     public readonly Formal K;
     public readonly ExtremePredicate ExtremePred;
-    public PrefixPredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected,
-                     List<TypeParameter> typeArgs, Formal k, List<Formal> formals,
-                     List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
-                     Expression body, Attributes attributes, ExtremePredicate extremePred)
-      : base(tok, name, hasStaticKeyword, isProtected, true, typeArgs, formals, null, Type.Bool, req, reads, ens, decreases, body, attributes, null) {
+    public PrefixPredicate(IToken tok, string name, bool hasStaticKeyword,
+      List<TypeParameter> typeArgs, Formal k, List<Formal> formals,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
+      Expression body, Attributes attributes, ExtremePredicate extremePred)
+      : base(tok, name, hasStaticKeyword, true, typeArgs, formals, null, Type.Bool, req, reads, ens, decreases, body, attributes, null) {
       Contract.Requires(k != null);
       Contract.Requires(extremePred != null);
       Contract.Requires(formals != null && 1 <= formals.Count && formals[0] == k);
@@ -6117,11 +6114,11 @@ namespace Microsoft.Dafny {
     public readonly List<FunctionCallExpr> Uses = new List<FunctionCallExpr>();  // filled in during resolution, used by verifier
     public PrefixPredicate PrefixPredicate;  // filled in during resolution (name registration)
 
-    public ExtremePredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
-                             List<TypeParameter> typeArgs, List<Formal> formals,
-                             List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
-                             Expression body, Attributes attributes, IToken signatureEllipsis)
-      : base(tok, name, hasStaticKeyword, isProtected, true, typeArgs, formals, null, Type.Bool,
+    public ExtremePredicate(IToken tok, string name, bool hasStaticKeyword, KType typeOfK,
+      List<TypeParameter> typeArgs, List<Formal> formals,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
+      Expression body, Attributes attributes, IToken signatureEllipsis)
+      : base(tok, name, hasStaticKeyword, true, typeArgs, formals, null, Type.Bool,
              req, reads, ens, new Specification<Expression>(new List<Expression>(), null), body, attributes, signatureEllipsis) {
       TypeOfK = typeOfK;
     }
@@ -6151,11 +6148,11 @@ namespace Microsoft.Dafny {
   public class LeastPredicate : ExtremePredicate
   {
     public override string WhatKind { get { return "least predicate"; } }
-    public LeastPredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
-                              List<TypeParameter> typeArgs, List<Formal> formals,
-                              List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
-                              Expression body, Attributes attributes, IToken signatureEllipsis)
-      : base(tok, name, hasStaticKeyword, isProtected, typeOfK, typeArgs, formals,
+    public LeastPredicate(IToken tok, string name, bool hasStaticKeyword, KType typeOfK,
+      List<TypeParameter> typeArgs, List<Formal> formals,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
+      Expression body, Attributes attributes, IToken signatureEllipsis)
+      : base(tok, name, hasStaticKeyword, typeOfK, typeArgs, formals,
              req, reads, ens, body, attributes, signatureEllipsis) {
     }
   }
@@ -6163,11 +6160,11 @@ namespace Microsoft.Dafny {
   public class GreatestPredicate : ExtremePredicate
   {
     public override string WhatKind { get { return "greatest predicate"; } }
-    public GreatestPredicate(IToken tok, string name, bool hasStaticKeyword, bool isProtected, KType typeOfK,
-                       List<TypeParameter> typeArgs, List<Formal> formals,
-                       List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
-                       Expression body, Attributes attributes, IToken signatureEllipsis)
-      : base(tok, name, hasStaticKeyword, isProtected, typeOfK, typeArgs, formals,
+    public GreatestPredicate(IToken tok, string name, bool hasStaticKeyword, KType typeOfK,
+      List<TypeParameter> typeArgs, List<Formal> formals,
+      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens,
+      Expression body, Attributes attributes, IToken signatureEllipsis)
+      : base(tok, name, hasStaticKeyword, typeOfK, typeArgs, formals,
              req, reads, ens, body, attributes, signatureEllipsis) {
     }
   }
@@ -6179,7 +6176,7 @@ namespace Microsoft.Dafny {
                      List<TypeParameter> typeArgs, List<Formal> formals, Formal result, Type resultType,
                      List<AttributedExpression> req, List<FrameExpression> reads, List<AttributedExpression> ens, Specification<Expression> decreases,
                      Expression body, Attributes attributes, IToken signatureEllipsis)
-      : base(tok, name, hasStaticKeyword, false, true, typeArgs, formals, result, resultType, req, reads, ens, decreases, body, attributes, signatureEllipsis) {
+      : base(tok, name, hasStaticKeyword, true, typeArgs, formals, result, resultType, req, reads, ens, decreases, body, attributes, signatureEllipsis) {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
       Contract.Requires(typeArgs != null);

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -483,9 +483,6 @@ namespace Microsoft.Dafny {
       if (module.IsAbstract) {
         wr.Write("abstract ");
       }
-      if (module.IsProtected) {
-        wr.Write("protected ");
-      }
       wr.Write("module");
       PrintAttributes(module.Attributes);
       wr.Write(" ");
@@ -828,7 +825,6 @@ namespace Microsoft.Dafny {
       var isPredicate = f is Predicate || f is PrefixPredicate;
       Indent(indent);
       string k = isPredicate ? "predicate" : f.WhatKind;
-      if (f.IsProtected) { k = "protected " + k; }
       if (f.HasStaticKeyword) { k = "static " + k; }
       if (!f.IsGhost) { k += " method"; }
       PrintClassMethodHelper(k, f.Attributes, f.Name, f.TypeArgs);

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -270,14 +270,14 @@ namespace Microsoft.Dafny
       // The result type of the following bitvector methods is the type of the bitvector itself. However, we're representing all bitvector types as
       // a family of types rolled up in one ValuetypeDecl. Therefore, we use the special SelfType as the result type.
       List<Formal> formals = new List<Formal> { new Formal(Token.NoToken, "w", Type.Nat(), true, false, false) };
-      var rotateLeft = new SpecialFunction(Token.NoToken, "RotateLeft", prog.BuiltIns.SystemModule, false, false, false, new List<TypeParameter>(), formals, new SelfType(),
+      var rotateLeft = new SpecialFunction(Token.NoToken, "RotateLeft", prog.BuiltIns.SystemModule, false, false, new List<TypeParameter>(), formals, new SelfType(),
         new List<AttributedExpression>(), new List<FrameExpression>(), new List<AttributedExpression>(), new Specification<Expression>(new List<Expression>(), null), null, null, null);
       rotateLeft.EnclosingClass = valuetypeDecls[(int)ValuetypeVariety.Bitvector];
       rotateLeft.AddVisibilityScope(prog.BuiltIns.SystemModule.VisibilityScope, false);
       valuetypeDecls[(int)ValuetypeVariety.Bitvector].Members.Add(rotateLeft.Name, rotateLeft);
 
       formals = new List<Formal> { new Formal(Token.NoToken, "w", Type.Nat(), true, false, false) };
-      var rotateRight = new SpecialFunction(Token.NoToken, "RotateRight", prog.BuiltIns.SystemModule, false, false, false, new List<TypeParameter>(), formals, new SelfType(),
+      var rotateRight = new SpecialFunction(Token.NoToken, "RotateRight", prog.BuiltIns.SystemModule, false, false, new List<TypeParameter>(), formals, new SelfType(),
         new List<AttributedExpression>(), new List<FrameExpression>(), new List<AttributedExpression>(), new Specification<Expression>(new List<Expression>(), null), null, null, null);
       rotateRight.EnclosingClass = valuetypeDecls[(int)ValuetypeVariety.Bitvector];
       rotateRight.AddVisibilityScope(prog.BuiltIns.SystemModule.VisibilityScope, false);
@@ -1353,7 +1353,7 @@ namespace Microsoft.Dafny
         var name = entry.Key;
         var prefixNamedModules = entry.Value;
         var tok = prefixNamedModules.First().Item1[0];
-        var modDef = new ModuleDefinition(tok, name, new List<IToken>(), false, false, false, null, moduleDecl, null, false, true, true);
+        var modDef = new ModuleDefinition(tok, name, new List<IToken>(), false, false, null, moduleDecl, null, false, true, true);
         // Every module is expected to have a default class, so we create and add one now
         var defaultClass = new DefaultClassDecl(modDef, new List<MemberDecl>());
         modDef.TopLevelDecls.Add(defaultClass);
@@ -1780,7 +1780,7 @@ namespace Microsoft.Dafny
             new Specification<Expression>(new List<Expression>(), null),
             null, null, null);
           // --- here comes predicate Valid()
-          var valid = new Predicate(iter.tok, "Valid", false, true, true, new List<TypeParameter>(),
+          var valid = new Predicate(iter.tok, "Valid", false, true, new List<TypeParameter>(),
             new List<Formal>(),
             new List<AttributedExpression>(),
             new List<FrameExpression>(),
@@ -1981,7 +1981,7 @@ namespace Microsoft.Dafny
               List<TypeParameter> tyvars = cop.TypeArgs.ConvertAll(cloner.CloneTypeParam);
 
               // create prefix predicate
-              cop.PrefixPredicate = new PrefixPredicate(cop.tok, extraName, cop.HasStaticKeyword, cop.IsProtected,
+              cop.PrefixPredicate = new PrefixPredicate(cop.tok, extraName, cop.HasStaticKeyword,
                 tyvars, k, formals,
                 cop.Req.ConvertAll(cloner.CloneAttributedExpr),
                 cop.Reads.ConvertAll(cloner.CloneFrameExpr),
@@ -2034,7 +2034,7 @@ namespace Microsoft.Dafny
       Contract.Requires(compilationModuleClones != null);
       var errCount = reporter.Count(ErrorLevel.Error);
 
-      var mod = new ModuleDefinition(Token.NoToken, Name + ".Abs", new List<IToken>(), true, true, true, null, null, null, false,
+      var mod = new ModuleDefinition(Token.NoToken, Name + ".Abs", new List<IToken>(), true, true, null, null, null, false,
                                      p.ModuleDef.IsToBeVerified, p.ModuleDef.IsToBeCompiled);
       mod.Height = Height;
       bool hasDefaultClass = false;
@@ -7036,9 +7036,6 @@ namespace Microsoft.Dafny
               Function f = selectExpr.Member as Function;
               if (f != null) {
                 f.IsFueled = true;
-                if (f.IsProtected && currentModule != f.EnclosingClass.Module) {
-                  reporter.Error(MessageSource.Resolver, tok, "cannot adjust fuel for protected function {0} from another module", f.Name);
-                }
                 if (args.Count >= 3) {
                   LiteralExpr literalLow = args[1] as LiteralExpr;
                   LiteralExpr literalHigh = args[2] as LiteralExpr;

--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -480,7 +480,7 @@ namespace Microsoft.Dafny
       // Add:  predicate Valid()
       // ...unless an instance function with that name is already present
       if (!cl.Members.Exists(member => member is Function && member.Name == "Valid" && !member.IsStatic)) {
-        var valid = new Predicate(cl.tok, "Valid", false, false, true, new List<TypeParameter>(), new List<Formal>(),
+        var valid = new Predicate(cl.tok, "Valid", false, true, new List<TypeParameter>(), new List<Formal>(),
           new List<AttributedExpression>(), new List<FrameExpression>(), new List<AttributedExpression>(), new Specification<Expression>(new List<Expression>(), null),
           null, Predicate.BodyOriginKind.OriginalOrInherited, null, null);
         cl.Members.Add(valid);
@@ -973,8 +973,6 @@ namespace Microsoft.Dafny
 
           if (!Attributes.Contains(f.Attributes, "opaque")) {
             // Nothing to do
-          } else if (f.IsProtected) {
-            reporter.Error(MessageSource.Rewriter, f.tok, ":opaque is not allowed to be applied to protected functions (this will be allowed when the language introduces 'opaque'/'reveal' as keywords)");
           } else if (!RefinementToken.IsInherited(f.tok, c.Module)) {
             RewriteOpaqueFunctionUseFuel(f, newDecls);
           }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -2351,12 +2351,11 @@ namespace Microsoft.Dafny {
     /// This happens when the following conditions all hold:
     ///   - "f" has a body
     ///   - "f" is not opaque
-    ///   - "f" is declared as protected, then "context" is the current module and parameter "revealProtectedBody" is passed in as "true".
     /// </summary>
     static bool FunctionBodyIsAvailable(Function f, ModuleDefinition context, VisibilityScope scope, bool revealProtectedBody) {
       Contract.Requires(f != null);
       Contract.Requires(context != null);
-      return f.Body != null && !IsOpaqueFunction(f) && f.IsRevealedInScope(scope) && (!f.IsProtected || (revealProtectedBody && f.EnclosingClass.Module == context));
+      return f.Body != null && !IsOpaqueFunction(f) && f.IsRevealedInScope(scope);
     }
     static bool IsOpaqueFunction(Function f) {
       Contract.Requires(f != null);
@@ -3301,7 +3300,7 @@ namespace Microsoft.Dafny {
 
       Bpl.Trigger tr = BplTriggerHeap(this, f.tok, funcAppl, readsHeap ? etran.HeapExpr : null);
       Bpl.Expr tastyVegetarianOption; // a.k.a. the "meat" of the operation :)
-      if (!RevealedInScope(f) || (f.IsProtected && !InVerificationScope(f))) {
+      if (!RevealedInScope(f)) {
         tastyVegetarianOption = Bpl.Expr.True;
       } else {
         var bodyWithSubst = Substitute(body, receiverReplacement, substMap);

--- a/Test/allocated1/dafny0/AutoContracts.dfy.expect
+++ b/Test/allocated1/dafny0/AutoContracts.dfy.expect
@@ -1,6 +1,6 @@
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
@@ -31,7 +31,7 @@ Execution trace:
     (0,0): anon24_Then
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
@@ -47,7 +47,7 @@ Execution trace:
     (0,0): anon24_Then
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
@@ -63,7 +63,7 @@ Execution trace:
     (0,0): anon24_Then
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then

--- a/Test/allocated1/dafny0/Modules1.dfy.expect
+++ b/Test/allocated1/dafny0/Modules1.dfy.expect
@@ -2,34 +2,34 @@ Modules1.dfy(10,8): Error: target object may not be allocated
 Execution trace:
     (0,0): anon0
     (0,0): anon4_Else
-Modules1.dfy(79,15): Error: assertion violation
+Modules1.dfy(82,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
-Modules1.dfy(92,15): Error: assertion violation
+Modules1.dfy(95,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
-Modules1.dfy(94,18): Error: assertion violation
+Modules1.dfy(97,18): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Else
-Modules1.dfy(208,16): Error: assertion violation
+Modules1.dfy(211,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(209,22): Error: assertion violation
+Modules1.dfy(212,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(210,22): Error: assertion violation
+Modules1.dfy(213,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(216,16): Error: assertion violation
+Modules1.dfy(219,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(217,16): Error: assertion violation
+Modules1.dfy(220,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(218,16): Error: assertion violation
+Modules1.dfy(221,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
 Modules1.dfy(56,8): Error: decreases expression must be bounded below by 0

--- a/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
@@ -1,95 +1,101 @@
-OpaqueFunctions.dfy(27,15): Error: assertion violation
+OpaqueFunctions.dfy(38,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(52,7): Error BP5002: A precondition for this call might not hold.
-OpaqueFunctions.dfy(24,15): Related location: This is the precondition that might not hold.
+OpaqueFunctions.dfy(69,7): Error BP5002: A precondition for this call might not hold.
+OpaqueFunctions.dfy(35,15): Related location: This is the precondition that might not hold.
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(57,19): Error: assertion violation
+OpaqueFunctions.dfy(75,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(59,20): Error: assertion violation
+OpaqueFunctions.dfy(77,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon5_Then
-OpaqueFunctions.dfy(62,20): Error: assertion violation
+OpaqueFunctions.dfy(80,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Then
-OpaqueFunctions.dfy(65,20): Error: assertion violation
+OpaqueFunctions.dfy(96,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
+    (0,0): anon5_Then
+    (0,0): anon6_Then
+OpaqueFunctions.dfy(98,11): Error BP5002: A precondition for this call might not hold.
+OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
     (0,0): anon6_Else
-OpaqueFunctions.dfy(76,20): Error: assertion violation
+OpaqueFunctions.dfy(102,17): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Else
+OpaqueFunctions.dfy(109,19): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+OpaqueFunctions.dfy(111,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
+OpaqueFunctions.dfy(114,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Then
+OpaqueFunctions.dfy(123,31): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon7_Then
+    (0,0): anon8_Then
+    (0,0): anon3
+OpaqueFunctions.dfy(146,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
-OpaqueFunctions.dfy(78,9): Error BP5002: A precondition for this call might not hold.
-OpaqueFunctions.dfy[A'](24,15): Related location: This is the precondition that might not hold.
+OpaqueFunctions.dfy(148,9): Error BP5002: A precondition for this call might not hold.
+OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Else
-OpaqueFunctions.dfy(84,19): Error: assertion violation
+OpaqueFunctions.dfy(155,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(86,20): Error: assertion violation
+OpaqueFunctions.dfy(157,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon5_Then
-OpaqueFunctions.dfy(89,20): Error: assertion violation
+    (0,0): anon9_Then
+OpaqueFunctions.dfy(160,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon6_Then
-OpaqueFunctions.dfy(92,20): Error: assertion violation
+    (0,0): anon10_Then
+OpaqueFunctions.dfy(165,31): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon6_Else
-OpaqueFunctions.dfy(103,20): Error: assertion violation
+    (0,0): anon11_Else
+    (0,0): anon12_Then
+    (0,0): anon8
+OpaqueFunctions.dfy(181,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon3_Then
-OpaqueFunctions.dfy(105,9): Error BP5002: A precondition for this call might not hold.
-OpaqueFunctions.dfy[A'](24,15): Related location: This is the precondition that might not hold.
+OpaqueFunctions.dfy(246,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon3_Else
-OpaqueFunctions.dfy(111,19): Error: assertion violation
+OpaqueFunctions.dfy(261,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(113,20): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-    (0,0): anon5_Then
-OpaqueFunctions.dfy(116,20): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-    (0,0): anon6_Then
-OpaqueFunctions.dfy(119,20): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-    (0,0): anon6_Else
-OpaqueFunctions.dfy(135,11): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-OpaqueFunctions.dfy(199,11): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-OpaqueFunctions.dfy(215,11): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-OpaqueFunctions.dfy(280,16): Error: assertion violation
+OpaqueFunctions.dfy(326,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon19_Then
-OpaqueFunctions.dfy(282,15): Error: assertion violation
+OpaqueFunctions.dfy(328,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon20_Then
-OpaqueFunctions.dfy(284,15): Error: assertion violation
+OpaqueFunctions.dfy(330,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon21_Then
-OpaqueFunctions.dfy(297,46): Error: result of operation might violate newtype constraint for 'Small'
+OpaqueFunctions.dfy(343,46): Error: result of operation might violate newtype constraint for 'Small'
 Execution trace:
     (0,0): anon0
     (0,0): anon25_Then
@@ -99,19 +105,19 @@ Execution trace:
     (0,0): anon28_Then
     (0,0): anon29_Then
     (0,0): anon30_Then
-OpaqueFunctions.dfy(304,15): Error: assertion violation
+OpaqueFunctions.dfy(350,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon15_Then
-OpaqueFunctions.dfy(306,15): Error: assertion violation
+OpaqueFunctions.dfy(352,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon16_Then
-OpaqueFunctions.dfy(308,15): Error: assertion violation
+OpaqueFunctions.dfy(354,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
-OpaqueFunctions.dfy(321,17): Error: assertion violation
+OpaqueFunctions.dfy(367,17): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon21_Then
@@ -119,11 +125,11 @@ Execution trace:
     (0,0): anon23_Then
     (0,0): anon11
     (0,0): anon24_Then
-OpaqueFunctions.dfy(167,15): Error: assertion violation
+OpaqueFunctions.dfy(214,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(182,19): Error: assertion violation
+OpaqueFunctions.dfy(229,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 20 verified, 31 errors
+Dafny program verifier finished with 26 verified, 31 errors

--- a/Test/allocated1/dafny0/Predicates.dfy
+++ b/Test/allocated1/dafny0/Predicates.dfy
@@ -1,67 +1,41 @@
 // RUN: %dafny /verifyAllModules /allocated:1 /compile:0 /print:"%t.print" /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-module A {
-  class C {
-    var x: int;
-    protected predicate P()
-      reads this;
-    {
-      x < 100
-    }
-    method M()
-      modifies this;
-      ensures P();
-    {
-      x := 28;
-    }
-    method N()
-      modifies this;
-      ensures P();
-    {  // error: in module B, the postcondition P() has been strengthened and no longer holds
-      x := -28;
-    }
-  }
-}
-
-module B refines A {
-  class C {
-    protected predicate P()
-    {
-      0 <= x
-    }
-  }
-}
-
 // ------------------------------------------------
 
-module Loose {
+abstract module Loose {
   class MyNumber {
-    var N: int;
-    ghost var Repr: set<object>;
-    protected predicate Valid()
-      reads this, Repr;
+    var N: int
+    ghost var Repr: set<object>
+    predicate Valid()
+      reads this, Repr
     {
       this in Repr &&
-      0 <= N
+      0 <= N &&
+      CustomValid()
     }
+    predicate CustomValid()
+      reads this, Repr
     constructor Init()
-      ensures Valid() && fresh(Repr - {this});
+      ensures Valid() && fresh(Repr)
     {
       N, Repr := 0, {this};
+      new;
+      assume CustomValid();  // to be verified in refinement modules
     }
 
     method Inc()
-      requires Valid();
-      modifies Repr;
-      ensures old(N) < N;
-      ensures Valid() && fresh(Repr - old(Repr));
+      requires Valid()
+      modifies Repr
+      ensures old(N) < N
+      ensures Valid() && fresh(Repr - old(Repr))
     {
       N := N + 2;
+      assume CustomValid();
     }
     method Get() returns (n: int)
-      requires Valid();
-      ensures n == N;
+      requires Valid()
+      ensures n == N
     {
       n := N;
     }
@@ -70,18 +44,18 @@ module Loose {
 
 module Tight refines Loose {
   class MyNumber {
-    protected predicate Valid()
+    predicate CustomValid...
     {
       N % 2 == 0
     }
     constructor Init()
-      ensures N == 0;
+      ensures N == 0
     method Inc()
-      ensures N == old(N) + 2;
+      ensures N == old(N) + 2
   }
 }
 
-module UnawareClient {
+abstract module UnawareClient {
   import L = Loose
   method Main0() {
     var n := new L.MyNumber.Init();
@@ -105,81 +79,45 @@ module AwareClient {
   }
 }
 
-// -------- Tricky refinement inheritance ----------------------------------------
-
-module Tricky_Base {
-  class Tree {
-    var x: int;
-    predicate Constrained()
-      reads this;
-    {
-      x < 10
-    }
-    protected predicate Valid()
-      reads this;
-    {
-      x < 100
-    }
-    method Init()
-      modifies this;
-      ensures Valid();
-    {  // error: in module Tricky_Full, the strengthened postcondition Valid() no longer holds
-      x := 20;
-    }
-  }
-}
-
-module Tricky_Full refines Tricky_Base {
-  class Tree {
-    protected predicate Valid()
-    {
-      Constrained()  // this causes an error to be generated for the inherited Init
-    }
-  }
-}
-
 // -------- Quantifiers ----------------------------------------
 
 module Q0 {
   class C {
-    var x: int;
-    protected predicate P()
-      reads this;
+    var x: int
+    predicate P()
+      reads this
     {
       true
     }
     method M()
-      modifies this;
-      ensures forall c: C :: c.P();
-    {  // error: in module Q1, the postcondition no longer holds
+      modifies this
+      ensures forall c: C :: c.P()  // this is the only line that's different from Test/dafn0/Predicates.dfy
+    {
     }
     predicate Q()
-      reads this;
+      reads this
     {
       x < 100
     }
     method N()
-      modifies this;
-      ensures forall c: C :: c == this ==> c.Q();
-    {  // error: fails to establish postcondition (but this error should not be repeated in Q1 below)
+      modifies this
+      ensures forall c: C :: c == this ==> c.Q()
+    {  // error: fails to establish postcondition (but this error should not be repeated in Q1 or Q2 below)
       x := 102;
     }
-    predicate R() reads this;  // a body-less predicate
+    predicate R()  // a body-less predicate
+      reads this
   }
 }
 
 module Q1 refines Q0 {
   class C {
-    protected predicate P()
-    {
-      x == 18
-    }
-    predicate R()  // no body yet
+    predicate R...  // no body yet
   }
 }
 
 module Q2 refines Q1 {
   class C {
-    predicate R() { x % 3 == 2 }  // finally, give it a body
+    predicate R... { x % 3 == 2 }  // finally, give it a body
   }
 }

--- a/Test/allocated1/dafny0/Predicates.dfy.expect
+++ b/Test/allocated1/dafny0/Predicates.dfy.expect
@@ -1,37 +1,21 @@
-Predicates.dfy[B](21,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy[B](20,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(31,8): Related location
+Predicates.dfy(62,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Predicates.dfy(88,15): Error: assertion violation
+Predicates.dfy(66,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Predicates.dfy(92,13): Error: assertion violation
+Predicates.dfy(94,31): Error: target object may not be allocated
 Execution trace:
     (0,0): anon0
-Predicates.dfy[Tricky_Full](126,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy[Tricky_Full](125,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(136,6): Related location
-Predicates.dfy[Tricky_Full](116,8): Related location
+Predicates.dfy(95,4): Error BP5003: A postcondition might not hold on this return path.
+Predicates.dfy(94,14): Related location: This is the postcondition that might not hold.
+Predicates.dfy(94,31): Related location
 Execution trace:
     (0,0): anon0
-Predicates.dfy(153,31): Error: target object may not be allocated
-Execution trace:
-    (0,0): anon0
-Predicates.dfy(154,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy(153,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(153,31): Related location
-Execution trace:
-    (0,0): anon0
-Predicates.dfy(164,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy(163,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(163,45): Related location
-Execution trace:
-    (0,0): anon0
-Predicates.dfy[Q1](154,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy[Q1](153,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy[Q1](153,31): Related location
+Predicates.dfy(105,4): Error BP5003: A postcondition might not hold on this return path.
+Predicates.dfy(104,14): Related location: This is the postcondition that might not hold.
+Predicates.dfy(104,45): Related location
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 27 verified, 8 errors
+Dafny program verifier finished with 19 verified, 5 errors

--- a/Test/allocated1/dafny0/Protected.dfy.expect
+++ b/Test/allocated1/dafny0/Protected.dfy.expect
@@ -1,20 +1,20 @@
-Protected.dfy(17,19): Error: assertion violation
+Protected.dfy(21,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon9_Then
-Protected.dfy(31,17): Error: assertion violation
+Protected.dfy(35,17): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon12_Then
     (0,0): anon6
     (0,0): anon13_Else
-Protected.dfy(35,15): Error: assertion violation
+Protected.dfy(39,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Protected.dfy(48,19): Error: assertion violation
+Protected.dfy(52,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Protected.dfy(55,19): Error: assertion violation
+Protected.dfy(59,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
 

--- a/Test/allocated1/dafny0/Refinement.dfy.expect
+++ b/Test/allocated1/dafny0/Refinement.dfy.expect
@@ -21,20 +21,18 @@ Refinement.dfy(102,2): Error BP5003: A postcondition might not hold on this retu
 Refinement.dfy(83,14): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-Refinement.dfy(189,4): Error BP5003: A postcondition might not hold on this return path.
-Refinement.dfy[IncorrectConcrete](120,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(186,8): Related location
+Refinement.dfy(198,6): Error: assertion violation
+Refinement.dfy[IncorrectConcrete](122,18): Related location
 Execution trace:
     (0,0): anon0
-Refinement.dfy(194,4): Error BP5003: A postcondition might not hold on this return path.
-Refinement.dfy[IncorrectConcrete](128,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(186,8): Related location
+Refinement.dfy(204,6): Error: assertion violation
+Refinement.dfy[IncorrectConcrete](131,18): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon4_Then
     (0,0): anon3
-Refinement.dfy(200,6): Error: assertion violation
-Refinement.dfy[IncorrectConcrete](136,23): Related location
+Refinement.dfy(209,6): Error: assertion violation
+Refinement.dfy[IncorrectConcrete](137,23): Related location
 Execution trace:
     (0,0): anon0
 

--- a/Test/allocated1/dafny0/Simple.dfy.expect
+++ b/Test/allocated1/dafny0/Simple.dfy.expect
@@ -70,11 +70,11 @@ class CF {
 
   greatest predicate Co()
 
-  protected function H(): int
+  function H(): int
 
-  static protected function method I(): real
+  static function method I(): real
 
-  static protected predicate method J()
+  static predicate method J()
 }
 
 module A {

--- a/Test/allocated1/dafny0/Superposition.dfy.expect
+++ b/Test/allocated1/dafny0/Superposition.dfy.expect
@@ -2,21 +2,18 @@
 Verifying Impl$$M0.C.M ...
   [4 proof obligations]  verified
 
-Verifying CheckWellformed$$M0.C.P ...
-  [4 proof obligations]  verified
-
 Verifying CheckWellformed$$M0.C.Q ...
   [3 proof obligations]  error
-Superposition.dfy(27,14): Error BP5003: A postcondition might not hold on this return path.
-Superposition.dfy(28,25): Related location: This is the postcondition that might not hold.
+Superposition.dfy(20,14): Error BP5003: A postcondition might not hold on this return path.
+Superposition.dfy(21,25): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
     (0,0): anon7_Else
 
 Verifying CheckWellformed$$M0.C.R ...
   [3 proof obligations]  error
-Superposition.dfy(33,14): Error BP5003: A postcondition might not hold on this return path.
-Superposition.dfy(34,25): Related location: This is the postcondition that might not hold.
+Superposition.dfy(26,14): Error BP5003: A postcondition might not hold on this return path.
+Superposition.dfy(27,25): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
     (0,0): anon7_Else
@@ -24,14 +21,4 @@ Execution trace:
 Verifying Impl$$M1.C.M ...
   [1 proof obligation]  verified
 
-Verifying CheckWellformed$$M1.C.P ...
-  [1 proof obligation]  error
-Superposition.dfy(50,24): Error BP5003: A postcondition might not hold on this return path.
-Superposition.dfy[M1](22,25): Related location: This is the postcondition that might not hold.
-Execution trace:
-    (0,0): anon0
-    (0,0): anon9_Else
-    (0,0): anon11_Then
-    (0,0): anon8
-
-Dafny program verifier finished with 3 verified, 3 errors
+Dafny program verifier finished with 2 verified, 2 errors

--- a/Test/dafny0/AutoContracts.dfy
+++ b/Test/dafny0/AutoContracts.dfy
@@ -9,7 +9,7 @@ module OneModule {
     var dd: D?
     var {:autocontracts false} ee: D?
     var arr: array?<C?>
-    protected predicate Valid()
+    predicate Valid()
     {
       0 <= data < 100
     }

--- a/Test/dafny0/AutoContracts.dfy.expect
+++ b/Test/dafny0/AutoContracts.dfy.expect
@@ -150,7 +150,7 @@ module OneModule {
     var {:autocontracts false} ee: D?
     var arr: array?<C?>
 
-    protected predicate Valid()
+    predicate Valid()
       reads this, Repr
       decreases Repr + {this}
     {
@@ -547,7 +547,7 @@ module N2 refines N1 {
 }
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
@@ -578,7 +578,7 @@ Execution trace:
     (0,0): anon24_Then
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
@@ -594,7 +594,7 @@ Execution trace:
     (0,0): anon24_Then
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
@@ -610,7 +610,7 @@ Execution trace:
     (0,0): anon24_Then
 AutoContracts.dfy(17,4): Error BP5003: A postcondition might not hold on this return path.
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,24): Related location
+AutoContracts.dfy(12,14): Related location
 AutoContracts.dfy(5,25): Related location
 Execution trace:
     (0,0): anon0

--- a/Test/dafny0/Deprecation.dfy
+++ b/Test/dafny0/Deprecation.dfy
@@ -39,3 +39,7 @@ inductive lemma InductiveLemma()  // deprecation warning: "inductive lemma" has 
 
 colemma CoLemma()  // deprecation warning: "colemma" has been renamed to "greatest lemma"
 { }
+
+// ----------
+
+protected predicate ProtectedPredicate() { true }  // deprecation warning: "protected" is no longer supported

--- a/Test/dafny0/Deprecation.dfy.expect
+++ b/Test/dafny0/Deprecation.dfy.expect
@@ -3,6 +3,7 @@ Deprecation.dfy(31,0): Warning: the old keyword phrase 'inductive predicate' has
 Deprecation.dfy(34,0): Warning: the old keyword 'copredicate' has been renamed to the keyword phrase 'greatest predicate'
 Deprecation.dfy(37,0): Warning: the old keyword phrase 'inductive lemma' has been renamed to 'least lemma'
 Deprecation.dfy(40,0): Warning: the old keyword 'colemma' has been renamed to the keyword phrase 'greatest lemma'
+Deprecation.dfy(45,0): Warning: the 'protected' modifier is no longer supported; to restrict access from outside the module, use a 'provides' clause in the module's export set; if you're trying to add conjuncts to a predicate in a refinement module, see Test/dafny3/CachedContainer.dfy, Test/dafny2/StoreAndRetrieve.dfy, and Test/dafny2/MonotonicHeapstate.dfy in the Dafny test suite on github
 Deprecation.dfy(26,12): Warning: the syntax "MyInt(expr)" for type conversions has been deprecated; the new syntax is "expr as MyInt"
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/dafny0/Modules1.dfy
+++ b/Test/dafny0/Modules1.dfy
@@ -65,8 +65,11 @@ method Botch1(x: int)
 // ------ modules ------------------------------------------------
 
 module A_Visibility {
+  export
+    provides C, C.P
+
   class C {
-    protected static predicate P(x: int)
+    static predicate P(x: int)
       ensures P(x) ==> -10 <= x;
     {
       0 <= x

--- a/Test/dafny0/Modules1.dfy.expect
+++ b/Test/dafny0/Modules1.dfy.expect
@@ -1,31 +1,31 @@
-Modules1.dfy(79,15): Error: assertion violation
+Modules1.dfy(82,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
-Modules1.dfy(92,15): Error: assertion violation
+Modules1.dfy(95,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
-Modules1.dfy(94,18): Error: assertion violation
+Modules1.dfy(97,18): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Else
-Modules1.dfy(208,16): Error: assertion violation
+Modules1.dfy(211,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(209,22): Error: assertion violation
+Modules1.dfy(212,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(210,22): Error: assertion violation
+Modules1.dfy(213,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(216,16): Error: assertion violation
+Modules1.dfy(219,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(217,16): Error: assertion violation
+Modules1.dfy(220,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Modules1.dfy(218,16): Error: assertion violation
+Modules1.dfy(221,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
 Modules1.dfy(56,8): Error: decreases expression must be bounded below by 0

--- a/Test/dafny0/OpaqueFunctions.dfy
+++ b/Test/dafny0/OpaqueFunctions.dfy
@@ -2,99 +2,142 @@
 // RUN: %diff "%s.expect" "%t"
 
 module A {
+  export NotSoMuch
+    reveals C, C.RevealedValid
+    provides C.Valid, C.Get, C.M, C.x
+  export More extends NotSoMuch
+    reveals C.Get
+
   class C {
     var x: int;
-    protected predicate Valid()
-      reads this;
-    {
-      0 <= x
-    }
-    protected function Get(): int
-      reads this;
+
+    predicate Valid()
+      reads this
+      ensures Valid() ==> 0 <= x ensures x == 8 ==> Valid()  // holds for 8, does not hold for negative numbers
+
+    predicate RevealedValid()
+      reads this
+      ensures Valid() ==> 0 <= x ensures x == 8 ==> Valid()  // holds for 8, does not hold for negative numbers
+
+    function Get(): int
+      reads this
     {
       x
     }
+
     constructor ()
-      ensures Valid();
+      ensures Valid()
     {
       x := 8;
     }
 
     method M()
-      requires Valid();
+      requires Valid()
     {
       assert Get() == x;
       assert x == 8;  // error
     }
   }
 }
+
 module A' refines A {
   class C {
-    protected predicate Valid...
+    // provide bodies for Valid, RevealedValid, and M
+    predicate Valid...
+    {
+      x == 8
+    }
+    predicate RevealedValid...
     {
       x == 8
     }
     method N()
       requires Valid();
     {
-      assert Get() == x;
+      assert Get() == x;  // this is known, because the refined body of Get is considered inside A'
       assert x == 8;
     }
   }
 }
 
 abstract module B {
-  import X : A
+  import X : A`NotSoMuch
   method Main() {
     var c := new X.C();
     c.M();  // fine
     c.x := c.x + 1;
-    c.M();  // error, because Valid() is opaque
+    c.M();  // error, because no body of Valid() is known
   }
+
   method L(c: X.C)
     modifies c;
   {
-    assert c.Get() == c.x;  // error because Get() is opaque
+    assert c.Get() == c.x;  // error because Get() is only provided
     if * {
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // error, because Valid() may be false (for example, if c.x is negative)
     } else if * {
       c.x := 7;
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // error, because Valid() is not known to hold for x==7
     } else {
       c.x := 8;
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // fine, because the postcondition of Valid() says it holds for x==8
     }
   }
 }
+
 abstract module B_direct {
-  import X : A'
+  import X : A'`NotSoMuch
   method Main() {
     var c := new X.C();
-    c.M();  // fine
-    c.x := c.x + 1;
     if * {
-      assert c.Valid();  // error, because Valid() is opaque
+      c.M();  // fine
+      c.x := c.x + 1;  // this may ruin Valid()
+      if * {
+        assert c.Valid();  // error
+      } else {
+        c.M();  // error
+      }
     } else {
-      c.M();  // error, because Valid() is opaque
+      assert c.Valid();
+      assert c.x == 8;  // error, because Valid is only provided
     }
   }
+
   method L(c: X.C)
-    modifies c;
+    modifies c
   {
-    assert c.Get() == c.x;  // error because Get() s opaque
+    assert c.Get() == c.x;  // error because Get() is only provided
     if * {
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // error, because Valid() is only provided
     } else if * {
       c.x := 7;
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // error, because Valid() is only provided
     } else {
       c.x := 8;
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // fine, because the postcondition of Valid() says it holds for x==8
+    }
+  }
+
+  method K(c: X.C) {
+    if * {
+      assert c.Valid() ==> c.x == 8;  // error, because Valid() is only provided
+    } else {
+      assert c.RevealedValid() ==> c.x == 8;  // good
     }
   }
 }
+
+abstract module B_more {
+  import X : A'`More
+  method L(c: X.C)
+    modifies c;
+  {
+    assert c.Get() == c.x;  // yes, this is known, due to using the larger export set of A'
+  }
+}
+
 module B' refines B {
-  import X = A'  // this by itself produces no more error
+  import X = A'`NotSoMuch
   method Main'() {
     var c := new X.C();
     c.M();  // fine
@@ -105,18 +148,21 @@ module B' refines B {
       c.M();  // error, because Valid() is opaque
     }
   }
+
   method L'(c: X.C)
-    modifies c;
+    modifies c
   {
-    assert c.Get() == c.x;  // error because Get() s opaque
+    assert c.Get() == c.x;  // error because Get() is only provided
     if * {
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // error, because Valid() is only provided
     } else if * {
       c.x := 7;
-      assert c.Valid();  // error, because Valid() is opaque
-    } else {
+      assert c.Valid();  // error, because Valid() is only provided
+    } else if * {
       c.x := 8;
-      assert c.Valid();  // error, because Valid() is opaque
+      assert c.Valid();  // fine, because Valid()'s postcondition says it holds for x==8
+    } else {
+      assert c.Valid() ==> c.x == 8;  // error, because Valid is only provided
     }
   }
 }
@@ -149,12 +195,13 @@ module M0 {
   function {:opaque} F(): int
   { 12 }
 }
+
 module M1 refines M0 {
 }
 
 // ---------------------------------- opaque and generics
 
-function{:opaque} id<A>(x : A):A { x }
+function {:opaque} id<A>(x: A): A { x }
 
 method id_ok()
 {
@@ -164,12 +211,12 @@ method id_ok()
 
 method id_fail()
 {
-  assert id(1) == 1;
+  assert id(1) == 1;  // error
 }
 
 datatype Box<A> = Bx(A)
 
-function{:opaque} id_box(x : Box):Box { x }
+function {:opaque} id_box(x: Box): Box { x }
 
 method box_ok()
 {
@@ -179,14 +226,14 @@ method box_ok()
 
 method box_fail()
 {
-  assert id(Bx(1)) == Bx(1);
+  assert id(Bx(1)) == Bx(1);  // error
 }
 
 // ------------------------- opaque and layer quantifiers
 
 module LayerQuantifiers
 {
-  function{:opaque} f(x:nat) : bool { if x == 0 then true else f(x-1) }
+  function {:opaque} f(x: nat): bool { if x == 0 then true else f(x-1) }
 
   method rec_should_ok()
   {
@@ -196,11 +243,11 @@ module LayerQuantifiers
 
   method rec_should_fail()
   {
-    assert f(1);
+    assert f(1);  // error
   }
 
   method rec_should_unroll_ok(one : int)
-    requires one == 1;
+    requires one == 1
   {
     reveal f();
     // this one should have enough fuel
@@ -208,11 +255,10 @@ module LayerQuantifiers
   }
 
   method rec_should_unroll_fail(one : int)
-    requires one == 1;
+    requires one == 1
   {
     reveal f();
-    // this one does not have enough fuel
-    assert f(one + one + one);
+    assert f(one + one + one);  // error: this one does not have enough fuel
   }
 }
 
@@ -239,7 +285,7 @@ module Regression
 
 // This function used to cause a problem for the old version of opaque,
 // but it's fine with the new fuel-based version
-function{:opaque} zero<A>():int { 0 }
+function {:opaque} zero<A>(): int { 0 }
 
 // ------------------------- opaque for members of non-reference types
 
@@ -308,13 +354,13 @@ module TypeMembers {
       assert x == 5;  // error: this is not known here
     case Tr.IsFive(x) =>
       reveal Tr.IsFive();
-      assert x == 5;  // error: this is not known here
+      assert x == 5;
     case Color.IsFive(x) =>
       reveal Color.IsFive();
-      assert x == 5;  // error: this is not known here
+      assert x == 5;
     case Small.IsFive(x) =>
       reveal Small.IsFive();
-      assert x == 5;  // error: this is not known here
+      assert x == 5;
     case true =>
       if Tr.IsFive(x) && Color.IsFive(x) && Small.IsFive(x) {
         reveal Tr.IsFive(), Color.IsFive(), Small.IsFive();

--- a/Test/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/dafny0/OpaqueFunctions.dfy.expect
@@ -1,95 +1,101 @@
-OpaqueFunctions.dfy(27,15): Error: assertion violation
+OpaqueFunctions.dfy(38,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(52,7): Error BP5002: A precondition for this call might not hold.
-OpaqueFunctions.dfy(24,15): Related location: This is the precondition that might not hold.
+OpaqueFunctions.dfy(69,7): Error BP5002: A precondition for this call might not hold.
+OpaqueFunctions.dfy(35,15): Related location: This is the precondition that might not hold.
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(57,19): Error: assertion violation
+OpaqueFunctions.dfy(75,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(59,20): Error: assertion violation
+OpaqueFunctions.dfy(77,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon5_Then
-OpaqueFunctions.dfy(62,20): Error: assertion violation
+OpaqueFunctions.dfy(80,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Then
-OpaqueFunctions.dfy(65,20): Error: assertion violation
+OpaqueFunctions.dfy(96,22): Error: assertion violation
 Execution trace:
     (0,0): anon0
+    (0,0): anon5_Then
+    (0,0): anon6_Then
+OpaqueFunctions.dfy(98,11): Error BP5002: A precondition for this call might not hold.
+OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
     (0,0): anon6_Else
-OpaqueFunctions.dfy(76,20): Error: assertion violation
+OpaqueFunctions.dfy(102,17): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Else
+OpaqueFunctions.dfy(109,19): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+OpaqueFunctions.dfy(111,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
+OpaqueFunctions.dfy(114,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon6_Then
+OpaqueFunctions.dfy(123,31): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon7_Then
+    (0,0): anon8_Then
+    (0,0): anon3
+OpaqueFunctions.dfy(146,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
-OpaqueFunctions.dfy(78,9): Error BP5002: A precondition for this call might not hold.
-OpaqueFunctions.dfy[A'](24,15): Related location: This is the precondition that might not hold.
+OpaqueFunctions.dfy(148,9): Error BP5002: A precondition for this call might not hold.
+OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Else
-OpaqueFunctions.dfy(84,19): Error: assertion violation
+OpaqueFunctions.dfy(155,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(86,20): Error: assertion violation
+OpaqueFunctions.dfy(157,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon5_Then
-OpaqueFunctions.dfy(89,20): Error: assertion violation
+    (0,0): anon9_Then
+OpaqueFunctions.dfy(160,20): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon6_Then
-OpaqueFunctions.dfy(92,20): Error: assertion violation
+    (0,0): anon10_Then
+OpaqueFunctions.dfy(165,31): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon6_Else
-OpaqueFunctions.dfy(103,20): Error: assertion violation
+    (0,0): anon11_Else
+    (0,0): anon12_Then
+    (0,0): anon8
+OpaqueFunctions.dfy(181,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon3_Then
-OpaqueFunctions.dfy(105,9): Error BP5002: A precondition for this call might not hold.
-OpaqueFunctions.dfy[A'](24,15): Related location: This is the precondition that might not hold.
+OpaqueFunctions.dfy(246,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    (0,0): anon3_Else
-OpaqueFunctions.dfy(111,19): Error: assertion violation
+OpaqueFunctions.dfy(261,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(113,20): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-    (0,0): anon5_Then
-OpaqueFunctions.dfy(116,20): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-    (0,0): anon6_Then
-OpaqueFunctions.dfy(119,20): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-    (0,0): anon6_Else
-OpaqueFunctions.dfy(135,11): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-OpaqueFunctions.dfy(199,11): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-OpaqueFunctions.dfy(215,11): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-OpaqueFunctions.dfy(280,16): Error: assertion violation
+OpaqueFunctions.dfy(326,16): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon19_Then
-OpaqueFunctions.dfy(282,15): Error: assertion violation
+OpaqueFunctions.dfy(328,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon20_Then
-OpaqueFunctions.dfy(284,15): Error: assertion violation
+OpaqueFunctions.dfy(330,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon21_Then
-OpaqueFunctions.dfy(297,46): Error: result of operation might violate newtype constraint for 'Small'
+OpaqueFunctions.dfy(343,46): Error: result of operation might violate newtype constraint for 'Small'
 Execution trace:
     (0,0): anon0
     (0,0): anon25_Then
@@ -99,19 +105,19 @@ Execution trace:
     (0,0): anon28_Then
     (0,0): anon29_Then
     (0,0): anon30_Then
-OpaqueFunctions.dfy(304,15): Error: assertion violation
+OpaqueFunctions.dfy(350,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon15_Then
-OpaqueFunctions.dfy(306,15): Error: assertion violation
+OpaqueFunctions.dfy(352,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon16_Then
-OpaqueFunctions.dfy(308,15): Error: assertion violation
+OpaqueFunctions.dfy(354,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon17_Then
-OpaqueFunctions.dfy(321,17): Error: assertion violation
+OpaqueFunctions.dfy(367,17): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon21_Then
@@ -119,11 +125,11 @@ Execution trace:
     (0,0): anon23_Then
     (0,0): anon11
     (0,0): anon24_Then
-OpaqueFunctions.dfy(167,15): Error: assertion violation
+OpaqueFunctions.dfy(214,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-OpaqueFunctions.dfy(182,19): Error: assertion violation
+OpaqueFunctions.dfy(229,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 20 verified, 31 errors
+Dafny program verifier finished with 26 verified, 31 errors

--- a/Test/dafny0/Predicates.dfy
+++ b/Test/dafny0/Predicates.dfy
@@ -1,67 +1,41 @@
 // RUN: %dafny /compile:0 /print:"%t.print" /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-module A {
-  class C {
-    var x: int;
-    protected predicate P()
-      reads this;
-    {
-      x < 100
-    }
-    method M()
-      modifies this;
-      ensures P();
-    {
-      x := 28;
-    }
-    method N()
-      modifies this;
-      ensures P();
-    {  // error: in module B, the postcondition P() has been strengthened and no longer holds
-      x := -28;
-    }
-  }
-}
-
-module B refines A {
-  class C {
-    protected predicate P()
-    {
-      0 <= x
-    }
-  }
-}
-
 // ------------------------------------------------
 
-module Loose {
+abstract module Loose {
   class MyNumber {
-    var N: int;
-    ghost var Repr: set<object>;
-    protected predicate Valid()
-      reads this, Repr;
+    var N: int
+    ghost var Repr: set<object>
+    predicate Valid()
+      reads this, Repr
     {
       this in Repr &&
-      0 <= N
+      0 <= N &&
+      CustomValid()
     }
+    predicate CustomValid()
+      reads this, Repr
     constructor Init()
-      ensures Valid() && fresh(Repr - {this});
+      ensures Valid() && fresh(Repr)
     {
       N, Repr := 0, {this};
+      new;
+      assume CustomValid();  // to be verified in refinement modules
     }
 
     method Inc()
-      requires Valid();
-      modifies Repr;
-      ensures old(N) < N;
-      ensures Valid() && fresh(Repr - old(Repr));
+      requires Valid()
+      modifies Repr
+      ensures old(N) < N
+      ensures Valid() && fresh(Repr - old(Repr))
     {
       N := N + 2;
+      assume CustomValid();
     }
     method Get() returns (n: int)
-      requires Valid();
-      ensures n == N;
+      requires Valid()
+      ensures n == N
     {
       n := N;
     }
@@ -70,18 +44,18 @@ module Loose {
 
 module Tight refines Loose {
   class MyNumber {
-    protected predicate Valid()
+    predicate CustomValid...
     {
       N % 2 == 0
     }
     constructor Init()
-      ensures N == 0;
+      ensures N == 0
     method Inc()
-      ensures N == old(N) + 2;
+      ensures N == old(N) + 2
   }
 }
 
-module UnawareClient {
+abstract module UnawareClient {
   import L = Loose
   method Main0() {
     var n := new L.MyNumber.Init();
@@ -105,81 +79,45 @@ module AwareClient {
   }
 }
 
-// -------- Tricky refinement inheritance ----------------------------------------
-
-module Tricky_Base {
-  class Tree {
-    var x: int;
-    predicate Constrained()
-      reads this;
-    {
-      x < 10
-    }
-    protected predicate Valid()
-      reads this;
-    {
-      x < 100
-    }
-    method Init()
-      modifies this;
-      ensures Valid();
-    {  // error: in module Tricky_Full, the strengthened postcondition Valid() no longer holds
-      x := 20;
-    }
-  }
-}
-
-module Tricky_Full refines Tricky_Base {
-  class Tree {
-    protected predicate Valid()
-    {
-      Constrained()  // this causes an error to be generated for the inherited Init
-    }
-  }
-}
-
 // -------- Quantifiers ----------------------------------------
 
 module Q0 {
   class C {
-    var x: int;
-    protected predicate P()
-      reads this;
+    var x: int
+    predicate P()
+      reads this
     {
       true
     }
     method M()
-      modifies this;
-      ensures forall c: C :: allocated(c) ==> c.P();
-    {  // error: in module Q1, the postcondition no longer holds
+      modifies this
+      ensures forall c: C :: allocated(c) ==> c.P()
+    {
     }
     predicate Q()
-      reads this;
+      reads this
     {
       x < 100
     }
     method N()
-      modifies this;
-      ensures forall c: C :: c == this ==> c.Q();
-    {  // error: fails to establish postcondition (but this error should not be repeated in Q1 below)
+      modifies this
+      ensures forall c: C :: c == this ==> c.Q()
+    {  // error: fails to establish postcondition (but this error should not be repeated in Q1 or Q2 below)
       x := 102;
     }
-    predicate R() reads this;  // a body-less predicate
+    predicate R()  // a body-less predicate
+      reads this
   }
 }
 
 module Q1 refines Q0 {
   class C {
-    protected predicate P()
-    {
-      x == 18
-    }
-    predicate R()  // no body yet
+    predicate R...  // no body yet
   }
 }
 
 module Q2 refines Q1 {
   class C {
-    predicate R() { x % 3 == 2 }  // finally, give it a body
+    predicate R... { x % 3 == 2 }  // finally, give it a body
   }
 }

--- a/Test/dafny0/Predicates.dfy.expect
+++ b/Test/dafny0/Predicates.dfy.expect
@@ -1,29 +1,13 @@
-Predicates.dfy[B](21,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy[B](20,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(31,8): Related location
+Predicates.dfy(62,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Predicates.dfy(88,15): Error: assertion violation
+Predicates.dfy(66,13): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Predicates.dfy(92,13): Error: assertion violation
-Execution trace:
-    (0,0): anon0
-Predicates.dfy[Tricky_Full](126,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy[Tricky_Full](125,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(136,6): Related location
-Predicates.dfy[Tricky_Full](116,8): Related location
-Execution trace:
-    (0,0): anon0
-Predicates.dfy(164,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy(163,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy(163,45): Related location
-Execution trace:
-    (0,0): anon0
-Predicates.dfy[Q1](154,4): Error BP5003: A postcondition might not hold on this return path.
-Predicates.dfy[Q1](153,14): Related location: This is the postcondition that might not hold.
-Predicates.dfy[Q1](153,48): Related location
+Predicates.dfy(105,4): Error BP5003: A postcondition might not hold on this return path.
+Predicates.dfy(104,14): Related location: This is the postcondition that might not hold.
+Predicates.dfy(104,45): Related location
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 29 verified, 6 errors
+Dafny program verifier finished with 21 verified, 3 errors

--- a/Test/dafny0/Protected.dfy
+++ b/Test/dafny0/Protected.dfy
@@ -2,9 +2,13 @@
 // RUN: %diff "%s.expect" "%t"
 
 module Library {
+  export
+    reveals F, G
+    provides H
+
   function F(): int { 5 }
   function {:opaque} G(): int { 5 }
-  protected function H(): int { 5 }
+  function H(): int { 5 }
 
   lemma L0() {
     assert F() == 5;
@@ -52,6 +56,6 @@ module Client {
     assert Lib.G() == 5;  // yes, the definition has been revealed
   }
   lemma L2() {
-    assert Lib.H() == 5;  // error: H() is protected, so its definition is not available
+    assert Lib.H() == 5;  // error: H() is only provided, so its definition is not available
   }
 }

--- a/Test/dafny0/Protected.dfy.expect
+++ b/Test/dafny0/Protected.dfy.expect
@@ -1,20 +1,20 @@
-Protected.dfy(17,19): Error: assertion violation
+Protected.dfy(21,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon9_Then
-Protected.dfy(31,17): Error: assertion violation
+Protected.dfy(35,17): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon12_Then
     (0,0): anon6
     (0,0): anon13_Else
-Protected.dfy(35,15): Error: assertion violation
+Protected.dfy(39,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Protected.dfy(48,19): Error: assertion violation
+Protected.dfy(52,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Protected.dfy(55,19): Error: assertion violation
+Protected.dfy(59,19): Error: assertion violation
 Execution trace:
     (0,0): anon0
 

--- a/Test/dafny0/ProtectedResolution.dfy
+++ b/Test/dafny0/ProtectedResolution.dfy
@@ -1,32 +1,11 @@
 // RUN: %dafny /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-module J0 {
-  function F0(): int
-  protected function F1(): int
-  predicate R0()
-  protected predicate R1()
-}
-module J1 refines J0 {
-  protected function F0(): int  // error: cannot add 'protected' modifier
-  function F1(): int  // error: cannot drop 'protected' modifier
-  protected predicate R0()  // error: cannot add 'protected' modifier
-  predicate R1()  // error: cannot drop 'protected' modifier
-}
-
 module M0 {
   function F(): int { 5 }
-  protected function G(): int { 5 }
   predicate P() { true }
-  protected predicate Q() { true }
 }
 module M1 refines M0 {
   function F... { 7 }  // error: not allowed to change body
-  protected function G... { 7 }  // error: not allowed to change body
   predicate P... { true }  // error: not allowed to extend body
-  protected predicate Q... { true }  // fine
-}
-
-module Y0 {
-  protected function {:opaque} F(): int { 5 }  // error: protected and opaque are incompatible
 }

--- a/Test/dafny0/ProtectedResolution.dfy.expect
+++ b/Test/dafny0/ProtectedResolution.dfy.expect
@@ -1,9 +1,3 @@
-ProtectedResolution.dfy(11,21): Error: a function in a refinement module must be declared 'protected' if and only if the refined function is
-ProtectedResolution.dfy(12,11): Error: a function in a refinement module must be declared 'protected' if and only if the refined function is
-ProtectedResolution.dfy(13,22): Error: a predicate in a refinement module must be declared 'protected' if and only if the refined predicate is
-ProtectedResolution.dfy(14,12): Error: a predicate in a refinement module must be declared 'protected' if and only if the refined predicate is
-ProtectedResolution.dfy(24,11): Error: a refining function is not allowed to extend/change the body
-ProtectedResolution.dfy(25,21): Error: a refining function is not allowed to extend/change the body
-ProtectedResolution.dfy(26,12): Error: a refining predicate is not allowed to extend/change the body unless it is declared 'protected'
-ProtectedResolution.dfy(31,31): Error: :opaque is not allowed to be applied to protected functions (this will be allowed when the language introduces 'opaque'/'reveal' as keywords)
-8 resolution/type errors detected in ProtectedResolution.dfy
+ProtectedResolution.dfy(9,11): Error: a refining function is not allowed to extend/change the body
+ProtectedResolution.dfy(10,12): Error: a refining predicate is not allowed to extend/change the body
+2 resolution/type errors detected in ProtectedResolution.dfy

--- a/Test/dafny0/Refinement.dfy
+++ b/Test/dafny0/Refinement.dfy
@@ -108,30 +108,31 @@ module FullBodied refines BodyFree {
 
 module Abstract {
   class MyNumber {
-    ghost var N: int;
-    ghost var Repr: set<object>;
-    protected predicate Valid()
-      reads this, Repr;
-    {
-      this in Repr
-    }
+    ghost var N: int
+    ghost var Repr: set<object>
+    predicate Valid()
+      reads this, Repr
+      ensures Valid() ==> this in Repr
     constructor Init()
-      ensures N == 0;
-      ensures Valid() && fresh(Repr - {this});
+      ensures N == 0
+      ensures Valid() && fresh(Repr)
     {
       N, Repr := 0, {this};
+      new;
+      assume Valid();
     }
     method Inc()
-      requires Valid();
-      modifies Repr;
-      ensures N == old(N) + 1;
-      ensures Valid() && fresh(Repr - old(Repr));
+      requires Valid()
+      modifies Repr
+      ensures N == old(N) + 1
+      ensures Valid() && fresh(Repr - old(Repr))
     {
       N := N + 1;
+      assume Valid();
     }
     method Get() returns (n: int)
-      requires Valid();
-      ensures n == N;
+      requires Valid()
+      ensures n == N
     {
       var k;  assume k == N;
       n := k;
@@ -141,22 +142,26 @@ module Abstract {
 
 module Concrete refines Abstract {
   class MyNumber {
-    var a: int;
-    var b: int;
-    protected predicate Valid()
+    var a: int
+    var b: int
+    predicate Valid...
     {
+      this in Repr &&
       N == a - b
     }
-    constructor Init()
+    constructor Init...
     {
       new;
       a := b;
+      assert ...;
     }
-    method Inc()
+    method Inc...
     {
-      if (*) { a := a + 1; } else { b := b - 1; }
+      if * { a := a + 1; } else { b := b - 1; }
+      ...;
+      assert ...;
     }
-    method Get() returns (n: int)
+    method Get...
     {
       var k := a - b;
       assert ...;
@@ -179,27 +184,29 @@ module Client {
 
 module IncorrectConcrete refines Abstract {
   class MyNumber {
-    var a: int;
-    var b: int;
-    protected predicate Valid()
+    var a: int
+    var b: int
+    predicate Valid...
     {
+      this in Repr &&
       N == 2*a - b
     }
-    constructor Init()
-    {  // error: postcondition violation
+    constructor Init...
+    {
       new;
       a := b;
+      assert ...;  // error: Valid does not hold
     }
-    method Inc()
-    {  // error: postcondition violation
-      if (*) { a := a + 1; } else { b := b - 1; }
+    method Inc...
+    {
+      if * { a := a + 1; } else { b := b - 1; }
+      ...;
+      assert ...;  // error: Valid does not hold
     }
-    method Get() returns (n: int)
+    method Get...
     {
       var k := a - b;
       assert ...;  // error: assertion violation
     }
   }
 }
-
-

--- a/Test/dafny0/Refinement.dfy.expect
+++ b/Test/dafny0/Refinement.dfy.expect
@@ -21,20 +21,18 @@ Refinement.dfy(102,2): Error BP5003: A postcondition might not hold on this retu
 Refinement.dfy(83,14): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-Refinement.dfy(189,4): Error BP5003: A postcondition might not hold on this return path.
-Refinement.dfy[IncorrectConcrete](120,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(186,8): Related location
+Refinement.dfy(198,6): Error: assertion violation
+Refinement.dfy[IncorrectConcrete](122,18): Related location
 Execution trace:
     (0,0): anon0
-Refinement.dfy(194,4): Error BP5003: A postcondition might not hold on this return path.
-Refinement.dfy[IncorrectConcrete](128,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(186,8): Related location
+Refinement.dfy(204,6): Error: assertion violation
+Refinement.dfy[IncorrectConcrete](131,18): Related location
 Execution trace:
     (0,0): anon0
     (0,0): anon4_Then
     (0,0): anon3
-Refinement.dfy(200,6): Error: assertion violation
-Refinement.dfy[IncorrectConcrete](136,23): Related location
+Refinement.dfy(209,6): Error: assertion violation
+Refinement.dfy[IncorrectConcrete](137,23): Related location
 Execution trace:
     (0,0): anon0
 

--- a/Test/dafny0/RefinementErrors.dfy
+++ b/Test/dafny0/RefinementErrors.dfy
@@ -97,11 +97,11 @@ module Forall1 refines Forall0 {
   }
 }
 
-protected module CannotRefine {
+module FineToRefine {
   type T
 }
 
-module TryToRefine refines CannotRefine { // error
+module TryToRefine refines FineToRefine {
   type T = int
 }
 

--- a/Test/dafny0/RefinementErrors.dfy.expect
+++ b/Test/dafny0/RefinementErrors.dfy.expect
@@ -10,7 +10,6 @@ RefinementErrors.dfy(39,23): Error: the type of parameter 'z' is different from 
 RefinementErrors.dfy(40,9): Error: there is a difference in name of parameter 3 ('k' versus 'b') of function F compared to corresponding function in the module it refines
 RefinementErrors.dfy(57,20): Error: a function can be changed into a function method in a refining module only if the function has not yet been given a body: G
 RefinementErrors.dfy(94,10): Error: refinement method cannot assign to a field defined in parent module ('a')
-RefinementErrors.dfy(104,27): Error: module (CannotRefine) named as a refinement base is marked protected and cannot be refined
 RefinementErrors.dfy(114,7): Error: type 'T' is declared with a different number of type parameters (3 instead of 2) than the corresponding type in the module it refines
 RefinementErrors.dfy(121,9): Error: type parameter 'C' is not allowed to change the requirement of supporting zero initialization
 RefinementErrors.dfy(121,14): Error: type parameter 'D' is not allowed to change the requirement of supporting zero initialization
@@ -90,4 +89,4 @@ RefinementErrors.dfy(189,17): Error: iterator declarations only support non-vari
 RefinementErrors.dfy(189,20): Error: iterator declarations only support non-variant type parameters
 RefinementErrors.dfy(189,26): Error: iterator declarations only support non-variant type parameters
 RefinementErrors.dfy(189,29): Error: iterator declarations only support non-variant type parameters
-92 resolution/type errors detected in RefinementErrors.dfy
+91 resolution/type errors detected in RefinementErrors.dfy

--- a/Test/dafny0/Simple.dfy
+++ b/Test/dafny0/Simple.dfy
@@ -70,9 +70,9 @@ class CF {
   static function F(): int
   predicate method G()
   greatest predicate Co()
-  protected function H(): int
-  static protected function method I(): real
-  protected static predicate method J()
+  function H(): int
+  static function method I(): real
+  static predicate method J()
 }
 
 // test printing of various if statements, including with omitted guards

--- a/Test/dafny0/Simple.dfy.expect
+++ b/Test/dafny0/Simple.dfy.expect
@@ -60,11 +60,11 @@ class CF {
 
   greatest predicate Co()
 
-  protected function H(): int
+  function H(): int
 
-  static protected function method I(): real
+  static function method I(): real
 
-  static protected predicate method J()
+  static predicate method J()
 }
 
 module A {

--- a/Test/dafny0/Superposition.dfy
+++ b/Test/dafny0/Superposition.dfy
@@ -17,13 +17,6 @@ module M0 {
       r := 8;
     }
 
-    protected predicate P(x: int)
-      ensures true;  // this postcondition will not be re-checked in refinements, because it does not mention P itself (or anything else that may change in the refinement)
-      ensures x < 60 ==> P(x);
-    {
-      true
-    }
-
     predicate Q(x: int)
       ensures Q(x) ==> x < 60;  // error: postcondition violation
     {
@@ -45,11 +38,6 @@ module M1 refines M0 {
       if ... {}
       else if (x == y) {}
       else {}
-    }
-
-    protected predicate P...  // error: inherited postcondition 'x < 60 ==> P(x)' is violated by this strengthening of P()
-    {
-      false  // with this strengthening of P(), the postcondition fails (still, note that only one of the postconditions is re-checked)
     }
 
     predicate Q...  // we don't want another error about Q's body here (because it should not be re-checked here)

--- a/Test/dafny0/Superposition.dfy.expect
+++ b/Test/dafny0/Superposition.dfy.expect
@@ -2,21 +2,18 @@
 Verifying Impl$$M0.C.M ...
   [4 proof obligations]  verified
 
-Verifying CheckWellformed$$M0.C.P ...
-  [4 proof obligations]  verified
-
 Verifying CheckWellformed$$M0.C.Q ...
   [3 proof obligations]  error
-Superposition.dfy(27,14): Error BP5003: A postcondition might not hold on this return path.
-Superposition.dfy(28,25): Related location: This is the postcondition that might not hold.
+Superposition.dfy(20,14): Error BP5003: A postcondition might not hold on this return path.
+Superposition.dfy(21,25): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
     (0,0): anon7_Else
 
 Verifying CheckWellformed$$M0.C.R ...
   [3 proof obligations]  error
-Superposition.dfy(33,14): Error BP5003: A postcondition might not hold on this return path.
-Superposition.dfy(34,25): Related location: This is the postcondition that might not hold.
+Superposition.dfy(26,14): Error BP5003: A postcondition might not hold on this return path.
+Superposition.dfy(27,25): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
     (0,0): anon7_Else
@@ -24,14 +21,4 @@ Execution trace:
 Verifying Impl$$M1.C.M ...
   [1 proof obligation]  verified
 
-Verifying CheckWellformed$$M1.C.P ...
-  [1 proof obligation]  error
-Superposition.dfy(50,24): Error BP5003: A postcondition might not hold on this return path.
-Superposition.dfy[M1](22,25): Related location: This is the postcondition that might not hold.
-Execution trace:
-    (0,0): anon0
-    (0,0): anon9_Else
-    (0,0): anon11_Then
-    (0,0): anon8
-
-Dafny program verifier finished with 3 verified, 3 errors
+Dafny program verifier finished with 2 verified, 2 errors

--- a/Test/dafny2/MonotonicHeapstate.dfy
+++ b/Test/dafny2/MonotonicHeapstate.dfy
@@ -12,8 +12,16 @@ module M0 {
 
     ghost var Repr: set<object>
 
-    protected predicate Valid()
+    predicate Valid()
       reads this, Repr
+    {
+      Core() &&
+      Valid'()
+    }
+
+    predicate Core()
+      reads this, Repr
+      decreases Repr, 0
     {
       this in Repr &&
       (left != null ==> left in Repr && this !in left.Repr && right !in left.Repr && left.Repr <= Repr && left.Valid()) &&
@@ -21,31 +29,42 @@ module M0 {
       (kind == Binary ==> left != null && right != null && left.Repr !! right.Repr)
     }
 
+    predicate Valid'()
+      requires Core()
+      reads this, Repr
+      decreases Repr, 1
+
     constructor CreateConstant(x: int)
-      ensures Valid() && fresh(Repr - {this})
+      ensures Valid() && fresh(Repr)
     {
       kind, value := Constant, x;
       left, right := null, null;
       Repr := {this};
+      new;
+      assume Valid'();  // to be proved in refinement modules
     }
 
     constructor CreateIdent(name: int)
-      ensures Valid() && fresh(Repr - {this})
+      ensures Valid() && fresh(Repr)
     {
       kind, value := Ident, name;
       left, right := null, null;
       Repr := {this};
+      new;
+      assume Valid'();  // to be proved in refinement modules
     }
 
     constructor CreateBinary(op: int, left: Expr, right: Expr)
       requires left.Valid()
       requires right.Valid()
       requires left.Repr !! right.Repr
-      ensures Valid() && fresh(Repr - {this} - left.Repr - right.Repr)
+      ensures Valid() && fresh(Repr - left.Repr - right.Repr)
     {
       kind, value := Binary, op;
       this.left, this.right := left, right;
       Repr := {this} + left.Repr + right.Repr;
+      new;
+      assume Valid'();  // to be proved in refinement modules
     }
   }
 }
@@ -55,25 +74,35 @@ module M1 refines M0 {
   class Expr {
     ghost var resolved: bool
 
-    protected predicate Valid()
+    predicate Valid'...
     {
-      resolved ==>
-        (kind == Binary ==> left.resolved && right.resolved)
+      (resolved ==>
+        (kind == Binary ==> left.resolved && right.resolved)) &&
+      Valid''()
     }
+    predicate Valid''()
+      reads this, Repr
+      ensures !resolved ==> Valid''()
 
     constructor CreateConstant...
     {
       resolved := false;
+      new;
+      assert ...;
     }
 
     constructor CreateIdent...
     {
       resolved := false;
+      new;
+      assert ...;
     }
 
     constructor CreateBinary...
     {
       resolved := false;
+      new;
+      assert ...;
     }
 
     method Resolve()
@@ -83,12 +112,13 @@ module M1 refines M0 {
       ensures resolved
       decreases Repr
     {
-      if (kind == Binary) {
+      if kind == Binary {
         left.Resolve();
         right.Resolve();
       }
       Repr := Repr + (if left != null then left.Repr else {}) + (if right != null then right.Repr else {});
       resolved := true;
+      assume Valid'();  // to be checked in refinement modules
     }
   }
 }
@@ -101,7 +131,7 @@ module M2 refines M1 {
   class Expr {
     var decl: VarDecl?  // if kind==Ident, filled in during resolution
 
-    protected predicate Valid()
+    predicate Valid''...
     {
       resolved ==>
         (kind == Ident ==> decl != null)
@@ -109,9 +139,11 @@ module M2 refines M1 {
 
     method Resolve...
     {
-      if (kind == Ident) {
+      if kind == Ident {
         decl := new VarDecl;
       }
+      ...;
+      assert ...;
     }
   }
 }

--- a/Test/dafny2/MonotonicHeapstate.dfy.expect
+++ b/Test/dafny2/MonotonicHeapstate.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 21 verified, 0 errors
+Dafny program verifier finished with 24 verified, 0 errors

--- a/Test/dafny2/StoreAndRetrieve.dfy
+++ b/Test/dafny2/StoreAndRetrieve.dfy
@@ -1,56 +1,85 @@
 // RUN: %dafny /compile:0 /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
-abstract module A {
-  import L = Library
+// This file shows an example program that uses both refinement and :autocontracts
+// specify a class that stores a set of things that can be retrieved using a query.
+//
+// (For another example that uses these features, see Test/dafny3/CachedContainer.dfy.)
+
+abstract module AbstractInterface {
   class {:autocontracts} StoreAndRetrieve<Thing(==)> {
-    ghost var Contents: set<Thing>;
-    protected predicate Valid()
-    {
-      true
+    ghost var Contents: set<Thing>
+    predicate Valid() {
+      Valid'()
     }
+    predicate {:autocontracts false} Valid'()
+      reads this, Repr
     constructor Init()
+      ensures Contents == {}
+    method Store(t: Thing)
+      ensures Contents == old(Contents) + {t}
+    method Retrieve(matchCriterion: Thing -> bool) returns (thing: Thing)
+      requires exists t :: t in Contents && matchCriterion(t)
+      ensures Contents == old(Contents)
+      ensures thing in Contents && matchCriterion(thing)
+  }
+}
+
+abstract module A refines AbstractInterface {
+  class StoreAndRetrieve<Thing(==)> {
+    constructor Init...
     {
       Contents := {};
+      Repr := {this};
+      new;
+      assume Valid'();  // to be checked in module B
     }
-    method Store(t: Thing)
+    method Store...
     {
       Contents := Contents + {t};
+      assume Valid'();  // to be checked in module B
     }
-    method Retrieve(matchCriterion: L.Function) returns (thing: Thing)
-      requires exists t :: t in Contents && L.Function.Apply(matchCriterion, t);
-      ensures Contents == old(Contents);
-      ensures thing in Contents && L.Function.Apply(matchCriterion, thing);
+    method Retrieve...
     {
-      var k :| assume k in Contents && L.Function.Apply(matchCriterion, k);
+      var k :| assume k in Contents && matchCriterion(k);
       thing := k;
     }
   }
 }
 
-module B refines A {
+abstract module B refines A {
   class StoreAndRetrieve<Thing(==)> {
-    var arr: seq<Thing>;
-    protected predicate Valid()
+    var arr: seq<Thing>
+    predicate Valid'...
     {
       Contents == set x | x in arr
     }
-    constructor Init()
+    constructor Init...
     {
       arr := [];
+      new;
+      assert ...;
     }
     method Store...
     {
       arr := arr + [t];
+      ...;
+      assert ...;
     }
     method Retrieve...
     {
       var i := 0;
       while (i < |arr|)
         invariant i < |arr|;
-        invariant forall j :: 0 <= j < i ==> !L.Function.Apply(matchCriterion, arr[j]);
+        invariant forall j :: 0 <= j < i ==> !matchCriterion(arr[j]);
       {
-        if (L.Function.Apply(matchCriterion, arr[i])) { break; }
+        if matchCriterion(arr[i]) {
+          break;
+        }
         i := i + 1;
       }
       var k := arr[i];
@@ -71,9 +100,21 @@ module C refines B {
   }
 }
 
-module Library {
-  // This class simulates function parameters
-  class Function {
-    static function method Apply<T>(f: Function, t: T): bool
+abstract module AbstractClient {
+  import S : AbstractInterface
+
+  method Test() {
+    var s := new S.StoreAndRetrieve<real>.Init();
+    s.Store(20.3);
+    var fn := r => true;
+    var r := s.Retrieve(fn);
+    print r, "\n";  // 20.3
+  }
+}
+
+module Client refines AbstractClient {
+  import S = C
+  method Main() {
+    Test();
   }
 }

--- a/Test/dafny2/StoreAndRetrieve.dfy.expect
+++ b/Test/dafny2/StoreAndRetrieve.dfy.expect
@@ -1,2 +1,14 @@
 
-Dafny program verifier finished with 13 verified, 0 errors
+Dafny program verifier finished with 22 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+20.3
+
+Dafny program verifier did not attempt verification
+20.3
+
+Dafny program verifier did not attempt verification
+20.3
+
+Dafny program verifier did not attempt verification
+20.3

--- a/Test/dafny3/CachedContainer.dfy
+++ b/Test/dafny3/CachedContainer.dfy
@@ -1,11 +1,47 @@
 // RUN: %dafny /compile:0 /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
+
+// This file contains an example chain of module refinements, starting from a
+// simple interface M0 to an implementation M3. Module Client.Test() is
+// verified against the original M0 module. Module CachedClient instantiates
+// the abstract import of M0 with the concrete module M3, and then gets to
+// reuse the proof done in Client.
+//
+// At a sufficiently abstract level, the concepts used are all standard.
+// However, it can be tricky to set these things up in Dafny, if you want
+// the final program to be a composition of smaller refinement steps.
+//
+// Textually, refinement modules in Dafny are written with "...", rather
+// than by repeating the program text from the module being refined.
+// This can be difficult to both author and read, so this file can be
+// used as a guide for what to aim for. Undoubtedly, use of the /rprint:-
+// option on the command line will be useful, since it lets you see what
+// all the ...'s expand to.
+//
+// As a convenience, this program also uses a second experimental feature,
+// namely the preprocessing requested by :autocontracts, which supplies
+// much of the boilerplate specifications that one uses with the
+// dynamic-frames idiom in Dafny. This feature was designed to reduce clutter
+// in the program text, but can increase the mystery behind what's really
+// going on. Here, too, using the /rprint:- option will be useful, since
+// it shows the automatically generated specifications and code.
+//
+// (For another example that uses these features, see Test/dafny2/StoreAndRetrieve.dfy.)
+
 
 // give the method signatures and specs
 abstract module M0 {
   class {:autocontracts} Container<T(==)> {
     ghost var Contents: set<T>
-    protected predicate Valid()
+    predicate Valid() {
+      Valid'()
+    }
+    predicate {:autocontracts false} Valid'()
+      reads this, Repr
     constructor ()
       ensures Contents == {}
     method Add(t: T)
@@ -24,12 +60,19 @@ abstract module M1 refines M0 {
     constructor... {
       Contents := {};
       Repr := {this};
+      new;
+      label CheckPost:
+      assume Valid'();  // to be checked in further refinements
     }
     method Add... {
       Contents := Contents + {t};
+      label CheckPost:
+      assume Valid'();  // to be checked in further refinements
     }
     method Remove... {
       Contents := Contents - {t};
+      label CheckPost:
+      assume Valid'();  // to be checked in further refinements
     }
     method Contains... {
       // b := t in Contents;
@@ -39,14 +82,17 @@ abstract module M1 refines M0 {
 }
 
 // implement the set in terms of a sequence
-module M2 refines M1 {
+abstract module M2 refines M1 {
   class Container<T(==)> {
     var elems: seq<T>
-    protected predicate Valid()
+    predicate Valid'...
     {
       Contents == (set x | x in elems) &&
-      forall i,j :: 0 <= i < j < |elems| ==> elems[i] != elems[j]
+      (forall i,j :: 0 <= i < j < |elems| ==> elems[i] != elems[j]) &&
+      Valid''()
     }
+    predicate {:autocontracts false} Valid''()
+      reads this, Repr
     method FindIndex(t: T) returns (j: nat)
       ensures j <= |elems|
       ensures if j < |elems| then elems[j] == t else t !in elems
@@ -65,18 +111,30 @@ module M2 refines M1 {
 
     constructor... {
       elems := [];
+      new;
+      label CheckPost:
+      assume Valid''();  // to be checked in further refinements
+      assert ...;
     }
     method Add... {
       var j := FindIndex(t);
       if j == |elems| {
         elems := elems + [t];
       }
+      ...;
+      label CheckPost:
+      assume Valid''();  // to be checked in further refinements
+      assert ...;
     }
     method Remove... {
       var j := FindIndex(t);
       if j < |elems| {
         elems := elems[..j] + elems[j+1..];
       }
+      ...;
+      label CheckPost:
+      assume Valid''();  // to be checked in further refinements
+      assert ...;
     }
     method Contains... {
       var j := FindIndex(t);
@@ -86,20 +144,28 @@ module M2 refines M1 {
 }
 
 // implement a cache
+
 module M3 refines M2 {
   datatype Cache<T> = None | Some(index: nat, value: T)
   class Container<T(==)> {
     var cache: Cache<T>
-    protected predicate Valid() {
+    predicate Valid''... {
       cache.Some? ==> cache.index < |elems| && elems[cache.index] == cache.value
     }
     constructor... {
       cache := None;
+      new;
+      ...;
+      assert ...;
     }
     method FindIndex... {
       if cache.Some? && cache.value == t {
         return cache.index;
       }
+    }
+    method Add... {
+      ...;
+      assert ...;
     }
     method Remove... {
       ...;
@@ -114,6 +180,8 @@ module M3 refines M2 {
           }
         }
       }
+      ...;
+      assert ...;
     }
   }
 }
@@ -127,12 +195,18 @@ abstract module Client {
     c.Add(12);
     var b := c.Contains(17);
     assert !b;
+    print b, " ";  // false (does not contain 17)
     b := c.Contains(12);
     assert b;
+    print b, " ";  // true (contains 12)
     c.Remove(12);
     b := c.Contains(12);
     assert !b;
+    print b, " ";  // false (no longer contains 12)
     assert c.Contents == {56};
+    b := c.Contains(56);
+    assert b;
+    print b, "\n";  // true (still contains 56)
   }
 }
 

--- a/Test/dafny3/CachedContainer.dfy.expect
+++ b/Test/dafny3/CachedContainer.dfy.expect
@@ -1,2 +1,14 @@
 
-Dafny program verifier finished with 30 verified, 0 errors
+Dafny program verifier finished with 33 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+false true false true
+
+Dafny program verifier did not attempt verification
+false true false true
+
+Dafny program verifier did not attempt verification
+false true false true
+
+Dafny program verifier did not attempt verification
+false true false true

--- a/Test/dafny4/ClassRefinement.dfy
+++ b/Test/dafny4/ClassRefinement.dfy
@@ -1,4 +1,8 @@
 // RUN: %dafny /compile:0 /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 abstract module M0 {
@@ -11,20 +15,19 @@ abstract module M0 {
   class Counter {
     ghost var N: int
     ghost var Repr: set<object>
-    protected predicate Valid()
+    predicate Valid()
       reads this, Repr
-    {
-      this in Repr
-    }
+      ensures Valid() ==> this in Repr
 
     constructor Init()
       ensures N == 0
-      ensures Valid() && fresh(Repr - {this})
+      ensures Valid() && fresh(Repr)
     {
       Repr := {};
       new;
       ghost var repr :| {this} <= repr && fresh(repr - {this});
       N, Repr := 0, repr;
+      assume Valid();  // to be verified in refinement module
     }
 
     method Inc()
@@ -35,6 +38,7 @@ abstract module M0 {
     {
       N := N + 1;
       modify Repr - {this};
+      assume Valid();  // to be verified in refinement module
     }
 
     method Get() returns (n: int)
@@ -50,8 +54,9 @@ module M1 refines M0 {
   class Counter {
     var c: Cell
     var d: Cell
-    protected predicate Valid...
+    predicate Valid...
     {
+      this in Repr &&
       c in Repr &&
       d in Repr &&
       c != d &&
@@ -64,6 +69,8 @@ module M1 refines M0 {
       d := new Cell(0);
       new;
       ghost var repr := Repr + {this} + {c,d};
+      ...;
+      assert ...;
     }
 
     method Inc...
@@ -72,6 +79,7 @@ module M1 refines M0 {
       modify ... {
         c.data := c.data + 1;
       }
+      assert ...;
     }
 
     method Get...
@@ -79,4 +87,17 @@ module M1 refines M0 {
       n := c.data - d.data;
     }
   }
+}
+
+method Main() {
+  var mx := new M1.Counter.Init();
+  var my := new M1.Counter.Init();
+  assert mx.N == 0 && my.N == 0;
+  mx.Inc();
+  my.Inc();
+  mx.Inc();
+  var nx := mx.Get();
+  var ny := my.Get();
+  assert nx == 2 && ny == 1;
+  print nx, " ", ny, "\n";
 }

--- a/Test/dafny4/ClassRefinement.dfy.expect
+++ b/Test/dafny4/ClassRefinement.dfy.expect
@@ -1,2 +1,14 @@
 
-Dafny program verifier finished with 11 verified, 0 errors
+Dafny program verifier finished with 12 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+2 1
+
+Dafny program verifier did not attempt verification
+2 1
+
+Dafny program verifier did not attempt verification
+2 1
+
+Dafny program verifier did not attempt verification
+2 1

--- a/Test/dafny4/UnionFind.dfy
+++ b/Test/dafny4/UnionFind.dfy
@@ -8,7 +8,12 @@ abstract module M0 {
 
   class {:autocontracts} UnionFind {
     ghost var M: map<Element, Element>
-    protected predicate Valid()
+    predicate Valid() {
+      ValidM1()
+    }
+    predicate {:autocontracts false} ValidM1()
+      reads this, Repr
+      ensures M == map[] ==> ValidM1()
 
     constructor ()
       ensures M == map[]
@@ -47,7 +52,7 @@ abstract module M1 refines M0 {
   }
 
   class UnionFind {
-    protected predicate Valid...
+    predicate ValidM1()
     {
       M.Keys <= Repr &&
       (forall e :: e in M ==> M[e] in M && M[M[e]] == M[e]) &&

--- a/Test/dafny4/UnionFind.dfy.expect
+++ b/Test/dafny4/UnionFind.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 62 verified, 0 errors
+Dafny program verifier finished with 63 verified, 0 errors
 false
 true true
 false true true

--- a/docs/_includes/Grammar.md
+++ b/docs/_includes/Grammar.md
@@ -304,7 +304,7 @@ reservedword =
     "iterator" | "label" | "lemma" | "map" | "match" | "method" |
     "modifies" | "modify" | "module" | "multiset" | "nat" |
     "new" | "newtype" | "null" | "object" | "old" | "opened" |
-    "predicate" | "print" | "protected" | "provides" "reads" |
+    "predicate" | "print" | "provides" "reads" |
     "real" | "refines" | "requires" | "return" | "returns" |
     "reveals" | "seq" | "set" | "static" | "string" | "then" |
     "this" | "trait" | "true" | "twostate" | "type" |

--- a/docs/_includes/Programs.md
+++ b/docs/_includes/Programs.md
@@ -63,7 +63,7 @@ explicitly on the command line.
 
 The file name may be a path using the customary `/`, `.`, and `..` specifiers.
 The interpretation of the name (e.g., case-sensitivity) will depend on the
-underlying operating system. A path not beginning with `/` is looked up in 
+underlying operating system. A path not beginning with `/` is looked up in
 the underlying file system relative to the current working directory (the
 one in which the dafny tool is invoked). Paths beginning with a device
 designator (e.g., `C:`) are only permitted on Windows systems.
@@ -82,7 +82,7 @@ TopDecl = { { DeclModifier }
   }
 ````
 Top-level declarations may appear either at the top level of a Dafny file,
-or within a ``SubModuleDecl``. A top-level declaration is one of the 
+or within a ``SubModuleDecl``. A top-level declaration is one of the
 various kinds of declarations described later. Top-level declarations are
 implicitly members of a default (unnamed) top-level module.
 
@@ -98,8 +98,7 @@ the top level cannot be a ``FieldDecl``.
 ## Declaration Modifiers
 ````grammar
 DeclModifier =
-  ( "abstract" | "ghost" | "static" | "protected"
-  | "extern" [ stringToken]
+  ( "abstract" | "ghost" | "static"
   )
 ````
 
@@ -117,13 +116,6 @@ The `static` modifier is used for class members that that
 are associated with the class as a whole rather than with
 an instance of the class.
 
-The `protected` modifier is used to control the visibility of the
-body of functions.
-
-The `extern` modifier is used to alter the CompileName of
-entities. The CompileName is the name for the entity
-when translating to Boogie or a target programming language.
-
 The following table shows modifiers that are available
 for each of the kinds of declaration. In the table
 we use already-ghost (already-non-ghost) to denote that the item is not
@@ -131,26 +123,26 @@ allowed to have the ghost modifier because it is already
 implicitly ghost (non-ghost).
 
 
- Declaration              | allowed modifiers                     
+ Declaration              | allowed modifiers
 --------------------------|---------------------------------------
- module                   | abstract                              
- class                    | extern                                
- trait                    | -                                     
- datatype or codatatype   | -                                     
- field                    | ghost                                 
- newtype                  | -                                     
- synonym types            | -                                     
- iterators                | -                                     
- method                   | ghost static extern                   
- lemma, colemma, comethod | already-ghost static protected        
- inductive lemma          | already-ghost static                  
- constructor              | -                                     
- function (non-method)    | already-ghost static protected        
- function method          | already-non-ghost static protected extern 
- predicate (non-method)   | already-ghost static protected        
- predicate method         | already-non-ghost static protected extern 
- inductive predicate      | already-ghost static protected        
- copredicate              | already-ghost static protected        
+ module                   | abstract
+ class                    | -
+ trait                    | -
+ datatype or codatatype   | -
+ field                    | ghost
+ newtype                  | -
+ synonym types            | -
+ iterators                | -
+ method                   | ghost static
+ lemma, colemma, comethod | already-ghost static
+ inductive lemma          | already-ghost static
+ constructor              | -
+ function (non-method)    | already-ghost static
+ function method          | already-non-ghost static
+ predicate (non-method)   | already-ghost static
+ predicate method         | already-non-ghost static
+ inductive predicate      | already-ghost static
+ copredicate              | already-ghost static
 
 
 

--- a/docs/_includes/Types.md
+++ b/docs/_includes/Types.md
@@ -1187,8 +1187,6 @@ not in code that will be compiled into executable code.
 
 Fields may not be declared static.
 
-`protected` is not allowed for fields.
-
 ## Method Declarations
 ````grammar
 MethodDecl(isGhost, allowConstructor) =
@@ -1532,30 +1530,22 @@ A function is usually transparent up to some unrolling level (up to
 1, or maybe 2 or 3). If its arguments are all literals it is
 transparent all the way.
 
-**The protected modifier is being deprecated**
-
-But the transparency of a function is affected by the following:
-
-* whether the function was declared to be protected, and
-* whether the function was given the `{:opaque}` attribute (as explained
+But the transparency of a function is affected by
+whether the function was given the `{:opaque}` attribute (as explained
 in Section [#sec-opaque]).
 
 The following table summarizes where the function is transparent.
 The module referenced in the table is the module in which the
 function is defined.
 
- Protected? | `{:opaque}`? | Transparent Inside Module | Transparent Outside Module
-:----------:|:------------:|:-----------:|:-----------:
- N          | N            | Y           | Y
- Y          | N            | Y           | N
- N          | Y            | N           | N
+ `{:opaque}`? | Transparent Inside Module | Transparent Outside Module
+:------------:|:-----------:|:-----------:
+ N            | Y           | Y
+ Y            | N           | N
 
 When `{:opaque}` is specified for function `g`, `g` is opaque,
 however the lemma `reveal_g` is available to give the semantics
 of `g` whether in the defining module or outside.
-
-It currently is not allowed to have both `protected` and
-`{:opaque}` specified for a function.
 
 ### Inductive Predicates and Lemmas
 See section [#sec-friendliness] for descriptions


### PR DESCRIPTION
This PR removes the `protected` keyword from the language. Instead:

* To restrict access from outside the module, use a `provides` clause in the module's export set.
* If you're trying to add conjuncts to a predicate in a refinement module, see
    - `Test/dafny3/CachedContainer.dfy`,
    - `Test/dafny2/StoreAndRetrieve.dfy`, and
    - `Test/dafny2/MonotonicHeapstate.dfy`

    for examples of how to effectively strengthen predicates in refinement modules.

## Background

The keyword `protected` was introduced in support of refinement modules. In particular, by marking a predicate with `protected`, refinement modules gain the ability to add conjuncts to the body of the predicate. To make this sound while allowing refinement modules to take the place of the modules they are refining, the body of the protected predicate was never visible outside the declaring module.

While this feature made it easy to strengthen predicate definitions, which is often desirable in refinement, it is possible to use other features to accomplish this (see the examples listed above). Since the semantics of these alternative, existing features are more standard, they are easier to understand. And since superimposition refinement is not heavily used in programs anyway, it seems better to remove the unusual feature -- it saves explanations and reduces maintenance work on Dafny.

Because `protected` had the necessary side effect of confining a predicate's body inside the defining module, the `protected` keyword could also be used for this purpose alone, even in modules that are never refined. By deprecating the `protected` keyword, this PR breaks such uses. Luckily, this functionality is supported well by _export sets_. If an export set `provides` the predicate (as opposed to `reveals` the predicate), then the signature of the predicate is made available outside the module, but the predicate's body is not.

Finally, the `protected` modifier could also be applied to a `module`. I don't remember the reason for allowing this in the first place, but the effect of it was to disallow refinements of the module. This (probably completely unused) functionality is removed by this PR as well, and there is no replacement for it.