### PR TITLE
Simplifying the grammar, per TODO notes in the reference manual

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1657,11 +1657,16 @@ MethodSpec<.List<AttributedExpression> req, List<FrameExpression> mod, List<Attr
     [ IF(IsLabel(true))
       LabelIdent<out lbl> ":"
     ]
-    Expression<out e, false, false> OldSemi       (. req.Add(new AttributedExpression(e, lbl == null ? null : new AssertLabel(lbl, lbl.val), reqAttrs)); .)
+    Expression<out e, false, false>
+    OldSemi       (. req.Add(new AttributedExpression(e, lbl == null ? null : new AssertLabel(lbl, lbl.val), reqAttrs)); .)
   | "ensures"
     { Attribute<ref ensAttrs> }
-    Expression<out e, false, false> OldSemi       (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
-  | "decreases" { Attribute<ref decAttrs> } DecreasesList<decreases, true, false> OldSemi
+    Expression<out e, false, false>
+    OldSemi       (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
+  | "decreases"
+    { Attribute<ref decAttrs> }
+    DecreasesList<decreases, true, false>
+    OldSemi
   )
   .
 IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/*!*/ mod, List<Expression/*!*/> decreases,
@@ -1695,7 +1700,8 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
                                                                   req.Add(new AttributedExpression(e, al, null));
                                                                 }
                                                              .)
-    | "ensures" { Attribute<ref ensAttrs> }
+    | "ensures"
+      { Attribute<ref ensAttrs> }
       Expression<out e, false, false> OldSemi                (. if (isYield) {
                                                                   yieldEns.Add(new AttributedExpression(e, ensAttrs));
                                                                 } else {
@@ -1703,7 +1709,10 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
                                                                 }
                                                              .)
     )
-  | "decreases" { Attribute<ref decrAttrs> } DecreasesList<decreases, false, false> OldSemi
+  | "decreases"
+    { Attribute<ref decrAttrs> }
+    DecreasesList<decreases, false, false>
+    OldSemi
   )
   .
 Formals<.bool incoming, bool allowGhostKeyword, bool allowNewKeyword, List<Formal> formals.>
@@ -2055,25 +2064,30 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
      Contract.Requires(cce.NonNullElements(reads));
      Contract.Requires(decreases == null || cce.NonNullElements(decreases));
      Expression/*!*/ e;  FrameExpression/*!*/ fe;
-     Attributes ensAttrs = null; Attributes reqAttrs = null; .)
+     Attributes ensAttrs = null; Attributes reqAttrs = null;
+  .)
   SYNC
   ( "requires"
     { Attribute<ref reqAttrs> }
-    Expression<out e, false, false> OldSemi                (. reqs.Add(new AttributedExpression(e, reqAttrs)); .)
-  | "reads"
+    Expression<out e, false, false> OldSemi             (. reqs.Add(new AttributedExpression(e, reqAttrs)); .)
+  | "reads"                                             (. Attributes readsAttrs = null; .)
+    { Attribute<ref readsAttrs> }
     PossiblyWildFrameExpression<out fe, false>          (. reads.Add(fe); .)
     { "," PossiblyWildFrameExpression<out fe, false>    (. reads.Add(fe); .)
     }
     OldSemi
   | "ensures"
-      { Attribute<ref ensAttrs> }
-      Expression<out e, false, false> OldSemi                (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
+    { Attribute<ref ensAttrs> }
+    Expression<out e, false, false> OldSemi             (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
   | "decreases"                               (. if (decreases == null) {
                                                    SemErr(t, "'decreases' clauses are meaningless for greatest predicates, so they are not allowed");
                                                    decreases = new List<Expression/*!*/>();
                                                  }
+                                                 Attributes decrAttrs = null;
                                               .)
-    DecreasesList<decreases, false, false> OldSemi
+    { Attribute<ref decrAttrs> }
+    DecreasesList<decreases, false, false>
+    OldSemi
   )
   .
 
@@ -2589,11 +2603,13 @@ LoopSpec<.List<AttributedExpression> invariants, List<Expression> decreases, ref
     { Attribute<ref attrs> }
     Expression<out e, false, true>                (. invariants.Add(new AttributedExpression(e, attrs)); .)
     OldSemi
-  | SYNC "decreases"
+  | SYNC
+    "decreases"
     { Attribute<ref decAttrs> }
     DecreasesList<decreases, true, true>
     OldSemi
-  | SYNC "modifies"                               (. mod = mod ?? new List<FrameExpression>(); .)
+  | SYNC
+    "modifies"                                    (. mod = mod ?? new List<FrameExpression>(); .)
     { Attribute<ref modAttrs> }
     FrameExpression<out fe, false, true>          (. mod.Add(fe); .)
     { "," FrameExpression<out fe, false, true>    (. mod.Add(fe); .)
@@ -2832,7 +2848,9 @@ ForallStmt<out Statement/*!*/ s>
   .)
 
   {
-    "ensures" Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e)); .)
+    "ensures"                       (. Attributes ensAttrs = null; .)
+    { Attribute<ref ensAttrs> }
+    Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
     OldSemi                                   (. tok = t; .)
   }
   [ IF(la.kind == _lbrace)  /* if the input continues like a block statement, take it to be the body of the forall statement; a body-less forall statement must continue in some other way */
@@ -3445,7 +3463,8 @@ LambdaExpression<out Expression e, bool allowSemi, bool allowBitwiseOps>
       ]
     ")"
   )
