### PR TITLE
fix: Keep type synonyms in some special cases

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -1842,6 +1842,11 @@ namespace Microsoft.Dafny {
       Contract.Requires(b != null);
       Contract.Requires(builtIns != null);
 
+      // As a special-case optimization, check for equality here, which will better preserve un-expanded type synonyms
+      if (a.Equals(b, true)) {
+        return a;
+      }
+
       // Before we do anything else, make a note of whether or not both "a" and "b" are non-null types.
       var abNonNullTypes = a.IsNonNullRefType && b.IsNonNullRefType;
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -4378,7 +4378,7 @@ namespace Microsoft.Dafny
       Contract.Requires(!(t is TypeProxy));
       Contract.Requires(!(t is ArtificialType));
 
-      t = keepConstraints ? t.NormalizeExpandKeepConstraints() : t.NormalizeExpand();
+      t = keepConstraints ? t.Normalize() : t.NormalizeExpand();
       // never violate the type constraint of a literal expression
       var followedRequestedAssignment = true;
       foreach (var su in proxy.Supertypes) {
@@ -6051,7 +6051,7 @@ namespace Microsoft.Dafny
       var meets = new List<Type>();
       foreach (var xc in AllXConstraints) {
         if (xc.ConstraintName == "Assignable" && xc.Types[1].Normalize() == proxy) {
-          var su = xc.Types[0].NormalizeExpandKeepConstraints();
+          var su = xc.Types[0].Normalize();
           if (su is TypeProxy) {
             continue;  // don't include proxies in the meet computation
           }

--- a/Test/git-issues/git-issue-623.dfy
+++ b/Test/git-issues/git-issue-623.dfy
@@ -1,0 +1,107 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// ----- example reported in Issue 623
+
+module M1 {
+  export Abs
+    provides M, T
+  export Conc
+    provides M, MyClass
+    reveals T
+
+  class MyClass {
+  }
+
+  type T = MyClass
+
+  lemma M(f: T ~> bool)
+    requires forall t :: f.requires(t) ==> f(t)  // regression test: this once crashed during checking of M2
+  { }
+}
+
+module M2 {
+  import M1`Abs
+
+  method K(t: M1.T) {
+  }
+}
+
+module M3 {
+  import M1`Conc
+
+  method K(t: M1.T) {
+  }
+}
+
+// ----- example reported in Issue 150
+
+module N1 {
+  export
+    provides T, Equal, Foo
+
+  type T(==) = seq<real>
+
+  predicate Equal(u: T, v: T)
+  {
+    u == v
+  }
+
+  lemma Foo()
+    ensures forall u, v :: Equal(u, v) ==> u == v  // regression test: this once crashed during checking of N2
+  { }
+}
+
+module N2 {
+  import N1
+
+  lemma Bar(u: N1.T, v: N1.T)
+    requires N1.Equal(u, v)
+  {
+    N1.Foo();
+    assert u == v;
+  }
+}
+
+
+// ------------------- additional examples
+
+module Library {
+  export
+    provides W, P, X, Q
+    provides M0, M1
+
+  type W = MyTrait
+  trait MyTrait {
+  }
+  predicate P(u: W)
+
+  type X = MyClass
+  class MyClass extends MyTrait {
+  }
+  predicate Q(x: X)
+
+  lemma M0()
+    requires forall t :: P(t)
+  { }
+  lemma M1()
+    requires forall t :: Q(t)
+  { }
+
+  lemma Private0()
+    requires forall t :: P(t) && Q(t)  // error: t is inferred as MyTrait, so can't prove that Q(t) is well-formed
+  { }
+  lemma Private1()
+    requires forall t :: Q(t) && P(t)  // error: t is inferred as MyTrait, so can't prove that Q(t) is well-formed
+  { }
+}
+
+module Client {
+  import Library
+
+  method K()
+    requires forall t :: Library.P(t)
+    requires forall t :: Library.Q(t)
+  {
+  }
+}

--- a/Test/git-issues/git-issue-623.dfy.expect
+++ b/Test/git-issues/git-issue-623.dfy.expect
@@ -1,0 +1,8 @@
+git-issue-623.dfy(92,35): Error: the RHS value (a MyTrait) is not known to be an instance of the LHS type (MyClass)
+Execution trace:
+    (0,0): anon0
+git-issue-623.dfy(95,27): Error: the RHS value (a MyTrait) is not known to be an instance of the LHS type (MyClass)
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 3 verified, 2 errors


### PR DESCRIPTION
This PR fixes a type inference issue reported in #150 and #623. The PR is a replacement for PR #971.

Fixes #150 
Fixes #623 
Closes #971 

## Problem description

A module with an export set is resolved twice. The first time (call it the _yardstick resolution_) considers all declarations in the module. The second time (call it the _export-set resolution_) considers only those declarations that are exported. Suppose the module declares a type synonym

``` dafny
type Public = Internal
```

where the name `Public` is exported and the name `Internal` is not, and suppose that the export-set resolution infers the type of a variable `x` to be `Public`. Then, the yardstick resolution may infer either type `Public` or type `Internal` for `x` -- either will work, since one of the types is a synonym for the other.

A client that imports the module can only see `Public`, not `Internal`. Therefore, the results of the export-set resolution would seem appropriate for use by importers. However, because a module can have several export sets and a client to import any subset thereof, the current implementation uses the yardstick-resolved module for importers.

This is a problem if the yardstick resolution infers the type of `x` to be `Internal`, as has been reported in issues #150 and #623.

## A remedy

The discussion comments for PR #971 sketch an idea for solving this problem. The idea is to first do the yardstick resolution and all the module's export-set resolutions, and then to somehow change in the yardstick resolution the inferred type of any variable `x` to the "most synonymized" type of all export-set resolutions that contain `x`. The claim is that such a "most synonymized" type exists.

It's not clear how to do this in a reasonable way, because each export-set resolution starts with a clone of the original module, so one would have to keep track of the correspondence between these clones.

Instead, this PR settles for a simpler remedy. The remedy is good enough to work for the examples provided in #150 and #623, but it probably does not work in the general case. Because the remedy is simple and does not seem to obstruct a full solution in the future, it seems worth accepting at this time.

The remedy is to expand type synonyms less eagerly in two places, and to add a special case when computing the meet of two types that are the same (to return that type, not its expanded form).