### PR TITLE
Compile placebo value for extern opaque type in C#

### DIFF
--- a/Test/git-issues/git-issue-1151-concrete.cs
+++ b/Test/git-issues/git-issue-1151-concrete.cs
@@ -1,0 +1,24 @@
+namespace M {
+  // try an unusual type here, namely a struct
+  public struct T {
+  }
+
+  public partial class __default {
+    public static T GetT() {
+      return new T();
+    }
+  }
+
+  // By declaring U a class here, it allows "null" as a value.
+  // In other words, the opaque type M.U declared in the Dafny program
+  // evidently stands for what in Dafny could have been declared as
+  // type U? for a class U.
+  public class U {
+  }
+
+  public struct V {
+  }
+
+  public struct W<A> {
+  }
+}

--- a/Test/git-issues/git-issue-1151.dfy
+++ b/Test/git-issues/git-issue-1151.dfy
@@ -1,0 +1,29 @@
+// RUN: %dafny /compile:3 "%s" git-issue-1151-concrete.cs > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module {:extern "M"} M {
+  type {:extern "T"} T
+  method {:extern} GetT() returns (t: T)
+
+  datatype D = D(t: T)
+  datatype E<X> = E(t: T, x: X)
+
+  type {:extern "U"} U(0)
+  type {:extern "V"} V(0)
+  datatype F = F(u: U, v: V)
+}
+
+method Main() {
+  var t := M.GetT();
+
+  var d: M.D;
+  d := M.D(t);
+  print d, "\n";
+
+  var e: M.E<int>;
+  e := M.E(t, 45);
+  print e, "\n";
+
+  var f: M.F;
+  print f, "\n";
+}

--- a/Test/git-issues/git-issue-1151.dfy.expect
+++ b/Test/git-issues/git-issue-1151.dfy.expect
@@ -1,0 +1,5 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+M_Compile.D.D(M.T)
+M_Compile.E.E(M.T, 45)
+M_Compile.F.F(null, M.V)


### PR DESCRIPTION
Emit `default(T)` in C# when needing a placebo value for an `:extern` opaque type `T`. If that placebo value is also an actual value of the type to be represented, then the opaque type can safely be marked with the `(0)` type characteristic.

This solution is specific to C# (which may not be too surprising, since `:extern` tries to connect code in Dafny with code written in some other language). The solution has limitations--it only works for opaque types declared in the same module that needs the default value, and it works only for opaque types that don't take type parameters.

Note, if the extern type is known to be a C# class type, then it would be better for the Dafny program to declare it as an extern class.

Fixes #1151