### PR TITLE
#327, #659: Fixing module name lookup in refines parent

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -927,7 +927,6 @@ SubModuleDecl<DeclModifierData dmod, ModuleDefinition parent, out ModuleDecl sub
       (. submodule = new AliasModuleDecl(idPath, id, parent, opened, idExports); .)
     | ":" QualifiedModuleExport<out idPath, out idExports>
         (. submodule = new ModuleFacadeDecl(idPath, id, parent, opened, idExports); .)
-
     )
 
   | (.

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -3683,13 +3683,13 @@ namespace Microsoft.Dafny {
     public int? ResolvedHash { get; set; }
 
     // Qualified accesses follow module imports
-    public bool FindImport(string name, out ModuleSignature pp) {
+    public bool FindImport(string name, out ModuleDecl decl) {
       TopLevelDecl top;
       if (TopLevels.TryGetValue(name, out top) && top is ModuleDecl) {
-          pp = ((ModuleDecl)top).AccessibleSignature();
+          decl = (ModuleDecl)top;
         return true;
       } else {
-        pp = null;
+        decl = null;
         return false;
       }
     }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -2132,7 +2132,7 @@ namespace Microsoft.Dafny
       // Although the module is known, we demand it be imported before we're willing to access it.
       // Imports are resolved before their containing module, so we cannot rely on
       // the parent module to have any names that might come in through refines.
-      // However the parent refines will lready have been fully refined.
+      // However the parent refines will already have been fully refined.
       ModuleDefinition par = parent;
       TopLevelDecl thisImport = par.TopLevelDecls.FirstOrDefault(t => t.Name == Path[0].val && t != alias);
       if (thisImport == null) {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -2130,7 +2130,18 @@ namespace Microsoft.Dafny
       }
 
       // Although the module is known, we demand it be imported before we're willing to access it.
-      var thisImport = parent.TopLevelDecls.FirstOrDefault(t => t.Name == Path[0].val && t != alias);
+      // Imports are resolved before their containing module, so we cannot rely on
+      // the parent module to have any names that might come in through refines.
+      // However the parent refines will lready have been fully refined.
+      ModuleDefinition par = parent;
+      TopLevelDecl thisImport = null;
+      thisImport = par.TopLevelDecls.FirstOrDefault(t => t.Name == Path[0].val && t != alias);
+      if (thisImport == null) {
+        LiteralModuleDecl md = par.RefinementBaseRoot as LiteralModuleDecl;
+        if (md != null) {
+          thisImport = md.ModuleDef.TopLevelDecls.FirstOrDefault(t => t.Name == Path[0].val && t != alias);
+        }
+      }
 
       if (thisImport == null || !(thisImport is ModuleDecl)) {
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -2088,7 +2088,17 @@ namespace Microsoft.Dafny
 
       ModuleDecl decl = root;
       for (int k = 1; k < Path.Count; k++) {
-        var tld = decl.Signature.TopLevels.GetValueOrDefault(Path[k].val, null);
+        if (decl is LiteralModuleDecl) {
+          p = ((LiteralModuleDecl) decl).DefaultExport;
+          if (p == null) {
+            reporter.Error(MessageSource.Resolver, Path[k],
+              ModuleNotFoundErrorMessage(k, Path, $" because {decl.Name} does not have a default export"));
+            return false;
+          }
+        } else {
+          p = decl.Signature;
+        }
+        var tld = p.TopLevels.GetValueOrDefault(Path[k].val, null);
         if (!(tld is ModuleDecl dd)) {
           if (decl.Signature.ModuleDef == null) {
             reporter.Error(MessageSource.Resolver, Path[k],

--- a/Test/exports/ExportImport.dfy
+++ b/Test/exports/ExportImport.dfy
@@ -31,7 +31,7 @@ module B {
 }
 
 module C {
-  import CAO = B.BAO // OK now
+  import CAO = B.BAO // error - BAO not in B`B
 }
 
 module CC {

--- a/Test/exports/ExportImport.dfy
+++ b/Test/exports/ExportImport.dfy
@@ -31,7 +31,7 @@ module B {
 }
 
 module C {
-  import CAO = B.BAO // error
+  import CAO = B.BAO // OK now
 }
 
 module CC {

--- a/Test/exports/ExportImport.dfy.expect
+++ b/Test/exports/ExportImport.dfy.expect
@@ -1,5 +1,4 @@
-ExportImport.dfy(34,15): Error: module B does not exist (position 0 in path B.BAO)
 ExportImport.dfy(39,18): Error: module BAO does not exist (position 1 in path B.BAO)
 ExportImport.dfy(48,18): Error: arguments must have comparable types (got DAO.T and bool)
 ExportImport.dfy(51,18): Error: arguments must have comparable types (got DAO.T and B.TT)
-4 resolution/type errors detected in ExportImport.dfy
+3 resolution/type errors detected in ExportImport.dfy

--- a/Test/exports/ExportImport.dfy.expect
+++ b/Test/exports/ExportImport.dfy.expect
@@ -1,4 +1,5 @@
+ExportImport.dfy(34,17): Error: module BAO does not exist (position 1 in path B.BAO)
 ExportImport.dfy(39,18): Error: module BAO does not exist (position 1 in path B.BAO)
 ExportImport.dfy(48,18): Error: arguments must have comparable types (got DAO.T and bool)
 ExportImport.dfy(51,18): Error: arguments must have comparable types (got DAO.T and B.TT)
-3 resolution/type errors detected in ExportImport.dfy
+4 resolution/type errors detected in ExportImport.dfy

--- a/Test/git-issues/git-issue-327.dfy
+++ b/Test/git-issues/git-issue-327.dfy
@@ -1,0 +1,30 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+}
+
+module B {
+  import A
+}
+
+module C0 {}
+
+module C refines C0 {
+  import B
+}
+
+module CC refines C {}
+
+module D refines CC {
+  import A = B.A
+}
+
+module E {
+  import A
+}
+
+module F {
+  import E
+  import E.A
+}

--- a/Test/git-issues/git-issue-327.dfy.expect
+++ b/Test/git-issues/git-issue-327.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/git-issues/git-issue-327.dfy.expect
+++ b/Test/git-issues/git-issue-327.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished with 5 verified, 0 errors

--- a/Test/git-issues/git-issue-327a.dfy
+++ b/Test/git-issues/git-issue-327a.dfy
@@ -1,0 +1,10 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  module X { }
+}
+module B {
+  import A.X  // used to require an 'import A' first
+}
+

--- a/Test/git-issues/git-issue-327a.dfy.expect
+++ b/Test/git-issues/git-issue-327a.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/git-issues/git-issue-327cir.dfy
+++ b/Test/git-issues/git-issue-327cir.dfy
@@ -1,0 +1,13 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+
+module A {
+  module B {
+    module C {
+      import A.B
+    }
+  }
+
+}
+

--- a/Test/git-issues/git-issue-327cir.dfy.expect
+++ b/Test/git-issues/git-issue-327cir.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-327cir.dfy(5,7): Error: module definition contains a cycle (note: parent modules implicitly depend on submodules): A -> B -> C -> B
+1 resolution/type errors detected in git-issue-327cir.dfy

--- a/Test/git-issues/git-issue-327cir1.dfy
+++ b/Test/git-issues/git-issue-327cir1.dfy
@@ -1,0 +1,13 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+
+module A {
+  module B {
+    module C {
+    }
+  }
+
+  import B
+}
+

--- a/Test/git-issues/git-issue-327cir1.dfy.expect
+++ b/Test/git-issues/git-issue-327cir1.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-327cir1.dfy(11,9): Error: Import declaration uses same name as a module in the same scope: B
+1 resolution/type errors detected in git-issue-327cir1.dfy

--- a/Test/git-issues/git-issue-327cir2.dfy
+++ b/Test/git-issues/git-issue-327cir2.dfy
@@ -1,0 +1,12 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Error - circular
+
+module D {
+  import E
+}
+
+module E {
+  import D
+}

--- a/Test/git-issues/git-issue-327cir2.dfy.expect
+++ b/Test/git-issues/git-issue-327cir2.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-327cir2.dfy(6,7): Error: module definition contains a cycle (note: parent modules implicitly depend on submodules): D -> E -> E -> D
+1 resolution/type errors detected in git-issue-327cir2.dfy

--- a/Test/git-issues/git-issue-327cir3.dfy
+++ b/Test/git-issues/git-issue-327cir3.dfy
@@ -1,0 +1,11 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {  // error: cyclic import
+  import B
+  module X { }
+}
+module B {
+  import A.X
+}
+

--- a/Test/git-issues/git-issue-327cir3.dfy.expect
+++ b/Test/git-issues/git-issue-327cir3.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-327cir3.dfy(4,7): Error: module definition contains a cycle (note: parent modules implicitly depend on submodules): A -> B -> B -> X
+1 resolution/type errors detected in git-issue-327cir3.dfy

--- a/Test/git-issues/git-issue-327err.dfy
+++ b/Test/git-issues/git-issue-327err.dfy
@@ -4,10 +4,8 @@
 module A {
   module AA {
     module AAA {
-      const aaa := 50;
     }
   }
-  const a := 51;
 }
 
 module B {
@@ -27,12 +25,11 @@ module D refines CC {
 }
 
 module E {
-  import S = A.AA
+  import S = A.X // error
 }
 
 module F {
   import DD = D.A
-  method m() { assert DD.a == 51; }
 }
 
 module G {
@@ -44,17 +41,12 @@ module G {
 
   module I {
     module J {
-      import E.S.AAA
-      import HH = H.Z
-      import D.A
-      import D.A.AA
-      import F
-      method m0() { assert AAA.aaa == 50; }
-      method m1() { assert HH.z == 52; }
-      method m2() { assert A.a == 51; }
-      method m3() { assert AA.AAA.aaa == 50; }
+      import E.S.AAA // S is an error
     }
     module K {
+      import H.Y  // error
+    }
+    module L {
     }
   }
 }

--- a/Test/git-issues/git-issue-327err.dfy.expect
+++ b/Test/git-issues/git-issue-327err.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-327err.dfy(28,15): Error: module X does not exist (position 1 in path A.X)
+git-issue-327err.dfy(44,17): Error: module AAA does not exist (position 2 in path E.S.AAA) because of previous error
+git-issue-327err.dfy(47,15): Error: module Y does not exist (position 1 in path H.Y)
+3 resolution/type errors detected in git-issue-327err.dfy

--- a/Test/git-issues/git-issue-371-errors2.dfy
+++ b/Test/git-issues/git-issue-371-errors2.dfy
@@ -15,12 +15,12 @@ module MB {
   module I {
     type T42 = x | 0 <= x < 42
     type T43 = x | 0 <= x < 43
-  } 
+  }
 }
 
 module B {
-  import MAI = MA.Inner // error - no MA
-  import MA.Inner // error - no MA
+  import MAI = MA.Inner // now OK
+  import MA.Inner // now OK
 }
 
 module C {

--- a/Test/git-issues/git-issue-371-errors2.dfy.expect
+++ b/Test/git-issues/git-issue-371-errors2.dfy.expect
@@ -1,5 +1,3 @@
-git-issue-371-errors2.dfy(22,15): Error: module MA does not exist (position 0 in path MA.Inner)
-git-issue-371-errors2.dfy(23,9): Error: module MA does not exist (position 0 in path MA.Inner)
 git-issue-371-errors2.dfy(28,17): Error: module K does not exist (position 1 in path MB.K)
 git-issue-371-errors2.dfy(29,12): Error: module K does not exist (position 1 in path MB.K)
-4 resolution/type errors detected in git-issue-371-errors2.dfy
+2 resolution/type errors detected in git-issue-371-errors2.dfy

--- a/Test/git-issues/git-issue-659.dfy
+++ b/Test/git-issues/git-issue-659.dfy
@@ -1,0 +1,29 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  module Inner {
+    export P reveals a,c
+    export Q reveals b,c
+    const a := 10
+    const b := 20
+    const c := 30
+  }
+}
+
+module X {
+  import I = A.Inner`P
+  method m() {
+    assert I.a == 10;
+    assert I.c == 30;
+  }
+}
+
+module Y {
+  import I = A.Inner`{P,Q}
+  method m() {
+    assert I.a == 10;
+    assert I.b == 20;
+  }
+}
+

--- a/Test/git-issues/git-issue-659.dfy.expect
+++ b/Test/git-issues/git-issue-659.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue-659.dfy.expect
+++ b/Test/git-issues/git-issue-659.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/git-issues/git-issue-659b.dfy
+++ b/Test/git-issues/git-issue-659b.dfy
@@ -1,0 +1,39 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  module Inner {
+    export P reveals a,c
+    export Q reveals b,c
+    const a := 10
+    const b := 20
+    const c := 30
+  }
+}
+
+module Z {
+  import I = A.Inner`P
+  import J = A.Inner`Q
+  method m() {
+    assert I.a == 10;
+    assert I.b == 20; // error
+  }
+}
+
+module B {
+  export P reveals a,c
+  export Q reveals b,c
+  const a := 10
+  const b := 20
+  const c := 30
+}
+
+module Y {
+  import I = B`P
+  import J = B`Q
+  method m() {
+    assert I.a == 10;
+    assert I.b == 20; // error
+  }
+}
+

--- a/Test/git-issues/git-issue-659b.dfy.expect
+++ b/Test/git-issues/git-issue-659b.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-659b.dfy(19,13): Error: unresolved identifier: b
+git-issue-659b.dfy(36,13): Error: unresolved identifier: b
+2 resolution/type errors detected in git-issue-659b.dfy

--- a/Test/git-issues/git-issue-659e.dfy
+++ b/Test/git-issues/git-issue-659e.dfy
@@ -29,3 +29,17 @@ module Z {
 module T {
   import Z.A  // error -- Z has no default export
 }
+
+module Y {
+  module A {}
+  module B {
+    const b := 10;
+  }
+  export A provides A
+  export Y provides B
+}
+
+module TY {
+  import YB = Y.B  // OK - Y has a default export set
+  const b := YB.b;
+}

--- a/Test/git-issues/git-issue-659e.dfy
+++ b/Test/git-issues/git-issue-659e.dfy
@@ -1,0 +1,31 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module M {
+  module Inner {
+    export P reveals a,c
+    export Q reveals b,c
+    const a := 10
+    const b := 20
+    const c := 30
+  }
+}
+
+module X {
+  import I = M.Inner`Q
+  method m() {
+    assert I.a == 10;
+    assert I.c == 30;
+  }
+}
+
+module Z {
+  module A {}
+  module B {}
+  export A provides A
+  export B provides B
+}
+
+module T {
+  import Z.A  // error -- Z has no default export
+}

--- a/Test/git-issues/git-issue-659e.dfy
+++ b/Test/git-issues/git-issue-659e.dfy
@@ -14,7 +14,7 @@ module M {
 module X {
   import I = M.Inner`Q
   method m() {
-    assert I.a == 10;
+    assert I.a == 10; // error -- no a in Q
     assert I.c == 30;
   }
 }

--- a/Test/git-issues/git-issue-659e.dfy.expect
+++ b/Test/git-issues/git-issue-659e.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-659e.dfy(17,13): Error: unresolved identifier: a
+git-issue-659e.dfy(30,11): Error: module A does not exist (position 1 in path Z.A) because Z does not have a default export
+2 resolution/type errors detected in git-issue-659e.dfy

--- a/package.py
+++ b/package.py
@@ -47,8 +47,6 @@ DLLs = ["BoogieAbsInt",
         "BoogieCodeContractsExtender",
         "BoogieConcurrency",
         "BoogieCore",
-        "DafnyPipeline",
-        "Dafny",
         "BoogieDoomed",
         "BoogieExecutionEngine",
         "BoogieGraph",
@@ -56,14 +54,17 @@ DLLs = ["BoogieAbsInt",
         "BoogieModel",
         "BoogieModelViewer",
         "BoogieParserHelper",
-        "Provers.SMTLib",
         "BoogieVCExpr",
         "BoogieVCGeneration",
+        "Dafny",
+        "DafnyRuntime",
+        "DafnyPipeline",
         "Mono.Cecil",
+        "Provers.SMTLib",
         "System.Collections.Immutable",
         "System.Runtime"]
 EXEs = ["Dafny", "DafnyServer"]
-ETCs = UNIX_EXECUTABLES + ["DafnyPrelude.bpl", "DafnyRuntime.cs", "DafnyRuntime.js", "DafnyRuntime.go", "DafnyRuntime.jar", "libhostpolicy.dylib"]
+ETCs = UNIX_EXECUTABLES + ["DafnyPrelude.bpl", "DafnyRuntime.cs", "DafnyRuntime.js", "DafnyRuntime.go", "DafnyRuntime.jar", "Dafny.deps.json", "Dafny.runtimeconfig.json"]
 
 # Constants
 

--- a/package.py
+++ b/package.py
@@ -47,6 +47,8 @@ DLLs = ["BoogieAbsInt",
         "BoogieCodeContractsExtender",
         "BoogieConcurrency",
         "BoogieCore",
+        "DafnyPipeline",
+        "Dafny",
         "BoogieDoomed",
         "BoogieExecutionEngine",
         "BoogieGraph",
@@ -54,17 +56,14 @@ DLLs = ["BoogieAbsInt",
         "BoogieModel",
         "BoogieModelViewer",
         "BoogieParserHelper",
+        "Provers.SMTLib",
         "BoogieVCExpr",
         "BoogieVCGeneration",
-        "Dafny",
-        "DafnyRuntime",
-        "DafnyPipeline",
         "Mono.Cecil",
-        "Provers.SMTLib",
         "System.Collections.Immutable",
         "System.Runtime"]
 EXEs = ["Dafny", "DafnyServer"]
-ETCs = UNIX_EXECUTABLES + ["DafnyPrelude.bpl", "DafnyRuntime.cs", "DafnyRuntime.js", "DafnyRuntime.go", "DafnyRuntime.jar", "Dafny.deps.json", "Dafny.runtimeconfig.json"]
+ETCs = UNIX_EXECUTABLES + ["DafnyPrelude.bpl", "DafnyRuntime.cs", "DafnyRuntime.js", "DafnyRuntime.go", "DafnyRuntime.jar", "libhostpolicy.dylib"]
 
 # Constants
 


### PR DESCRIPTION
Fixes #327, #659

Fixes the logic for resolving a qualified name for a module.
Does not requires 'import A' before 'import A.B'
Implements export sets for qualified names: import Z = A.B.C`{X,Y}