### PR TITLE
Fix termination check for infinite/unknown types

### DIFF
--- a/Test/allocated1/dafny0/Termination.dfy.expect
+++ b/Test/allocated1/dafny0/Termination.dfy.expect
@@ -48,11 +48,65 @@ Execution trace:
     Termination.dfy(296,3): anon10_Else
     Termination.dfy(296,3): anon11_Else
     (0,0): anon12_Else
+Termination.dfy(534,2): Error: decreases expression might not decrease
+Execution trace:
+    (0,0): anon0
+    Termination.dfy(534,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(534,3): anon7_Else
+    Termination.dfy(534,3): anon8_Else
+Termination.dfy(542,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(542,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(542,3): anon7_Else
+    Termination.dfy(542,3): anon8_Else
+Termination.dfy(549,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(549,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(549,3): anon7_Else
+    Termination.dfy(549,3): anon8_Else
+Termination.dfy(556,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(556,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(556,3): anon7_Else
+    Termination.dfy(556,3): anon8_Else
+Termination.dfy(563,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(563,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(563,3): anon7_Else
+    Termination.dfy(563,3): anon8_Else
+Termination.dfy(571,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(571,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(571,3): anon7_Else
+    Termination.dfy(571,3): anon8_Else
+Termination.dfy(579,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(579,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(579,3): anon7_Else
+    Termination.dfy(579,3): anon8_Else
+Termination.dfy(589,2): Error: decreases expression might not decrease
+Execution trace:
+    (0,0): anon0
+    Termination.dfy(589,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(589,3): anon7_Else
+    Termination.dfy(589,3): anon8_Else
 Termination.dfy(361,46): Error: failure to decrease termination measure
 Execution trace:
     (0,0): anon0
     (0,0): anon9_Else
     (0,0): anon10_Then
     (0,0): anon11_Else
+Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
 
-Dafny program verifier finished with 43 verified, 8 errors
+Dafny program verifier finished with 44 verified, 17 errors

--- a/Test/dafny0/Termination.dfy
+++ b/Test/dafny0/Termination.dfy
@@ -527,3 +527,78 @@ lemma ExtEvensSumToEven(t: Tree)
     assert right.Sum() % 2 == 0;
     assert t.Sum() % 2 == 0;
 }
+
+// ------ attempts to use a decreases term whose "less" relation is "false"
+
+method LoopyInt(x: int) {
+  while x < 100  // error: failure to decreases termination metric
+    decreases 58
+  {
+  }
+}
+
+method LoopyISet(m: imap<int, int>)
+{
+  while m != imap[]  // error: failure to decreases termination metric
+    decreases m.Keys
+  {
+  }
+}
+
+method LoopyIMap(x: int, m: imap<int, int>) {
+  while x < 100  // error: failure to decreases termination metric
+    decreases m
+  {
+  }
+}
+
+method LoopyFunction(x: int, f: int -> int) {
+  while x < 100  // error: failure to decreases termination metric
+    decreases f
+  {
+  }
+}
+
+method LoopyTypeParam<Y>(x: int, y: Y) {
+  while x < 100  // error: failure to decreases termination metric
+    decreases y
+  {
+  }
+}
+
+type ZOT
+method LoopyOpaqueType(x: int, z: ZOT) {
+  while x < 100  // error: failure to decreases termination metric
+    decreases z
+  {
+  }
+}
+
+type SubZOT = z: ZOT | true  // error: cannot find witness
+method LoopySubsetType(x: int, z: SubZOT) {
+  while x < 100  // error: failure to decreases termination metric
+    decreases z
+  {
+  }
+}
+
+codatatype Forever = More(next: Forever)
+
+method LoopyForever(x: int, f: Forever) {
+  var f := f;
+  while x < 100  // error: failure to decreases termination metric
+    decreases f
+  {
+    f := f.next;
+  }
+}
+
+method GoodLoop<Y>(x: int, y: Y, z0: ZOT, z1: SubZOT, f: int -> int, forever: Forever, m: imap<int, int>, s: iset<int>)
+{
+  var i := 0;
+  while i < x
+    decreases y, z0, z1, f, forever, m, s, x - i
+  {
+    i := i + 1;
+  }
+}

--- a/Test/dafny0/Termination.dfy.expect
+++ b/Test/dafny0/Termination.dfy.expect
@@ -7,6 +7,10 @@ Execution trace:
     (0,0): anon9_Else
     (0,0): anon10_Then
     (0,0): anon11_Else
+Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
 Termination.dfy(108,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Execution trace:
     (0,0): anon0
@@ -54,5 +58,55 @@ Execution trace:
     Termination.dfy(296,3): anon10_Else
     Termination.dfy(296,3): anon11_Else
     (0,0): anon12_Else
+Termination.dfy(534,2): Error: decreases expression might not decrease
+Execution trace:
+    (0,0): anon0
+    Termination.dfy(534,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(534,3): anon7_Else
+    Termination.dfy(534,3): anon8_Else
+Termination.dfy(542,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(542,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(542,3): anon7_Else
+    Termination.dfy(542,3): anon8_Else
+Termination.dfy(549,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(549,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(549,3): anon7_Else
+    Termination.dfy(549,3): anon8_Else
+Termination.dfy(556,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(556,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(556,3): anon7_Else
+    Termination.dfy(556,3): anon8_Else
+Termination.dfy(563,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(563,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(563,3): anon7_Else
+    Termination.dfy(563,3): anon8_Else
+Termination.dfy(571,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(571,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(571,3): anon7_Else
+    Termination.dfy(571,3): anon8_Else
+Termination.dfy(579,2): Error: decreases expression might not decrease
+Execution trace:
+    Termination.dfy(579,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(579,3): anon7_Else
+    Termination.dfy(579,3): anon8_Else
+Termination.dfy(589,2): Error: decreases expression might not decrease
+Execution trace:
+    (0,0): anon0
+    Termination.dfy(589,3): anon6_LoopHead
+    (0,0): anon6_LoopBody
+    Termination.dfy(589,3): anon7_Else
+    Termination.dfy(589,3): anon8_Else
 
-Dafny program verifier finished with 43 verified, 8 errors
+Dafny program verifier finished with 44 verified, 17 errors


### PR DESCRIPTION
This PR fixes some problems with termination checking where the type involved is one that has no non-trivial well-founded relation.

## Details

For an expression `E` occurring in a `decreases` clause, the Dafny implementation defines 3 relations: equals (`==)`, less (`<`), and at most (`<=`). The first of these is equality for the type. The last of these is the disjunction of the first two, but is represented differently in the implementation, because some types have a more efficient representation of "at most" than combining "equals" and "less" with an "or".

Dafny pre-defines a well-founded relation for every type. It corresponds to the "less" relation I just mentioned. For some cases, like infinite sets, Dafny only defines a trivial well-founded relation, namely `false`. But even in those cases, it is important that "equals" is still equality. This was done incorrectly, giving rise to unsoundness.

Specifically,

* The cases for `iset<T>`, type parameters, and opaque types were missing, causing a crash
* The cases for `imap<T>` and for arrow type used the wrong definitions or "equals" and "at most".