### PR TITLE
Trigger release-downloads only on releases

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -72,7 +72,7 @@ jobs:
         path: dafny
     - name: Create release
       run: |
-        python dafny/Scripts/package.py 0.0.0-CI --os ${{ matrix.os_for_build }} --skip_manual=true --trial=true --out=CI.zip
+        python dafny/Scripts/package.py 0.0.0-CI --os ${{ matrix.os_for_build }} --skip_manual=true --trial=true --github_secret=${{ secrets.GITHUB_TOKEN }} --out=CI.zip
     - if: runner.os == 'Windows'
       shell: pwsh
       run: |

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -3,12 +3,8 @@ name: Test Release Downloads
 #### For a new release: Change 'ver' in the strategy
 
 on:
-  workflow_dispatch:
-    branches: [ master ]
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  release:
+    types: [ published ]
 
 jobs:
   build:

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -40,9 +40,9 @@ jobs:
       if: runner.os != 'Windows'
       run: |
         curl --silent "https://api.github.com/repos/dafny-lang/dafny/releases/latest" \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' > tmp.curl.out
-        cat tmp.curl.out
-        wget -q `grep 'browser_download_url' tmp.curl.out |  grep "${{matrix.osn}}" | sed -e 's@"browser_download_url":@@' -e 's@"@@g'`
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          | grep 'browser_download_url' > tmp.curl.out
+        wget -q `grep "${{matrix.osn}}" tmp.curl.out | sed -e 's@"browser_download_url":@@' -e 's@"@@g'`
         unzip dafny*.zip && rm dafny*.zip
     - if: runner.os == 'Windows'
       shell: pwsh

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -39,7 +39,10 @@ jobs:
     - name: Download ${{matrix.os}} releases
       if: runner.os != 'Windows'
       run: |
-        wget -q `curl --silent "https://api.github.com/repos/dafny-lang/dafny/releases/latest" | grep 'browser_download_url' |  grep "${{matrix.osn}}" | sed -e 's@"browser_download_url":@@' -e 's@"@@g'`
+        curl --silent "https://api.github.com/repos/dafny-lang/dafny/releases/latest" \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' > tmp.curl.out
+        cat tmp.curl.out
+        wget -q `grep 'browser_download_url' tmp.curl.out |  grep "${{matrix.osn}}" | sed -e 's@"browser_download_url":@@' -e 's@"@@g'`
         unzip dafny*.zip && rm dafny*.zip
     - if: runner.os == 'Windows'
       shell: pwsh

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 import time
-import urllib.request
+from urllib import request
 import zipfile
 import shutil
 import ntpath
@@ -108,7 +108,7 @@ class Release:
             print("cached!")
         else:
             flush("downloading {:.2f}MB...".format(self.MB), end=' ')
-            with urllib.request.urlopen(self.url) as reader:
+            with request.urlopen(self.url) as reader:
                 with open(self.z3_zip, mode="wb") as writer:
                     writer.write(reader.read())
             flush("done!")
@@ -185,7 +185,9 @@ class Release:
 
 def discover(args):
     flush("  - Getting information about latest release")
-    with urllib.request.urlopen(Z3_RELEASES_URL) as reader:
+    options = {"Authorization": "Bearer " + args.github_secret} if args.github_secret else {}
+    req = request.Request(Z3_RELEASES_URL, None, options)
+    with request.urlopen(req) as reader:
         js = json.loads(reader.read().decode("utf-8"))
 
         for release_js in js["assets"]:
@@ -261,6 +263,7 @@ def parse_arguments():
     parser.add_argument("--os", help="operating system name for which to make a release")
     parser.add_argument("--skip_manual", help="do not create the reference manual")
     parser.add_argument("--trial", help="ignore version.cs discrepancies")
+    parser.add_argument("--github_secret", help="access token for making an authenticated GitHub call, to prevent being rate limited.")
     parser.add_argument("--out", help="output zip file")
     return parser.parse_args()
 


### PR DESCRIPTION
The purpose of this change is to reduce the number of github API requests done with each Pull Request. Since github throttles such API requests, Dafny CI builds often fail. The `release-downloads.yml` tests call the github API and don’t seem necessary unless there’s a new release. Therefore, this seems like a simple fix to an annoying problem. (This change can, of course, be reverted if we authenticate the API requests—which does not count against the throttling limit—or see the need to have more frequent release tests again.)

Co-authored-by: @keyboardDrummer 