### PR TITLE
fix: No second constructor, correct equals

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1873,9 +1873,6 @@ namespace Microsoft.Dafny{
           }
         }
       }
-      if (ctor.Formals.Count > 0){
-        wr.WriteLine($"public {DtCtorDeclarationName(ctor)}() {{ }}");
-      }
       if (dt is CoDatatypeDecl) {
         string typeParams = TypeParameters(dt.TypeArgs);
         wr.WriteLine($"public {dt.CompileName}{typeParams} Get() {{ return this; }}");
@@ -1887,27 +1884,23 @@ namespace Microsoft.Dafny{
         w.WriteLine("if (this == other) return true;");
         w.WriteLine("if (other == null) return false;");
         w.WriteLine("if (getClass() != other.getClass()) return false;");
-        if(ctor.Formals.Count > 0){string typeParams = TypeParameters(dt.TypeArgs);
-          w.WriteLine("{0} o = ({0})other;", DtCtorDeclarationName(ctor, dt.TypeArgs));
-          w.Write("return ");
-          i = 0;
-          foreach (Formal arg in ctor.Formals) {
-            if (!arg.IsGhost) {
-              string nm = FormalName(arg, i);
-              if(i!= 0)
-                w.Write(" && ");
-              if (IsDirectlyComparable(arg.Type)) {
-                w.Write($"this.{nm} == o.{nm}");
-              } else {
-                w.Write($"java.util.Objects.equals(this.{nm}, o.{nm})");
-              }
-              i++;
+        string typeParams = TypeParameters(dt.TypeArgs);
+        w.WriteLine("{0} o = ({0})other;", DtCtorDeclarationName(ctor, dt.TypeArgs));
+        w.Write("return true");
+        i = 0;
+        foreach (Formal arg in ctor.Formals) {
+          if (!arg.IsGhost) {
+            string nm = FormalName(arg, i);
+            w.Write(" && ");
+            if (IsDirectlyComparable(arg.Type)) {
+              w.Write($"this.{nm} == o.{nm}");
+            } else {
+              w.Write($"java.util.Objects.equals(this.{nm}, o.{nm})");
             }
+            i++;
           }
-          w.WriteLine(";");
-        } else {
-          w.WriteLine("return true;");
         }
+        w.WriteLine(";");
       }
       // GetHashCode method (Uses the djb2 algorithm)
       wr.WriteLine("@Override");

--- a/Test/comp/Collections.dfy
+++ b/Test/comp/Collections.dfy
@@ -1,4 +1,4 @@
-// RUN: %dafny /compile:0 /compileTarget:cs "%s" > "%t"
+// RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:cs "%s" > "%t"
 // RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:js "%s" >> "%t"
 // RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"

--- a/Test/git-issues/git-issue-1105.dfy
+++ b/Test/git-issues/git-issue-1105.dfy
@@ -1,0 +1,18 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Regression: A constructor like PushOp with 1+ ghost parameters and 0 non-ghost parameters
+// once caused the Java compiler to emit two 0-parameter constructors
+
+datatype Op =
+  | NoOp
+  | PushOp(ghost id: int)
+
+method Main() {
+  var o := PushOp(20);
+  print o, "\n";
+}

--- a/Test/git-issues/git-issue-1105.dfy.expect
+++ b/Test/git-issues/git-issue-1105.dfy.expect
@@ -1,0 +1,12 @@
+
+Dafny program verifier did not attempt verification
+Op.PushOp()
+
+Dafny program verifier did not attempt verification
+Op.PushOp
+
+Dafny program verifier did not attempt verification
+Op.PushOp
+
+Dafny program verifier did not attempt verification
+Op.PushOp()


### PR DESCRIPTION
This PR fixes two bugs in the compilation of datatypes to Java. Both problems manifested when a datatype has a constructor with 1 or more ghost parameters, but no compiled parameters. In this case, two Java constructors were generated for the class, and the `equals` method did a `return;` without a value.

Fixes #1105 
