### PR TITLE
Upgrade to kramdown 2.3.1

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.3)
       jemoji (= 0.12.0)
-      kramdown (= 2.3.0)
+      kramdown (>= 2.3.1)
       kramdown-parser-gfm (= 1.1.0)
       liquid (= 4.0.3)
       mercenary (~> 0.3)
@@ -195,7 +195,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    kramdown (2.3.0)
+    kramdown (>= 2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -260,7 +260,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages (~> 209)
   jekyll-numbered-headings
-  kramdown (>= 2.3.0)
+  kramdown (>= 2.3.1)
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data


### PR DESCRIPTION
To fix vulnerabilities in older versions of kramdown