### PR TITLE
fix: Use correct env var in allow_on_mac.sh

### DIFF
--- a/Scripts/allow_on_mac.sh
+++ b/Scripts/allow_on_mac.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-cd $( dirname $SOURCE )
-xattr -d com.apple.quarantine *.dylib dafny DafnyServer *.dll z3/bin/z3
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+xattr -d com.apple.quarantine ./*.dylib dafny DafnyServer ./*.dll z3/bin/z3


### PR DESCRIPTION
`$SOURCE` doesn't actually work for me on macOS 11.1, but `$BASH_SOURCE[0]` should be cross-platform. I also fixed a couple warnings flagged by shellcheck to make the script more robust.

`./*.dylib` might look a bit funny; it's to prevent a file that starts with `-` from becoming an option for `xattr`.