### PR TITLE
Add -Wno-unknown-warning-option

### DIFF
--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -2346,7 +2346,7 @@ namespace Microsoft.Dafny {
       var codebase = System.IO.Path.GetDirectoryName(assemblyLocation);
       Contract.Assert(codebase != null);
       var exeName = ComputeExeName(targetFilename);
-      var args = $"-g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy -std=c++17 -I{codebase} -o {exeName} {targetFilename}";
+      var args = $"-g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy -Wno-unknown-warning-option -std=c++17 -I{codebase} -o {exeName} {targetFilename}";
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", args) {
         CreateNoWindow = true,


### PR DESCRIPTION
The `-Wno-deprecated-copy` flag is apparently not recognized by `g++` on the Mac. Adding `-Wno-unknown-warning-option` suppresses the warning about the unknown warning.

This PR attempts to fix the test-suite break introduced in PR https://github.com/dafny-lang/dafny/pull/1115, which I merged too hastily.