### PR TITLE
fix: Tighten up errors around decreases/reads *

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1791,6 +1791,10 @@ ReadsClause<.List<FrameExpression/*!*/>/*!*/ reads,
   PossiblyWildFrameExpression<out fe, allowLemma, allowLambda, allowWild>          (. reads.Add(fe); .)
   { "," PossiblyWildFrameExpression<out fe, allowLemma, allowLambda, allowWild>    (. reads.Add(fe); .)
   }
+  (. if (allowWild && reads.Count > 1 && reads.Exists(fe => fe.E is WildcardExpr)) {
+       SemErr(fe.tok, "A 'reads' clause that contains '*' is not allowed to contain any other expressions");
+     }
+  .)
   OldSemi
   .
 
@@ -2802,6 +2806,11 @@ DecreasesList<.List<Expression> decreases, bool allowWildcard, bool allowLambda.
   PossiblyWildExpression<out e, allowLambda, allowWildcard>       (. decreases.Add(e); .)
   { "," PossiblyWildExpression<out e, allowLambda, allowWildcard> (. decreases.Add(e); .)
   }
+  (. if (allowWildcard && decreases.Count > 1 && decreases.Exists(e => e is WildcardExpr)) {
+       SemErr(e.tok, "A 'decreases' clause that contains '*' is not allowed to contain any other expressions");
+
+     }
+  .)
   .
 
 /*------------------------------------------------------------------------*/

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1692,7 +1692,8 @@ MethodDecl<DeclModifierData dmod, bool allowConstructor, out Method/*!*/ m>
     ]
   | ellipsis                                    (. signatureEllipsis = t; .)
   )
-  MethodSpec<req, mod, ens, dec, ref decAttrs, ref modAttrs, caption, isConstructor>
+  MethodSpec<dmod.IsGhost || isLemma || isTwoStateLemma || isLeastLemma || isGreatestLemma,
+             req, mod, ens, dec, ref decAttrs, ref modAttrs, caption, isConstructor>
   [ IF(isConstructor)
     (. DividedBlockStmt dividedBody; .)
     DividedBlockStmt<out dividedBody, out bodyStart, out bodyEnd>
@@ -1804,7 +1805,7 @@ InvariantClause<. List<AttributedExpression> invariants.> =
   .
 
 /*------------------------------------------------------------------------*/
-MethodSpec<.List<AttributedExpression> req, List<FrameExpression> mod, List<AttributedExpression> ens,
+MethodSpec<.bool isGhost, List<AttributedExpression> req, List<FrameExpression> mod, List<AttributedExpression> ens,
             List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, string caption, bool performThisDeprecatedCheck.>
 = (. Contract.Requires(cce.NonNullElements(req));
      Contract.Requires(cce.NonNullElements(mod));
@@ -1815,7 +1816,7 @@ MethodSpec<.List<AttributedExpression> req, List<FrameExpression> mod, List<Attr
   { ModifiesClause<ref mod, ref modAttrs, false, performThisDeprecatedCheck>
   | RequiresClause<req, true>
   | EnsuresClause<ens, false>
-  | DecreasesClause<decreases, ref decAttrs, true, false>
+  | DecreasesClause<decreases, ref decAttrs, !isGhost, false>
   }
   .
 

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2214,12 +2214,12 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
   { RequiresClause<reqs, true>
   | ReadsClause<reads, false, false, true>
   | EnsuresClause<ens, false>
-  | DecreasesClause<decreases, ref attrs, false, false>
-                                              (. if (decreases == null) {
-                                                   SemErr(t, "'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed");
-                                                   decreases = new List<Expression/*!*/>();
-                                                 }
-                                              .)
+  | (. if (decreases == null) {
+         SemErr(t, "'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed");
+         decreases = new List<Expression/*!*/>();
+       }
+    .)
+    DecreasesClause<decreases, ref attrs, false, false>
   }
   .
 

--- a/Test/git-issues/git-issue-1172.dfy
+++ b/Test/git-issues/git-issue-1172.dfy
@@ -1,0 +1,76 @@
+// RUN: %dafny /compile:3 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// The following examples show that verification would be unsound if ghost methods would
+// be allowed to avoid termination checking.
+
+function F(): int
+  ensures false
+  decreases *  // error: this is not allowed on a function
+{
+  F()
+}
+
+function method G(): int
+  ensures false
+  decreases *  // error: this is not allowed on a function
+{
+  G()
+}
+
+twostate predicate P2()
+  ensures false
+  decreases *  // error: this is not allowed on a function
+{
+  P2()
+}
+
+ghost method GM()
+  ensures false
+  decreases *  // error: this is not allowed on a ghost method
+{
+  GM();
+}
+
+lemma Lemma()
+  ensures false
+  decreases *  // error: this is not allowed on a lemma
+{
+  Lemma();
+}
+
+twostate lemma L2()
+  ensures false
+  decreases *  // error: this is not allowed on a lemma
+{
+  L2();
+}
+
+least lemma Least()
+  ensures false  // even without the "decreases *", this postcondition would not get passed the verifier
+  decreases *  // error: this is not allowed on a lemma
+{
+  Least#[_k]();
+}
+
+method Main()
+  decreases *
+{
+  if {
+    case true =>
+      var x := F();
+    case true =>
+      var x := G();
+    case true =>
+      var p := P2();
+    case true =>
+      GM();
+    case true =>
+      Lemma();
+    case true =>
+      L2();
+    case true =>
+      Least();
+  }
+  var x := 1 / 0;  // no error, because all postconditions of the called methods/functions imply "false"
+}

--- a/Test/git-issues/git-issue-1172.dfy
+++ b/Test/git-issues/git-issue-1172.dfy
@@ -74,3 +74,33 @@ method Main()
   }
   var x := 1 / 0;  // no error, because all postconditions of the called methods/functions imply "false"
 }
