### PR TITLE
Java runtime clean-up

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1212,16 +1212,16 @@ namespace Microsoft.Dafny{
           postString = ")";
           break;
         case SpecialField.ID.Keys:
-          compiledName = "dafnyKeySet()";
+          compiledName = "keySet()";
           break;
         case SpecialField.ID.Values:
-          compiledName = "dafnyValues()";
+          compiledName = "valueSet()";
           break;
         case SpecialField.ID.Items:
           var mapType = receiverType.AsMapType;
           Contract.Assert(mapType != null);
           var errorWr = new TargetWriter();
-          compiledName = $"<{BoxedTypeName(mapType.Domain, errorWr, Bpl.Token.NoToken)}, {BoxedTypeName(mapType.Range, errorWr, Bpl.Token.NoToken)}>dafnyEntrySet()";
+          compiledName = $"<{BoxedTypeName(mapType.Domain, errorWr, Bpl.Token.NoToken)}, {BoxedTypeName(mapType.Range, errorWr, Bpl.Token.NoToken)}>entrySet()";
           break;
         case SpecialField.ID.Reads:
           compiledName = "_reads";

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -2495,7 +2495,7 @@ namespace Microsoft.Dafny{
       var mt = e.Type.AsMapType;
       var domType = mt.Domain;
       var ranType = mt.Range;
-      wr.WriteLine($"{DafnyMapClass}<{BoxedTypeName(domType, wr, e.tok)}, {BoxedTypeName(ranType, wr, e.tok)}> {collectionName} = new {DafnyMapClass}<>();");
+      wr.WriteLine($"java.util.HashMap<{BoxedTypeName(domType, wr, e.tok)}, {BoxedTypeName(ranType, wr, e.tok)}> {collectionName} = new java.util.HashMap<>();");
     }
 
     protected override void OrganizeModules(Program program, out List<ModuleDefinition> modules){

--- a/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
@@ -19,6 +19,7 @@ sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+    options.compilerArgs += ['-Xlint:unchecked']
 }
 
 test {

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMap.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMap.java
@@ -133,17 +133,17 @@ public class DafnyMap<K, V> {
         return innerMap.get(key);
     }
 
-    public DafnySet<K> dafnyKeySet() {
+    public DafnySet<K> keySet() {
         return new DafnySet<>(innerMap.keySet());
     }
 
-    public DafnySet<V> dafnyValues() {
+    public DafnySet<V> valueSet() {
         return new DafnySet<>(innerMap.values());
     }
 
     // Until tuples (and other datatypes) are compiled with type-argument variance, the following
     // method takes type parameters <KK, VV>. The expectation is that <K, V> is <? extends KK, ? extends VV>.
-    public <KK, VV> DafnySet<? extends Tuple2<KK, VV>> dafnyEntrySet() {
+    public <KK, VV> DafnySet<? extends Tuple2<KK, VV>> entrySet() {
         ArrayList<Tuple2<K, V>> list = new ArrayList<Tuple2<K, V>>();
         for (Map.Entry<K, V> entry : innerMap.entrySet()) {
             list.add(new Tuple2<K, V>(entry.getKey(), entry.getValue()));

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMap.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMap.java
@@ -5,7 +5,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-public class DafnyMap<K, V> implements Map<K, V> {
+public class DafnyMap<K, V> {
     private Map<K, V> innerMap;
 
     public DafnyMap() {
@@ -19,7 +19,7 @@ public class DafnyMap<K, V> implements Map<K, V> {
     public DafnyMap(Map<K, V> m) {
         assert m != null : "Precondition Violation";
         innerMap = new HashMap<>();
-        m.forEach((k, v) -> put(k, v));
+        m.forEach((k, v) -> innerMap.put(k, v));
     }
 
     public static <K, V> DafnyMap<K, V> empty() { return new DafnyMap<K, V>(); }
@@ -27,7 +27,7 @@ public class DafnyMap<K, V> implements Map<K, V> {
     public static <K, V> DafnyMap<K, V> fromElements(Tuple2<K, V> ... pairs) {
         DafnyMap<K, V> result = new DafnyMap<K, V>();
         for (Tuple2<K, V> pair : pairs) {
-            result.put(pair.dtor__0(), pair.dtor__1());
+            result.innerMap.put(pair.dtor__0(), pair.dtor__1());
         }
         return result;
     }
@@ -55,11 +55,6 @@ public class DafnyMap<K, V> implements Map<K, V> {
     }
 
     @Override
-    protected Object clone() throws CloneNotSupportedException {
-        return super.clone();
-    }
-
-    @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
         if (obj == null) return false;
@@ -77,36 +72,15 @@ public class DafnyMap<K, V> implements Map<K, V> {
     public String toString() {
         String s = "map[";
         String sep = "";
-        for (Entry<K, V> entry : innerMap.entrySet()) {
+        for (Map.Entry<K, V> entry : innerMap.entrySet()) {
             s += sep + Helpers.toString(entry.getKey()) + " := " + Helpers.toString(entry.getValue());
             sep = ", ";
         }
         return s + "]";
     }
 
-    @Override
     public void forEach(BiConsumer<? super K, ? super V> action) {
         innerMap.forEach(action);
-    }
-
-    @Override
-    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
-        innerMap.replaceAll(function);
-    }
-
-    @Override
-    public V getOrDefault(Object key, V defaultValue) {
-        return innerMap.getOrDefault(key, defaultValue);
-    }
-
-    @Override
-    public V putIfAbsent(K key, V value) {
-        return innerMap.putIfAbsent(key, value);
-    }
-
-    @Override
-    public boolean remove(Object key, Object value) {
-        return innerMap.remove(key, value);
     }
 
     public static <K, V> DafnyMap<? extends K, ? extends V> merge(DafnyMap<? extends K, ? extends V> th, DafnyMap<? extends K, ? extends V> other) {
@@ -143,37 +117,6 @@ public class DafnyMap<K, V> implements Map<K, V> {
         return new DafnyMap<K, V>(m);
     }
 
-    @Override
-    public boolean replace(K key, V oldValue, V newValue) {
-        return innerMap.replace(key, oldValue, newValue);
-    }
-
-    @Override
-    public V replace(K key, V value) {
-        return innerMap.replace(key, value);
-    }
-
-    @Override
-    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
-        return innerMap.computeIfAbsent(key, mappingFunction);
-    }
-
-    @Override
-    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return innerMap.computeIfPresent(key, remappingFunction);
-    }
-
-    @Override
-    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return innerMap.compute(key, remappingFunction);
-    }
-
-    @Override
-    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
-        return innerMap.merge(key, value, remappingFunction);
-    }
-
-    @Override
     public int size() {
         return innerMap.size();
     }
@@ -182,59 +125,12 @@ public class DafnyMap<K, V> implements Map<K, V> {
         return size();
     }
 
-    @Override
     public boolean isEmpty() {
         return innerMap.isEmpty();
     }
 
-    @Override
-    public boolean containsKey(Object key) {
-        return innerMap.containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-        return innerMap.containsValue(value);
-    }
-
-    @Override
     public V get(Object key) {
         return innerMap.get(key);
-    }
-
-    @Override
-    public V put(K key, V value) {
-        return innerMap.put(key, value);
-    }
-
-    @Override
-    public V remove(Object key) {
-        return innerMap.remove(key);
-    }
-
-    @Override
-    public void putAll(Map<? extends K, ? extends V> m) {
-        innerMap.putAll(m);
-    }
-
-    @Override
-    public void clear() {
-        innerMap.clear();
-    }
-
-    @Override
-    public Set<K> keySet() {
-        return innerMap.keySet();
-    }
-
-    @Override
-    public Collection<V> values() {
-        return new HashSet<>(innerMap.values());
-    }
-
-    @Override
-    public Set<Entry<K, V>> entrySet() {
-        return innerMap.entrySet();
     }
 
     public DafnySet<K> dafnyKeySet() {
@@ -249,7 +145,7 @@ public class DafnyMap<K, V> implements Map<K, V> {
     // method takes type parameters <KK, VV>. The expectation is that <K, V> is <? extends KK, ? extends VV>.
     public <KK, VV> DafnySet<? extends Tuple2<KK, VV>> dafnyEntrySet() {
         ArrayList<Tuple2<K, V>> list = new ArrayList<Tuple2<K, V>>();
-        for (Entry<K, V> entry : innerMap.entrySet()) {
+        for (Map.Entry<K, V> entry : innerMap.entrySet()) {
             list.add(new Tuple2<K, V>(entry.getKey(), entry.getValue()));
         }
         return (DafnySet<? extends Tuple2<KK, VV>>)(Object)new DafnySet<Tuple2<K, V>>(list);

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMap.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMap.java
@@ -24,6 +24,7 @@ public class DafnyMap<K, V> {
 
     public static <K, V> DafnyMap<K, V> empty() { return new DafnyMap<K, V>(); }
 
+    @SuppressWarnings("unchecked")
     public static <K, V> DafnyMap<K, V> fromElements(Tuple2<K, V> ... pairs) {
         DafnyMap<K, V> result = new DafnyMap<K, V>();
         for (Tuple2<K, V> pair : pairs) {
@@ -83,6 +84,7 @@ public class DafnyMap<K, V> {
         innerMap.forEach(action);
     }
 
+    @SuppressWarnings("unchecked")
     public static <K, V> DafnyMap<? extends K, ? extends V> merge(DafnyMap<? extends K, ? extends V> th, DafnyMap<? extends K, ? extends V> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";
@@ -102,6 +104,7 @@ public class DafnyMap<K, V> {
         return new DafnyMap<K, V>(m);
     }
 
+    @SuppressWarnings("unchecked")
     public static <K, V> DafnyMap<? extends K, ? extends V> subtract(DafnyMap<? extends K, ? extends V> th, DafnySet<? extends K> keys) {
         assert th != null : "Precondition Violation";
         assert keys != null : "Precondition Violation";
@@ -143,6 +146,7 @@ public class DafnyMap<K, V> {
 
     // Until tuples (and other datatypes) are compiled with type-argument variance, the following
     // method takes type parameters <KK, VV>. The expectation is that <K, V> is <? extends KK, ? extends VV>.
+    @SuppressWarnings("unchecked")
     public <KK, VV> DafnySet<? extends Tuple2<KK, VV>> entrySet() {
         ArrayList<Tuple2<K, V>> list = new ArrayList<Tuple2<K, V>>();
         for (Map.Entry<K, V> entry : innerMap.entrySet()) {

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMultiset.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnyMultiset.java
@@ -95,6 +95,7 @@ public class DafnyMultiset<T> {
 
     // Determines if the current object is a subset of the DafnyMultiSet passed in. Requires that the input
     // DafnyMultiset is not null.
+    @SuppressWarnings("unchecked")
     public boolean isSubsetOf(DafnyMultiset other) {
         assert other != null : "Precondition Violation";
         for (Map.Entry<T, BigInteger> entry : innerMap.entrySet()) {
@@ -123,11 +124,13 @@ public class DafnyMultiset<T> {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> BigInteger multiplicity(DafnyMultiset<? extends T> th, T t) {
         BigInteger m = th.innerMap.get(t);
         return m == null ? BigInteger.ZERO : m;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> DafnyMultiset<T> update(DafnyMultiset<? extends T> th, T t, BigInteger b) {
         assert th != null : "Precondition Violation";
         assert b != null && b.compareTo(BigInteger.ZERO) >= 0 : "Precondition Violation";
@@ -152,6 +155,7 @@ public class DafnyMultiset<T> {
         setMultiplicity(t, multiplicity(this, t).add(b));
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> DafnyMultiset<T> union(DafnyMultiset<? extends T> th, DafnyMultiset<? extends T> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";
@@ -165,6 +169,7 @@ public class DafnyMultiset<T> {
 
     // Returns a DafnyMultiSet with multiplicities that are
     // max(this.multiplicity(e)-other.multiplicity(e), BigInteger.ZERO)
+    @SuppressWarnings("unchecked")
     public static <T> DafnyMultiset<T> difference(DafnyMultiset<? extends T> th, DafnyMultiset<? extends T> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";
@@ -180,6 +185,7 @@ public class DafnyMultiset<T> {
     }
 
     // Returns a DafnyMultiSet with multiplicities that are min(this.multiplicity(e), other.multiplicity(e))
+    @SuppressWarnings("unchecked")
     public static <T> DafnyMultiset<T> intersection(DafnyMultiset<? extends T> th, DafnyMultiset<? extends T> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
@@ -176,6 +176,7 @@ public abstract class DafnySequence<T> implements Iterable<T> {
         };
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> DafnySequence<T> concatenate(DafnySequence<? extends T> th, DafnySequence<? extends T> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";
@@ -254,6 +255,7 @@ public abstract class DafnySequence<T> implements Iterable<T> {
         return seq.<R>update((int)idx, t);
     }
 
+    @SuppressWarnings("unchecked")
     public boolean contains(Object t) {
         assert t != null : "Precondition Violation";
         return asList().indexOf((T)t) != -1;
@@ -456,6 +458,7 @@ final class ArrayDafnySequence<T> extends NonLazyDafnySequence<T> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <R> ArrayDafnySequence<R> update(int i, R t) {
         assert t != null : "Precondition Violation";
         //todo: should we allow i=length, and return a new sequence with t appended to the sequence?
@@ -583,6 +586,7 @@ final class StringDafnySequence extends NonLazyDafnySequence<Character> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <R> DafnySequence<R> update(int i, R t) {
         // assume R == Character
         assert t != null : "Precondition Violation";

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySet.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySet.java
@@ -79,6 +79,7 @@ public class DafnySet<T> {
         return true;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> DafnySet<T> union(DafnySet<? extends T> th, DafnySet<? extends T> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";
@@ -95,6 +96,7 @@ public class DafnySet<T> {
     }
 
     //Returns a DafnySet containing elements only found in the current DafnySet
+    @SuppressWarnings("unchecked")
     public static <T> DafnySet<T> difference(DafnySet<? extends T> th, DafnySet<? extends T> other) {
         assert th != null : "Precondition Violation";
         assert other != null : "Precondition Violation";

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/MapTest.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/MapTest.java
@@ -8,22 +8,32 @@ import org.junit.jupiter.api.Test;
 
 class MapTest {
     HashMap<Integer, Character> h = new HashMap<>();
-    DafnyMap<Integer, Character> dm = new DafnyMap<>(h);
+    DafnyMap<? extends Integer, ? extends Character> dm = new DafnyMap<>(h);
 
     @Test
     void testSubset(){
+        // add map[1 := 'c'] to both h and dm
         h.put(1, 'c');
-        dm.put(1, 'c');
+        dm = DafnyMap.update(dm, 1, 'c');
         assertEquals(dm, new DafnyMap<>(h));
-        DafnyMap.<Integer, Character>update(dm, 6, 't');
-        assertEquals(dm, new DafnyMap<>(h));
-        assertEquals(dm.entrySet(), h.entrySet());
-        assertEquals(dm.keySet(), h.keySet());
+        assertEquals(dm.dafnyKeySet(), new DafnySet(h.keySet()));
         assertTrue(dm.contains(1));
-        HashMap<Integer, Character> d = new HashMap<>();
-        d.put(6,'l');
-        h.remove(1);
-        dm.remove(1);
+
+        // create an updated map, but dm stays the same
+        DafnyMap<? extends Integer, ? extends Character> dmUpdated;
+        dmUpdated = DafnyMap.<Integer, Character>update(dm, 6, 't');
         assertEquals(dm, new DafnyMap<>(h));
+
+        // remove key 1 from both h and dm
+        h.remove(1);
+        DafnySet<? extends Integer> ds = DafnySet.of(1);
+        dm = DafnyMap.<Integer, Character>subtract(dm, ds);
+        assertEquals(dm, new DafnyMap<>(h));
+
+        // remove key 1 from dmUpdated, which gives map[6 := 't']
+        dmUpdated = DafnyMap.<Integer, Character>subtract(dmUpdated, ds);
+        HashMap<Integer, Character> k = new HashMap<>();
+        k.put(6, 't');
+        assertEquals(dmUpdated, new DafnyMap<>(k));
     }
 }

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/MapTest.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/MapTest.java
@@ -16,7 +16,7 @@ class MapTest {
         h.put(1, 'c');
         dm = DafnyMap.update(dm, 1, 'c');
         assertEquals(dm, new DafnyMap<>(h));
-        assertEquals(dm.dafnyKeySet(), new DafnySet(h.keySet()));
+        assertEquals(dm.keySet(), new DafnySet(h.keySet()));
         assertTrue(dm.contains(1));
 
         // create an updated map, but dm stays the same

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/MapTest.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/MapTest.java
@@ -11,6 +11,7 @@ class MapTest {
     DafnyMap<? extends Integer, ? extends Character> dm = new DafnyMap<>(h);
 
     @Test
+    @SuppressWarnings("unchecked")
     void testSubset(){
         // add map[1 := 'c'] to both h and dm
         h.put(1, 'c');

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/SetTest.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/SetTest.java
@@ -122,6 +122,7 @@ class SetTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void testAddRemove() {
         testSet.add(19);
         assertTrue(testSet.contains(19));

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/TupleTest.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/test/java/dafny/TupleTest.java
@@ -81,10 +81,10 @@ class TupleTest {
     complex.dtor__1().append("J");
     assertEquals(complex.dtor__1(), sb);
     assertNotEquals(new StringBuilder(), complex.dtor__1());
-    assertEquals(complex.dtor__2(), new Integer(3));
+    assertEquals(complex.dtor__2(), 3);
     @SuppressWarnings("unused")
     Integer a = 1 + complex.dtor__2();
-    assertEquals(complex.dtor__2(), new Integer(3));
+    assertEquals(complex.dtor__2(), 3);
     Tuple3<Integer, String, Integer> nullTest = new Tuple3<>(null, null, null);
     assertNull(nullTest.dtor__0());
     assertNull(nullTest.dtor__1());


### PR DESCRIPTION
* The previous `DafnyMap` class in the runtime for Java implemented Java’s `Map` interface. However, the mutable methods of the `Map` interface don’t go with the immutable nature of `DafnyMap`. Therefore, the ties with `Map` are hereby severed.
* The names of some methods in `DafnyMap` had the prefix `dafny` (to avoid confusion with the inherited methods from `Map`). These have now been renamed.
* Suppress warnings about unchecked casts.
* Fix some deprecated syntax.
* Leave `-Xlint:unchecked` on in `gradle.build`.