### PR TITLE
Treat ghost-method out-parameters as ghosts

### DIFF
--- a/Test/dafny0/GhostAutoInit.dfy.expect
+++ b/Test/dafny0/GhostAutoInit.dfy.expect
@@ -59,5 +59,83 @@ Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
     (0,0): anon2
+GhostAutoInit.dfy(161,2): Error: out-parameter 'c', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(161,2): Error: out-parameter 'd', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(161,2): Error: out-parameter 'h', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(166,20): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(169,20): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(169,25): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(178,20): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(178,25): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(179,2): Error: out-parameter 'h', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(184,2): Error: out-parameter 'c', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(184,2): Error: out-parameter 'd', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(184,2): Error: out-parameter 'h', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(193,22): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(193,27): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(205,22): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(205,27): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(220,26): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
+GhostAutoInit.dfy(220,31): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
+GhostAutoInit.dfy(231,11): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(231,17): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(231,20): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(244,23): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(244,29): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(244,32): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
 
-Dafny program verifier finished with 1 verified, 15 errors
+Dafny program verifier finished with 5 verified, 39 errors


### PR DESCRIPTION
Whether or not a variable is subject to definite-assignment checking depends on the type of the variable as well as on whether the variable compiled or ghost. This was previously not done correctly for out-parameters of ghost methods. This PR fixes that. It also adds tests for other kinds of variables that are to be considered ghosts.