### PR TITLE
Fix map update go

### DIFF
--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -2565,15 +2565,19 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value, CollectionType resultCollectionType, bool inLetExprBody, TargetWriter wr) {
-      EmitIndexCollectionUpdate(out var wSource, out var wIndex, out var wValue, wr);
+      EmitIndexCollectionUpdate(out var wSource, out var wIndex, out var wValue, wr, false);
       TrParenExpr(source, wSource, inLetExprBody);
-      TrExprToBigInt(index, wIndex, inLetExprBody);
+      if (source.Type.AsSeqType != null) {
+        TrExprToBigInt(index, wIndex, inLetExprBody);
+      } else {
+        TrExpr(index, wIndex, inLetExprBody);
+      }
       TrExpr(value, wValue, inLetExprBody);
     }
 
-    protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex = false) {
+    protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
       wSource = wr.Fork();
-      wr.Write(nativeIndex ? ".UpdateInt(" : ".Update(");
+      wr.Write(".Update(");
       wIndex = wr.Fork();
       wr.Write(", ");
       wValue = wr.Fork();

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -2577,7 +2577,7 @@ namespace Microsoft.Dafny {
 
     protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
       wSource = wr.Fork();
-      wr.Write(".Update(");
+      wr.Write(nativeIndex ? ".UpdateInt(" : ".Update(");
       wIndex = wr.Fork();
       wr.Write(", ");
       wValue = wr.Fork();

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -2565,7 +2565,7 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value, CollectionType resultCollectionType, bool inLetExprBody, TargetWriter wr) {
-      EmitIndexCollectionUpdate(out var wSource, out var wIndex, out var wValue, wr);
+      EmitIndexCollectionUpdate(out var wSource, out var wIndex, out var wValue, wr, false);
       TrParenExpr(source, wSource, inLetExprBody);
       if (source.Type.AsSeqType != null) {
         TrExprToBigInt(index, wIndex, inLetExprBody);
@@ -2575,7 +2575,7 @@ namespace Microsoft.Dafny {
       TrExpr(value, wValue, inLetExprBody);
     }
 
-    protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr) {
+    protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
       wSource = wr.Fork();
       wr.Write(".Update(");
       wIndex = wr.Fork();

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -2565,7 +2565,7 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value, CollectionType resultCollectionType, bool inLetExprBody, TargetWriter wr) {
-      EmitIndexCollectionUpdate(out var wSource, out var wIndex, out var wValue, wr, false);
+      EmitIndexCollectionUpdate(out var wSource, out var wIndex, out var wValue, wr);
       TrParenExpr(source, wSource, inLetExprBody);
       if (source.Type.AsSeqType != null) {
         TrExprToBigInt(index, wIndex, inLetExprBody);
@@ -2575,7 +2575,7 @@ namespace Microsoft.Dafny {
       TrExpr(value, wValue, inLetExprBody);
     }
 
-    protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
+    protected override void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr) {
       wSource = wr.Fork();
       wr.Write(".Update(");
       wIndex = wr.Fork();

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Dafny{
       wr.Write("(");
       var lhs = (SeqSelectExpr) s0.Lhs;
       TargetWriter wColl, wIndex, wValue;
-      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr);
+      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr, nativeIndex: true);
       var wCoerce = EmitCoercionIfNecessary(from: null, to: lhs.Seq.Type, tok: s0.Tok, wr: wColl);
         wCoerce.Write($"({TypeName(lhs.Seq.Type.NormalizeExpand(), wCoerce, s0.Tok)})");
         EmitTupleSelect(tup, 0, wCoerce);

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Dafny{
       wr.Write("(");
       var lhs = (SeqSelectExpr) s0.Lhs;
       TargetWriter wColl, wIndex, wValue;
-      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr, nativeIndex: true);
+      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr);
       var wCoerce = EmitCoercionIfNecessary(from: null, to: lhs.Seq.Type, tok: s0.Tok, wr: wColl);
         wCoerce.Write($"({TypeName(lhs.Seq.Type.NormalizeExpand(), wCoerce, s0.Tok)})");
         EmitTupleSelect(tup, 0, wCoerce);

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -912,7 +912,7 @@ namespace Microsoft.Dafny {
     protected abstract void EmitExprAsInt(Expression expr, bool inLetExprBody, TargetWriter wr);
     protected abstract void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody, TargetWriter wr);
     protected abstract void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value, CollectionType resultCollectionType, bool inLetExprBody, TargetWriter wr);
-    protected virtual void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr) {
+    protected virtual void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
       wSource = wr.Fork();
       wr.Write('[');
       wIndex = wr.Fork();
@@ -3104,7 +3104,7 @@ namespace Microsoft.Dafny {
     protected virtual void EmitSeqSelect(AssignStmt s0, List<Type> tupleTypeArgsList, TargetWriter wr, string tup){
       var lhs = (SeqSelectExpr) s0.Lhs;
       TargetWriter wColl, wIndex, wValue;
-      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr);
+      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr, nativeIndex: true);
       var wCoerce = EmitCoercionIfNecessary(from: null, to: lhs.Seq.Type, tok: s0.Tok, wr: wColl);
       EmitTupleSelect(tup, 0, wCoerce);
       var wCast = EmitCoercionToNativeInt(wIndex);

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -912,7 +912,7 @@ namespace Microsoft.Dafny {
     protected abstract void EmitExprAsInt(Expression expr, bool inLetExprBody, TargetWriter wr);
     protected abstract void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody, TargetWriter wr);
     protected abstract void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value, CollectionType resultCollectionType, bool inLetExprBody, TargetWriter wr);
