### PR TITLE
Update dynamic frames idiom

### DIFF
--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Dafny
   /// be added.
   ///
   /// For every constructor, add:
-  ///    ensures Valid() && fresh(Repr - {this})
+  ///    ensures Valid() && fresh(Repr)
   /// At the end of the body of the constructor, add:
   ///    Repr := {this};
   ///    if (A != null) { Repr := Repr + {A}; }
@@ -529,10 +529,9 @@ namespace Microsoft.Dafny
           // ensures Valid();
           var valid = new FunctionCallExpr(tok, "Valid", new ImplicitThisExpr(tok), tok, new List<Expression>());
           ctor.Ens.Insert(0, new AttributedExpression(valid));
-          // ensures fresh(Repr - {this});
-          var freshness = new UnaryOpExpr(tok, UnaryOpExpr.Opcode.Fresh, new BinaryExpr(tok, BinaryExpr.Opcode.Sub,
-            new MemberSelectExpr(tok, new ImplicitThisExpr(tok), "Repr"),
-            new SetDisplayExpr(tok, true, new List<Expression>() { new ThisExpr(tok) })));
+          // ensures fresh(Repr);
+          var freshness = new UnaryOpExpr(tok, UnaryOpExpr.Opcode.Fresh,
+            new MemberSelectExpr(tok, new ImplicitThisExpr(tok), "Repr"));
           ctor.Ens.Insert(1, new AttributedExpression(freshness));
           var m0 = new ThisExpr(tok);
           AddHoverText(member.tok, "modifies {0}\nensures {1} && {2}", m0, valid, freshness);

