### PR TITLE
fix: Check type-synonym type-characteristics to be accurate

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -3250,7 +3250,15 @@ namespace Microsoft.Dafny
             var syn = (TypeSynonymDecl)d;
             CheckEqualityTypes_Type(syn.tok, syn.Rhs);
             if (syn.SupportsEquality && !syn.Rhs.SupportsEquality) {
-              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as supporting equality, but the RHS type ({1}) does not", syn.Name, syn.Rhs);
+              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as supporting equality, but the RHS type ({1}) might not", syn.Name, syn.Rhs);
+            }
+            if (syn.Characteristics.IsNonempty && !syn.Rhs.IsNonempty) {
+              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as being nonempty, but the RHS type ({1}) may be empty", syn.Name, syn.Rhs);
+            } else if (syn.Characteristics.HasCompiledValue && !syn.Rhs.HasCompilableValue) {
+              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as auto-initialization type, but the RHS type ({1}) does not support auto-initialization", syn.Name, syn.Rhs);
+            }
+            if (syn.Characteristics.ContainsNoReferenceTypes && !syn.Rhs.IsAllocFree) {
+              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as containing no reference types, but the RHS type ({1}) may contain reference types", syn.Name, syn.Rhs);
             }
           }
         }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -3249,16 +3249,22 @@ namespace Microsoft.Dafny
           } else if (d is TypeSynonymDecl) {
             var syn = (TypeSynonymDecl)d;
             CheckEqualityTypes_Type(syn.tok, syn.Rhs);
-            if (syn.SupportsEquality && !syn.Rhs.SupportsEquality) {
-              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as supporting equality, but the RHS type ({1}) might not", syn.Name, syn.Rhs);
-            }
-            if (syn.Characteristics.IsNonempty && !syn.Rhs.IsNonempty) {
-              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as being nonempty, but the RHS type ({1}) may be empty", syn.Name, syn.Rhs);
-            } else if (syn.Characteristics.HasCompiledValue && !syn.Rhs.HasCompilableValue) {
-              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as auto-initialization type, but the RHS type ({1}) does not support auto-initialization", syn.Name, syn.Rhs);
-            }
-            if (syn.Characteristics.ContainsNoReferenceTypes && !syn.Rhs.IsAllocFree) {
-              reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as containing no reference types, but the RHS type ({1}) may contain reference types", syn.Name, syn.Rhs);
+            if (!isAnExport) {
+              if (syn.SupportsEquality && !syn.Rhs.SupportsEquality) {
+                reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as supporting equality, but the RHS type ({1}) might not",
+                  syn.Name, syn.Rhs);
+              }
+              if (syn.Characteristics.IsNonempty && !syn.Rhs.IsNonempty) {
+                reporter.Error(MessageSource.Resolver, syn.tok, "type '{0}' declared as being nonempty, but the RHS type ({1}) may be empty",
+                  syn.Name, syn.Rhs);
+              } else if (syn.Characteristics.HasCompiledValue && !syn.Rhs.HasCompilableValue) {
+                reporter.Error(MessageSource.Resolver, syn.tok,
+                  "type '{0}' declared as auto-initialization type, but the RHS type ({1}) does not support auto-initialization", syn.Name, syn.Rhs);
+              }
+              if (syn.Characteristics.ContainsNoReferenceTypes && !syn.Rhs.IsAllocFree) {
+                reporter.Error(MessageSource.Resolver, syn.tok,
+                  "type '{0}' declared as containing no reference types, but the RHS type ({1}) may contain reference types", syn.Name, syn.Rhs);
+              }
             }
           }
         }