-    protected virtual void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex = false) {
+    protected virtual void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
       wSource = wr.Fork();
       wr.Write('[');
       wIndex = wr.Fork();

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -912,7 +912,7 @@ namespace Microsoft.Dafny {
     protected abstract void EmitExprAsInt(Expression expr, bool inLetExprBody, TargetWriter wr);
     protected abstract void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody, TargetWriter wr);
     protected abstract void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value, CollectionType resultCollectionType, bool inLetExprBody, TargetWriter wr);
-    protected virtual void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr, bool nativeIndex) {
+    protected virtual void EmitIndexCollectionUpdate(out TargetWriter wSource, out TargetWriter wIndex, out TargetWriter wValue, TargetWriter wr) {
       wSource = wr.Fork();
       wr.Write('[');
       wIndex = wr.Fork();
@@ -3104,7 +3104,7 @@ namespace Microsoft.Dafny {
     protected virtual void EmitSeqSelect(AssignStmt s0, List<Type> tupleTypeArgsList, TargetWriter wr, string tup){
       var lhs = (SeqSelectExpr) s0.Lhs;
       TargetWriter wColl, wIndex, wValue;
-      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr, nativeIndex: true);
+      EmitIndexCollectionUpdate(out wColl, out wIndex, out wValue, wr);
       var wCoerce = EmitCoercionIfNecessary(from: null, to: lhs.Seq.Type, tok: s0.Tok, wr: wColl);
       EmitTupleSelect(tup, 0, wCoerce);
       var wCast = EmitCoercionToNativeInt(wIndex);

--- a/Test/comp/Collections.dfy
+++ b/Test/comp/Collections.dfy
@@ -14,6 +14,7 @@ method Main() {
   Maps();
   MultiSetForming();
   TestExplosiveUnion();
+  Regressions.Test();
 }
 
 // -------------------------------------------------------------------------------------------
@@ -403,4 +404,63 @@ method TestExplosiveUnion() {
   TestExplosiveUnion1(multiset{58}, 100, 58);  // this requires BigInteger multiplicities in multisets
   var m: multiset<MyClass?> := multiset{null};
   TestExplosiveUnion1(m, 100, null);  // also test null, since the C# implementation does something different for null
+}
+
+// -------------------------------------------------------------------------------------------
+
+module Regressions {
+  newtype uint32 = i:int | 0 <= i < 0x1_0000_0000
+
+  method Test() {
+    TestMap();
+    TestSeq();
+    TestMultiset();
+  }
+
+  method TestMap() {
+    print "Map===\n";
+    var s: map<uint32, uint32> := map[1 := 123];
+    var u := s[1 := 40];
+    print "|s|=", |s|, " |u|=", |u|, "\n";  // 1 1
+    print "s[1]=", s[1], " u[1]=", u[1], "\n";  // 123 40
+
+    var S: map<int, uint32> := map[1 := 123];
+    var U := S[1 := 41];
+    print "|S|=", |S|, " |U|=", |U|, "\n";  // 1 1
+    print "S[1]=", S[1], " U[1]=", U[1], "\n";  // 123 41
+  }
+
+  method TestSeq() {
+    print "Seq===\n";
+    var s: seq<uint32> := [14, 123];
+    var u := s[1 := 42];
+    print "|s|=", |s|, " |u|=", |u|, "\n";  // 2 2
+    print s[1], " ", u[1], ", ";  // 123 42
+    print s[1 as int], " ", u[1 as int], ", ";  // 123 42
+    print s[1 as bv3], " ", u[1 as bv3], "\n";  // 123 42
+
+    u := s[1 as uint32 := 43];
+    print "|s|=", |s|, " |u|=", |u|, "\n";  // 2 2
+    print s[1], " ", u[1], ", ";  // 123 43
+    print s[1 as int], " ", u[1 as int], ", ";  // 123 43
+    print s[1 as bv3], " ", u[1 as bv3], "\n";  // 123 43
+
+    u := s[1 as bv3 := 44];
+    print "|s|=", |s|, " |u|=", |u|, "\n";  // 2 2
+    print s[1], " ", u[1], ", ";  // 123 44
+    print s[1 as int], " ", u[1 as int], ", ";  // 123 44
+    print s[1 as bv3], " ", u[1 as bv3], "\n";  // 123 44
+  }
+
+  method TestMultiset() {
+    print "Multiset===\n";
+    var s: multiset<uint32> := multiset{14, 123};
+    var u := s[123 := 3];
+    print "|s|=", |s|, " |u|=", |u|, "\n";  // 2 4
+    print s[123], " ", u[123], "\n";  // 1 3
+
+    u := s[123 := 3 /*as uint32*/];
+    print "|s|=", |s|, " |u|=", |u|, "\n";  // 2 4
+    print s[123], " ", u[123], "\n";  // 1 3
+  }
 }

--- a/Test/comp/Collections.dfy.expect
+++ b/Test/comp/Collections.dfy.expect
@@ -96,6 +96,23 @@ There are 0 occurrences of 58 in the multiset
 There are 536870912 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of null in the multiset
+Map===
+|s|=1 |u|=1
+s[1]=123 u[1]=40
+|S|=1 |U|=1
+S[1]=123 U[1]=41
+Seq===
+|s|=2 |u|=2
+123 42, 123 42, 123 42
+|s|=2 |u|=2
+123 43, 123 43, 123 43
+|s|=2 |u|=2
+123 44, 123 44, 123 44
+Multiset===
+|s|=2 |u|=4
+1 3
+|s|=2 |u|=4
+1 3
 
 Dafny program verifier did not attempt verification
 Sets: {} {17, 82} {12, 17}
@@ -194,6 +211,23 @@ There are 0 occurrences of 58 in the multiset
 There are 536870912 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of null in the multiset
+Map===
+|s|=1 |u|=1
+s[1]=123 u[1]=40
+|S|=1 |U|=1
+S[1]=123 U[1]=41
+Seq===
+|s|=2 |u|=2
+123 42, 123 42, 123 42
+|s|=2 |u|=2
+123 43, 123 43, 123 43
+|s|=2 |u|=2
+123 44, 123 44, 123 44
+Multiset===
+|s|=2 |u|=4
+1 3
+|s|=2 |u|=4
+1 3
 
 Dafny program verifier did not attempt verification
 Sets: {} {17, 82} {12, 17}
@@ -292,6 +326,23 @@ There are 0 occurrences of 58 in the multiset
 There are 536870912 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of null in the multiset
+Map===
+|s|=1 |u|=1
+s[1]=123 u[1]=40
+|S|=1 |U|=1
+S[1]=123 U[1]=41
+Seq===
+|s|=2 |u|=2
+123 42, 123 42, 123 42
+|s|=2 |u|=2
+123 43, 123 43, 123 43
+|s|=2 |u|=2
+123 44, 123 44, 123 44
+Multiset===
+|s|=2 |u|=4
+1 3
+|s|=2 |u|=4
+1 3
 
 Dafny program verifier did not attempt verification
 Sets: {} {17, 82} {17, 12}
@@ -390,3 +441,20 @@ There are 0 occurrences of 58 in the multiset
 There are 536870912 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of 58 in the multiset
 There are 633825300114114700748351602688 occurrences of null in the multiset
+Map===
+|s|=1 |u|=1
+s[1]=123 u[1]=40
+|S|=1 |U|=1
+S[1]=123 U[1]=41
+Seq===
+|s|=2 |u|=2
+123 42, 123 42, 123 42
+|s|=2 |u|=2
+123 43, 123 43, 123 43
+|s|=2 |u|=2
+123 44, 123 44, 123 44
+Multiset===
+|s|=2 |u|=4
+1 3
+|s|=2 |u|=4
+1 3


### PR DESCRIPTION
This PR fixes an issue in the compilation of map update for Go.

For a map `m: map<uint32, X>`, where `uint32` is a native integer type, the expression `m[1 as uint32 := x]` was previously compiled, essentially, as `m[1 as int := x]`. This caused the equality on keys to fail, since such a comparison would be between any existing key `1 as uint32` and the new key `1 as int`.