### PR TITLE
Doc: Update the location of the dafny script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ or
        cp dafny/Binaries/z3/bin/z3 boogie/Binaries/z3.exe
 
 5. Run Dafny using the `dafny` shell script in the Binaries directory:
-       BASE_DIRECTORY/dafny/Binaries/dafny
+       BASE_DIRECTORY/dafny/Scripts/dafny
 
 6. In VSCode, open any `.dfy` file, and when asked if you want to install the Dafny extension, click "install". This will install both the latest release of Dafny (which you decided not to use), but also the editor extension (which you want to use with your locally compiled Dafny version). To make sure the editor extension uses your locally compiled Dafny version, open the Settings page, search for "dafny base path", and set it to `BASE-DIRECTORY/dafny/Binaries`.
 
@@ -109,7 +109,7 @@ or
        cp dafny/Binaries/z3/bin/z3 boogie/Binaries/z3.exe
 
 5. Run Dafny using the `dafny` shell script in the Binaries directory:
-       BASE_DIRECTORY/dafny/Binaries/dafny
+       BASE_DIRECTORY/dafny/Scripts/dafny
 
 6. (Optional) An IDE is available for dafny as an extension to VSCode.
 VSCode itself is available from `https://code.visualstudio.com/download`.


### PR DESCRIPTION
Commit a6a5704b8ac7 moved the `dafny` script from `Binaries` to `Scripts`, so the documentation should be updated as well.