### PR TITLE
Remove use of _ctor

### DIFF
--- a/Test/dafny0/IteratorResolution.dfy
+++ b/Test/dafny0/IteratorResolution.dfy
@@ -68,7 +68,7 @@ module Mx {
 
       assert g2.u == 200;  // error: the type parameter of g2 is unknown
 
-      var h0 := new GenericIteratorResult._ctor();
+      var h0 := new GenericIteratorResult();
       // so far, the instantiated type of h0 is unknown
       var k := h0.t;
       assert k < 87;
@@ -83,7 +83,7 @@ module Mx {
 
       var h2 := new GenericIteratorResult;  // error: constructor is not mentioned
 
-      var h3 := new GenericIterator._ctor(30);  // see two lines down
+      var h3 := new GenericIterator(30);  // see two lines down
       if h3.t == h3.u {
         assert !h3.t;  // error: type mismatch (here or two lines ago)
       }

--- a/Test/dafny0/IteratorResolution.dfy.expect
+++ b/Test/dafny0/IteratorResolution.dfy.expect
@@ -1,7 +1,7 @@
 IteratorResolution.dfy(64,9): Error: LHS of assignment must denote a mutable field
 IteratorResolution.dfy(84,13): Error: when allocating an object of type 'GenericIteratorResult', one of its constructor methods must be called
 IteratorResolution.dfy(69,18): Error: arguments must have comparable types (got _T0 and int)
-IteratorResolution.dfy(86,36): Error: incorrect type of method in-parameter (expected bool, got int)
+IteratorResolution.dfy(86,16): Error: incorrect type of method in-parameter (expected bool, got int)
 IteratorResolution.dfy(81,19): Error: RHS (of type bool) not assignable to LHS (of type int)
 IteratorResolution.dfy(22,9): Error: LHS of assignment must denote a mutable field
 IteratorResolution.dfy(24,9): Error: LHS of assignment must denote a mutable field

--- a/Test/dafny0/ResolutionErrors.dfy
+++ b/Test/dafny0/ResolutionErrors.dfy
@@ -481,12 +481,12 @@ module MiscAgain {
     }
     method Test() {
       var i := new Y(5);
-      i := new Y._ctor(7);  // but, in fact, it is also possible to use the underlying name
+      i := new Y(7);
       i := new Y;  // error: the class has a constructor, so one must be used
       var s := new Luci.Init(5);
       s := new Luci.FromArray(null);
       s := new Luci(false);
-      s := new Luci._ctor(false);
+      s := new Luci(true);
       s := new Luci.M();  // error: there is a constructor, so one must be called
       s := new Luci;  // error: there is a constructor, so one must be called
       var l := new Lamb;


### PR DESCRIPTION
Internally, the name of an anonymous class (or iterator) constructor is `_ctor`. Although this name can be used, it is not intended to be used in programs (not only is it uglier and more cryptic in the program text, but this internal name may also change to something else in the future). Thus, it also seems appropriate not to use this name in the test suite.