--- a/Test/VSComp2010/Problem3-FindZero.dfy
+++ b/Test/VSComp2010/Problem3-FindZero.dfy
@@ -28,8 +28,9 @@ class Node {
   var head: int
   var next: Node?
 
-  function Valid(): bool
+  predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     1 <= |List| && List[0] == head &&

--- a/Test/VSComp2010/Problem5-DoubleEndedQueue.dfy
+++ b/Test/VSComp2010/Problem5-DoubleEndedQueue.dfy
@@ -21,6 +21,7 @@ class AmortizedQueue<T(0)> {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     front in Repr && front.Repr <= Repr && front.Valid() &&
@@ -92,6 +93,7 @@ class LinkedList<T(0)> {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     0 <= length && length == |List| &&

--- a/Test/VSI-Benchmarks/b4.dfy
+++ b/Test/VSI-Benchmarks/b4.dfy
@@ -54,7 +54,7 @@ class Map<Key(==),Value> {
 
 
   constructor Init()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures M == map[]
   {
     head, Spine := null, {};

--- a/Test/VSI-Benchmarks/b4.dfy
+++ b/Test/VSI-Benchmarks/b4.dfy
@@ -17,6 +17,7 @@ class Map<Key(==),Value> {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr && Spine <= Repr &&
     SpineValid(Spine, head) &&

--- a/Test/allocated1/dafny0/Twostate-Verification.dfy
+++ b/Test/allocated1/dafny0/Twostate-Verification.dfy
@@ -90,14 +90,14 @@ class Node {
     (next != null ==> next in Repr && next.Repr <= Repr && this !in next.Repr && next.Valid())
   }
   constructor (y: int)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
   {
     x, next := y, null;
     Repr := {this};
   }
   constructor Prepend(y: int, nxt: Node)
     requires nxt.Valid()
-    ensures Valid() && fresh(Repr - {this} - nxt.Repr)
+    ensures Valid() && fresh(Repr - nxt.Repr)
   {
     x, next := y, nxt;
     Repr := {this} + nxt.Repr;
@@ -198,7 +198,7 @@ class {:autocontracts} NodeAuto {
   }
   constructor {:autocontracts false} Prepend(y: int, nxt: NodeAuto)
     requires nxt.Valid() && allocated(nxt.Repr);
-    ensures Valid() && fresh(Repr - {this} - nxt.Repr)
+    ensures Valid() && fresh(Repr - nxt.Repr)
   {
     x, next := y, nxt;
     Repr := {this} + nxt.Repr;

--- a/Test/allocated1/dafny0/Twostate-Verification.dfy
+++ b/Test/allocated1/dafny0/Twostate-Verification.dfy
@@ -85,6 +85,7 @@ class Node {
   ghost var Repr: set<Node>
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr && (forall o :: o in Repr ==> allocated(o)) &&
     (next != null ==> next in Repr && next.Repr <= Repr && this !in next.Repr && next.Valid())

--- a/Test/allocated1/dafny0/Twostate-Verification.dfy.expect
+++ b/Test/allocated1/dafny0/Twostate-Verification.dfy.expect
@@ -23,11 +23,11 @@ Execution trace:
 Twostate-Verification.dfy(78,15): Error: assertion violation
 Execution trace:
     (0,0): anon0
-Twostate-Verification.dfy(234,69): Error: target object may not be allocated
+Twostate-Verification.dfy(235,69): Error: target object may not be allocated
 Execution trace:
     (0,0): anon0
     (0,0): anon4_Then
-Twostate-Verification.dfy(234,80): Error: target object may not be allocated
+Twostate-Verification.dfy(235,80): Error: target object may not be allocated
 Execution trace:
     (0,0): anon0
     (0,0): anon4_Then

--- a/Test/dafny0/AutoContracts.dfy.expect
+++ b/Test/dafny0/AutoContracts.dfy.expect
@@ -132,6 +132,7 @@ module OneModule {
 
     predicate Valid()
       reads this, Repr
+      ensures Valid() ==> this in Repr
       decreases Repr + {this}
     {
       this in Repr &&
@@ -152,6 +153,7 @@ module OneModule {
 
     predicate Valid()
       reads this, Repr
+      ensures Valid() ==> this in Repr
       decreases Repr + {this}
     {
       this in Repr &&
@@ -317,6 +319,7 @@ module N0 {
 
     predicate Valid()
       reads this, Repr
+      ensures Valid() ==> this in Repr
       decreases Repr + {this}
     {
       this in Repr &&
@@ -433,6 +436,7 @@ module N1 refines N0 {
 
     predicate Valid()
       reads this, Repr
+      ensures Valid() ==> this in Repr
       decreases Repr + {this}
     {
       this in Repr &&
@@ -532,6 +536,7 @@ module N2 refines N1 {
 
     predicate Valid()
       reads this, Repr
+      ensures Valid() ==> this in Repr
       decreases Repr + {this}
     {
       this in Repr &&

--- a/Test/dafny0/AutoContracts.dfy.expect
+++ b/Test/dafny0/AutoContracts.dfy.expect
@@ -173,7 +173,7 @@ module OneModule {
 
     constructor ()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
     {
       data := 0;
       new;
@@ -281,15 +281,15 @@ module N0 {
   class {:autocontracts} C {
     constructor X()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
 
     constructor Y()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
 
     constructor Z()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
     {
       new;
       Repr := {this};
@@ -374,17 +374,17 @@ module N1 refines N0 {
   class {:autocontracts} C {
     constructor X()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
 
     constructor Y()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
     {
     }
 
     constructor Z()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
     {
       new;
       Repr := {this};
@@ -473,17 +473,17 @@ module N2 refines N1 {
   class {:autocontracts} C {
     constructor X()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
 
     constructor Y()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
     {
     }
 
     constructor Z()
       ensures Valid()
-      ensures fresh(Repr - {this})
+      ensures fresh(Repr)
     {
       new;
       Repr := {this};

--- a/Test/dafny0/Twostate-Verification.dfy
+++ b/Test/dafny0/Twostate-Verification.dfy
@@ -86,14 +86,14 @@ class Node {
     (next != null ==> next in Repr && next.Repr <= Repr && this !in next.Repr && next.Valid())
   }
   constructor (y: int)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
   {
     x, next := y, null;
     Repr := {this};
   }
   constructor Prepend(y: int, nxt: Node)
     requires nxt.Valid()
-    ensures Valid() && fresh(Repr - {this} - nxt.Repr)
+    ensures Valid() && fresh(Repr - nxt.Repr)
   {
     x, next := y, nxt;
     Repr := {this} + nxt.Repr;
@@ -194,7 +194,7 @@ class {:autocontracts} NodeAuto {
   }
   constructor {:autocontracts false} Prepend(y: int, nxt: NodeAuto)
     requires nxt.Valid()
-    ensures Valid() && fresh(Repr - {this} - nxt.Repr)
+    ensures Valid() && fresh(Repr - nxt.Repr)
   {
     x, next := y, nxt;
     Repr := {this} + nxt.Repr;

--- a/Test/dafny0/Twostate-Verification.dfy
+++ b/Test/dafny0/Twostate-Verification.dfy
@@ -81,6 +81,7 @@ class Node {
   ghost var Repr: set<Node?>
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     (next != null ==> next in Repr && next.Repr <= Repr && this !in next.Repr && next.Valid())

--- a/Test/dafny1/BinaryTree.dfy
+++ b/Test/dafny1/BinaryTree.dfy
@@ -19,7 +19,7 @@ class IntSet {
   }
 
   constructor Init()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Contents == {}
   {
     root := null;
@@ -131,7 +131,7 @@ class Node {
   }
 
   constructor Init(x: int)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Contents == {x}
   {
     data := x;

--- a/Test/dafny1/BinaryTree.dfy
+++ b/Test/dafny1/BinaryTree.dfy
@@ -9,6 +9,7 @@ class IntSet {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     (root == null ==> Contents == {}) &&
@@ -107,6 +108,7 @@ class Node {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     (left != null ==>

--- a/Test/dafny1/ExtensibleArray.dfy
+++ b/Test/dafny1/ExtensibleArray.dfy
@@ -39,7 +39,7 @@ class ExtensibleArray<T> {
   }
 
   constructor Init()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Contents == []
   {
     elements := null;

--- a/Test/dafny1/ExtensibleArray.dfy
+++ b/Test/dafny1/ExtensibleArray.dfy
@@ -12,6 +12,7 @@ class ExtensibleArray<T> {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     // shape of data structure
     this in Repr && null !in Repr &&

--- a/Test/dafny1/ListContents.dfy
+++ b/Test/dafny1/ListContents.dfy
@@ -21,7 +21,7 @@ class Node<T> {
   }
 
   constructor (d: T)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures List == [d]
   {
     data, next := d, null;
@@ -30,7 +30,7 @@ class Node<T> {
 
   constructor InitAsPredecessor(d: T, succ: Node<T>)
     requires succ.Valid()
-    ensures Valid() && fresh(Repr - {this} - succ.Repr)
+    ensures Valid() && fresh(Repr - succ.Repr)
     ensures List == [d] + succ.List
   {
     data, next := d, succ;

--- a/Test/dafny1/SeparationLogicList.dfy
+++ b/Test/dafny1/SeparationLogicList.dfy
@@ -120,7 +120,7 @@ class List<T(0)>
   }
 
   constructor Init()
-    ensures IsList() && Contents == [] && fresh(Repr - {this})
+    ensures IsList() && Contents == [] && fresh(Repr)
   {
     var h: LLNode<T> := new LLNode<T>;
     h.next := null;

--- a/Test/dafny2/COST-verif-comp-2011-2-MaxTree-class.dfy
+++ b/Test/dafny2/COST-verif-comp-2011-2-MaxTree-class.dfy
@@ -79,6 +79,7 @@ class Tree {
   ghost var Repr: set<object>
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     left != null && right != null &&

--- a/Test/dafny2/MonotonicHeapstate.dfy
+++ b/Test/dafny2/MonotonicHeapstate.dfy
@@ -14,6 +14,7 @@ module M0 {
 
     predicate Valid()
       reads this, Repr
+      ensures Valid() ==> this in Repr
     {
       Core() &&
       Valid'()

--- a/Test/dafny2/SnapshotableTrees.dfy
+++ b/Test/dafny2/SnapshotableTrees.dfy
@@ -287,7 +287,7 @@ module SnapTree {
     }
 
     constructor Init(x: int)
-      ensures NodeValid() && fresh(Repr - {this})
+      ensures NodeValid() && fresh(Repr)
       ensures Contents == [x]
     {
       Contents := [x];
@@ -305,10 +305,10 @@ module SnapTree {
       requires left != null && right != null ==> left.Repr !! right.Repr
       ensures NodeValid()
       ensures Contents == CombineSplit(left, x, right)
-      ensures left == null && right == null ==> fresh(Repr - {this})
-      ensures left != null && right == null ==> fresh(Repr - {this} - left.Repr)
-      ensures left == null && right != null ==> fresh(Repr - {this} - right.Repr)
-      ensures left != null && right != null ==> fresh(Repr - {this} - left.Repr - right.Repr)
+      ensures left == null && right == null ==> fresh(Repr)
+      ensures left != null && right == null ==> fresh(Repr - left.Repr)
+      ensures left == null && right != null ==> fresh(Repr - right.Repr)
+      ensures left != null && right != null ==> fresh(Repr - left.Repr - right.Repr)
     {
       Contents := [x];
       Repr := {this};
@@ -521,7 +521,7 @@ module SnapTree {
 
     constructor Init(t: Tree)
       requires t.Valid()
-      ensures Valid() && fresh(IterRepr - {this})
+      ensures Valid() && fresh(IterRepr)
       ensures T == t && Contents == t.Contents && N == -1
     {
       new;

--- a/Test/dafny3/Iter.dfy
+++ b/Test/dafny3/Iter.dfy
@@ -10,6 +10,7 @@ class List<T> {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     a in Repr &&

--- a/Test/dafny3/Iter.dfy
+++ b/Test/dafny3/Iter.dfy
@@ -18,7 +18,7 @@ class List<T> {
   }
 
   constructor Init()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Contents == []
   {
     Contents, n := [], 0;

--- a/Test/dafny4/Bug140.dfy
+++ b/Test/dafny4/Bug140.dfy
@@ -21,7 +21,7 @@ class Node<T> {
   }
 
   constructor (d: T)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures List == [d]
   {
     data, next := d, null;
@@ -30,7 +30,7 @@ class Node<T> {
 
   constructor InitAsPredecessor(d: T, succ: Node<T>)
     requires succ.Valid()
-    ensures Valid() && fresh(Repr - {this} - succ.Repr);
+    ensures Valid() && fresh(Repr - succ.Repr);
     ensures List == [d] + succ.List;
   {
     data, next := d, succ;

--- a/Test/dafny4/Bug140.dfy
+++ b/Test/dafny4/Bug140.dfy
@@ -10,6 +10,7 @@ class Node<T> {
 
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     (next == null ==> List == [data]) &&

--- a/Test/dafny4/FlyingRobots.dfy
+++ b/Test/dafny4/FlyingRobots.dfy
@@ -29,7 +29,7 @@ class Point {
   var x:Cell, y:Cell, z:Cell
 
   constructor (a:int, b:int, c:int)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Value == (a, b, c)
   {
     x := new Cell(a);
@@ -67,7 +67,7 @@ class Arm {
   var azim:Cell
 
   constructor (polar_in:int, azim_in:int)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Value == (polar_in, azim_in)
   {
     polar := new Cell(polar_in);
@@ -106,7 +106,7 @@ class Bot {
   var right:Arm
 
   constructor ()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
   {
     pos := new Point(0, 0, 0);
     left := new Arm(0, 0);

--- a/Test/dafny4/FlyingRobots.dfy
+++ b/Test/dafny4/FlyingRobots.dfy
@@ -19,6 +19,7 @@ class Point {
   ghost var Repr: set<object>
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     {x,y,z} <= Repr &&
@@ -56,6 +57,7 @@ class Arm {
   ghost var Repr: set<object>
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr &&
     {polar, azim} <= Repr &&

--- a/Test/traits/TraitExample.dfy
+++ b/Test/traits/TraitExample.dfy
@@ -24,7 +24,7 @@ class Fiat extends Automobile {
   }
   constructor (pos: int)
     requires pos <= 100
-    ensures Valid() && fresh(Repr - {this}) && position == pos
+    ensures Valid() && fresh(Repr) && position == pos
   {
     position, Repr := pos, {this};
   }
@@ -52,7 +52,7 @@ class Volvo extends Automobile {
     odometer.value == position
   }
   constructor ()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
   {
     position, Repr := 0, {this};
     odometer := new Odometer();
@@ -102,7 +102,7 @@ class Catacar extends Automobile {
     position == f.position + v.position
   }
   constructor ()
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
   {
     var fiat := new Fiat(0);
     var volvo := new Volvo();

--- a/Test/vstte2012/RingBuffer.dfy
+++ b/Test/vstte2012/RingBuffer.dfy
@@ -27,7 +27,7 @@ class RingBuffer<T(0)>
   }
 
   constructor Create(n: nat)
-    ensures Valid() && fresh(Repr - {this})
+    ensures Valid() && fresh(Repr)
     ensures Contents == [] && N == n
   {
     data := new T[n];

--- a/Test/vstte2012/RingBuffer.dfy
+++ b/Test/vstte2012/RingBuffer.dfy
@@ -16,6 +16,7 @@ class RingBuffer<T(0)>
   // Valid encodes the consistency of RingBuffer objects (think, invariant)
   predicate Valid()
     reads this, Repr
+    ensures Valid() ==> this in Repr
   {
     this in Repr && null !in Repr &&
     data in Repr &&


### PR DESCRIPTION
The standard dynamic-frames idiom has evolved over the last few years. This PR reflects these changes.

* Many moons ago, a class `constructor` in Dafny started considering `this` as being allocated by the constructor, not the caller. One consequence of this is that the dynamic-frames postcondition

    ``` dafny
    ensures fresh(Repr - {this})
    ```

    on a constructor can be simplified to

    ``` dafny
    ensures fresh(Repr)
    ```

* It is often useful, especially when modules and hiding are relevant, to include the following postcondition of the `Valid()` predicate:

    ``` dafny
    ensures Valid() ==> this in Repr
    ```

    rather than clients having to get this information from the (possibly inaccessible) body of the `Valid()` predicate.

This PR makes these changes throughout the test suite (except, in some places where modularity is not much of a concern, it seemed better to omit the second change). Also, this PR makes these changes for the specifications generated by the `:autocontracts` pre-processor.