-  { "reads"
+  { "reads"                                           (. Attributes readsAttrs = null; .)
+    { Attribute<ref readsAttrs> }
     PossiblyWildFrameExpression<out fe, true>         (. reads.Add(fe); .)
     { ","
       PossiblyWildFrameExpression<out fe, true>       (. reads.Add(fe); .)

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2848,7 +2848,7 @@ ForallStmt<out Statement/*!*/ s>
   .)
 
   {
-    "ensures"                       (. Attributes attrs = null; .)
+    "ensures"
     { Attribute<ref attrs> }
     Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e, attrs)); .)
     OldSemi                         (. tok = t; .)

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2068,15 +2068,16 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
      Attributes attrs = null;
   .)
   SYNC
-  ( "requires"
+  ( "requires"                                          (. attrs = null; .)
     { Attribute<ref attrs> }
     Expression<out e, false, false> OldSemi             (. reqs.Add(new AttributedExpression(e, attrs)); .)
-  | "reads"
+  | "reads"                                             (. attrs = null; .)
     { Attribute<ref attrs> }
     PossiblyWildFrameExpression<out fe, false>          (. reads.Add(fe); .)
-    { "," PossiblyWildFrameExpression<out fe, false> }  (. reads.Add(fe); .)
+    { "," PossiblyWildFrameExpression<out fe, false>    (. reads.Add(fe); .)
+    }
     OldSemi
-  | "ensures"
+  | "ensures"                                           (. attrs = null; .)
     { Attribute<ref attrs> }
     Expression<out e, false, false>
     OldSemi                                   (. ens.Add(new AttributedExpression(e, attrs)); .)
@@ -2084,6 +2085,7 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
                                                    SemErr(t, "'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed");
                                                    decreases = new List<Expression/*!*/>();
                                                  }
+                                                 attrs = null;
                                               .)
     { Attribute<ref attrs> }
     DecreasesList<decreases, false, false>

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2065,7 +2065,7 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
      Contract.Requires(cce.NonNullElements(reads));
      Contract.Requires(decreases == null || cce.NonNullElements(decreases));
      Expression/*!*/ e;  FrameExpression/*!*/ fe;
-     Attributes attrs = null
+     Attributes attrs = null;
   .)
   SYNC
   ( "requires"

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1643,28 +1643,28 @@ MethodSpec<.List<AttributedExpression> req, List<FrameExpression> mod, List<Attr
      Contract.Requires(cce.NonNullElements(mod));
      Contract.Requires(cce.NonNullElements(ens));
      Contract.Requires(cce.NonNullElements(decreases));
-     Expression e;  FrameExpression fe;  Attributes ensAttrs = null; Attributes reqAttrs = null;
+     Expression e;  FrameExpression fe;  Attributes attrs = null;
      IToken lbl = null;
   .)
   SYNC
