### PR TITLE
Correctly set the z3 lit variable so git-issue-401 passes locally

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -6,6 +6,7 @@ import os
 import sys
 import re
 import platform
+from os import path
 
 import lit.util
 import lit.formats
@@ -134,8 +135,6 @@ ver = "0"
 if os.name != "nt":
     ver = os.uname().version
 
-z3Path = os.path.join(os.path.dirname(bareDafnyExecutable), "z3", "bin", "z3")
-config.substitutions.append( ('%z3', z3Path ) )
 config.substitutions.append( ('%dafny', dafnyExecutable) )
 config.substitutions.append( ('%baredafny', bareDafnyExecutable) )
 config.substitutions.append( ('%server', serverExecutable) )
@@ -150,24 +149,27 @@ elif "16.04" in ver and "Ubuntu" in ver:
 else:
     config.available_features = [ 'ubuntu', 'posix' ]
 
-
-
 # Sanity check: Check solver executable is available
 solvers = ['z3.exe','cvc4.exe']
-solverFound = False
-for solver in solvers:
-    if os.path.exists( os.path.join(binaryDir, solver)):
-        solverFound = True
-if not solverFound:
-    if os.path.exists( os.path.join(binaryDir, 'z3', 'bin', 'z3')):
-        solverFound = True
+z3Path = None
 
-if not solverFound:
+potentialZ3Roots = [path.dirname(bareDafnyExecutable), binaryDir]
+potentialZ3Executables = ['cvc4.exe', path.join("z3", "bin", "z3"), 'z3.exe']
+
+for root in potentialZ3Roots:
+    for executable in potentialZ3Executables:
+        if not z3Path:
+            potentialPath = path.join(root, executable)
+            if path.exists(potentialPath):
+                z3Path = potentialPath
+
+if not z3Path:
     lit_config.fatal('Could not find solver in "{binaryDir}". Tried looking for {solvers}'.format(
                        binaryDir=binaryDir,
                        solvers=solvers
                        )
                     )
+config.substitutions.append( ('%z3', z3Path ) )
 
 # Add diff tool substitution
 commonDiffFlags=' --unified=3 --strip-trailing-cr'

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -153,11 +153,11 @@ else:
 solvers = ['z3.exe','cvc4.exe']
 z3Path = None
 
-potentialZ3Roots = [path.dirname(bareDafnyExecutable), binaryDir]
-potentialZ3Executables = ['cvc4.exe', path.join("z3", "bin", "z3"), 'z3.exe']
+potentialSolverRoots = [path.dirname(bareDafnyExecutable), binaryDir]
+potentialSolverExecutables = ['cvc4.exe', path.join("z3", "bin", "z3"), 'z3.exe']
 
-for root in potentialZ3Roots:
-    for executable in potentialZ3Executables:
+for root in potentialSolverRoots:
+    for executable in potentialSolverExecutables:
         if not z3Path:
             potentialPath = path.join(root, executable)
             if path.exists(potentialPath):


### PR DESCRIPTION
Currently we have one test that exercises the Dafny option to configure a custom solver. The test uses the same solver as Dafny is using to run the tests, but to find the path of this solver we're forced to do some guesswork.

I think this PR solves the issue, but I'm not very happy with the solution since it's fragile. For example, if we would bundle the solver Dafny uses inside the Dafny release executable, then `git-issue-401` would fail again. More robust alternatives I see are:
- Let the test download a solver. This seems wasteful since package.py is also downloading a solver, but I think that's OK. The biggest problem I see is that the test then becomes dependent on having an internet connection. We could have a single solver download script that both the test and package.py use which puts the solver in a cached location, that way if you run the local tests repeatedly it wouldn't need to do any downloading. 
- Remove the option to specify a custom solver from Dafny, and then remove this test. I'm curious what the use-case for this option is.
