### PR TITLE
Check all var/const fields to have initial values

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -4144,8 +4144,15 @@ namespace Microsoft.Dafny {
 
     public static IEnumerable<ClassDecl> AllClasses(List<TopLevelDecl> declarations) {
       foreach (var d in declarations) {
-        var cl = d as ClassDecl;
-        if (cl != null) {
+        if (d is ClassDecl cl) {
+          yield return cl;
+        }
+      }
+    }
+
+    public static IEnumerable<TopLevelDeclWithMembers> AllTypesWithMembers(List<TopLevelDecl> declarations) {
+      foreach (var d in declarations) {
+        if (d is TopLevelDeclWithMembers cl) {
           yield return cl;
         }
       }

--- a/Test/dafny0/Constant.dfy
+++ b/Test/dafny0/Constant.dfy
@@ -170,7 +170,7 @@ class MyOnePurposeClass {
   static const self: MyOnePurposeClass?
 }
 
-class MyGenericClass<X,Y> {
+class MyGenericClass<X(00), Y(00)> {
   ghost static const x: X
   ghost static const y: Y
   static const z: int

--- a/Test/dafny0/ResolutionErrors.dfy
+++ b/Test/dafny0/ResolutionErrors.dfy
@@ -2254,7 +2254,7 @@ module UninterpretedModuleLevelConst {
 
   class MyClass { }
   const Y: MyClass  // error: the type of a non-ghost static const must have a known (non-ghost) initializer
-  ghost const Y': MyClass  // fine, Y' is ghost
+  ghost const Y': MyClass  // error: the type of a ghost static const must be known to be nonempty
 
   class AnotherClass {  // fine, the class itself is not required to have a constructor, because the bad fields are static
     static const k := 18
@@ -2280,10 +2280,10 @@ module UninterpretedModuleLevelConst {
   }
 
   trait GhostTr {
-    ghost const w: MyClass  // ghost, so no prob
+    ghost const w: MyClass  // the responsibility to initialize "w" lies with any class that implements "GhostTr"
   }
-  class GhostCl extends GhostTr {
-    ghost const z: MyClass  // ghost, so no prob
+  class GhostCl extends GhostTr {  // error: w and z need initialization, so GhostCl must have a constructor
+    ghost const z: MyClass
   }
 }
 

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -338,8 +338,10 @@ ResolutionErrors.dfy(2263,17): Error: static non-ghost const field 'O' of type '
 ResolutionErrors.dfy(2269,17): Error: static non-ghost const field 'W' of type 'MyClass' (which does not have a default compiled value) must give a defining value
 ResolutionErrors.dfy(2271,17): Error: static non-ghost const field 'O' of type 'Odd' (which does not have a default compiled value) must give a defining value
 ResolutionErrors.dfy(2279,8): Error: class 'Instance' with fields without known initializers, like 'w' of type 'MyClass', must declare a constructor
+ResolutionErrors.dfy(2285,8): Error: class 'GhostCl' with fields without known initializers, like 'z' of type 'MyClass', must declare a constructor
 ResolutionErrors.dfy(2253,8): Error: static non-ghost const field 'X' of type 'Odd' (which does not have a default compiled value) must give a defining value
 ResolutionErrors.dfy(2256,8): Error: static non-ghost const field 'Y' of type 'MyClass' (which does not have a default compiled value) must give a defining value
+ResolutionErrors.dfy(2257,14): Error: static ghost const field 'Y'' of type 'MyClass' (which may be empty) must give a defining value
 ResolutionErrors.dfy(2295,6): Error: LHS of assignment must denote a mutable field
 ResolutionErrors.dfy(2296,10): Error: LHS of assignment must denote a mutable field
 ResolutionErrors.dfy(2303,6): Error: LHS of assignment must denote a mutable field
@@ -525,4 +527,4 @@ ResolutionErrors.dfy(3340,6): Error: type parameter (T) passed to function NoRef
 ResolutionErrors.dfy(3346,9): Error: type parameter (T) passed to function MustBeNonempty must support nonempty (got PossiblyEmpty)
 ResolutionErrors.dfy(3352,9): Error: type parameter (T) passed to function MustBeAutoInit must support auto-initialization (got PossiblyEmpty)
 ResolutionErrors.dfy(3367,9): Error: type parameter (T) passed to function NoReferences must support no references (got Class?)
-522 resolution/type errors detected in ResolutionErrors.dfy
+524 resolution/type errors detected in ResolutionErrors.dfy

--- a/Test/git-issues/git-issue-1148.dfy
+++ b/Test/git-issues/git-issue-1148.dfy
@@ -1,0 +1,82 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module AutoInitRegressions {
+  trait Y { }
+
+  datatype Datatype = Make
+  {
+    static const Static: Y  // error: Y is not auto-init
+    const Instance: Y  // error: Y is not auto-init
+  }
+
+  method Main() {
+    print Datatype.Static, "\n";
+    var c := Make;
+    print c.Instance, "\n";
+  }
+
+  const Global: Y  // error: Y is not auto-init
+
+  class Class {  // error: InstanceField is of type Y, which is not auto-init, so class must have a constructor
+    static const StaticField: Y  // error: Y is not auto-init
+    const InstanceField: Y
+  }
+
+  trait Trait {
+    static const StaticField: Y  // error: Y is not auto-init
+    const InstanceField: Y
+  }
+
+  class TraitImpl extends Trait {  // error: inherited InstanceField is of type Y, which is not auto-init, so class must have a constructor
+  }
+
+  newtype Newtype = int
+  {
+    static const Static: Y  // error: Y is not auto-init
+    const Instance: Y  // error: Y is not auto-init
+  }
+
+  type Opaque
+  {
+    static const Static: Y  // error: Y is not auto-init
+    const Instance: Y  // error: Y is not auto-init
+  }
+}
+
+module NonemptyRegressions {
+  type Y { }
+
+  datatype Datatype = Make
+  {
+    ghost static const Static: Y  // error: Y is not nonempty
+    ghost const Instance: Y  // error: Y is not nonempty
+  }
+
+  ghost const Global: Y  // error: Y is not nonempty
+
+  class Class {  // error: InstanceField is of type Y, which is not nonempty, so class must have a constructor
+    ghost static const StaticField: Y  // error: Y is not nonempty
+    ghost const InstanceField: Y
+  }
+
+  trait Trait {
+    ghost static const StaticField: Y  // error: Y is not nonempty
+    ghost const InstanceField: Y
+  }
+
+  class TraitImpl extends Trait {  // error: inherited InstanceField is of type Y, which is not auto-init, so class must have a constructor
+  }
+
+  newtype Newtype = int
+  {
+    ghost static const Static: Y  // error: Y is not nonempty
+    ghost const Instance: Y  // error: Y is not nonempty
+  }
+
+  type Opaque
+  {
+    ghost static const Static: Y  // error: Y is not nonempty
+    ghost const Instance: Y  // error: Y is not nonempty
+  }
+}

--- a/Test/git-issues/git-issue-1148.dfy.expect
+++ b/Test/git-issues/git-issue-1148.dfy.expect
@@ -1,0 +1,23 @@
+git-issue-1148.dfy(9,17): Error: static non-ghost const field 'Static' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(10,10): Error: non-ghost const field 'Instance' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(22,17): Error: static non-ghost const field 'StaticField' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(21,8): Error: class 'Class' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
+git-issue-1148.dfy(27,17): Error: static non-ghost const field 'StaticField' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(31,8): Error: class 'TraitImpl' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
+git-issue-1148.dfy(36,17): Error: static non-ghost const field 'Static' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(37,10): Error: non-ghost const field 'Instance' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(42,17): Error: static non-ghost const field 'Static' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(43,10): Error: non-ghost const field 'Instance' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(19,8): Error: static non-ghost const field 'Global' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(52,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(53,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(59,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(58,8): Error: class 'Class' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
+git-issue-1148.dfy(64,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(68,8): Error: class 'TraitImpl' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
+git-issue-1148.dfy(73,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(74,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(79,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(80,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(56,14): Error: static ghost const field 'Global' of type 'Y' (which may be empty) must give a defining value
+22 resolution/type errors detected in git-issue-1148.dfy

--- a/Test/git-issues/git-issue-615.dfy
+++ b/Test/git-issues/git-issue-615.dfy
@@ -3,6 +3,9 @@
 
 class MyClass {
   ghost const repr: object
+  constructor (ghost r: object) {
+    repr := r;
+  }
 }
 
 datatype D1 = D1(o: MyClass)

--- a/Test/git-issues/git-issue-615.dfy.expect
+++ b/Test/git-issues/git-issue-615.dfy.expect
@@ -1,8 +1,8 @@
-git-issue-615.dfy(10,35): Error: insufficient reads clause to invoke function
+git-issue-615.dfy(13,35): Error: insufficient reads clause to invoke function
 Execution trace:
     (0,0): anon0
-git-issue-615.dfy(21,13): Error: insufficient reads clause to invoke function
+git-issue-615.dfy(24,13): Error: insufficient reads clause to invoke function
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 2 verified, 2 errors
+Dafny program verifier finished with 3 verified, 2 errors

--- a/Test/traits/TraitResolution1.dfy
+++ b/Test/traits/TraitResolution1.dfy
@@ -451,7 +451,7 @@ module ProvidingModule {
     const M := 100
     ghost const N: BB
   }
-  datatype Dt<CC> = X | Y | More(u: int) {
+  datatype Dt<CC(00)> = X | Y | More(u: int) {
     const M := 100
     ghost const N: CC
   }


### PR DESCRIPTION
Previously, only non-ghost fields in classes and traits were checked to have proper initialization. Now, all (ghost and non-ghost) const/var fields (in all types that can have members) are checked.

Fixes #1148 