### PR TITLE
Fix Map#Glue encoding of map comprehensions

### DIFF
--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1213,16 +1213,19 @@ axiom (forall<U, V> u: U ::
         { Map#Domain(Map#Empty(): Map U V)[u] }
         !Map#Domain(Map#Empty(): Map U V)[u]);
 
-function Map#Glue<U, V>([U] bool, [U]V, Ty): Map U V;
-axiom (forall<U, V> a: [U] bool, b:[U]V, t:Ty ::
-        { Map#Domain(Map#Glue(a, b, t)) }
-        Map#Domain(Map#Glue(a, b, t)) == a);
-axiom (forall<U, V> a: [U] bool, b:[U]V, t:Ty ::
-        { Map#Elements(Map#Glue(a, b, t)) }
-        Map#Elements(Map#Glue(a, b, t)) == b);
-axiom (forall<U, V> a: [U] bool, b:[U]V, t:Ty ::
-        { $Is(Map#Glue(a, b, t), t) }
-        $Is(Map#Glue(a, b, t), t));
+function Map#Glue<U, V>([U]bool, [U]V, Ty): Map U V;
+axiom (forall<U, V> a: [U]bool, b: [U]V, t: Ty ::
+  { Map#Domain(Map#Glue(a, b, t)) }
+  Map#Domain(Map#Glue(a, b, t)) == a);
+axiom (forall<U, V> a: [U]bool, b: [U]V, t: Ty ::
+  { Map#Elements(Map#Glue(a, b, t)) }
+  Map#Elements(Map#Glue(a, b, t)) == b);
+axiom (forall a: [Box]bool, b: [Box]Box, t0, t1: Ty ::
+  { Map#Glue(a, b, TMap(t0, t1)) }
+  // In the following line, no trigger needed, since the quantifier only gets used in negative contexts
+  (forall bx: Box :: a[bx] ==> $IsBox(bx, t0) && $IsBox(b[bx], t1))
+  ==>
+  $Is(Map#Glue(a, b, TMap(t0, t1)), TMap(t0, t1)));
 
 
 //Build is used in displays, and for map updates
@@ -1346,15 +1349,18 @@ axiom (forall<U, V> u: U ::
         !IMap#Domain(IMap#Empty(): IMap U V)[u]);
 
 function IMap#Glue<U, V>([U] bool, [U]V, Ty): IMap U V;
-axiom (forall<U, V> a: [U] bool, b:[U]V, t:Ty ::
-        { IMap#Domain(IMap#Glue(a, b, t)) }
-        IMap#Domain(IMap#Glue(a, b, t)) == a);
-axiom (forall<U, V> a: [U] bool, b:[U]V, t:Ty ::
-        { IMap#Elements(IMap#Glue(a, b, t)) }
-        IMap#Elements(IMap#Glue(a, b, t)) == b);
-axiom (forall<U, V> a: [U] bool, b:[U]V, t:Ty ::
-        { $Is(IMap#Glue(a, b, t), t) }
-        $Is(IMap#Glue(a, b, t), t));
+axiom (forall<U, V> a: [U]bool, b: [U]V, t: Ty ::
+  { IMap#Domain(IMap#Glue(a, b, t)) }
+  IMap#Domain(IMap#Glue(a, b, t)) == a);
+axiom (forall<U, V> a: [U]bool, b: [U]V, t: Ty ::
+  { IMap#Elements(IMap#Glue(a, b, t)) }
+  IMap#Elements(IMap#Glue(a, b, t)) == b);
+axiom (forall a: [Box]bool, b: [Box]Box, t0, t1: Ty ::
+  { IMap#Glue(a, b, TIMap(t0, t1)) }
+  // In the following line, no trigger needed, since the quantifier only gets used in negative contexts
+  (forall bx: Box :: a[bx] ==> $IsBox(bx, t0) && $IsBox(b[bx], t1))
+  ==>
+  $Is(Map#Glue(a, b, TIMap(t0, t1)), TIMap(t0, t1)));
 
 //Build is used in displays
 function IMap#Build<U, V>(IMap U V, U, V): IMap U V;

--- a/Test/git-issues/git-issue-1158.dfy
+++ b/Test/git-issues/git-issue-1158.dfy
@@ -1,0 +1,27 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Id(==)
+
+function F(s: set<Id>): int
+
+lemma Test(x: Id)
+{
+  var X := {x};
+  var a := map i | i <= X :: F(i);
+  var b := map[{} := F({}), X := F(X)];
+
+  assert a.Keys == b.Keys by {  // spurious error reported here
+    forall i
+      ensures i in a.Keys <==> i in b.Keys
+    {
+      calc {
+        i in a.Keys;
+      ==
+        i <= X;
+      ==  { assert i <= X <==> i == {} || i == X; }
+        i in b.Keys;
+      }
+    }
+  }
+}

--- a/Test/git-issues/git-issue-1158.dfy.expect
+++ b/Test/git-issues/git-issue-1158.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
The previous axiom for `$Is(Map#Glue(…` was unsound, because the third parameter of `Map#Glue` was unconditionally taken to be the type of the constructed map.

Also, the previous version didn’t cause the right thing to happen with boxing/unboxing, which caused some set-equality proofs to not go through.

Fixes #1158 