### PR TITLE
Member function fixes

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -16372,10 +16372,12 @@ namespace Microsoft.Dafny {
             Statistics_HeapAsQuantifierCount++;
           }
         }
-        if (!e.Function.IsStatic) {
-          args.Add(TrExpr(e.Receiver));
-        }
         argsAreLit = true;
+        if (!e.Function.IsStatic) {
+          var tr_ee = TrExpr(e.Receiver);
+          argsAreLit = argsAreLit && translator.IsLit(tr_ee);
+          args.Add(tr_ee);
+        }
         for (int i = 0; i < e.Args.Count; i++) {
           Expression ee = e.Args[i];
           Type t = e.Function.Formals[i].Type;

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -7548,6 +7548,12 @@ namespace Microsoft.Dafny {
           } else if (e.Receiver.Type.IsArrowType) {
             CheckFunctionSelectWF("function specification", builder, etran, e.Receiver, "");
           }
+          if (!e.Function.IsStatic && CommonHeapUse && !etran.UsesOldHeap) {
+            // the argument can't be assumed to be allocated for the old heap
+            Type et = Resolver.SubstType(UserDefinedType.FromTopLevelDecl(e.tok, e.Function.EnclosingClass), e.GetTypeArgumentSubstitutions());
+            builder.Add(new Bpl.CommentCmd("assume allocatedness for receiver argument to function"));
+            builder.Add(TrAssumeCmd(e.Receiver.tok, MkIsAlloc(etran.TrExpr(e.Receiver), et, etran.HeapExpr)));
+          }
           // check well-formedness of the other parameters
           foreach (Expression arg in e.Args) {
             CheckWellformed(arg, options, locals, builder, etran);

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -18112,7 +18112,10 @@ namespace Microsoft.Dafny {
       var FVsHeapAt = new HashSet<Label>();
       Type usesThis = null;
       ComputeFreeVariables(expr, new HashSet<IVariable>(), ref usesHeap, ref usesOldHeap, FVsHeapAt, ref usesThis);
-      return usesHeap || usesOldHeap || FVsHeapAt.Count != 0 || usesThis != null;
+      if (usesHeap || usesOldHeap || FVsHeapAt.Count != 0) {
+        return true;
+      }
+      return usesThis != null && usesThis.IsRefType;
     }
 
     class UsesHeapVisitor : BottomUpVisitor

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -18112,10 +18112,7 @@ namespace Microsoft.Dafny {
       var FVsHeapAt = new HashSet<Label>();
       Type usesThis = null;
       ComputeFreeVariables(expr, new HashSet<IVariable>(), ref usesHeap, ref usesOldHeap, FVsHeapAt, ref usesThis);
-      if (usesHeap || usesOldHeap || FVsHeapAt.Count != 0) {
-        return true;
-      }
-      return usesThis != null && usesThis.IsRefType;
+      return usesHeap || usesOldHeap || FVsHeapAt.Count != 0;
     }
 
     class UsesHeapVisitor : BottomUpVisitor

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -839,7 +839,7 @@ namespace Dafny
     ISequence<U> DowncastClone<U>(Func<T, U> converter);
   }
 
-  public abstract class Sequence<T>: ISequence<T>
+  public abstract class Sequence<T> : ISequence<T>
   {
     public static readonly ISequence<T> Empty = new ArraySequence<T>(new T[0]);
 
@@ -1148,7 +1148,7 @@ namespace Dafny
       while (toVisit.Count != 0) {
         var seq = toVisit.Pop();
         var cs = seq as ConcatSequence<T>;
-        if (cs != null && cs.elmts == null) {
+        if (cs != null && cs.elmts.IsDefault) {
           toVisit.Push(cs.right);
           toVisit.Push(cs.left);
         } else {

--- a/Test/git-issues/git-issue-1143.dfy
+++ b/Test/git-issues/git-issue-1143.dfy
@@ -1,0 +1,25 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Nat = Zero | Succ(pred: Nat)
+{
+  function method MemberToInt(): int {
+    match this
+    case Zero => 0
+    case Succ(p) => 1 + p.MemberToInt()
+  }
+}
+
+function method ExternalToInt(n: Nat): int {
+  match n
+  case Zero => 0
+  case Succ(p) => 1 + ExternalToInt(p)
+}
+
+function method Prefix(n: Nat, len: nat): Nat
+  requires len <= n.MemberToInt() && len <= ExternalToInt(n)
+  ensures ExternalToInt(Prefix(n, len)) == len  // this line verifies
+  ensures Prefix(n, len).MemberToInt() == len  // this once failed to verify
+{
+  if len == 0 then Zero else Succ(Prefix(n.pred, len - 1))
+}

--- a/Test/git-issues/git-issue-1143.dfy.expect
+++ b/Test/git-issues/git-issue-1143.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 3 verified, 0 errors


### PR DESCRIPTION
This PR removes some unintended differences between receiver parameters and ordinary parameters. In particular:

* Emit `IsAlloc` assumption for receivers
* Consider receivers when `Lit`-wrapping
* Don't let non-reference `this` affect the use of a heap argument

Fixes #1143 