### PR TITLE
#151, #328: Matching declarations are not considered ambiguous

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -842,7 +842,7 @@ namespace Microsoft.Dafny {
     /// Returns whether or not "this" and "that" denote the same type, module proxies and type synonyms and subset types.
     /// </summary>
     [Pure]
-    public abstract bool Equals(Type that);
+    public abstract bool Equals(Type that, bool keepConstraints = false);
 
     public bool IsBoolType { get { return NormalizeExpand() is BoolType; } }
     public bool IsCharType { get { return NormalizeExpand() is CharType; } }
@@ -2138,8 +2138,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "int";
     }
-    public override bool Equals(Type that) {
-      return that is IntVarietiesSupertype;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return keepConstraints ? this.GetType() == that.GetType() : that is IntVarietiesSupertype;
     }
   }
   public class RealVarietiesSupertype : ArtificialType
@@ -2148,8 +2148,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "real";
     }
-    public override bool Equals(Type that) {
-      return that is RealVarietiesSupertype;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return keepConstraints ? this.GetType() == that.GetType() : that is RealVarietiesSupertype;
     }
   }
 
@@ -2169,7 +2169,7 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "bool";
     }
-    public override bool Equals(Type that) {
+    public override bool Equals(Type that, bool keepConstraints = false) {
       return that.IsBoolType;
     }
   }
@@ -2182,7 +2182,7 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "char";
     }
-    public override bool Equals(Type that) {
+    public override bool Equals(Type that, bool keepConstraints = false) {
       return that.IsCharType;
     }
   }
@@ -2193,8 +2193,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "int";
     }
