### PR TITLE
feat: Opt-out witness for possibly empty types

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -1631,7 +1631,7 @@ namespace Microsoft.Dafny
       Contract.Assert(cl != null);
       if (cl is NewtypeDecl) {
         var td = (NewtypeDecl)cl;
-        return td.WitnessKind == SubsetTypeDecl.WKind.None;
+        return td.WitnessKind == SubsetTypeDecl.WKind.CompiledZero;
       } else if (cl is ClassDecl) {
         return true; // null is a value of this type
       } else {

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1297,7 +1297,6 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
      Expression constraint;
      Expression witness = null;
      bool isRefining = false;
-     bool witnessIsGhost = false;
      CheckDeclModifiers(dmod, "newtype", AllowedDeclModifiers.None);
      var members = new List<MemberDecl>();
   .)
@@ -1312,15 +1311,18 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
     [ ":" Type<out baseType> ]       (. if (baseType == null) { baseType = new InferredTypeProxy(); } .)
     "|"
     Expression<out constraint, false, true>
+    (. var witnessKind = SubsetTypeDecl.WKind.CompiledZero; .)
     [ IF(IsWitness())
-      [ "ghost"                      (. witnessIsGhost = true; .)
-      ]
-      "witness" Expression<out witness, false, true>
+      ( "ghost" "witness"                            (. witnessKind = SubsetTypeDecl.WKind.Ghost; .) 
+        Expression<out witness, false, true>
+      | "witness"
+        ( "*"                                        (. witnessKind = SubsetTypeDecl.WKind.OptOut; .)
+        | Expression<out witness, false, true>       (. witnessKind = SubsetTypeDecl.WKind.Compiled; .)
+        )
+      )
     ]
     [ TypeMembers<module, members> ]
-    (. var witnessKind = witness == null ? SubsetTypeDecl.WKind.CompiledZero :
-       witnessIsGhost ? SubsetTypeDecl.WKind.Ghost : SubsetTypeDecl.WKind.Compiled;
-       td = new NewtypeDecl(id, id.val, module, new BoundVar(bvId, bvId.val, baseType), constraint, witnessKind, witness, members, attrs, isRefining);
+    (. td = new NewtypeDecl(id, id.val, module, new BoundVar(bvId, bvId.val, baseType), constraint, witnessKind, witness, members, attrs, isRefining);
     .)
   | Type<out baseType>
     [ TypeMembers<module, members> ]
@@ -1339,7 +1341,6 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
      Type ty = null;
      Expression constraint;
      Expression witness = null;
-     bool witnessIsGhost = false;
      var kind = "opaque type";
      var members = new List<MemberDecl>();
   .)
@@ -1354,31 +1355,35 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
       [ ":" Type<out ty> ]   (. if (ty == null) { ty = new InferredTypeProxy(); } .)
       "|"
       Expression<out constraint, false, true>
+      (. var witnessKind = SubsetTypeDecl.WKind.CompiledZero; .)
       [ IF(IsWitness())
-        [ "ghost"            (. witnessIsGhost = true; .)
-        ]
-        "witness" Expression<out witness, false, true>
+        ( "ghost" "witness"                            (. witnessKind = SubsetTypeDecl.WKind.Ghost; .) 
+          Expression<out witness, false, true>
+        | "witness"
+          ( "*"                                        (. witnessKind = SubsetTypeDecl.WKind.OptOut; .)
+          | Expression<out witness, false, true>       (. witnessKind = SubsetTypeDecl.WKind.Compiled; .)
+          )
+        )
       ]
-                             (. var witnessKind = witness == null ? SubsetTypeDecl.WKind.CompiledZero :
-                                  witnessIsGhost ? SubsetTypeDecl.WKind.Ghost : SubsetTypeDecl.WKind.Compiled;
-                                td = new SubsetTypeDecl(id, id.val, characteristics, typeArgs, module, new BoundVar(bvId, bvId.val, ty), constraint, witnessKind, witness, attrs);
-                                kind = "subset type";
-                             .)
+      (. td = new SubsetTypeDecl(id, id.val, characteristics, typeArgs, module, new BoundVar(bvId, bvId.val, ty), constraint, witnessKind, witness, attrs);
+         kind = "subset type";
+      .)
     |
-      Type<out ty>           (. td = new TypeSynonymDecl(id, id.val, characteristics, typeArgs, module, ty, attrs);
-                                kind = "type synonym";
-                             .)
+      Type<out ty>
+      (. td = new TypeSynonymDecl(id, id.val, characteristics, typeArgs, module, ty, attrs);
+         kind = "type synonym";
+      .)
     )
   | TypeMembers<module, members>
   ]
