### PR TITLE
Add more auto-triggers for collections

### DIFF
--- a/Source/Dafny/Triggers/TriggersCollector.cs
+++ b/Source/Dafny/Triggers/TriggersCollector.cs
@@ -248,15 +248,18 @@ namespace Microsoft.Dafny.Triggers {
           expr is OldExpr ||
           expr is ApplyExpr ||
           expr is DisplayExpression ||
+          expr is MapDisplayExpr ||
           expr is DatatypeValue ||
           TranslateToFunctionCall(expr)) {
         return true;
       } else if (expr is BinaryExpr) {
         var e = (BinaryExpr)expr;
-        if ((e.Op == BinaryExpr.Opcode.NotIn || e.Op == BinaryExpr.Opcode.In) && !(e.E1 is DisplayExpression)) {
+        if ((e.Op == BinaryExpr.Opcode.NotIn || e.Op == BinaryExpr.Opcode.In) && !Translator.ExpressionTranslator.RewriteInExpr(e.E1)) {
+          return true;
+        } else if (CandidateCollectionOperation(e)) {
           return true;
         } else if (e.E0.Type.IsBigOrdinalType &&
-          (e.ResolvedOp == BinaryExpr.ResolvedOpcode.Lt || e.ResolvedOp == BinaryExpr.ResolvedOpcode.LessThanLimit || e.ResolvedOp == BinaryExpr.ResolvedOpcode.Gt)) {
+                   (e.ResolvedOp == BinaryExpr.ResolvedOpcode.Lt || e.ResolvedOp == BinaryExpr.ResolvedOpcode.LessThanLimit || e.ResolvedOp == BinaryExpr.ResolvedOpcode.Gt)) {
           return true;
         } else {
           return false;
@@ -303,6 +306,58 @@ namespace Microsoft.Dafny.Triggers {
       }
       return false;
     }
+
+    static bool CandidateCollectionOperation(BinaryExpr binExpr) {
+      Contract.Requires(binExpr != null);
+      var type = binExpr.E0.Type.AsCollectionType;
+      if (type == null) {
+        return false;
+      }
+      if (type is SetType) {
+        switch (binExpr.ResolvedOp) {
+          case BinaryExpr.ResolvedOpcode.Union:
+          case BinaryExpr.ResolvedOpcode.Intersection:
+          case BinaryExpr.ResolvedOpcode.SetDifference:
+          case BinaryExpr.ResolvedOpcode.ProperSubset:
+          case BinaryExpr.ResolvedOpcode.Subset:
+          case BinaryExpr.ResolvedOpcode.Superset:
+          case BinaryExpr.ResolvedOpcode.ProperSuperset:
+            return true;
+          default:
+            break;
+        }
+      } else if (type is MultiSetType) {
+        switch (binExpr.ResolvedOp) {
+          case BinaryExpr.ResolvedOpcode.MultiSetUnion:
+          case BinaryExpr.ResolvedOpcode.MultiSetIntersection:
+          case BinaryExpr.ResolvedOpcode.MultiSetDifference:
+          case BinaryExpr.ResolvedOpcode.ProperMultiSubset:
+          case BinaryExpr.ResolvedOpcode.MultiSubset:
+          case BinaryExpr.ResolvedOpcode.MultiSuperset:
+          case BinaryExpr.ResolvedOpcode.ProperMultiSuperset:
+            return true;
+          default:
+            break;
+        }
+      } else if (type is SeqType) {
+        switch (binExpr.ResolvedOp) {
+          case BinaryExpr.ResolvedOpcode.Concat:
+            return true;
+          default:
+            break;
+        }
+      } else if (type is MapType) {
+        switch (binExpr.ResolvedOp) {
+          case BinaryExpr.ResolvedOpcode.MapMerge:
+          case BinaryExpr.ResolvedOpcode.MapSubtraction:
+            return true;
+          default:
+            break;
+        }
+      }
+      return false;
+    }
+
     private TriggerAnnotation AnnotatePotentialCandidate(Expression expr) {
       bool expr_is_killer = false;
       HashSet<OldExpr> oldExprSet;

--- a/Test/dafny1/UltraFilter.dfy.expect
+++ b/Test/dafny1/UltraFilter.dfy.expect
@@ -1,3 +1,2 @@
-UltraFilter.dfy(39,7): Warning: /!\ No trigger covering all quantified variables found.
 
 Dafny program verifier finished with 7 verified, 0 errors

--- a/Test/dafny4/Bug60.dfy
+++ b/Test/dafny4/Bug60.dfy
@@ -4,10 +4,10 @@
 // This method can be used to test compilation.
 method Main()
 {
-    var s := {2, 3};
-    var m := map[2 := 20, 3 := 30];
-    print (s, m), "\n";
-    print (|s|, |m|), "\n";
-    print(set s | s in m), "\n";
-    print (forall x {:nowarn} :: x in (map [1:=10, 2:=20]) ==> x > 0), "\n";
+  var s := {2, 3};
+  var m := map[2 := 20, 3 := 30];
+  print (s, m), "\n";
+  print (|s|, |m|), "\n";
+  print set s | s in m, "\n";
+  print forall x :: x in (map[1 := 10, 2 := 20]) ==> x > 0, "\n";
 }

--- a/Test/dafny4/Primes.dfy
+++ b/Test/dafny4/Primes.dfy
@@ -201,7 +201,7 @@ lemma LargestElementExists(s: set<int>)
   var s' := s;
   while true
     invariant s' != {} && s' <= s
-    invariant forall x,y {:nowarn} :: x in s' && y in s - s' ==> y <= x
+    invariant forall x,y :: x in s' && y in s && y !in s' ==> y <= x
     decreases s'
   {
     var x :| x in s';  // pick something

--- a/Test/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy
+++ b/Test/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy
@@ -5,7 +5,7 @@
 // AST matches. This file also checks that triggers are reported exactly as
 // picked (that is, `x in s` yields `s[x]` for a multiset s), but matches as
 // they appear in the buffer text (that is, `x+1 in s` is not translated to
-// s[x+1] when highlited as a cause for a potential matching loop.
+// s[x+1] when highlighted as a cause for a potential matching loop.
 
 method M() {
   // This is an obvious loop
@@ -13,4 +13,130 @@ method M() {
 
   // x in s loops with s[x+1] due to the way [x in s] is translated
   ghost var a := forall s: multiset<int>, x: int :: x in s ==> s[x+1] > 0 && x+2 !in s;
+}
+
+// "in" expressions are often rewritten by the ExpressionTranslator. The following
+// tests check that triggers are not selected from expressions that will be
+// rewritten.
+
+method RewriteSet(s: set<int>, t: set<int>) {
+  // set union
+  ghost var u0 := forall x | x in s + t :: x < 200; // warning: no trigger
+  ghost var u1 := forall x | x in s || x in t :: x < 200;
+  ghost var u2 := set x | x in s + t; // warning: no trigger
+  ghost var u3 := set x | x in s + t && (x in s || x in t);
+  assert u0 == u1 && u2 == u3;
+
+  // set intersection
+  ghost var i0 := forall x | x in s * t :: x < 200; // warning: no trigger
+  ghost var i1 := forall x | x in s * t && x in s && x in t :: x < 200;
+  assert i0 == i1;
+
+  // set difference
+  ghost var d0 := forall x | x in s - t :: x < 200; // warning: no trigger
+  ghost var d1 := forall x | x in s - t && x in s && x !in t :: x < 200;
+  assert d0 == d1;
+
+  // set display
+  ghost var c0 := forall x | x in {2, 3, 5} :: x < 200; // warning: no trigger
+  ghost var c1 := forall x | x in ({2, 3, 5}) :: x < 200;
+  assert c0 == c1;
+
+  // set comprehension
+  ghost var h0 := forall x :: (x in set y | y in s) ==> x < 200; // warning: no trigger
+  ghost var h1 := forall x :: var S := set y | y in s; x in S ==> x < 200; // warning: no trigger
+  assert h0 == h1;
+  ghost var h2 := forall x :: var S := F(set y | y in s); x in S ==> x < 200; // warning: no trigger
+  ghost var h3 := forall x :: x in s ==> x < 200;
+  ghost var h4 := forall x :: x in F(s) ==> x < 200;
+}
+
+function F<X>(s: X): X { s }
+
+method RewriteMultiSet(s: multiset<int>, t: multiset<int>) {
+  // multiset union
+  ghost var u0 := forall x | x in s + t :: x < 200; // warning: no trigger
+  ghost var u1 := forall x | x in s || x in t :: x < 200;
+  assert u0 == u1;
+
+  // multiset intersection
+  ghost var i0 := forall x | x in s * t :: x < 200; // warning: no trigger
+  ghost var i1 := forall x | x in s * t && x in s && x in t :: x < 200;
+  assert i0 == i1;
+
+  // multiset difference
+  ghost var d0 := forall x | x in s - t :: x < 200; // fine (multiset difference is not rewritten)
+  ghost var d1 := forall x | x in s - t && x in s && s[x] > t[x] :: x < 200;
+  assert d0 == d1;
+
+  // multiset display
+  ghost var c0 := forall x | x in multiset{2, 3, 5} :: x < 200; // warning: no trigger
+  ghost var c1 := forall x | x in (multiset{2, 3, 5}) :: x < 200;
+  assert c0 == c1;
+}
+
+method RewriteSeq(s: seq<int>, t: seq<int>) {
+  // concat
+  ghost var u0 := forall x | x in s + t :: x < 200; // fine (seq + does is not rewritten)
+  ghost var u1 := forall x | x in s || x in t :: x < 200;
+  assert u0 == u1 by {
+    if u0 {
+      forall x | x in s || x in t
+        ensures x < 200
+      {
+        assert x in s + t;
+      }
+      assert u1;
+    }
+    assert u1 ==> u0;
+  }
+
+  // seq display
+  ghost var c0 := forall x | x in [2, 3, 5] :: x < 200; // fine (currently, "in seq-display" is not rewritten)
+  ghost var c1 := forall x | x in ([2, 3, 5]) :: x < 200;
+  assert c0 == c1;
+}
+
+method RewriteMap(s: map<int, int>, t: map<int, int>, u: set<int>) {
+  // map merge
+  ghost var u0 := forall x | x in s + t :: x < 200; // fine (map merge is not rewritten)
+  ghost var u1 := forall x | x in s || x in t :: x < 200;
+  assert u0 == u1;
+
+  // map domain subtraction
+  ghost var d0 := forall x | x in s - u :: x < 200; // fine (map subtraction is not rewritten)
+  ghost var d1 := forall x | x in s && x !in u :: x < 200;
+  assert d0 == d1 by {
+    if d0 {
+      forall x | x in s && x !in u
+        ensures x < 200
+      {
+        assert x in s - u;
+      }
+      assert d1;
+    }
+    assert d1 ==> d0;
+  }
+
+  // map display
+  ghost var c0 := forall x | x in map[2 := 20, 3 := 30, 5 := 50] :: x < 200; // fine (map comprehension is not rewritten)
+  ghost var c1 := forall x | x in F(map[2 := 20, 3 := 30, 5 := 50]) :: x < 200;
+  assert c0 == c1;
+
+  assert false;  // error: sanity check
+}
+
+method Orderings(s: set<int>, ms: multiset<int>, q: seq<int>) {
+  var a0 := exists x :: x < s;
+  var a1 := exists x :: x <= s;
+  var a2 := exists x :: x >= s;
+  var a3 := exists x :: x > s;
+
+  var b0 := exists x :: x < ms;
+  var b1 := exists x :: x <= ms;
+  var b2 := exists x :: x >= ms;
+  var b3 := exists x :: x > ms;
+
+  var c0 := exists x :: x < q; // warning: no trigger
+  var c1 := exists x :: x <= q; // warning: no trigger
 }

--- a/Test/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy.expect
+++ b/Test/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy.expect
@@ -3,5 +3,89 @@ some-terms-do-not-look-like-the-triggers-they-match.dfy(15,17): Info: For expres
    Selected triggers: {s[_t#0], s[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(15,17): Info: For expression "x in s ==> _t#0 !in s":
    Selected triggers: {s[_t#0], s[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(24,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(25,18): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(26,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(27,18): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(31,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(32,18): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(36,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(37,18): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(41,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(42,18): Info: Selected triggers: {x in {2, 3, 5}}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(46,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(46,36): Info: Selected triggers: {y in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(47,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(47,39): Info: Selected triggers: {y in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(49,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(49,41): Info: Selected triggers: {y in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(50,18): Info: Selected triggers: {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(51,18): Info: Selected triggers: {x in F(s)}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(58,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(59,18): Info: Selected triggers:
+   {t[x]}, {s[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(63,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(64,18): Info: Selected triggers:
+   {t[x]}, {s[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(68,18): Info: Selected triggers: {(s - t)[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(69,18): Info: Selected triggers:
+   {t[x]}, {s[x]}, {(s - t)[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(73,18): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(74,18): Info: Selected triggers: {multiset{2, 3, 5}[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(80,18): Info: Selected triggers: {x in s + t}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(81,18): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(84,6): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(95,18): Info: Selected triggers: {x in [2, 3, 5]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(96,18): Info: Selected triggers: {x in [2, 3, 5]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(102,18): Info: Selected triggers: {x in s + t}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(103,18): Info: Selected triggers:
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(107,18): Info: Selected triggers: {x in s - u}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(108,18): Info: Selected triggers:
+   {x in u}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(111,6): Info: Selected triggers:
+   {x in u}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(122,18): Info: Selected triggers: {x in map[2 := 20, 3 := 30, 5 := 50]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(123,18): Info: Selected triggers: {x in F(map[2 := 20, 3 := 30, 5 := 50])}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(130,12): Info: Selected triggers: {x < s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(131,12): Info: Selected triggers: {x <= s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(132,12): Info: Selected triggers: {x >= s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(133,12): Info: Selected triggers: {x > s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(135,12): Info: Selected triggers: {x < ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(136,12): Info: Selected triggers: {x <= ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(137,12): Info: Selected triggers: {x >= ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(138,12): Info: Selected triggers: {x > ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(140,12): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(141,12): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(126,9): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    (0,0): anon35_Then
+    (0,0): anon36_Then
+    (0,0): anon3
+    (0,0): anon37_Then
+    (0,0): anon38_Then
+    (0,0): anon39_Then
+    (0,0): anon8
+    (0,0): anon40_Then
+    (0,0): anon41_Then
+    (0,0): anon11
+    (0,0): anon42_Then
+    (0,0): anon43_Then
+    (0,0): anon44_Then
+    (0,0): anon16
+    some-terms-do-not-look-like-the-triggers-they-match.dfy(109,3): anon45_Else
+    (0,0): anon50_Then
+    (0,0): anon51_Then
+    (0,0): anon31
+    (0,0): anon52_Then
+    (0,0): anon53_Then
+    (0,0): anon34
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished with 3 verified, 1 error


### PR DESCRIPTION
Allow operations like subset, set union, set intersection, and set difference as trigger candidates. This means fewer "no trigger" warnings, which in turn means more stable verifier performance.

It is in principle possible that the new triggers will _cause_ performance problems. This could happen if triggers were indeed selected before and those triggers were sufficient. The new triggers could then cause additional instantiations, which could slow down performance. No such case was detected in the test suite.