-    public override bool Equals(Type that) {
-      return that.IsIntegerType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return that.NormalizeExpand(keepConstraints) is IntType;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
       if (super is IntVarietiesSupertype) {
@@ -2209,8 +2209,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "real";
     }
-    public override bool Equals(Type that) {
-      return that.IsRealType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return that.NormalizeExpand(keepConstraints) is RealType;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
       if (super is RealVarietiesSupertype) {
@@ -2226,8 +2226,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "ORDINAL";
     }
-    public override bool Equals(Type that) {
-      return that.IsBigOrdinalType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return that.NormalizeExpand(keepConstraints) is BigOrdinalType;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
       if (super is IntVarietiesSupertype) {
@@ -2257,8 +2257,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "bv" + Width;
     }
-    public override bool Equals(Type that) {
-      var bv = that.NormalizeExpand() as BitvectorType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var bv = that.NormalizeExpand(keepConstraints) as BitvectorType;
       return bv != null && bv.Width == Width;
     }
     public override bool IsSubtypeOf(Type super, bool ignoreTypeArguments) {
@@ -2281,8 +2281,8 @@ namespace Microsoft.Dafny {
     public override string TypeName(ModuleDefinition context, bool parseAble) {
       return "selftype";
     }
-    public override bool Equals(Type that) {
-      return that.NormalizeExpand() is SelfType;
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      return that.NormalizeExpand(keepConstraints) is SelfType;
     }
   }
 
@@ -2486,9 +2486,9 @@ namespace Microsoft.Dafny {
     }
     public override string CollectionTypeName { get { return finite ? "set" : "iset"; } }
     [Pure]
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as SetType;
-      return t != null && Finite == t.Finite && Arg.Equals(t.Arg);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as SetType;
+      return t != null && Finite == t.Finite && Arg.Equals(t.Arg, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2503,9 +2503,9 @@ namespace Microsoft.Dafny {
     public MultiSetType(Type arg) : base(arg) {
     }
     public override string CollectionTypeName { get { return "multiset"; } }
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as MultiSetType;
-      return t != null && Arg.Equals(t.Arg);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as MultiSetType;
+      return t != null && Arg.Equals(t.Arg, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2519,9 +2519,9 @@ namespace Microsoft.Dafny {
     public SeqType(Type arg) : base(arg) {
     }
     public override string CollectionTypeName { get { return "seq"; } }
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as SeqType;
-      return t != null && Arg.Equals(t.Arg);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as SeqType;
+      return t != null && Arg.Equals(t.Arg, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2561,9 +2561,9 @@ namespace Microsoft.Dafny {
       var targs = HasTypeArg() ? this.TypeArgsToString(context, parseAble) : "";
       return CollectionTypeName + targs;
     }
-    public override bool Equals(Type that) {
-      var t = that.NormalizeExpand() as MapType;
-      return t != null && Finite == t.Finite && Arg.Equals(t.Arg) && Range.Equals(t.Range);
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var t = that.NormalizeExpand(keepConstraints) as MapType;
+      return t != null && Finite == t.Finite && Arg.Equals(t.Arg, keepConstraints) && Range.Equals(t.Range, keepConstraints);
     }
     public override bool SupportsEquality {
       get {
@@ -2782,23 +2782,31 @@ namespace Microsoft.Dafny {
       this.NamePath = ns;
     }
 
-    public override bool Equals(Type that) {
-      var i = NormalizeExpand();
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var i = NormalizeExpand(keepConstraints);
       if (i is UserDefinedType) {
         var ii = (UserDefinedType)i;
-        var t = that.NormalizeExpand() as UserDefinedType;
-        if (t == null || ii.ResolvedParam != t.ResolvedParam || ii.ResolvedClass != t.ResolvedClass || ii.TypeArgs.Count != t.TypeArgs.Count) {
+        var t = that.NormalizeExpand(keepConstraints) as UserDefinedType;
+        if (t == null || ii.ResolvedClass != t.ResolvedClass || ii.TypeArgs.Count != t.TypeArgs.Count) {
+          return false;
+        } else if (ii.TypeArgs.Count == 0 && ii.ResolvedClass is OpaqueTypeDecl) {
+          // Check for the special case in which ResolvedParam holds a (non-unique) copy of
+          // the type, for OpaqueTypeDecl, likely a hold over from prior to adding ResolvedClass
+          if (ii.ResolvedParam == t.ResolvedParam) return true;
+          if (ii.ResolvedParam == null || ii.ResolvedParam == ((OpaqueTypeDecl)ii.ResolvedClass).TheType) {
+            if (t.ResolvedParam == null || t.ResolvedParam == ((OpaqueTypeDecl)t.ResolvedClass).TheType) return true;
+          }
           return false;
         } else {
           for (int j = 0; j < ii.TypeArgs.Count; j++) {
-            if (!ii.TypeArgs[j].Equals(t.TypeArgs[j])) {
+            if (!ii.TypeArgs[j].Equals(t.TypeArgs[j], keepConstraints)) {
               return false;
             }
           }
           return true;
         }
       } else {
-        return i.Equals(that);
+        return i.Equals(that, keepConstraints);
       }
     }
 
@@ -3077,13 +3085,13 @@ namespace Microsoft.Dafny {
         }
       }
     }
-    public override bool Equals(Type that) {
-      var i = NormalizeExpand();
+    public override bool Equals(Type that, bool keepConstraints = false) {
+      var i = NormalizeExpand(keepConstraints);
       if (i is TypeProxy) {
-        var u = that.NormalizeExpand() as TypeProxy;
+        var u = that.NormalizeExpand(keepConstraints) as TypeProxy;
         return u != null && object.ReferenceEquals(i, u);
       } else {
-        return i.Equals(that);
+        return i.Equals(that,keepConstraints);
       }
     }
 
@@ -4829,8 +4837,8 @@ namespace Microsoft.Dafny {
 
         return "_increasingInt";
       }
-      public override bool Equals(Type that) {
-        return that.NormalizeExpand() is EverIncreasingType;
+      public override bool Equals(Type that, bool keepConstraints = false) {
+        return that.NormalizeExpand(keepConstraints) is EverIncreasingType;
       }
     }
 
@@ -5272,15 +5280,12 @@ namespace Microsoft.Dafny {
     public static void NewSelfSynonym(this RevealableTypeDecl rtd) {
       var d = rtd.AsTopLevelDecl;
       Contract.Assert(!tsdMap.ContainsKey(d));
-
       var thisType = UserDefinedType.FromTopLevelDecl(d.tok, d);
       if (d is OpaqueTypeDecl) {
         thisType.ResolvedParam = ((OpaqueTypeDecl)d).TheType;
       }
-
       var tsd = new InternalTypeSynonymDecl(d.tok, d.Name, TypeParameter.GetExplicitCharacteristics(d), d.TypeArgs, d.EnclosingModuleDefinition, thisType, d.Attributes);
       tsd.InheritVisibility(d, false);
-
       tsdMap.Add(d, tsd);
     }
 
@@ -9387,8 +9392,8 @@ namespace Microsoft.Dafny {
         Contract.Assert(parseAble == false);
         return "#module";
       }
-      public override bool Equals(Type that) {
-        return that.NormalizeExpand() is ResolverType_Module;
+      public override bool Equals(Type that, bool keepConstraints = false) {
+        return that.NormalizeExpand(keepConstraints) is ResolverType_Module;
       }
     }
     public class ResolverType_Type : ResolverType {
@@ -9397,8 +9402,8 @@ namespace Microsoft.Dafny {
         Contract.Assert(parseAble == false);
         return "#type";
       }
-      public override bool Equals(Type that) {
-        return that.NormalizeExpand() is ResolverType_Type;
+      public override bool Equals(Type that, bool keepConstraints = false) {
+        return that.NormalizeExpand(keepConstraints) is ResolverType_Type;
       }
     }
 

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -2797,6 +2797,8 @@ namespace Microsoft.Dafny {
             if (t.ResolvedParam == null || t.ResolvedParam == ((OpaqueTypeDecl)t.ResolvedClass).TheType) return true;
           }
           return false;
+        } else if (ii.ResolvedParam != t.ResolvedParam) {
+          return false;
         } else {
           for (int j = 0; j < ii.TypeArgs.Count; j++) {
             if (!ii.TypeArgs[j].Equals(t.TypeArgs[j], keepConstraints)) {

--- a/Test/git-issues/git-issue-151.dfy
+++ b/Test/git-issues/git-issue-151.dfy
@@ -1,0 +1,44 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  type T = int
+  type U = int
+  type V = int
+  type W = int
+  type X = x: int | x > -10
+  type Y = x: int | x > -10
+  newtype Z = int
+  newtype K = int
+}
+
+module B {
+  type U = real
+  type V = int
+  type W = nat
+  type X = x: int | x > -10
+  newtype Z = int
+}
+
+module D {
+  import A
+  type Y = A.Y
+  type K = A.K
+}
+
+module C {
+  import opened A
+  import opened B
+  import opened D
+
+  type T = A.T
+
+  function method Baz(x: T): T { 0 } // OK C.T is local
+  function method Bar(x: U): U { 0 } // Error A.U, B.U conflict
+  function method Bam(x: V): V { 0 } // OK A.V, B.V are the same type
+  function method Baa(x: W): W { 0 } // Error A.W, B.W are different
+  function method Bag(x: X): X { 0 } // Error A.X, B.X are different
+  function method Bay(x: Y): Y { 0 } // OK A.Y, D.Y are the same type
+  function method Bat(x: Z): Z { 0 } // Error: A.Z, B.Z are different newtypes
+  function method Ban(x: K): K { 0 } // OK: A.K, D.K refer to same decl
+}

--- a/Test/git-issues/git-issue-151.dfy.expect
+++ b/Test/git-issues/git-issue-151.dfy.expect
@@ -1,0 +1,9 @@
+git-issue-151.dfy(37,25): Error: The name U ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(37,29): Error: The name U ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(39,25): Error: The name W ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(39,29): Error: The name W ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(40,25): Error: The name X ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(40,29): Error: The name X ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(42,25): Error: The name Z ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+git-issue-151.dfy(42,29): Error: The name Z ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
+8 resolution/type errors detected in git-issue-151.dfy

--- a/Test/git-issues/git-issue-151b.dfy
+++ b/Test/git-issues/git-issue-151b.dfy
@@ -1,0 +1,29 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  method m() {}
+  method p() {}
+  function f(): int { 0 }
+  function g(): int { 0 }
+}
+
+module B {
+  method m() {}
+  function f(): int { 0 }
+  function g(): int { 0 }
+}
+
+module C {
+  import opened A
+  import opened B
+
+  method p() {}
+  function g(): int { 0 }
+
+  method Bam() { m(); } // Ambiguous
+  method Bay() { p(); } // OK
+  function Baa(): int { f() } // Ambiguous
+  function Bag(): int { g() } // OK
+}
+

--- a/Test/git-issues/git-issue-151b.dfy.expect
+++ b/Test/git-issues/git-issue-151b.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-151b.dfy(24,17): Error: The name m ambiguously refers to a static member in one of the modules A, B (try qualifying the member name with the module name)
+git-issue-151b.dfy(24,18): Error: expected method call, found expression
+git-issue-151b.dfy(26,24): Error: The name f ambiguously refers to a static member in one of the modules A, B (try qualifying the member name with the module name)
+3 resolution/type errors detected in git-issue-151b.dfy

--- a/Test/git-issues/git-issue-328.dfy
+++ b/Test/git-issues/git-issue-328.dfy
@@ -1,0 +1,41 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Z {
+  datatype T = T(i: int)
+  type X
+  function z(): int { 0 }
+  const c := 10;
+}
+
+module B {
+  import A = Z
+  type T = A.T
+  type K
+}
+
+module C {
+  import A = Z
+  type T = A.T
+  type K
+  type X = A.X
+}
+
+module D {
+  import opened B
+  import opened C
+
+  function f(t: T) : T { t } // OK. B.T and C.T are both A.T
+  function g(k: K) : K { k } // Error: ambiguous
+  function h(): int { z() }
+  const d := c;
+}
+
+module E {
+  import opened A = Z
+  import opened CC = C
+
+  method g(x: X) {}  // OK - Z.X and C.X are the same
+  function h(): int { z() }
+  const d := c;
+}

--- a/Test/git-issues/git-issue-328.dfy.expect
+++ b/Test/git-issues/git-issue-328.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-328.dfy(29,16): Error: The name K ambiguously refers to a type in one of the modules B, C (try qualifying the type name with the module name)
+git-issue-328.dfy(29,21): Error: The name K ambiguously refers to a type in one of the modules B, C (try qualifying the type name with the module name)
+2 resolution/type errors detected in git-issue-328.dfy

--- a/Test/git-issues/git-issue-864z1.dfy.expect
+++ b/Test/git-issues/git-issue-864z1.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors


### PR DESCRIPTION
Types, modules or other entities imported through more than one import statement from a common ancestor are no longer considered ambiguous.

Fixes #151 
Fixes #328


This reverts commit d627cbcded9ba759d85386efafb7c3658724c532.