### PR TITLE
Remove code for deprecated type-conversion feature

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -16105,30 +16105,11 @@ namespace Microsoft.Dafny
           if (lhs != null && lhs.Type is Resolver_IdentifierExpr.ResolverType_Module) {
             reporter.Error(MessageSource.Resolver, e.tok, "name of module ({0}) is used as a function", ((Resolver_IdentifierExpr)lhs).Decl.Name);
           } else if (lhs != null && lhs.Type is Resolver_IdentifierExpr.ResolverType_Type) {
-            // It may be a conversion expression
             var ri = (Resolver_IdentifierExpr)lhs;
             if (ri.TypeParamDecl != null) {
               reporter.Error(MessageSource.Resolver, e.tok, "name of type parameter ({0}) is used as a function", ri.TypeParamDecl.Name);
             } else {
-              var decl = ri.Decl;
-              var ty = new UserDefinedType(e.tok, decl.Name, decl, ri.TypeArgs);
-              if (ty.AsNewtype != null) {
-                reporter.Deprecated(MessageSource.Resolver, e.tok, "the syntax \"{0}(expr)\" for type conversions has been deprecated; the new syntax is \"expr as {0}\"", decl.Name);
-                if (e.Args.Count != 1) {
-                  reporter.Error(MessageSource.Resolver, e.tok, "conversion operation to {0} got wrong number of arguments (expected 1, got {1})", decl.Name, e.Args.Count);
-                }
-                var conversionArg = 1 <= e.Args.Count ? e.Args[0] :
-                  ty.IsNumericBased(Type.NumericPersuasion.Int) ? LiteralExpr.CreateIntLiteral(e.tok, 0) :
-                  LiteralExpr.CreateRealLiteral(e.tok, BaseTypes.BigDec.ZERO);
-                r = new ConversionExpr(e.tok, conversionArg, ty);
-                ResolveExpression(r, opts);
-                // resolve the rest of the arguments, if any
-                for (int i = 1; i < e.Args.Count; i++) {
-                  ResolveExpression(e.Args[i], opts);
-                }
-              } else {
-                reporter.Error(MessageSource.Resolver, e.tok, "name of type ({0}) is used as a function", decl.Name);
-              }
+              reporter.Error(MessageSource.Resolver, e.tok, "name of type ({0}) is used as a function", ri.Decl.Name);
             }
           } else {
             if (lhs is MemberSelectExpr && ((MemberSelectExpr)lhs).Member is Method) {

--- a/Test/dafny0/Deprecation.dfy
+++ b/Test/dafny0/Deprecation.dfy
@@ -20,14 +20,6 @@ class C {
 
 // ----------
 
-newtype MyInt = int
-
-method TypeConversionSyntax(x: int) returns (y: MyInt) {
-  y := MyInt(x);  // deprecation warning: the current syntax is "x as MyInt"
-}
-
-// ----------
-
 inductive predicate InductivePredicate()  // deprecation warning: "inductive predicate" has been renamed to "least predicate"
 { true }
 

--- a/Test/dafny0/Deprecation.dfy.expect
+++ b/Test/dafny0/Deprecation.dfy.expect
@@ -1,10 +1,9 @@
 Deprecation.dfy(16,13): Warning: constructors no longer need 'this' to be listed in modifies clauses
-Deprecation.dfy(31,0): Warning: the old keyword phrase 'inductive predicate' has been renamed to 'least predicate'
-Deprecation.dfy(34,0): Warning: the old keyword 'copredicate' has been renamed to the keyword phrase 'greatest predicate'
-Deprecation.dfy(37,0): Warning: the old keyword phrase 'inductive lemma' has been renamed to 'least lemma'
-Deprecation.dfy(40,0): Warning: the old keyword 'colemma' has been renamed to the keyword phrase 'greatest lemma'
-Deprecation.dfy(45,0): Warning: the 'protected' modifier is no longer supported; to restrict access from outside the module, use a 'provides' clause in the module's export set; if you're trying to add conjuncts to a predicate in a refinement module, see Test/dafny3/CachedContainer.dfy, Test/dafny2/StoreAndRetrieve.dfy, and Test/dafny2/MonotonicHeapstate.dfy in the Dafny test suite on github
-Deprecation.dfy(26,12): Warning: the syntax "MyInt(expr)" for type conversions has been deprecated; the new syntax is "expr as MyInt"
+Deprecation.dfy(23,0): Warning: the old keyword phrase 'inductive predicate' has been renamed to 'least predicate'
+Deprecation.dfy(26,0): Warning: the old keyword 'copredicate' has been renamed to the keyword phrase 'greatest predicate'
+Deprecation.dfy(29,0): Warning: the old keyword phrase 'inductive lemma' has been renamed to 'least lemma'
+Deprecation.dfy(32,0): Warning: the old keyword 'colemma' has been renamed to the keyword phrase 'greatest lemma'
+Deprecation.dfy(37,0): Warning: the 'protected' modifier is no longer supported; to restrict access from outside the module, use a 'provides' clause in the module's export set; if you're trying to add conjuncts to a predicate in a refinement module, see Test/dafny3/CachedContainer.dfy, Test/dafny2/StoreAndRetrieve.dfy, and Test/dafny2/MonotonicHeapstate.dfy in the Dafny test suite on github
 
 Dafny program verifier finished with 0 verified, 0 errors
 yet here we are


### PR DESCRIPTION
Previously, the deprecated syntax `int(expr)` was removed. The deprecated syntax `NT(expr)`, where `NT` is the name of a `newtype`, should have been removed as well. This PR removes support for that old syntax.

The supported way to convert a value from one type to another uses `as`. The two expressions mentioned above are written `expr as int` and `expr as NT`.