--- a/Test/allocated1/dafny0/TypeSynonyms.dfy.expect
+++ b/Test/allocated1/dafny0/TypeSynonyms.dfy.expect
@@ -1,2 +1,62 @@
+TypeSynonyms.dfy(78,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(119,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(119,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(121,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(121,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(123,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(123,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(125,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(125,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(133,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(133,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(135,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(143,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(143,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(145,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(145,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(147,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(155,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(155,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(157,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 2 verified, 20 errors

--- a/Test/dafny0/EqualityTypesModuleExports.dfy
+++ b/Test/dafny0/EqualityTypesModuleExports.dfy
@@ -399,3 +399,39 @@ module ScopeRegressions {
     datatype BType = X | Y
   }
 }
+
+// ------------------------------------------------------
+// Tests that all declared type characteristics hold true
+// ------------------------------------------------------
+
+module SynonymTypes {
+  type Empty = x: int | false witness *
+  type Synonym(0) = Empty  // error
+  type AnotherSynonym(00) = Empty  // error
+
+  type NonEmpty = x: int | 0 <= x ghost witness 2
+  type NESynonym(0) = NonEmpty  // error
+  type NEAnotherSynonym(00) = NonEmpty
+
+  class C { }
+  type NoReference(!new) = C?  // error
+
+  codatatype Stream = More(Stream)
+  type PipeDreamEquality(==) = Stream  // error
+}
+
+module SubsetTypes {
+  type Empty = x: int | false witness *
+  type Subset(0) = e: Empty| true  // error
+  type AnotherSubset(00) = e: Empty | true  // error
+
+  type NonEmpty = x: int | 0 <= x ghost witness 2
+  type NESynonym(0) = e: NonEmpty | true  // error
+  type NEAnotherSynonym(00) = e: NonEmpty | true
+
+  class C { }
+  type NoReference(!new) = c: C? | true  // error
+
+  codatatype Stream = More(Stream)
+  type PipeDreamEquality(==) = s: Stream | true  // error
+}

--- a/Test/dafny0/EqualityTypesModuleExports.dfy.expect
+++ b/Test/dafny0/EqualityTypesModuleExports.dfy.expect
@@ -3,8 +3,8 @@ EqualityTypesModuleExports.dfy(13,23): Error: set argument type must support equ
 EqualityTypesModuleExports.dfy(32,15): Error: type parameter (X) passed to function Fib must support equality (got Y) (perhaps try declaring type parameter 'Y' on line 26 as 'Y(==)', which says it can only be instantiated with a type that supports equality)
 EqualityTypesModuleExports.dfy(32,23): Error: set argument type must support equality (got Y) (perhaps try declaring type parameter 'Y' on line 26 as 'Y(==)', which says it can only be instantiated with a type that supports equality)
 EqualityTypesModuleExports.dfy(34,13): Error: set argument type must support equality (got GG) (perhaps try declaring type parameter 'GG' on line 21 as 'GG(==)', which says it can only be instantiated with a type that supports equality)
-EqualityTypesModuleExports.dfy(84,7): Error: type 'Syn4' declared as supporting equality, but the RHS type ((real, A)) does not
-EqualityTypesModuleExports.dfy(92,7): Error: type 'Subset4' declared as supporting equality, but the RHS type ((A, int)) does not
+EqualityTypesModuleExports.dfy(84,7): Error: type 'Syn4' declared as supporting equality, but the RHS type ((real, A)) might not
+EqualityTypesModuleExports.dfy(92,7): Error: type 'Subset4' declared as supporting equality, but the RHS type ((A, int)) might not
 EqualityTypesModuleExports.dfy(50,11): Error: type parameter (X) passed to type Dt0 must support equality (got M) (perhaps try declaring type parameter 'M' on line 48 as 'M(==)', which says it can only be instantiated with a type that supports equality)
 EqualityTypesModuleExports.dfy(51,11): Error: type parameter (Y) passed to type Dt1 must support equality (got M) (perhaps try declaring type parameter 'M' on line 48 as 'M(==)', which says it can only be instantiated with a type that supports equality)
 EqualityTypesModuleExports.dfy(52,11): Error: type parameter (Z) passed to type Dt2 must support equality (got M) (perhaps try declaring type parameter 'M' on line 48 as 'M(==)', which says it can only be instantiated with a type that supports equality)
@@ -46,8 +46,18 @@ EqualityTypesModuleExports.dfy(249,7): Error: == can only be applied to expressi
 EqualityTypesModuleExports.dfy(252,7): Error: == can only be applied to expressions of types that support equality (got WWW0.YT)
 EqualityTypesModuleExports.dfy(255,7): Error: == can only be applied to expressions of types that support equality (got WWW0.ZT)
 EqualityTypesModuleExports.dfy(258,7): Error: == can only be applied to expressions of types that support equality (got WWW0.WT)
-EqualityTypesModuleExports.dfy(283,7): Error: type 'A' declared as supporting equality, but the RHS type (QQQ1.Syn<int>) does not
-EqualityTypesModuleExports.dfy(298,7): Error: type 'ExportedType' declared as supporting equality, but the RHS type (PrivateType<A>) does not
+EqualityTypesModuleExports.dfy(283,7): Error: type 'A' declared as supporting equality, but the RHS type (QQQ1.Syn<int>) might not
+EqualityTypesModuleExports.dfy(298,7): Error: type 'ExportedType' declared as supporting equality, but the RHS type (PrivateType<A>) might not
 EqualityTypesModuleExports.dfy(346,4): Error: == can only be applied to expressions of types that support equality (got List<A>)
 EqualityTypesModuleExports.dfy(366,9): Warning: note, this export set is empty (did you perhaps forget the 'provides' or 'reveals' keyword?)
-51 resolution/type errors detected in EqualityTypesModuleExports.dfy
+EqualityTypesModuleExports.dfy(409,7): Error: type 'Synonym' declared as being nonempty, but the RHS type (Empty) may be empty
+EqualityTypesModuleExports.dfy(410,7): Error: type 'AnotherSynonym' declared as being nonempty, but the RHS type (Empty) may be empty
+EqualityTypesModuleExports.dfy(413,7): Error: type 'NESynonym' declared as auto-initialization type, but the RHS type (NonEmpty) does not support auto-initialization
+EqualityTypesModuleExports.dfy(417,7): Error: type 'NoReference' declared as containing no reference types, but the RHS type (C?) may contain reference types
+EqualityTypesModuleExports.dfy(420,7): Error: type 'PipeDreamEquality' declared as supporting equality, but the RHS type (Stream) might not
+EqualityTypesModuleExports.dfy(425,7): Error: type 'Subset' declared as being nonempty, but the RHS type (Empty) may be empty
+EqualityTypesModuleExports.dfy(426,7): Error: type 'AnotherSubset' declared as being nonempty, but the RHS type (Empty) may be empty
+EqualityTypesModuleExports.dfy(429,7): Error: type 'NESynonym' declared as auto-initialization type, but the RHS type (NonEmpty) does not support auto-initialization
+EqualityTypesModuleExports.dfy(433,7): Error: type 'NoReference' declared as containing no reference types, but the RHS type (C?) may contain reference types
+EqualityTypesModuleExports.dfy(436,7): Error: type 'PipeDreamEquality' declared as supporting equality, but the RHS type (Stream) might not
+61 resolution/type errors detected in EqualityTypesModuleExports.dfy

--- a/Test/dafny0/TypeSynonyms.dfy
+++ b/Test/dafny0/TypeSynonyms.dfy
@@ -1,53 +1,55 @@
 // RUN: %dafny /compile:0 /print:"%t.print" /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type MyType<A> = int
+module Basic {
+  type MyType<A> = int
 
-type Int = int
+  type Int = int
 
-type PairaBools = (bool, bool)
+  type PairaBools = (bool, bool)
 
-datatype List<T> = Nil | Cons(T, List)
+  datatype List<T> = Nil | Cons(T, List)
 
-type Synonym0<T,U> = List<T>
+  type Synonym0<T,U> = List<T>
 
-type Synonym1<T> = List  // type argument of List filled in automatically
+  type Synonym1<T> = List  // type argument of List filled in automatically
 
-type Synonym2<A> = List<A>
+  type Synonym2<A> = List<A>
 
-type Synonym3<B> = Synonym4
+  type Synonym3<B> = Synonym4
 
-type Synonym4<C> = Synonym2<C>
+  type Synonym4<C> = Synonym2<C>
 
-type Synonym5<A,B> = List
+  type Synonym5<A,B> = List
 
-function Plus(x: Int, y: int): Int
-{
-  x + y
-}
+  function Plus(x: Int, y: int): Int
+  {
+    x + y
+  }
 
-method Next(s: Synonym1) returns (u: Synonym1)
-{
-  match s
-  case Nil => u := Nil;
-  case Cons(_, tail) => u := tail;
-}
+  method Next(s: Synonym1) returns (u: Synonym1)
+  {
+    match s
+    case Nil => u := Nil;
+    case Cons(_, tail) => u := tail;
+  }
 
-method Add<W>(t: W, s: Synonym1) returns (u: Synonym1)
-{
-  u := Cons(t, Nil);
-}
+  method Add<W>(t: W, s: Synonym1) returns (u: Synonym1)
+  {
+    u := Cons(t, Nil);
+  }
 
-function Skip(s: Synonym3): Synonym0
-{
-  match s
-  case Nil => Nil
-  case Cons(_, tail) => tail
-}
+  function Skip(s: Synonym3): Synonym0
+  {
+    match s
+    case Nil => Nil
+    case Cons(_, tail) => tail
+  }
 
-type MyMap = map<int, map<real, bool>>
+  type MyMap = map<int, map<real, bool>>
 
-predicate MyMapProperty(m: MyMap, x: int)
-{
-  x in m && x as real in m[x] && m[x][x as real]
+  predicate MyMapProperty(m: MyMap, x: int)
+  {
+    x in m && x as real in m[x] && m[x][x as real]
+  }
 }

--- a/Test/dafny0/TypeSynonyms.dfy
+++ b/Test/dafny0/TypeSynonyms.dfy
@@ -53,3 +53,108 @@ module Basic {
     x in m && x as real in m[x] && m[x][x as real]
   }
 }
+
+// --------------- Test knowledge of emptiness ---------------
+
+module Library {
+  export
+    reveals Empty
+  export Opaque
+    provides Empty
+
+  type Empty = x: int | false witness *
+}
+
+module KnowsItIsEmpty {
+  import L = Library
+  method M(x: L.Empty) {
+    assert false;  // no prob, since L.Empty is known to be empty
+  }
+}
+
+module OnlySeesOpaqueType {
+  import L = Library`Opaque
+  method M(x: L.Empty) {
+    assert false;  // error
+  }
+}
+
+// --------------- Test lack of knowledge of nonemptiness ---------------
+
+module NonemptyLibrary {
+  export E0
+    reveals Something, A, B, C
+  export E1
+    provides Something
+    reveals A, B, C
+  export E2
+    reveals Something
+    provides A, B, C
+  export E3
+    provides Something, A, B, C
+  export E4
+    provides A, B, C
+
+  type Something = int
+  type A = Something
+  type B(00) = Something
+  type C(0) = Something
+}
+
+module ClientE0 {
+  import L = NonemptyLibrary`E0
+  method MethodS() returns (x: L.Something, ghost y: L.Something) {
+  }
+  method MethodA() returns (x: L.A, ghost y: L.A) {
+  }
+  method MethodB() returns (x: L.B, ghost y: L.B) {
+  }
+  method MethodC() returns (x: L.C, ghost y: L.C) {
+  }
+}
+
+module ClientE1 {
+  import L = NonemptyLibrary`E1
+  method MethodS() returns (x: L.Something, ghost y: L.Something) {
+  } // error (x2): x, y have not been assigned
+  method MethodA() returns (x: L.A, ghost y: L.A) {
+  } // error (x2): x, y have not been assigned
+  method MethodB() returns (x: L.B, ghost y: L.B) {
+  } // error (x2): x, y have not been assigned
+  method MethodC() returns (x: L.C, ghost y: L.C) {
+  } // error (x2): x, y have not been assigned
+}
+
+module ClientE2 {
+  import L = NonemptyLibrary`E2
+  method MethodS() returns (x: L.Something, ghost y: L.Something) {
+  }
+  method MethodA() returns (x: L.A, ghost y: L.A) {
+  } // error (x2): x, y have not been assigned
+  method MethodB() returns (x: L.B, ghost y: L.B) {
+  } // error: x has not been assigned
+  method MethodC() returns (x: L.C, ghost y: L.C) {
+  }
+}
+
+module ClientE3 {
+  import L = NonemptyLibrary`E3
+  method MethodS() returns (x: L.Something, ghost y: L.Something) {
+  } // error (x2): x, y have not been assigned
+  method MethodA() returns (x: L.A, ghost y: L.A) {
+  } // error (x2): x, y have not been assigned
+  method MethodB() returns (x: L.B, ghost y: L.B) {
+  } // error: x has not been assigned
+  method MethodC() returns (x: L.C, ghost y: L.C) {
+  }
+}
+
+module ClientE4 {
+  import L = NonemptyLibrary`E4
+  method MethodA() returns (x: L.A, ghost y: L.A) {
+  } // error (x2): x, y have not been assigned
+  method MethodB() returns (x: L.B, ghost y: L.B) {
+  } // error: x has not been assigned
+  method MethodC() returns (x: L.C, ghost y: L.C) {
+  }
+}

--- a/Test/dafny0/TypeSynonyms.dfy.expect
+++ b/Test/dafny0/TypeSynonyms.dfy.expect
@@ -1,2 +1,62 @@
+TypeSynonyms.dfy(78,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(119,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(119,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(121,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(121,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(123,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(123,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(125,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(125,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(133,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(133,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(135,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(143,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(143,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(145,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(145,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(147,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(155,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(155,2): Error: out-parameter 'y', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
+TypeSynonyms.dfy(157,2): Error: out-parameter 'x', which is subject to definite-assignment rules, might not have been defined at this return point
+Execution trace:
+    (0,0): anon0
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 2 verified, 20 errors


### PR DESCRIPTION
Previously, any explicit type characteristics (except equality-support) of a type synonym or opaque type was not being checked. For example,

``` dafny
type Empty = x: int | false witness *
type Synonym(0) = Empty  // error
```

should result in an error, because `Synonym` claims to support auto-initialization, but its RHS type does not. This PR adds this checking.