+
+// ---------------------- other decreases related errors ----------------------
+
+least predicate Min(x: int)
+  decreases x  // error: decreases not allowed on extreme predicates
+{
+  true
+}
+
+greatest predicate Max(x: int)
+  decreases x  // error: decreases not allowed on extreme predicates
+{
+  true
+}
+
+least lemma MinLemma(x: int)
+  decreases x  // fine
+{
+  if 0 < x {
+    MinLemma(x - 1);
+  }
+}
+
+greatest lemma MaxLemma(x: int)
+  decreases x  // fine
+{
+  if 0 < x {
+    MaxLemma(x - 1);
+  }
+}

--- a/Test/git-issues/git-issue-1172.dfy
+++ b/Test/git-issues/git-issue-1172.dfy
@@ -104,3 +104,86 @@ greatest lemma MaxLemma(x: int)
     MaxLemma(x - 1);
   }
 }
+
+// ---------------------- duplicate *'s ----------------------
+
+method Recursive0(x: int, y: int)
+  decreases x, y, *  // error: * can only be mentioned alone in a decreases clause
+
+method Recursive1(x: int, y: int)
+  decreases *, x, y  // error: * can only be mentioned alone in a decreases clause
+
+method Recursive2(x: int, y: int)
+  decreases x, y
+  decreases *  // error: * can only be mentioned alone in a decreases clause
+
+method Recursive3(x: int, y: int)
+  decreases *
+  decreases x, y  // error: * can only be mentioned alone in a decreases clause
+
+method Recursive4(x: int, y: int)
+  decreases x, *, y  // error: * can only be mentioned alone in a decreases clause
+
+method Recursive5(x: int, y: int)
+  decreases x, *, y, *  // error: * can only be mentioned alone in a decreases clause
+
+method Recursive6(x: int, y: int)
+  decreases *
+  decreases x  // error: * can only be mentioned alone in a decreases clause
+  decreases *  // error: * can only be mentioned alone in a decreases clause
+  decreases y  // error: * can only be mentioned alone in a decreases clause
+  decreases *  // error: * can only be mentioned alone in a decreases clause
+
+method Loops(M: int, N: int, O: int, P: int) {
+  var i, j, k, l := M, N, O,  P;
+  while i != 0
+    decreases i, *  // error: * can only be mentioned alone in a decreases clause
+  {
+    i := i - 1;
+  }
+  while j != 0
+    decreases *, j  // error: * can only be mentioned alone in a decreases clause
+  {
+    j := j - 1;
+  }
+  while k != 0
+    decreases k
+    decreases *  // error: * can only be mentioned alone in a decreases clause
+    decreases *  // error: * can only be mentioned alone in a decreases clause
+  {
+    k := k - 1;
+  }
+  while l != 0
+    decreases *, k  // error: * can only be mentioned alone in a decreases clause
+    decreases l, *  // error: * can only be mentioned alone in a decreases clause
+  {
+    l := l - 1;
+  }
+}
+
+function Function0(x: object, y: object): int
+  reads x, y, *  // error: * can only be mentioned alone in a reads clause
+
+function Function1(x: object, y: object): int
+  reads *, x, y  // error: * can only be mentioned alone in a reads clause
+
+function Function2(x: object, y: object): int
+  reads x, y
+  reads *  // error: * can only be mentioned alone in a reads clause
+
+function Function3(x: object, y: object): int
+  reads *
+  reads x, y  // error: * can only be mentioned alone in a reads clause
+
+function Function4(x: object, y: object): int
+  reads x, *, y  // error: * can only be mentioned alone in a reads clause
+
+function Function5(x: object, y: object): int
+  reads x, *, y, *  // error: * can only be mentioned alone in a reads clause
+
+function Function6(x: object, y: object): int
+  reads *
+  reads x  // error: * can only be mentioned alone in a reads clause
+  reads *  // error: * can only be mentioned alone in a reads clause
+  reads y  // error: * can only be mentioned alone in a reads clause
+  reads *  // error: * can only be mentioned alone in a reads clause