-                             (. if (td == null) {
-                                  if (module is DefaultModuleDecl) {
-                                    // opaque type declarations at the very outermost program scope get an automatic (!new)
-                                    characteristics.DisallowReferenceTypes = true;
-                                  }
-                                  td = new OpaqueTypeDecl(id, id.val, module, characteristics, typeArgs, members, attrs);
-                                }
-                             .)
+  (. if (td == null) {
+       if (module is DefaultModuleDecl) {
+         // opaque type declarations at the very outermost program scope get an automatic (!new)
+         characteristics.DisallowReferenceTypes = true;
+       }
+       td = new OpaqueTypeDecl(id, id.val, module, characteristics, typeArgs, members, attrs);
+     }
+  .)
   (. CheckDeclModifiers(dmod, kind, AllowedDeclModifiers.None); .)
   .
 

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1318,7 +1318,7 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
       "witness" Expression<out witness, false, true>
     ]
     [ TypeMembers<module, members> ]
-    (. var witnessKind = witness == null ? SubsetTypeDecl.WKind.None :
+    (. var witnessKind = witness == null ? SubsetTypeDecl.WKind.CompiledZero :
        witnessIsGhost ? SubsetTypeDecl.WKind.Ghost : SubsetTypeDecl.WKind.Compiled;
        td = new NewtypeDecl(id, id.val, module, new BoundVar(bvId, bvId.val, baseType), constraint, witnessKind, witness, members, attrs, isRefining);
     .)
@@ -1359,7 +1359,7 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
         ]
         "witness" Expression<out witness, false, true>
       ]
