### PR TITLE
Use Boogie v2.8.26

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <!-- Boogie dependency -->
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="2.8.21" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="2.8.26" />
   </ItemGroup>
 
 </Project>

--- a/Test/server/counterexample.transcript
+++ b/Test/server/counterexample.transcript
@@ -1,6 +1,5 @@
 # RUN: %server "%s" > "%t"
 # RUN: %diff "%s.expect" "%t"
-# XFAIL: *
 
 counterexample
 eyJhcmdzIjpbXSwiZmlsZW5hbWUiOiJjOlxcREVWXFxEYWZueVxcYWJzLmRmeSIsInNvdXJjZSI6Im1ldGhvZCBBYnMoeDogaW50KSBcclxuICAgIHJldHVybnMgKHk6IGludClcclxuZW5zdXJlcyB5ID49IDAge1xyXG4gICAgcmV0dXJuIHg7XHJcbn0iLCJzb3VyY2VJc0ZpbGUiOmZhbHNlfQ==

--- a/Test/server/counterexample.transcript.expect
+++ b/Test/server/counterexample.transcript.expect
@@ -6,6 +6,6 @@ c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return 
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
+COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]

--- a/Test/server/git-issue223.transcript
+++ b/Test/server/git-issue223.transcript
@@ -1,6 +1,5 @@
 # RUN: %server "%s" > "%t"
 # RUN: %diff "%s.expect" "%t"
-# XFAIL: *
 
 counterexample
 eyJhcmdzIjpbXSwiZmlsZW5hbWUiOiJjOlxcREVWXFxEYWZueVxcYWJzLmRmeSIsInNvdXJjZSI6Im1ldGhvZCBBYnMoeDogaW50KSBcclxuICAgIHJldHVybnMgKHk6IGludClcclxuZW5zdXJlcyB5ID49IDAge1xyXG4gICAgcmV0dXJuIHg7XHJcbn0iLCJzb3VyY2VJc0ZpbGUiOmZhbHNlfQ==

--- a/Test/server/git-issue223.transcript.expect
+++ b/Test/server/git-issue223.transcript.expect
@@ -6,7 +6,7 @@ c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return 
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
+COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 
@@ -17,6 +17,6 @@ c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return 
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
+COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]


### PR DESCRIPTION
This fixes model generation.

Note, previously (before the period of time when Boogie model generation was broken for DafnyServer), when the SMT solver didn't associate any value with a variable `x`, the model coming back from Boogie would record the symbolic value `**x` for `x`. This has changed in Boogie. Now, if the SMT solver doesn't associate a value with `x`, the model coming back will not have any mapping for `x`. So, a tool (like the VS Code plug-in for Dafny) that uses the model should be prepared for the case when a Dafny program variable is not part of the mapping in the model.