### PR TITLE
#968: Fixes a missing error message

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -6453,8 +6453,14 @@ namespace Microsoft.Dafny
           if (expr is StaticReceiverExpr stexpr) {
             if (stexpr.OriginalResolved != null) {
               Visit(stexpr.OriginalResolved);
+            } else {
+              foreach (Type t in stexpr.Type.TypeArgs) {
+                if (t is InferredTypeProxy && ((InferredTypeProxy)t).T == null) {
+                  resolver.reporter.Error(MessageSource.Resolver, stexpr.tok, "type of type parameter could not be determined; please specify the type explicitly");
+                }
             }
           }
+        }
 
         } else if (expr is ComprehensionExpr) {
           var e = (ComprehensionExpr)expr;

--- a/Test/dafny0/TypeInstantiations.dfy.expect
+++ b/Test/dafny0/TypeInstantiations.dfy.expect
@@ -22,6 +22,7 @@ TypeInstantiations.dfy(108,8): Error: the type of this variable is underspecifie
 TypeInstantiations.dfy(109,8): Error: the type of this variable is underspecified
 TypeInstantiations.dfy(127,27): Error: RHS (of type int) not assignable to LHS (of type C.Classic<real>)
 TypeInstantiations.dfy(137,8): Error: the type of this variable is underspecified
+TypeInstantiations.dfy(137,23): Error: type of type parameter could not be determined; please specify the type explicitly
 TypeInstantiations.dfy(137,23): Error: type parameter 'A' (inferred to be '?') in the function call to 'F' could not be determined
 TypeInstantiations.dfy(137,24): Error: the type of this expression is underspecified
-26 resolution/type errors detected in TypeInstantiations.dfy
+27 resolution/type errors detected in TypeInstantiations.dfy

--- a/Test/dafny0/UserSpecifiedTypeParameters.dfy.expect
+++ b/Test/dafny0/UserSpecifiedTypeParameters.dfy.expect
@@ -1,4 +1,6 @@
 UserSpecifiedTypeParameters.dfy(26,10): Error: the type of this variable is underspecified
+UserSpecifiedTypeParameters.dfy(26,24): Error: type of type parameter could not be determined; please specify the type explicitly
+UserSpecifiedTypeParameters.dfy(26,24): Error: type of type parameter could not be determined; please specify the type explicitly
 UserSpecifiedTypeParameters.dfy(26,24): Error: type parameter 'T' (inferred to be '?') in the function call to 'H' could not be determined
 UserSpecifiedTypeParameters.dfy(26,24): Error: type parameter 'U' (inferred to be '?') in the function call to 'H' could not be determined
 UserSpecifiedTypeParameters.dfy(46,22): Error: Undeclared top-level type or type parameter: b (did you forget to qualify a name or declare a module import 'opened'?)
@@ -8,4 +10,4 @@ UserSpecifiedTypeParameters.dfy(46,30): Error: non-function expression (of type 
 UserSpecifiedTypeParameters.dfy(46,16): Error: wrong number of arguments to function application (function 'F' expects 2, got 1)
 UserSpecifiedTypeParameters.dfy(77,15): Error: incorrect type of method in-parameter (expected A, got int)
 UserSpecifiedTypeParameters.dfy(89,15): Error: type mismatch for argument (function expects A, got int)
-10 resolution/type errors detected in UserSpecifiedTypeParameters.dfy
+12 resolution/type errors detected in UserSpecifiedTypeParameters.dfy

--- a/Test/git-issues/git-issue-968.dfy
+++ b/Test/git-issues/git-issue-968.dfy
@@ -1,0 +1,13 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype DT<T(0)> = Make | Create {
+  static const b := 30
+  static const t: T
+}
+
+method Test0() {
+//  var x := DT<int>.b;  // this works
+  var y := DT.b;  // this causes a crash, but it should just have complained that "DT" is underspecified
+}
+

--- a/Test/git-issues/git-issue-968.dfy
+++ b/Test/git-issues/git-issue-968.dfy
@@ -7,7 +7,9 @@ datatype DT<T(0)> = Make | Create {
 }
 
 method Test0() {
-//  var x := DT<int>.b;  // this works
-  var y := DT.b;  // this causes a crash, but it should just have complained that "DT" is underspecified
+  var x := DT<int>.b;  // this works
+  var y := DT.b;  // this used to crash, because y had a known type but
+                  // the type parameter of DT did not, which made it past
+                  // Resolution but crashed in Translation
 }
 

--- a/Test/git-issues/git-issue-968.dfy.expect
+++ b/Test/git-issues/git-issue-968.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-968.dfy(11,14): Error: type of type parameter could not be determined; please specify the type explicitly
+1 resolution/type errors detected in git-issue-968.dfy

--- a/Test/git-issues/git-issue-968a.dfy
+++ b/Test/git-issues/git-issue-968a.dfy
@@ -1,0 +1,13 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype DT<T(0)> = Make | Create {
+  static const b := 30
+  static const t: T
+}
+
+method Test1() {
+  var t := DT<int>.t;  // this work
+  var u := DT.t;  // this gives an "underspecified type" error, as expected
+}
+

--- a/Test/git-issues/git-issue-968a.dfy.expect
+++ b/Test/git-issues/git-issue-968a.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-968a.dfy(11,6): Error: the type of this variable is underspecified
+git-issue-968a.dfy(11,14): Error: type of type parameter could not be determined; please specify the type explicitly
+git-issue-968a.dfy(11,14): Error: the type of this expression is underspecified
+3 resolution/type errors detected in git-issue-968a.dfy


### PR DESCRIPTION
The problem was detecting underspecified RHS when the underspecification did not affect the LHS.

Fixes #968.