### PR TITLE
Fix directory calculations in dafny-server bash script

### DIFF
--- a/Scripts/dafny-server
+++ b/Scripts/dafny-server
@@ -8,7 +8,7 @@ while [ -h "$SOURCE" ]; do
     SOURCE="$(readlink "$SOURCE")"
     [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
-DAFNY_ROOT="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DAFNY_ROOT="$( cd -P "$( dirname $( dirname "$SOURCE" ))" && pwd )"
 
 MY_OS=$(uname -s)
 if [ "${MY_OS:0:5}" == "MINGW" ] || [ "${MY_OS:0:6}" == "CYGWIN" ]; then
@@ -16,7 +16,7 @@ if [ "${MY_OS:0:5}" == "MINGW" ] || [ "${MY_OS:0:6}" == "CYGWIN" ]; then
 else
     DAFNYSERVER_EXE_NAME="DafnyServer.dll"
 fi
-DAFNYSERVER="$DAFNY_ROOT/$DAFNYSERVER_EXE_NAME"
+DAFNYSERVER="$DAFNY_ROOT/Binaries/$DAFNYSERVER_EXE_NAME"
 if [[ ! -e "$DAFNYSERVER" ]]; then
     echo "Error: $DAFNYSERVER_EXE_NAME not found at $DAFNY_ROOT."
     exit 1


### PR DESCRIPTION
If run from the base Dafny directory (e.g., as `dafny $ ./Scripts/dafny-server`), the current version of the script calculates the wrong location for the Dafny server executable.  In particular, it thinks that `DAFNY_ROOT` is `dafny/Scripts`, and so it looks for the executable in the `Scripts` directory, which fails.  This patch emulates the calculation done in the `dafny/Scripts/dafny` bash script, so that the server is located correctly.