-                             (. var witnessKind = witness == null ? SubsetTypeDecl.WKind.None :
+                             (. var witnessKind = witness == null ? SubsetTypeDecl.WKind.CompiledZero :
                                   witnessIsGhost ? SubsetTypeDecl.WKind.Ghost : SubsetTypeDecl.WKind.Compiled;
                                 td = new SubsetTypeDecl(id, id.val, characteristics, typeArgs, module, new BoundVar(bvId, bvId.val, ty), constraint, witnessKind, witness, attrs);
                                 kind = "subset type";

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Dafny {
       var bvNat = new BoundVar(Token.NoToken, "x", Type.Int);
       var natConstraint = Expression.CreateAtMost(Expression.CreateIntLiteral(Token.NoToken, 0), Expression.CreateIdentExpr(bvNat));
       var ax = AxiomAttribute();
-      NatDecl = new SubsetTypeDecl(Token.NoToken, "nat", new TypeParameter.TypeParameterCharacteristics(TypeParameter.EqualitySupportValue.InferredRequired, false, false), new List<TypeParameter>(), SystemModule, bvNat, natConstraint, SubsetTypeDecl.WKind.None, null, ax);
+      NatDecl = new SubsetTypeDecl(Token.NoToken, "nat", new TypeParameter.TypeParameterCharacteristics(TypeParameter.EqualitySupportValue.InferredRequired, false, false), new List<TypeParameter>(), SystemModule, bvNat, natConstraint, SubsetTypeDecl.WKind.CompiledZero, null, ax);
       SystemModule.TopLevelDecls.Add(NatDecl);
       // create trait 'object'
       ObjectDecl = new TraitDecl(Token.NoToken, "object", SystemModule, new List<TypeParameter>(), new List<MemberDecl>(), DontCompile(), false, null);
@@ -939,7 +939,7 @@ namespace Microsoft.Dafny {
       } else if (cl is NewtypeDecl) {
         var td = (NewtypeDecl)cl;
         switch (td.WitnessKind) {
-          case SubsetTypeDecl.WKind.None:
+          case SubsetTypeDecl.WKind.CompiledZero:
           case SubsetTypeDecl.WKind.Compiled:
             return AutoInitInfo.CompilableValue;
           case SubsetTypeDecl.WKind.Ghost:
@@ -952,7 +952,7 @@ namespace Microsoft.Dafny {
       } else if (cl is SubsetTypeDecl) {
         var td = (SubsetTypeDecl)cl;
         switch (td.WitnessKind) {
-          case SubsetTypeDecl.WKind.None:
+          case SubsetTypeDecl.WKind.CompiledZero:
           case SubsetTypeDecl.WKind.Compiled:
             return AutoInitInfo.CompilableValue;
           case SubsetTypeDecl.WKind.Ghost:
@@ -5523,7 +5523,7 @@ namespace Microsoft.Dafny {
     public readonly Type BaseType;
     public readonly BoundVar Var;  // can be null (if non-null, then object.ReferenceEquals(Var.Type, BaseType))
     public readonly Expression Constraint;  // is null iff Var is
-    public readonly SubsetTypeDecl.WKind WitnessKind = SubsetTypeDecl.WKind.None;
+    public readonly SubsetTypeDecl.WKind WitnessKind = SubsetTypeDecl.WKind.CompiledZero;
     public readonly Expression/*?*/ Witness;  // non-null iff WitnessKind is Compiled or Ghost
     public NativeType NativeType; // non-null for fixed-size representations (otherwise, use BigIntegers for integers)
     public NewtypeDecl(IToken tok, string name, ModuleDefinition module, Type baseType, List<MemberDecl> members, Attributes attributes, bool isRefining)
@@ -5650,7 +5650,7 @@ namespace Microsoft.Dafny {
     ModuleDefinition RedirectingTypeDecl.Module { get { return EnclosingModuleDefinition; } }
     BoundVar RedirectingTypeDecl.Var { get { return null; } }
     Expression RedirectingTypeDecl.Constraint { get { return null; } }
-    SubsetTypeDecl.WKind RedirectingTypeDecl.WitnessKind { get { return SubsetTypeDecl.WKind.None; } }
+    SubsetTypeDecl.WKind RedirectingTypeDecl.WitnessKind { get { return SubsetTypeDecl.WKind.CompiledZero; } }
     Expression RedirectingTypeDecl.Witness { get { return null; } }
     FreshIdGenerator RedirectingTypeDecl.IdGenerator { get { return IdGenerator; } }
 
@@ -5698,7 +5698,7 @@ namespace Microsoft.Dafny {
     public override string WhatKind { get { return "subset type"; } }
     public readonly BoundVar Var;
     public readonly Expression Constraint;
-    public enum WKind { None, Compiled, Ghost, Special }
+    public enum WKind { CompiledZero, Compiled, Ghost, Special }
     public readonly SubsetTypeDecl.WKind WitnessKind;
     public readonly Expression/*?*/ Witness;  // non-null iff WitnessKind is Compiled or Ghost
     public SubsetTypeDecl(IToken tok, string name, TypeParameter.TypeParameterCharacteristics characteristics, List<TypeParameter> typeArgs, ModuleDefinition module,

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -944,6 +944,8 @@ namespace Microsoft.Dafny {
             return AutoInitInfo.CompilableValue;
           case SubsetTypeDecl.WKind.Ghost:
             return AutoInitInfo.Nonempty;
+          case SubsetTypeDecl.WKind.OptOut:
+            return AutoInitInfo.MaybeEmpty;
           case SubsetTypeDecl.WKind.Special:
           default:
             Contract.Assert(false); // unexpected case
@@ -957,6 +959,8 @@ namespace Microsoft.Dafny {
             return AutoInitInfo.CompilableValue;
           case SubsetTypeDecl.WKind.Ghost:
             return AutoInitInfo.Nonempty;
+          case SubsetTypeDecl.WKind.OptOut:
+            return AutoInitInfo.MaybeEmpty;
           case SubsetTypeDecl.WKind.Special:
             // WKind.Special is only used with -->, ->, and non-null types:
             Contract.Assert(ArrowType.IsPartialArrowTypeName(td.Name) || ArrowType.IsTotalArrowTypeName(td.Name) || td is NonNullTypeDecl);
@@ -5698,7 +5702,7 @@ namespace Microsoft.Dafny {
     public override string WhatKind { get { return "subset type"; } }
     public readonly BoundVar Var;
     public readonly Expression Constraint;
-    public enum WKind { CompiledZero, Compiled, Ghost, Special }
+    public enum WKind { CompiledZero, Compiled, Ghost, OptOut, Special }
     public readonly SubsetTypeDecl.WKind WitnessKind;
     public readonly Expression/*?*/ Witness;  // non-null iff WitnessKind is Compiled or Ghost
     public SubsetTypeDecl(IToken tok, string name, TypeParameter.TypeParameterCharacteristics characteristics, List<TypeParameter> typeArgs, ModuleDefinition module,

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -432,6 +432,9 @@ namespace Microsoft.Dafny {
           wr.Write("witness ");
           PrintExpression(dd.Witness, true);
           break;
+        case SubsetTypeDecl.WKind.OptOut:
+          wr.Write("witness *");
+          break;
         case SubsetTypeDecl.WKind.Special:
           wr.Write("/*special witness*/");
           break;

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Dafny {
             wr.Write("| ");
             PrintExpression(dd.Constraint, true);
             wr.WriteLine();
-            if (dd.WitnessKind != SubsetTypeDecl.WKind.None) {
+            if (dd.WitnessKind != SubsetTypeDecl.WKind.CompiledZero) {
               Indent(indent + IndentAmount);
               PrintWitnessClause(dd);
               wr.WriteLine();
@@ -283,7 +283,7 @@ namespace Microsoft.Dafny {
           }
           wr.Write("| ");
           PrintExpression(dd.Constraint, true);
-          if (dd.WitnessKind != SubsetTypeDecl.WKind.None) {
+          if (dd.WitnessKind != SubsetTypeDecl.WKind.CompiledZero) {
             if (dd is NonNullTypeDecl) {
               wr.Write(" ");
             } else {
@@ -422,7 +422,7 @@ namespace Microsoft.Dafny {
 
     private void PrintWitnessClause(RedirectingTypeDecl dd) {
       Contract.Requires(dd != null);
-      Contract.Requires(dd.WitnessKind != SubsetTypeDecl.WKind.None);
+      Contract.Requires(dd.WitnessKind != SubsetTypeDecl.WKind.CompiledZero);
 
       switch (dd.WitnessKind) {
         case SubsetTypeDecl.WKind.Ghost:
@@ -435,7 +435,7 @@ namespace Microsoft.Dafny {
         case SubsetTypeDecl.WKind.Special:
           wr.Write("/*special witness*/");
           break;
-        case SubsetTypeDecl.WKind.None:
+        case SubsetTypeDecl.WKind.CompiledZero:
         default:
           Contract.Assert(false);  // unexpected WKind
           break;

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -6235,7 +6235,7 @@ namespace Microsoft.Dafny {
       // If there's no constraint, there's nothing to do
       if (decl.Var == null) {
         Contract.Assert(decl.Constraint == null);  // there's a constraint only if there's a variable to be constrained
-        Contract.Assert(decl.WitnessKind == SubsetTypeDecl.WKind.None);  // a witness makes sense only if there is a constraint
+        Contract.Assert(decl.WitnessKind == SubsetTypeDecl.WKind.CompiledZero);  // a witness makes sense only if there is a constraint
         Contract.Assert(decl.Witness == null);  // a witness makes sense only if there is a constraint
         return;
       }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -6314,7 +6314,7 @@ namespace Microsoft.Dafny {
         // check that the witness expression checks out
         witnessExpr = Substitute(decl.Constraint, decl.Var, decl.Witness);
         witnessErrorMsg = "the given witness expression might not satisfy constraint";
-      } else {
+      } else if (decl.WitnessKind == SubsetTypeDecl.WKind.CompiledZero) {
         var witness = Zero(decl.tok, decl.Var.Type);
         if (witness == null) {
           witnessCheckBuilder.Add(Assert(decl.tok, Bpl.Expr.False, "cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause"));

--- a/Test/dafny0/GhostAutoInit.dfy.expect
+++ b/Test/dafny0/GhostAutoInit.dfy.expect
@@ -137,5 +137,40 @@ Execution trace:
 GhostAutoInit.dfy(244,32): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
 Execution trace:
     (0,0): anon0
+GhostAutoInit.dfy(269,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+GhostAutoInit.dfy(285,2): Error: A postcondition might not hold on this return path.
+GhostAutoInit.dfy(284,12): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(290,9): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(295,9): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(302,9): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(309,9): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(316,9): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(318,19): Error: variable 'cell', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(319,11): Error: value does not satisfy the subset constraints of 'nat'
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(322,19): Error: variable 'e', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Else
 
-Dafny program verifier finished with 5 verified, 39 errors
+Dafny program verifier finished with 7 verified, 49 errors

--- a/Test/dafny0/GhostAutoInit.dfy.expect
+++ b/Test/dafny0/GhostAutoInit.dfy.expect
@@ -59,5 +59,83 @@ Execution trace:
     (0,0): anon0
     (0,0): anon3_Then
     (0,0): anon2
+GhostAutoInit.dfy(161,2): Error: out-parameter 'c', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(161,2): Error: out-parameter 'd', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(161,2): Error: out-parameter 'h', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(166,20): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(169,20): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(169,25): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(178,20): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(178,25): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(179,2): Error: out-parameter 'h', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(184,2): Error: out-parameter 'c', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(184,2): Error: out-parameter 'd', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(184,2): Error: out-parameter 'h', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(193,22): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(193,27): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(205,22): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(205,27): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon3_Then
+GhostAutoInit.dfy(220,26): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
+GhostAutoInit.dfy(220,31): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+    (0,0): anon5_Then
+GhostAutoInit.dfy(231,11): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(231,17): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(231,20): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(244,23): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(244,29): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
+GhostAutoInit.dfy(244,32): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
+Execution trace:
+    (0,0): anon0
 
-Dafny program verifier finished with 1 verified, 15 errors
+Dafny program verifier finished with 5 verified, 39 errors


### PR DESCRIPTION
Depends on PR https://github.com/dafny-lang/dafny/pull/1065

A subset type or `newtype` now supports the following witness clauses:

* `witness E` says that `E` is a compiled expression that is a value of the type
* the absence of a `witness` defaults to
    - `witness 0` for types based on integers or bitvectors,
    - `witness 0.0` for real-based types,
    - `witness {}` for set-based types,
    - etc.
* `ghost witness E` says that `E` is a ghost expression that is a value of the type
* `witness *` opts out of witness checking; instead, the type is treated as being possibly empty