--- a/Test/git-issues/git-issue-1172.dfy.expect
+++ b/Test/git-issues/git-issue-1172.dfy.expect
@@ -7,4 +7,30 @@ git-issue-1172.dfy(44,12): Error: A '*' expression is not allowed here
 git-issue-1172.dfy(51,12): Error: A '*' expression is not allowed here
 git-issue-1172.dfy(80,26): Error: 'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed
 git-issue-1172.dfy(86,29): Error: 'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed
-9 parse errors detected in git-issue-1172.dfy
+git-issue-1172.dfy(111,18): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(114,18): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(118,12): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(122,15): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(125,18): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(128,21): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(132,12): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(133,12): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(134,12): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(135,12): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(140,17): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(145,17): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(151,14): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(152,14): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(157,17): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(158,17): Error: A 'decreases' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(165,14): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(168,14): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(172,8): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(176,11): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(179,14): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(182,17): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(186,8): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(187,8): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(188,8): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+git-issue-1172.dfy(189,8): Error: A 'reads' clause that contains '*' is not allowed to contain any other expressions
+35 parse errors detected in git-issue-1172.dfy

--- a/Test/git-issues/git-issue-1172.dfy.expect
+++ b/Test/git-issues/git-issue-1172.dfy.expect
@@ -1,0 +1,8 @@
+git-issue-1172.dfy(9,12): Error: A '*' expression is not allowed here
+git-issue-1172.dfy(16,12): Error: A '*' expression is not allowed here
+git-issue-1172.dfy(23,12): Error: A '*' expression is not allowed here
+git-issue-1172.dfy(30,12): Error: A '*' expression is not allowed here
+git-issue-1172.dfy(37,12): Error: A '*' expression is not allowed here
+git-issue-1172.dfy(44,12): Error: A '*' expression is not allowed here
+git-issue-1172.dfy(51,12): Error: A '*' expression is not allowed here
+7 parse errors detected in git-issue-1172.dfy

--- a/Test/git-issues/git-issue-1172.dfy.expect
+++ b/Test/git-issues/git-issue-1172.dfy.expect
@@ -5,4 +5,6 @@ git-issue-1172.dfy(30,12): Error: A '*' expression is not allowed here
 git-issue-1172.dfy(37,12): Error: A '*' expression is not allowed here
 git-issue-1172.dfy(44,12): Error: A '*' expression is not allowed here
 git-issue-1172.dfy(51,12): Error: A '*' expression is not allowed here
-7 parse errors detected in git-issue-1172.dfy
+git-issue-1172.dfy(80,26): Error: 'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed
+git-issue-1172.dfy(86,29): Error: 'decreases' clauses are meaningless for least and greatest predicates, so they are not allowed
+9 parse errors detected in git-issue-1172.dfy

--- a/docs/DafnyRef/Specifications.md
+++ b/docs/DafnyRef/Specifications.md
@@ -107,8 +107,14 @@ Note that changing the order of multiple `decreases` clauses will change
 the order of the expressions within the equivalent single `decreases`
 clause, and will therefore have different semantics.
 
-If any of the expressions in the `decreases` clause are wild (i.e., `*`)
-then the proof of termination will be skipped.
+Loops and compiled methods (but not functions and not ghost methods,
+including lemmas) can be specified to be possibly non-terminating.
+This is done by declaring the method or loop with `decreases *`, which
+causes the proof of termination to be skipped. If a `*` is present
+in a `decreases` clause, no other expressions are allowed in the
+`decreases` clause. A method that contains a possibly non-terminating
+loop or a call to a possibly non-terminating method must itself be
+declared as possibly non-terminating.
 
 Termination metrics in Dafny, which are declared by `decreases` clauses,
 are lexicographic tuples of expressions. At each recursive (or mutually
@@ -374,7 +380,8 @@ function to read anything. In many cases, and in particular in all cases
 where the function is defined recursively, this makes it next to
 impossible to make any use of the function. Nevertheless, as an
 experimental feature, the language allows it (and it is sound).
-Note that a `*` makes the rest of the frame expression irrelevant.
+If a `reads` clause uses `*`, then the `reads` clause is not allowed to
+mention anything else (since anything else would be irrelevant, anyhow).
 
 A `reads` clause specifies the set of memory locations that a function,
 lambda, or iterator may read. If more than one `reads` clause is given


### PR DESCRIPTION
Disallow `decreases *` on ghost methods.
Disallow duplicate `*`s in `decreases` and `reads` clauses.
Fix crash in parsing disallowed `decreases`.

Fixes #1172 