### PR TITLE
Support tuples with arbitrary arity in C++

### DIFF
--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -119,12 +119,19 @@ struct get_default<std::shared_ptr<U>> {
  *********************************************************/
 
 template <typename... Types>
-struct TupleBase {
+struct Tuple{
  public:
-  TupleBase() : TupleBase(get_default<Types>::call()...) {}
-  TupleBase(Types... values) : values_(values...) {}
+  Tuple() : Tuple(get_default<Types>::call()...) {}
+  Tuple(Types... values) : values_(values...) {}
 
-  std::tuple<Types...> values_;
+  using StdTuple = std::tuple<Types...>;
+
+  template <std::size_t Index>
+  std::tuple_element_t<Index, StdTuple> get() {
+    return std::get<Index>(values_);
+  }
+
+  StdTuple values_;
 };
 
 template <typename TupleType, int Index = TupleType::size() - 1 >
@@ -135,48 +142,13 @@ std::ostream& PrintElements(const TupleType& tuple, std::ostream& out) {
   return out << std::get<Index>(tuple);
 }
 
+// Use a separate head template parameter to force Tuple to have at least one
+// element. This prevents the compiler from eagerly expanding Tail as an empty
+// list and causing compilation errors.
 template <typename Head, typename... Tail>
-inline std::ostream& operator<<(std::ostream& out, const TupleBase<Head, Tail...>& val){
+inline std::ostream& operator<<(std::ostream& out, const Tuple<Head, Tail...>& val){
   return PrintElements(val.values_);
 }
-
-template <typename T0, typename T1>
-struct Tuple2 : public TupleBase<T0, T1> {
-  using TupleBase<T0, T1>::TupleBase;
-  T0 get_0() const { return std::get<0>(this->values_); }
-  T1 get_1() const { return std::get<1>(this->values_); }
-};
-
-template <typename T0, typename T1, typename T2>
-struct Tuple3 : public TupleBase<T0, T1, T2> {
-  using TupleBase<T0, T1, T2>::TupleBase;
-
-  T0 get_0() const { return std::get<0>(this->values_); }
-  T1 get_1() const { return std::get<1>(this->values_); }
-  T2 get_2() const { return std::get<2>(this->values_); }
-};
-
-template <typename T0, typename T1, typename T2, typename T3>
-struct Tuple4 : public TupleBase<T0, T1, T2, T3> {
-  using TupleBase<T0, T1, T2, T3>::TupleBase;
-
-  T0 get_0() const { return std::get<0>(this->values_); }
-  T1 get_1() const { return std::get<1>(this->values_); }
-  T2 get_2() const { return std::get<2>(this->values_); }
-  T3 get_3() const { return std::get<3>(this->values_); }
-};
-
-template <typename T0, typename T1, typename T2, typename T3, typename T4>
-struct Tuple5 : public TupleBase<T0, T1, T2, T3, T4> {
-  using TupleBase<T0, T1, T2, T3>::TupleBase;
-
-  T0 get_0() const { return std::get<0>(this->values_); }
-  T1 get_1() const { return std::get<1>(this->values_); }
-  T2 get_2() const { return std::get<2>(this->values_); }
-  T3 get_3() const { return std::get<3>(this->values_); }
-  T4 get_4() const { return std::get<4>(this->values_); }
-};
-
 
 /*********************************************************
  *  MATH                                                 *
@@ -759,4 +731,3 @@ struct std::hash<DafnyMap<T,U>> {
         return seed;
     }
 };
-

--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -147,7 +147,7 @@ std::ostream& PrintElements(const TupleType& tuple, std::ostream& out) {
 // list and causing compilation errors.
 template <typename Head, typename... Tail>
 inline std::ostream& operator<<(std::ostream& out, const Tuple<Head, Tail...>& val){
-  return PrintElements(val.values_);
+  return PrintElements(val.values_, out);
 }
 
 /*********************************************************

--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -5,6 +5,8 @@
 
 #include <iostream>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 #include <memory>
 #include <unordered_set>
@@ -116,139 +118,65 @@ struct get_default<std::shared_ptr<U>> {
  *  TUPLES                                               *
  *********************************************************/
 
-template <typename T0, typename T1>
-struct Tuple2 {
-  T0 t0;
-  T1 t1;
+template <typename... Types>
+struct TupleBase {
+ public:
+  TupleBase() : TupleBase(get_default<Types>::call()...) {}
+  TupleBase(Types... values) : values_(values...) {}
 
-  Tuple2() {
-    t0 = get_default<T0>::call();
-    t1 = get_default<T1>::call();
-  }
-
-  Tuple2(T0 _t0, T1 _t1) {
-    t0 = _t0;
-    t1 = _t1;
-  }
-
-  T0 get_0() const { return t0; }
-  T1 get_1() const { return t1; }
+  std::tuple<Types...> values_;
 };
 
-template <typename T0, typename T1>
-inline std::ostream& operator<<(std::ostream& out, const Tuple2<T0, T1>& val){
-  out << val.get_0();
-  out << val.get_1();
-  return out;
+template <typename TupleType, int Index = TupleType::size() - 1 >
+std::ostream& PrintElements(const TupleType& tuple, std::ostream& out) {
+  if (Index != 0) {
+    PrintElements<TupleType, Index - 1>(tuple, out);
+  }
+  return out << std::get<Index>(tuple);
 }
 
-template <typename T0, typename T1, typename T2>
-struct Tuple3 {
-  T0 t0;
-  T1 t1;
-  T2 t2;
+template <typename Head, typename... Tail>
+inline std::ostream& operator<<(std::ostream& out, const TupleBase<Head, Tail...>& val){
+  return PrintElements(val.values_);
+}
 
-  Tuple3() {
-    t0 = get_default<T0>::call();
-    t1 = get_default<T1>::call();
-    t2 = get_default<T2>::call();
-  }
-
-  Tuple3(T0 _t0, T1 _t1, T2 _t2) {
-    t0 = _t0;
-    t1 = _t1;
-    t2 = _t2;
-  }
-
-  T0 get_0() const { return t0; }
-  T1 get_1() const { return t1; }
-  T2 get_2() const { return t2; }
+template <typename T0, typename T1>
+struct Tuple2 : public TupleBase<T0, T1> {
+  using TupleBase<T0, T1>::TupleBase;
+  T0 get_0() const { return std::get<0>(this->values_); }
+  T1 get_1() const { return std::get<1>(this->values_); }
 };
 
 template <typename T0, typename T1, typename T2>
-inline std::ostream& operator<<(std::ostream& out, const Tuple3<T0, T1, T2>& val){
-  out << val.get_0();
-  out << val.get_1();
-  out << val.get_2();
-  return out;
-}
+struct Tuple3 : public TupleBase<T0, T1, T2> {
+  using TupleBase<T0, T1, T2>::TupleBase;
 
-template <typename T0, typename T1, typename T2, typename T3>
-struct Tuple4 {
-  T0 t0;
-  T1 t1;
-  T2 t2;
-  T3 t3;
-
-  Tuple4() {
-    t0 = get_default<T0>::call();
-    t1 = get_default<T1>::call();
-    t2 = get_default<T2>::call();
-    t3 = get_default<T3>::call();
-  }
-
-  Tuple4(T0 _t0, T1 _t1, T2 _t2, T3 _t3) {
-    t0 = _t0;
-    t1 = _t1;
-    t2 = _t2;
-    t3 = _t3;
-  }
-
-  T0 get_0() const { return t0; }
-  T1 get_1() const { return t1; }
-  T2 get_2() const { return t2; }
-  T3 get_3() const { return t3; }
+  T0 get_0() const { return std::get<0>(this->values_); }
+  T1 get_1() const { return std::get<1>(this->values_); }
+  T2 get_2() const { return std::get<2>(this->values_); }
 };
 
 template <typename T0, typename T1, typename T2, typename T3>
-inline std::ostream& operator<<(std::ostream& out, const Tuple4<T0, T1, T2, T3>& val){
-  out << val.get_0();
-  out << val.get_1();
-  out << val.get_2();
-  out << val.get_3();
-  return out;
-}
+struct Tuple4 : public TupleBase<T0, T1, T2, T3> {
+  using TupleBase<T0, T1, T2, T3>::TupleBase;
 
-template <typename T0, typename T1, typename T2, typename T3, typename T4>
-struct Tuple5 {
-  T0 t0;
-  T1 t1;
-  T2 t2;
-  T3 t3;
-  T4 t4;
-
-  Tuple5() {
-    t0 = get_default<T0>::call();
-    t1 = get_default<T1>::call();
-    t2 = get_default<T2>::call();
-    t3 = get_default<T3>::call();
-    t4 = get_default<T4>::call();
-  }
-
-  Tuple5(T0 _t0, T1 _t1, T2 _t2, T3 _t3, T4 _t4) {
-    t0 = _t0;
-    t1 = _t1;
-    t2 = _t2;
-    t3 = _t3;
-    t4 = _t4;
-  }
-
-  T0 get_0() const { return t0; }
-  T1 get_1() const { return t1; }
-  T2 get_2() const { return t2; }
-  T3 get_3() const { return t3; }
-  T4 get_4() const { return t4; }
+  T0 get_0() const { return std::get<0>(this->values_); }
+  T1 get_1() const { return std::get<1>(this->values_); }
+  T2 get_2() const { return std::get<2>(this->values_); }
+  T3 get_3() const { return std::get<3>(this->values_); }
 };
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4>
-inline std::ostream& operator<<(std::ostream& out, const Tuple5<T0, T1, T2, T3, T4>& val){
-  out << val.get_0();
-  out << val.get_1();
-  out << val.get_2();
-  out << val.get_3();
-  out << val.get_4();
-  return out;
-}
+struct Tuple5 : public TupleBase<T0, T1, T2, T3, T4> {
+  using TupleBase<T0, T1, T2, T3>::TupleBase;
+
+  T0 get_0() const { return std::get<0>(this->values_); }
+  T1 get_1() const { return std::get<1>(this->values_); }
+  T2 get_2() const { return std::get<2>(this->values_); }
+  T3 get_3() const { return std::get<3>(this->values_); }
+  T4 get_4() const { return std::get<4>(this->values_); }
+};
+
 
 /*********************************************************
  *  MATH                                                 *

--- a/Test/c++/maps.dfy.expect
+++ b/Test/c++/maps.dfy.expect
@@ -32,10 +32,10 @@ Keys membership 4: This is expected
 0 2 0
 0 0 1
 0 1 1 1
-jack wendy 0x0
-jack 0x0 0x0
+jack wendy 0
+jack 0 0
 ronald ronald 0
 1 1 1 0
-jack wendy 0x0
-jack 0x0 0x0
+jack wendy 0
+jack 0 0
 ronald ronald 0

--- a/docs/Compilation/Cpp.md
+++ b/docs/Compilation/Cpp.md
@@ -15,8 +15,6 @@ implementation.
 - Very limited support for higher order functions even for array init.  Use
   extern definitions like newArrayFill (see extern.dfy) or similar.  See also
   the example in `functions.dfy`.
-- We currently only support tuples up to arity 5.  A common place where you
-  might go over that limit is print statements, which tuple the arguments.
 - The current backend also assumes the use of C++17 in order to cleanly and
   performantly implement datatypes.
 


### PR DESCRIPTION
Replace the explicitly specified TupleN classes with a templated class. This makes it possible to support tuples of arbitrary arity in exported C++ code, and reduces the size of the trusted library.