-  ( "modifies" { Attribute<ref modAttrs> }
+  ( "modifies" { Attribute<ref attrs> }
     FrameExpression<out fe, false, false>         (. Util.AddFrameExpression(mod, fe, performThisDeprecatedCheck, errors); .)
     { "," FrameExpression<out fe, false, false>   (. Util.AddFrameExpression(mod, fe, performThisDeprecatedCheck, errors); .)
     }
     OldSemi
   | "requires"
-    { Attribute<ref reqAttrs> }
+    { Attribute<ref attrs> }
     [ IF(IsLabel(true))
       LabelIdent<out lbl> ":"
     ]
     Expression<out e, false, false>
-    OldSemi       (. req.Add(new AttributedExpression(e, lbl == null ? null : new AssertLabel(lbl, lbl.val), reqAttrs)); .)
+    OldSemi       (. req.Add(new AttributedExpression(e, lbl == null ? null : new AssertLabel(lbl, lbl.val), attrs)); .)
   | "ensures"
-    { Attribute<ref ensAttrs> }
+    { Attribute<ref attrs> }
     Expression<out e, false, false>
-    OldSemi       (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
+    OldSemi       (. ens.Add(new AttributedExpression(e, attrs)); .)
   | "decreases"
-    { Attribute<ref decAttrs> }
+    { Attribute<ref attrs> }
     DecreasesList<decreases, true, false>
     OldSemi
   )
@@ -1673,7 +1673,7 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
               List<AttributedExpression/*!*/>/*!*/ req, List<AttributedExpression/*!*/>/*!*/ ens,
               List<AttributedExpression/*!*/>/*!*/ yieldReq, List<AttributedExpression/*!*/>/*!*/ yieldEns,
               ref Attributes readsAttrs, ref Attributes modAttrs, ref Attributes decrAttrs.>
-= (. Expression/*!*/ e; FrameExpression/*!*/ fe; bool isYield = false; Attributes ensAttrs = null;
+= (. Expression/*!*/ e; FrameExpression/*!*/ fe; bool isYield = false; Attributes attrs = null;
      IToken lbl = null;
   .)
   SYNC
@@ -1690,6 +1690,7 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
   | [ "yield"                                                (. isYield = true; .)
     ]
     ( "requires"
+      { Attribute<ref attrs> }
       [ IF(IsLabel(!isYield))
         LabelIdent<out lbl> ":"
       ]
@@ -1701,11 +1702,11 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
                                                                 }
                                                              .)
     | "ensures"
-      { Attribute<ref ensAttrs> }
+      { Attribute<ref attrs> }
       Expression<out e, false, false> OldSemi                (. if (isYield) {
-                                                                  yieldEns.Add(new AttributedExpression(e, ensAttrs));
+                                                                  yieldEns.Add(new AttributedExpression(e, attrs));
                                                                 } else {
-                                                                  ens.Add(new AttributedExpression(e, ensAttrs));
+                                                                  ens.Add(new AttributedExpression(e, attrs));
                                                                 }
                                                              .)
     )
@@ -2064,28 +2065,27 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
      Contract.Requires(cce.NonNullElements(reads));
      Contract.Requires(decreases == null || cce.NonNullElements(decreases));
      Expression/*!*/ e;  FrameExpression/*!*/ fe;
-     Attributes ensAttrs = null; Attributes reqAttrs = null;
+     Attributes attrs = null
   .)
   SYNC
   ( "requires"
-    { Attribute<ref reqAttrs> }
-    Expression<out e, false, false> OldSemi             (. reqs.Add(new AttributedExpression(e, reqAttrs)); .)
-  | "reads"                                             (. Attributes readsAttrs = null; .)
-    { Attribute<ref readsAttrs> }
+    { Attribute<ref attrs> }
+    Expression<out e, false, false> OldSemi             (. reqs.Add(new AttributedExpression(e, attrs)); .)
+  | "reads"
+    { Attribute<ref attrs> }
     PossiblyWildFrameExpression<out fe, false>          (. reads.Add(fe); .)
-    { "," PossiblyWildFrameExpression<out fe, false>    (. reads.Add(fe); .)
-    }
+    { "," PossiblyWildFrameExpression<out fe, false> }  (. reads.Add(fe); .)
     OldSemi
   | "ensures"
-    { Attribute<ref ensAttrs> }
-    Expression<out e, false, false> OldSemi             (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
+    { Attribute<ref attrs> }
+    Expression<out e, false, false>
+    OldSemi                                   (. ens.Add(new AttributedExpression(e, attrs)); .)
   | "decreases"                               (. if (decreases == null) {
-                                                   SemErr(t, "'decreases' clauses are meaningless for greatest predicates, so they are not allowed");
+                                                   SemErr(t, "'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed");
                                                    decreases = new List<Expression/*!*/>();
                                                  }
-                                                 Attributes decrAttrs = null;
                                               .)
-    { Attribute<ref decrAttrs> }
+    { Attribute<ref attrs> }
     DecreasesList<decreases, false, false>
     OldSemi
   )
@@ -2605,12 +2605,12 @@ LoopSpec<.List<AttributedExpression> invariants, List<Expression> decreases, ref
     OldSemi
   | SYNC
     "decreases"
-    { Attribute<ref decAttrs> }
+    { Attribute<ref attrs> }
     DecreasesList<decreases, true, true>
     OldSemi
   | SYNC
     "modifies"                                    (. mod = mod ?? new List<FrameExpression>(); .)
-    { Attribute<ref modAttrs> }
+    { Attribute<ref attrs> }
     FrameExpression<out fe, false, true>          (. mod.Add(fe); .)
     { "," FrameExpression<out fe, false, true>    (. mod.Add(fe); .)
     }
@@ -2848,10 +2848,10 @@ ForallStmt<out Statement/*!*/ s>
   .)
 
   {
-    "ensures"                       (. Attributes ensAttrs = null; .)
-    { Attribute<ref ensAttrs> }
-    Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e, ensAttrs)); .)
-    OldSemi                                   (. tok = t; .)
+    "ensures"                       (. Attributes attrs = null; .)
+    { Attribute<ref attrs> }
+    Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e, attrs)); .)
+    OldSemi                         (. tok = t; .)
   }
   [ IF(la.kind == _lbrace)  /* if the input continues like a block statement, take it to be the body of the forall statement; a body-less forall statement must continue in some other way */
     BlockStmt<out block, out bodyStart, out bodyEnd>
@@ -3453,6 +3453,7 @@ LambdaExpression<out Expression e, bool allowSemi, bool allowBitwiseOps>
      var reads = new List<FrameExpression>();
      Expression req = null;
      Expression body = null;
+     Attributes attrs = null;
   .)
   ( WildIdent<out id, true>                  (. x = t; bvs.Add(new BoundVar(id, id.val, new InferredTypeProxy())); .)
   | "("                                      (. x = t; .)
@@ -3463,13 +3464,15 @@ LambdaExpression<out Expression e, bool allowSemi, bool allowBitwiseOps>
       ]
     ")"
   )
