### PR TITLE
fix: Expand type synonym for arrays in Java

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1479,7 +1479,7 @@ namespace Microsoft.Dafny{
 
     protected override void EmitSeqSelectRange(Expression source, Expression lo, Expression hi, bool fromArray, bool inLetExprBody, TargetWriter wr) {
       if (fromArray) {
-        wr.Write($"{DafnySeqClass}.fromRawArrayRange({TypeDescriptor(source.Type.TypeArgs[0], wr, source.tok)}, ");
+        wr.Write($"{DafnySeqClass}.fromRawArrayRange({TypeDescriptor(source.Type.NormalizeExpand().TypeArgs[0], wr, source.tok)}, ");
       }
       TrParenExpr(source, wr, inLetExprBody);
       if (fromArray) {

--- a/Test/comp/Arrays.dfy
+++ b/Test/comp/Arrays.dfy
@@ -69,6 +69,8 @@ method Main() {
   Coercions();
 
   CharValues();
+
+  TypeSynonym.Test();
 }
 
 type lowercase = ch | 'a' <= ch <= 'z' witness 'd'
@@ -343,4 +345,24 @@ method CharValues() {
   var mx := new ychar[3, 3];
   var my := new zchar[3, 3];
   print mm[1, 2], " ", mx[1, 2], " ", my[1, 2], "\n";  // D D r
+}
+
+module TypeSynonym {
+  export
+    provides Test
+
+  newtype uint8 = i:int | 0 <= i < 0x100
+
+  type buffer<T> = a: array<T> | a.Length < 0x1_0000_0000 witness *
+  type buffer_t = buffer<uint8>
+
+  method BufferTest(b: buffer_t) {
+    var t := b[..];
+    print t, "\n";
+  }
+
+  method Test() {
+    var b := new uint8[] [19, 18, 9, 8];
+    BufferTest(b);
+  }
 }

--- a/Test/comp/Arrays.dfy.expect
+++ b/Test/comp/Arrays.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 37 verified, 0 errors
+Dafny program verifier finished with 41 verified, 0 errors
 
 Dafny program verifier did not attempt verification
 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 
@@ -50,6 +50,7 @@ D D D
 D D D 
 D D r (D, D, r)
 D D r
+[19, 18, 9, 8]
 
 Dafny program verifier did not attempt verification
 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 
@@ -100,6 +101,7 @@ D D D
 D D D 
 D D r (D, D, r)
 D D r
+[19, 18, 9, 8]
 
 Dafny program verifier did not attempt verification
 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 
@@ -150,6 +152,7 @@ D D D
 D D D 
 D D r (D, D, r)
 D D r
+[19, 18, 9, 8]
 
 Dafny program verifier did not attempt verification
 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 
@@ -200,3 +203,4 @@ D D D
 D D D 
 D D r (D, D, r)
 D D r
+[19, 18, 9, 8]


### PR DESCRIPTION
This PR fixes a crash in the Java compiler. The bug arose in the compilation of expression `b[..]` where the type of `b` is a type synonym that expands to an array type.