-  { "reads"                                           (. Attributes readsAttrs = null; .)
-    { Attribute<ref readsAttrs> }
+  { "reads"
+    { Attribute<ref attrs> }
     PossiblyWildFrameExpression<out fe, true>         (. reads.Add(fe); .)
     { ","
       PossiblyWildFrameExpression<out fe, true>       (. reads.Add(fe); .)
     }
-  | "requires" Expression<out ee, true, false>        (. req = req == null ? ee : new BinaryExpr(req.tok, BinaryExpr.Opcode.And, req, ee); .)
+  | "requires"
+    { Attribute<ref attrs> }
+    Expression<out ee, true, false>        (. req = req == null ? ee : new BinaryExpr(req.tok, BinaryExpr.Opcode.And, req, ee); .)
   }
   LambdaArrow
   Expression<out body, allowSemi, true, allowBitwiseOps>

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1689,7 +1689,7 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
                OldSemi
   | [ "yield"                                                (. isYield = true; .)
     ]
-    ( "requires"
+    ( "requires"                                             (. attrs = null; .)
       { Attribute<ref attrs> }
       [ IF(IsLabel(!isYield))
         LabelIdent<out lbl> ":"
@@ -1701,7 +1701,7 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
                                                                   req.Add(new AttributedExpression(e, al, null));
                                                                 }
                                                              .)
-    | "ensures"
+    | "ensures"                                              (. attrs = null; .)
       { Attribute<ref attrs> }
       Expression<out e, false, false> OldSemi                (. if (isYield) {
                                                                   yieldEns.Add(new AttributedExpression(e, attrs));
@@ -2068,16 +2068,16 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
      Attributes attrs = null;
   .)
   SYNC
-  ( "requires"                                          (. attrs = null; .)
+  ( "requires"
     { Attribute<ref attrs> }
     Expression<out e, false, false> OldSemi             (. reqs.Add(new AttributedExpression(e, attrs)); .)
-  | "reads"                                             (. attrs = null; .)
+  | "reads"
     { Attribute<ref attrs> }
     PossiblyWildFrameExpression<out fe, false>          (. reads.Add(fe); .)
     { "," PossiblyWildFrameExpression<out fe, false>    (. reads.Add(fe); .)
     }
     OldSemi
-  | "ensures"                                           (. attrs = null; .)
+  | "ensures"
     { Attribute<ref attrs> }
     Expression<out e, false, false>
     OldSemi                                   (. ens.Add(new AttributedExpression(e, attrs)); .)
@@ -2085,7 +2085,6 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
                                                    SemErr(t, "'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed");
                                                    decreases = new List<Expression/*!*/>();
                                                  }
-                                                 attrs = null;
                                               .)
     { Attribute<ref attrs> }
     DecreasesList<decreases, false, false>
@@ -2829,6 +2828,7 @@ ForallStmt<out Statement/*!*/ s>
 = (. Contract.Ensures(Contract.ValueAtReturn(out s) != null);
      IToken/*!*/ x = Token.NoToken;
      List<BoundVar> bvars = null;
+     Attributes qattrs = null;
      Attributes attrs = null;
      Expression range = null;
      var ens = new List<AttributedExpression/*!*/>();
@@ -2840,9 +2840,9 @@ ForallStmt<out Statement/*!*/ s>
   "forall"                                  (. x = t; tok = x; .)
 
   ( IF(la.kind == _openparen)  /* disambiguation needed, because of the possibility of a body-less forall statement */
-    "(" [ QuantifierDomain<out bvars, out attrs, out range> ] ")"
+    "(" [ QuantifierDomain<out bvars, out qattrs, out range> ] ")"
   |     [ IF(IsIdentifier(la.kind))  /* disambiguation needed, because of the possibility of a body-less forall statement */
-          QuantifierDomain<out bvars, out attrs, out range>
+          QuantifierDomain<out bvars, out qattrs, out range>
         ]
   )
   (. if (bvars == null) { bvars = new List<BoundVar>(); }
@@ -2852,7 +2852,7 @@ ForallStmt<out Statement/*!*/ s>
   {
     "ensures"
     { Attribute<ref attrs> }
-    Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e, attrs)); .)
+    Expression<out e, false, true>  (. ens.Add(new AttributedExpression(e)); .)
     OldSemi                         (. tok = t; .)
   }
   [ IF(la.kind == _lbrace)  /* if the input continues like a block statement, take it to be the body of the forall statement; a body-less forall statement must continue in some other way */
@@ -2865,7 +2865,7 @@ ForallStmt<out Statement/*!*/ s>
      if (block != null) {
         tok = block.EndTok;
      }
-     s = new ForallStmt(x, tok, bvars, attrs, range, ens, block);
+     s = new ForallStmt(x, tok, bvars, qattrs, range, ens, block);
   .)
   .
 
@@ -3466,13 +3466,13 @@ LambdaExpression<out Expression e, bool allowSemi, bool allowBitwiseOps>
       ]
     ")"
   )
-  { "reads"
+  { "reads"                                           (. attrs = null; .)
     { Attribute<ref attrs> }
     PossiblyWildFrameExpression<out fe, true>         (. reads.Add(fe); .)
     { ","
       PossiblyWildFrameExpression<out fe, true>       (. reads.Add(fe); .)
     }
-  | "requires"
+  | "requires"                                        (. attrs = null; .)
     { Attribute<ref attrs> }
     Expression<out ee, true, false>        (. req = req == null ? ee : new BinaryExpr(req.tok, BinaryExpr.Opcode.And, req, ee); .)
   }


### PR DESCRIPTION
The reference manual contained TODO notes recommending
a) more uniform permitting { Attribute } in specification clauses
b) reducing the number of non-terminals accordingly.

This small PR implements those changes. The effect is that attributes are now allowed in places where they were not before, and will be, at present, ignored there.