### PR TITLE
feat: Let any type with member refine its members

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Dafny
 
       if (d is OpaqueTypeDecl) {
         var dd = (OpaqueTypeDecl)d;
-        return new OpaqueTypeDecl(Tok(dd.tok), dd.Name, m, CloneTPChar(dd.TheType.Characteristics), dd.TypeArgs.ConvertAll(CloneTypeParam), dd.Members.ConvertAll(CloneMember), CloneAttributes(dd.Attributes));
+        return new OpaqueTypeDecl(Tok(dd.tok), dd.Name, m, CloneTPChar(dd.TheType.Characteristics), dd.TypeArgs.ConvertAll(CloneTypeParam), dd.Members.ConvertAll(CloneMember), CloneAttributes(dd.Attributes), dd.IsRefining);
       } else if (d is SubsetTypeDecl) {
         Contract.Assume(!(d is NonNullTypeDecl));  // don't clone the non-null type declaration; close the class, which will create a new non-null type declaration
         var dd = (SubsetTypeDecl)d;
@@ -925,7 +925,7 @@ namespace Microsoft.Dafny
         var tps = d.TypeArgs.ConvertAll(CloneTypeParam);
         var characteristics = TypeParameter.GetExplicitCharacteristics(d);
         var members = based is TopLevelDeclWithMembers tm ? tm.Members : new List<MemberDecl>();
-        var otd = new OpaqueTypeDecl(Tok(d.tok), d.Name, m, characteristics, tps, members, CloneAttributes(d.Attributes));
+        var otd = new OpaqueTypeDecl(Tok(d.tok), d.Name, m, characteristics, tps, members, CloneAttributes(d.Attributes), d.IsRefining);
         based = otd;
         if (d is ClassDecl) {
           reverseMap.Add(based, ((ClassDecl)d).NonNullTypeDecl);

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1356,6 +1356,7 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
      Expression witness = null;
      var kind = "opaque type";
      var members = new List<MemberDecl>();
+     var isRefining = false;
   .)
   "type"
   { Attribute<ref attrs> }
@@ -1387,6 +1388,8 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
          kind = "type synonym";
       .)
     )
+  | ellipsis                               (. isRefining = true; .)
+    [ TypeMembers<module, members> ]
   | TypeMembers<module, members>
   ]
   (. if (td == null) {
@@ -1394,7 +1397,7 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
          // opaque type declarations at the very outermost program scope get an automatic (!new)
          characteristics.ContainsNoReferenceTypes = true;
        }
-       td = new OpaqueTypeDecl(id, id.val, module, characteristics, typeArgs, members, attrs);
+       td = new OpaqueTypeDecl(id, id.val, module, characteristics, typeArgs, members, attrs, isRefining);
      }
   .)
   (. CheckDeclModifiers(dmod, kind, AllowedDeclModifiers.None); .)

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -5484,8 +5484,8 @@ namespace Microsoft.Dafny {
       Contract.Invariant(TheType != null && Name == TheType.Name);
     }
 
-    public OpaqueTypeDecl(IToken tok, string name, ModuleDefinition module, TypeParameter.TypeParameterCharacteristics characteristics, List<TypeParameter> typeArgs, List<MemberDecl> members, Attributes attributes)
-      : base(tok, name, module, typeArgs, members, attributes, false) {
+    public OpaqueTypeDecl(IToken tok, string name, ModuleDefinition module, TypeParameter.TypeParameterCharacteristics characteristics, List<TypeParameter> typeArgs, List<MemberDecl> members, Attributes attributes, bool isRefining)
+      : base(tok, name, module, typeArgs, members, attributes, isRefining) {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
       Contract.Requires(module != null);

--- a/Source/Dafny/RefinementTransformer.cs
+++ b/Source/Dafny/RefinementTransformer.cs
@@ -145,8 +145,7 @@ namespace Microsoft.Dafny
           m.TopLevelDecls.Add(refinementCloner.CloneDeclaration(d, m));
         } else {
           var nw = m.TopLevelDecls[index];
-          if (d.Name == "_default" || m.TopLevelDecls[index].IsRefining
-                                   || d is OpaqueTypeDecl) {
+          if (d.Name == "_default" || nw.IsRefining || d is OpaqueTypeDecl) {
             MergeTopLevelDecls(m, nw, d, index);
           } else if (d is TypeSynonymDecl) {
             reporter.Error(MessageSource.RefinementTransformer, nw.tok, $"module {m.Name} may not redeclare a non-opaque type name {d.Name} from module {m.RefinementQId.ToString()}, even with the same type, unless refining (...)");
@@ -161,7 +160,7 @@ namespace Microsoft.Dafny
       var prevTopLevelDecls = RefinedSig.TopLevels.Values;
       foreach (var d in prevTopLevelDecls) {
         int index;
-        if (!processedDecl.Contains(d.Name) && (declaredNames.TryGetValue(d.Name, out index))) {
+        if (!processedDecl.Contains(d.Name) && declaredNames.TryGetValue(d.Name, out index)) {
           // if it is redefined, we need to merge them.
           var nw = m.TopLevelDecls[index];
           MergeTopLevelDecls(m, nw, d, index);
@@ -282,9 +281,7 @@ namespace Microsoft.Dafny
             "a class declaration ({0}) in a refining module cannot replace a different kind of declaration in the refinement base",
             nw.Name);
         }
-      } else if (nw is TypeSynonymDecl && d is TypeSynonymDecl
-                                       && ((TypeSynonymDecl)nw).Rhs != null
-                                       && ((TypeSynonymDecl)d).Rhs != null) {
+      } else if (nw is TypeSynonymDecl && d is TypeSynonymDecl && ((TypeSynonymDecl)nw).Rhs != null && ((TypeSynonymDecl)d).Rhs != null) {
         reporter.Error(MessageSource.RefinementTransformer, d,
           "a type ({0}) in a refining module may not replace an already defined type (even with the same value)",
           d.Name);

--- a/Test/dafny0/EqualityTypes.dfy.expect
+++ b/Test/dafny0/EqualityTypes.dfy.expect
@@ -1,7 +1,7 @@
 EqualityTypes.dfy(34,13): Error: a type declaration that requires equality support cannot be replaced by a codatatype
 EqualityTypes.dfy(35,11): Error: type 'Y', which does not support equality, is used to refine an opaque type with equality support
-EqualityTypes.dfy(40,11): Error: type 'X' is declared with a different number of type parameters (1 instead of 0) than the corresponding type in the module it refines
-EqualityTypes.dfy(41,8): Error: type 'Y' is declared with a different number of type parameters (1 instead of 0) than the corresponding type in the module it refines
+EqualityTypes.dfy(40,11): Error: datatype 'X' is declared with a different number of type parameters (1 instead of 0) than the corresponding datatype in the module it refines
+EqualityTypes.dfy(41,8): Error: class 'Y' is declared with a different number of type parameters (1 instead of 0) than the corresponding class in the module it refines
 EqualityTypes.dfy(45,11): Error: type 'X', which does not support equality, is used to refine an opaque type with equality support
 EqualityTypes.dfy(46,11): Error: type 'Y', which does not support equality, is used to refine an opaque type with equality support
 EqualityTypes.dfy(66,7): Error: == can only be applied to expressions of types that support equality (got Dt<T>)

--- a/Test/dafny0/Modules0.dfy.expect
+++ b/Test/dafny0/Modules0.dfy.expect
@@ -35,5 +35,5 @@ Modules0.dfy(323,10): Error: new can be applied only to class types (got Q_Imp.L
 Modules0.dfy(324,30): Error: member 'Create' does not exist in class 'Klassy'
 Modules0.dfy(324,10): Error: when allocating an object of type 'Klassy', one of its constructor methods must be called
 Modules0.dfy(318,13): Error: arguments must have comparable types (got Q_Imp.Node and Node)
-Modules0.dfy(349,11): Error: a datatype declaration (T) in a refinement module can only replace an opaque type declaration
+Modules0.dfy(349,11): Error: a datatype declaration (T) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
 35 resolution/type errors detected in Modules0.dfy

--- a/Test/dafny0/RefinementErrors.dfy
+++ b/Test/dafny0/RefinementErrors.dfy
@@ -118,14 +118,14 @@ module OrigB {
   type T<A,B(0),C(00),D,E(0),F(00),G,H(0),I(00)>
 }
 module TpB refines OrigB {
-  type T<P,Q,R,U(0),V(0),W(0),X(00),Y(00),Z(00)>  // error (x6): change in (0)/(00) requirements
+  type T<A,B,C,D(0),E(0),F(0),G(00),H(00),I(00)>  // error (x6): change in (0)/(00) requirements
 }
 
 module OrigC {
   type T<A,B(==)>
 }
 module TpC refines OrigC {
-  type T<C(==),D>  // error (x2): change in (==) requirement
+  type T<A(==),B>  // error (x2): change in (==) requirement
 }
 
 module OrigD {

--- a/Test/dafny0/RefinementErrors.dfy.expect
+++ b/Test/dafny0/RefinementErrors.dfy.expect
@@ -10,15 +10,15 @@ RefinementErrors.dfy(39,23): Error: the type of parameter 'z' is different from 
 RefinementErrors.dfy(40,9): Error: there is a difference in name of parameter 3 ('k' versus 'b') of function F compared to corresponding function in the module it refines
 RefinementErrors.dfy(57,20): Error: a function can be changed into a function method in a refining module only if the function has not yet been given a body: G
 RefinementErrors.dfy(94,10): Error: refinement method cannot assign to a field defined in parent module ('a')
-RefinementErrors.dfy(114,7): Error: type 'T' is declared with a different number of type parameters (3 instead of 2) than the corresponding type in the module it refines
-RefinementErrors.dfy(121,11): Error: type parameter 'Q' is not allowed to change the requirement of supporting auto-initialization
-RefinementErrors.dfy(121,13): Error: type parameter 'R' is not allowed to change the requirement of being nonempty
-RefinementErrors.dfy(121,15): Error: type parameter 'U' is not allowed to change the requirement of supporting auto-initialization
-RefinementErrors.dfy(121,25): Error: type parameter 'W' is not allowed to change the requirement of supporting auto-initialization
-RefinementErrors.dfy(121,30): Error: type parameter 'X' is not allowed to change the requirement of being nonempty
-RefinementErrors.dfy(121,36): Error: type parameter 'Y' is not allowed to change the requirement of supporting auto-initialization
-RefinementErrors.dfy(128,9): Error: type parameter 'C' is not allowed to change the requirement of supporting equality
-RefinementErrors.dfy(128,15): Error: type parameter 'D' is not allowed to change the requirement of supporting equality
+RefinementErrors.dfy(114,7): Error: opaque type 'T' is declared with a different number of type parameters (3 instead of 2) than the corresponding opaque type in the module it refines
+RefinementErrors.dfy(121,11): Error: type parameter 'B' is not allowed to change the requirement of supporting auto-initialization
+RefinementErrors.dfy(121,13): Error: type parameter 'C' is not allowed to change the requirement of being nonempty
+RefinementErrors.dfy(121,15): Error: type parameter 'D' is not allowed to change the requirement of supporting auto-initialization
+RefinementErrors.dfy(121,25): Error: type parameter 'F' is not allowed to change the requirement of supporting auto-initialization
+RefinementErrors.dfy(121,30): Error: type parameter 'G' is not allowed to change the requirement of being nonempty
+RefinementErrors.dfy(121,36): Error: type parameter 'H' is not allowed to change the requirement of supporting auto-initialization
+RefinementErrors.dfy(128,9): Error: type parameter 'A' is not allowed to change the requirement of supporting equality
+RefinementErrors.dfy(128,15): Error: type parameter 'B' is not allowed to change the requirement of supporting equality
 RefinementErrors.dfy(135,10): Error: type parameter 'A' is not allowed to change variance (here, from '+' to '=')
 RefinementErrors.dfy(135,13): Error: type parameter 'B' is not allowed to change variance (here, from '=' to '-')
 RefinementErrors.dfy(135,16): Error: type parameter 'C' is not allowed to change variance (here, from '-' to '+')

--- a/Test/dafny0/TypeInstantiations.dfy
+++ b/Test/dafny0/TypeInstantiations.dfy
@@ -49,12 +49,12 @@ module M1 refines M0 {
   type O<U'(==)> = List<U'>  // error: change in (==)
   type P<U'> = List<U'>  // fine
   class R { }  // error: wrong number of type arguments
-  class S<T> { }
+  class S<T> { }  // error: not allowed to rename type parameter (U -> T)
   class T<T> { }  // error: wrong number of type arguments
 
   type TP0<E0>  // error: wrong number of type arguments
   type TP1  // error: wrong number of type arguments
-  type TP2<E0,E1>
+  type TP2<Y0, E1>  // error: not allowed to rename type parameter (Y1 -> E1)
 }
 
 module ListLibrary {

--- a/Test/dafny0/TypeInstantiations.dfy.expect
+++ b/Test/dafny0/TypeInstantiations.dfy.expect
@@ -1,4 +1,4 @@
-TypeInstantiations.dfy(33,7): Error: module M1 may not redeclare a non-opaque type name B from module M0, even with the same type, unless refining (...)
+TypeInstantiations.dfy(33,7): Error: to redeclare and refine declaration 'B' from module 'M0', you must use the refining (`...`) notation
 TypeInstantiations.dfy(36,13): Error: a type declaration that requires equality support cannot be replaced by a codatatype
 TypeInstantiations.dfy(40,7): Error: type 'G' is declared with a different number of type parameters (1 instead of 0) than the corresponding type in the module it refines
 TypeInstantiations.dfy(41,7): Error: type 'H' is declared with a different number of type parameters (1 instead of 2) than the corresponding type in the module it refines
@@ -7,10 +7,12 @@ TypeInstantiations.dfy(44,10): Error: type parameter 'W' is not allowed to chang
 TypeInstantiations.dfy(45,10): Error: type parameter 'W' is not allowed to change the requirement of supporting equality
 TypeInstantiations.dfy(46,9): Error: type parameter 'V' is not allowed to change the requirement of supporting equality
 TypeInstantiations.dfy(49,9): Error: type parameter 'U'' is not allowed to change the requirement of supporting equality
-TypeInstantiations.dfy(51,8): Error: type 'R' is declared with a different number of type parameters (0 instead of 1) than the corresponding type in the module it refines
-TypeInstantiations.dfy(53,8): Error: type 'T' is declared with a different number of type parameters (1 instead of 0) than the corresponding type in the module it refines
-TypeInstantiations.dfy(55,7): Error: type 'TP0' is declared with a different number of type parameters (1 instead of 0) than the corresponding type in the module it refines
-TypeInstantiations.dfy(56,7): Error: type 'TP1' is declared with a different number of type parameters (0 instead of 1) than the corresponding type in the module it refines
+TypeInstantiations.dfy(51,8): Error: class 'R' is declared with a different number of type parameters (0 instead of 1) than the corresponding class in the module it refines
+TypeInstantiations.dfy(52,10): Error: type parameters are not allowed to be renamed from the names given in the class in the module being refined (expected 'U', found 'T')
+TypeInstantiations.dfy(53,8): Error: class 'T' is declared with a different number of type parameters (1 instead of 0) than the corresponding class in the module it refines
+TypeInstantiations.dfy(55,7): Error: opaque type 'TP0' is declared with a different number of type parameters (1 instead of 0) than the corresponding opaque type in the module it refines
+TypeInstantiations.dfy(56,7): Error: opaque type 'TP1' is declared with a different number of type parameters (0 instead of 1) than the corresponding opaque type in the module it refines
+TypeInstantiations.dfy(57,15): Error: type parameters are not allowed to be renamed from the names given in the opaque type in the module being refined (expected 'Y1', found 'E1')
 TypeInstantiations.dfy(34,11): Error: type 'C', which does not support equality, is used to refine an opaque type with equality support
 TypeInstantiations.dfy(35,7): Error: type 'D', which does not support equality, is used to refine an opaque type with equality support
 TypeInstantiations.dfy(48,7): Error: type 'N', which does not support equality, is used to refine an opaque type with equality support
@@ -25,4 +27,4 @@ TypeInstantiations.dfy(137,8): Error: the type of this variable is underspecifie
 TypeInstantiations.dfy(137,23): Error: type of type parameter could not be determined; please specify the type explicitly
 TypeInstantiations.dfy(137,23): Error: type parameter 'A' (inferred to be '?') in the function call to 'F' could not be determined
 TypeInstantiations.dfy(137,24): Error: the type of this expression is underspecified
-27 resolution/type errors detected in TypeInstantiations.dfy
+29 resolution/type errors detected in TypeInstantiations.dfy

--- a/Test/git-issues/git-issue-1180a.dfy
+++ b/Test/git-issues/git-issue-1180a.dfy
@@ -1,0 +1,235 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// resolution errors
+
+module BadRefiningIndications {
+  type Opaque ... // error: uses ... but there's nothing to refine
+  type Opaque' ... { } // error: uses ... but there's nothing to refine
+  datatype Datatype = ... Make(x: int) // error: uses ... but there's nothing to refine
+  codatatype Codatatype = ... Make(x: int) // error: uses ... but there's nothing to refine
+  newtype Newtype = ... int // error: uses ... but there's nothing to refine
+  class Class ... { } // error: uses ... but there's nothing to refine
+  trait Trait ... { } // error: uses ... but there's nothing to refine
+}
+
+module EmptyRefinementParent { }
+
+module MoreBadRefiningIndications refines EmptyRefinementParent {
+  type Opaque ... // error: uses ... but there's nothing to refine
+  type Opaque' ... { } // error: uses ... but there's nothing to refine
+  datatype Datatype = ... Make(x: int) // error: uses ... but there's nothing to refine
+  codatatype Codatatype = ... Make(x: int) // error: uses ... but there's nothing to refine
+  newtype Newtype = ... int // error: uses ... but there's nothing to refine
+  class Class ... { } // error: uses ... but there's nothing to refine
+  trait Trait ... { } // error: uses ... but there's nothing to refine
+}
+
+module StartingFromOpaqueType {
+  abstract module A {
+    type Ty<X> {
+      const c: nat
+      function method F(x: nat): nat
+      method M(x: nat) returns (r: nat)
+    }
+  }
+  module OpaqueType refines A {
+    type Ty<X, Y> ... { // error: wrong number of type parameters
+      function method F<Z>(x: nat): Z // error (x2): wrong number of type parametes, and wrong result type
+      method M<Z>(x: nat) returns (r: Z) { r := c; } // error (x2): wrong number of type parameters, and wrong out-parameter type
+    }
+  }
+  module Datatype refines A {
+    datatype Ty = Make(x: int) { // error: wrong number of type parameters
+      function method F<Z>(x: nat): Z // error (x2): wrong number of type parametes, and wrong result type
+      method M<Z>(x: nat) returns (r: Z) { r := c; } // error (x2): wrong number of type parametes, and wrong out-parameter type
+    }
+  }
+  module Datatype' refines A {
+    datatype Ty<X> = Make(c: int, F: int, M: int) // error (x3): members c,F,M already declared (reported on lines 31-33)
+  }
+  module Codatatype refines A {
+    codatatype Ty = Make(w: int) { // error: wrong number of type parameters
+      function method F<Z>(x: nat): Z // error (x2): wrong number of type parametes, and wrong result type
+      method M<Z>(x: nat) returns (r: Z) { r := c; } // error (x2): wrong number of type parametes, and wrong out-parameter type
+    }
+  }
+  module Codatatype' refines A {
+    codatatype Ty<X> = Make(c: int, F: int, M: int) // error (x3): members c,F,M already declared (reported on lines 31-33)
+  }
+  module Newtype refines A {
+    newtype Ty = int { // error: wrong number of type parameters
+      function method F<Z>(x: nat): Z // error (x2): wrong number of type parametes, and wrong result type
+      method M<Z>(x: nat) returns (r: Z) { r := c; } // error (x2): wrong number of type parametes, and wrong out-parameter type
+    }
+  }
+  module Class refines A {
+    class Ty { // error: wrong number of type parameters
+      function method F<Z>(x: nat): Z // error (x2): wrong number of type parametes, and wrong result type
+      method M<Z>(x: nat) returns (r: Z) { r := c; } // error (x2): wrong number of type parametes, and wrong out-parameter type
+    }
+  }
+  module Trait refines A {
+    trait Ty { // error: wrong number of type parameters
+      function method F<Z>(x: nat): Z // error (x2): wrong number of type parametes, and wrong result type
+      method M<Z>(x: nat) returns (r: Z) { r := c; } // error (x2): wrong number of type parametes, and wrong out-parameter type
+    }
+  }
+  module TypeSynonym refines A {
+    type Ty = int  // error: not allowed, since the original type has members
+  }
+}
+
+module StartingFromDatatype {
+  abstract module A {
+    datatype Ty = Make(w: int) {
+      const c: nat
+      function method F(x: nat): nat
+      method M(x: nat) returns (r: nat)
+    }
+  }
+  module OpaqueType refines A {
+    type Ty ... // error: cannot refine a datatype with an opaque type
+  }
+  module OpaqueType' refines A {
+    type Ty ... { } // error: cannot refine a datatype with an opaque type
+  }
+  module Datatype refines A {
+    datatype Ty = ... Make(w: int) {
+    }
+  }
+  module Codatatype refines A {
+    codatatype Ty = ... Make(w: int) // error: cannot refine a datatype with a codatatype
+  }
+  module Newtype refines A {
+    newtype Ty = ... int { } // error: cannot refine a datatype with a newtype
+  }
+  module Class refines A {
+    class Ty ... { } // error: cannot refine a datatype with a class
+  }
+  module Trait refines A {
+    trait Ty ... { } // error: cannot refine a datatype with a trait
+  }
+  module TypeSynonym refines A {
+    type Ty = int  // error: cannot refine a datatype with a type synonym
+  }
+}
+
+module StartingFromCodatatype {
+  abstract module A {
+    codatatype Ty = Make(w: int) {
+      const c: nat
+      function method F(x: nat): nat
+      method M(x: nat) returns (r: nat)
+    }
+  }
+  module OpaqueType refines A {
+    type Ty ... // error: cannot refine a codatatype with an opaque type
+  }
+  module Datatype refines A {
+    datatype Ty = ... Make(w: int) // error: cannot refine a codatatype with a datatype
+  }
+  module Codatatype refines A {
+    codatatype Ty = ... Make(w: int) {
+    }
+  }
+  module Newtype refines A {
+    newtype Ty = ... int { } // error: cannot refine a codatatype with a newtype
+  }
+  module Class refines A {
+    class Ty ... { } // error: cannot refine a codatatype with a class
+  }
+  module Trait refines A {
+    trait Ty ... { } // error: cannot refine a codatatype with a trait
+  }
+  module TypeSynonym refines A {
+    type Ty = int  // error: cannot refine a codatatype with a type synonym
+  }
+}
+
+module StartingFromNewtype {
+  abstract module A {
+    newtype Ty = int {
+      const c: nat
+      function method F(x: nat): nat
+      method M(x: nat) returns (r: nat)
+    }
+  }
+  module OpaqueType refines A {
+    type Ty ... // error: cannot refine a newtype with an opaque type
+  }
+  module Datatype refines A {
+    datatype Ty = ... Make(w: int) // error: cannot refine a newtype with a datatype
+  }
+  module Codatatype refines A {
+    codatatype Ty = ... Make(w: int) { // error: cannot refine a newtype with a codatatype
+    }
+  }
+  module Class refines A {
+    class Ty ... { } // error: cannot refine a newtype with a class
+  }
+  module Trait refines A {
+    trait Ty ... { } // error: cannot refine a newtype with a trait
+  }
+  module TypeSynonym refines A {
+    type Ty = int  // error: cannot refine a newtype with a type synonym
+  }
+}
+
+module StartingFromClass {
+  abstract module A {
+    class Ty {
+      const c: nat
+      function method F(x: nat): nat
+      method M(x: nat) returns (r: nat)
+    }
+  }
+  module OpaqueType refines A {
+    type Ty ... // error: cannot refine a class with an opaque type
+  }
+  module Datatype refines A {
+    datatype Ty = ... Make(w: int) // error: cannot refine a class with a datatype
+  }
+  module Codatatype refines A {
+    codatatype Ty = ... Make(w: int) { // error: cannot refine a class with a codatatype
+    }
+  }
+  module Newtype refines A {
+    newtype Ty = ... int { } // error: cannot refine a class with a newtype
+  }
+  module Trait refines A {
+    trait Ty ... { } // error: cannot refine a class with a trait
+  }
+  module TypeSynonym refines A {
+    type Ty = int  // error: cannot refine a class with a type synonym
+  }
+}
+
+module StartingFromTrait {
+  abstract module A {
+    trait Ty {
+      const c: nat
+      function method F(x: nat): nat
+      method M(x: nat) returns (r: nat)
+    }
+  }
+  module OpaqueType refines A {
+    type Ty ... // error: cannot refine a trait with an opaque type
+  }
+  module Datatype refines A {
+    datatype Ty = ... Make(w: int) // error: cannot refine a trait with a datatype
+  }
+  module Codatatype refines A {
+    codatatype Ty = ... Make(w: int) { // error: cannot refine a trait with a codatatype
+    }
+  }
+  module Newtype refines A {
+    newtype Ty = ... int { } // error: cannot refine a trait with a newtype
+  }
+  module Class refines A {
+    class Ty ... { } // error: cannot refine a trait with a class
+  }
+  module TypeSynonym refines A {
+    type Ty = int  // error: cannot refine a trait with a type synonym
+  }
+}

--- a/Test/git-issues/git-issue-1180a.dfy.expect
+++ b/Test/git-issues/git-issue-1180a.dfy.expect
@@ -1,0 +1,83 @@
+git-issue-1180a.dfy(7,7): Error: declaration 'Opaque' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(8,7): Error: declaration 'Opaque'' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(9,11): Error: declaration 'Datatype' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(10,13): Error: declaration 'Codatatype' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(11,10): Error: declaration 'Newtype' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(12,8): Error: declaration 'Class' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(13,8): Error: declaration 'Trait' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(19,7): Error: declaration 'Opaque' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(20,7): Error: declaration 'Opaque'' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(21,11): Error: declaration 'Datatype' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(22,13): Error: declaration 'Codatatype' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(23,10): Error: declaration 'Newtype' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(24,8): Error: declaration 'Class' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(25,8): Error: declaration 'Trait' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(37,9): Error: opaque type 'Ty' is declared with a different number of type parameters (2 instead of 1) than the corresponding opaque type in the module it refines
+git-issue-1180a.dfy(38,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
+git-issue-1180a.dfy(38,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
+git-issue-1180a.dfy(39,13): Error: method 'M' is declared with a different number of type parameters (1 instead of 0) than the corresponding method in the module it refines
+git-issue-1180a.dfy(39,35): Error: the type of out-parameter 'r' is different from the type of the same out-parameter in the corresponding method in the module it refines ('Z' instead of 'nat')
+git-issue-1180a.dfy(43,13): Error: datatype 'Ty' is declared with a different number of type parameters (0 instead of 1) than the corresponding datatype in the module it refines
+git-issue-1180a.dfy(44,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
+git-issue-1180a.dfy(44,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
+git-issue-1180a.dfy(45,13): Error: method 'M' is declared with a different number of type parameters (1 instead of 0) than the corresponding method in the module it refines
+git-issue-1180a.dfy(45,35): Error: the type of out-parameter 'r' is different from the type of the same out-parameter in the corresponding method in the module it refines ('Z' instead of 'nat')
+git-issue-1180a.dfy[Datatype'](31,12): Error: Duplicate member name: c
+git-issue-1180a.dfy[Datatype'](32,22): Error: Duplicate member name: F
+git-issue-1180a.dfy[Datatype'](33,13): Error: Duplicate member name: M
+git-issue-1180a.dfy(52,15): Error: codatatype 'Ty' is declared with a different number of type parameters (0 instead of 1) than the corresponding codatatype in the module it refines
+git-issue-1180a.dfy(53,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
+git-issue-1180a.dfy(53,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
+git-issue-1180a.dfy(54,13): Error: method 'M' is declared with a different number of type parameters (1 instead of 0) than the corresponding method in the module it refines
+git-issue-1180a.dfy(54,35): Error: the type of out-parameter 'r' is different from the type of the same out-parameter in the corresponding method in the module it refines ('Z' instead of 'nat')
+git-issue-1180a.dfy[Codatatype'](31,12): Error: Duplicate member name: c
+git-issue-1180a.dfy[Codatatype'](32,22): Error: Duplicate member name: F
+git-issue-1180a.dfy[Codatatype'](33,13): Error: Duplicate member name: M
+git-issue-1180a.dfy(61,12): Error: newtype 'Ty' is declared with a different number of type parameters (0 instead of 1) than the corresponding newtype in the module it refines
+git-issue-1180a.dfy(62,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
+git-issue-1180a.dfy(62,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
+git-issue-1180a.dfy(63,13): Error: method 'M' is declared with a different number of type parameters (1 instead of 0) than the corresponding method in the module it refines
+git-issue-1180a.dfy(63,35): Error: the type of out-parameter 'r' is different from the type of the same out-parameter in the corresponding method in the module it refines ('Z' instead of 'nat')
+git-issue-1180a.dfy(67,10): Error: class 'Ty' is declared with a different number of type parameters (0 instead of 1) than the corresponding class in the module it refines
+git-issue-1180a.dfy(68,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
+git-issue-1180a.dfy(68,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
+git-issue-1180a.dfy(69,13): Error: method 'M' is declared with a different number of type parameters (1 instead of 0) than the corresponding method in the module it refines
+git-issue-1180a.dfy(69,35): Error: the type of out-parameter 'r' is different from the type of the same out-parameter in the corresponding method in the module it refines ('Z' instead of 'nat')
+git-issue-1180a.dfy(73,10): Error: trait 'Ty' is declared with a different number of type parameters (0 instead of 1) than the corresponding trait in the module it refines
+git-issue-1180a.dfy(74,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
+git-issue-1180a.dfy(74,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
+git-issue-1180a.dfy(75,13): Error: method 'M' is declared with a different number of type parameters (1 instead of 0) than the corresponding method in the module it refines
+git-issue-1180a.dfy(75,35): Error: the type of out-parameter 'r' is different from the type of the same out-parameter in the corresponding method in the module it refines ('Z' instead of 'nat')
+git-issue-1180a.dfy(79,9): Error: a type synonym (Ty) cannot declare members, so it cannot refine an opaque type with members
+git-issue-1180a.dfy(92,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
+git-issue-1180a.dfy(95,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
+git-issue-1180a.dfy(102,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(105,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(108,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
+git-issue-1180a.dfy(111,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
+git-issue-1180a.dfy(114,9): Error: a type synonym (Ty) is not allowed to replace a datatype from the refined module (A), even if it denotes the same type
+git-issue-1180a.dfy(127,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
+git-issue-1180a.dfy(130,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(137,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(140,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
+git-issue-1180a.dfy(143,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
+git-issue-1180a.dfy(146,9): Error: a type synonym (Ty) is not allowed to replace a codatatype from the refined module (A), even if it denotes the same type
+git-issue-1180a.dfy(159,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
+git-issue-1180a.dfy(162,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(165,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(169,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
+git-issue-1180a.dfy(172,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
+git-issue-1180a.dfy(175,9): Error: a type synonym (Ty) is not allowed to replace a newtype from the refined module (A), even if it denotes the same type
+git-issue-1180a.dfy(188,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
+git-issue-1180a.dfy(191,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(194,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(198,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(201,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
+git-issue-1180a.dfy(204,9): Error: a type synonym (Ty) is not allowed to replace a class from the refined module (A), even if it denotes the same type
+git-issue-1180a.dfy(217,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
+git-issue-1180a.dfy(220,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(223,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(227,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(230,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
+git-issue-1180a.dfy(233,9): Error: a type synonym (Ty) is not allowed to replace a trait from the refined module (A), even if it denotes the same type
+82 resolution/type errors detected in git-issue-1180a.dfy

--- a/Test/git-issues/git-issue-1180b.dfy
+++ b/Test/git-issues/git-issue-1180b.dfy
@@ -1,0 +1,147 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// verification errors
+
+module StartingFromOpaqueType {
+  abstract module A {
+    type Ty {
+      const c: nat
+      function method F(x: nat): nat
+        requires x != 7
+        ensures F(x) == c
+      method M(x: nat) returns (r: nat)
+        requires x != 9
+        ensures r == x
+    }
+    method Caller(t: Ty, x: int) {
+      var c := t.c;
+      if c != 9 {
+        var r := t.M(t.c);
+        var u := t.F(2 * c);
+        assert r == u;
+      }
+    }
+  }
+  module OpaqueType refines A {
+    type Ty ... {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+  module Datatype refines A {
+    datatype Ty = Make(w: int) {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+  module Codatatype refines A {
+    codatatype Ty = Make(w: int) {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+  module Newtype refines A {
+    newtype Ty = int {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+  module Class refines A {
+    class Ty {
+      constructor () {
+        c := 65;
+      }
+      var q: int
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+  module Trait refines A {
+    trait Ty {
+      var q: int
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+}
+
+module StartingFromDatatype {
+  abstract module A {
+    datatype Ty = Make(w: int) {
+      const c: nat
+      function method F(x: nat): nat
+        requires x != 7
+        ensures F(x) == c
+      method M(x: nat) returns (r: nat)
+        requires x != 9
+        ensures r == x
+    }
+  }
+  module Datatype refines A {
+    datatype Ty = ... Make(w: int) {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+}
+
+module StartingFromNewtype {
+  abstract module A {
+    newtype Ty = int {
+      const c: nat
+      function method F(x: nat): nat
+        requires x != 7
+        ensures F(x) == c
+      method M(x: nat) returns (r: nat)
+        requires x != 9
+        ensures r == x
+    }
+  }
+  module Newtype refines A {
+    newtype Ty = ... int {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+}
+
+module StartingFromClass {
+  abstract module A {
+    class Ty {
+      const c: nat
+      function method F(x: nat): nat
+        requires x != 7
+        ensures F(x) == c
+      method M(x: nat) returns (r: nat)
+        requires x != 9
+        ensures r == x
+    }
+  }
+  module Newtype refines A {
+    class Ty ... {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+}
+
+module StartingFromTrait {
+  abstract module A {
+    trait Ty {
+      const c: nat
+      function method F(x: nat): nat
+        requires x != 7
+        ensures F(x) == c
+      method M(x: nat) returns (r: nat)
+        requires x != 9
+        ensures r == x
+    }
+  }
+  module Newtype refines A {
+    trait Ty ... {
+      function method F(x: nat): nat { x } // error: postcondition violation
+      method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
+    }
+  }
+}

--- a/Test/git-issues/git-issue-1180b.dfy.expect
+++ b/Test/git-issues/git-issue-1180b.dfy.expect
@@ -1,0 +1,92 @@
+git-issue-1180b.dfy(28,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(29,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(34,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(35,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(40,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(41,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(46,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(47,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(56,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(57,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(63,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(64,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(83,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(75,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(84,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(78,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(103,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(95,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(104,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(98,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(123,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(115,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(124,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(118,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+git-issue-1180b.dfy(143,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(135,21): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+    (0,0): anon4_Else
+git-issue-1180b.dfy(144,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(138,18): Related location: This is the postcondition that might not hold.
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 7 verified, 20 errors

--- a/Test/git-issues/git-issue-288.dfy.expect
+++ b/Test/git-issues/git-issue-288.dfy.expect
@@ -1,2 +1,2 @@
-git-issue-288.dfy(9,7): Error: module B may not redeclare a non-opaque type name T from module A, even with the same type, unless refining (...)
+git-issue-288.dfy(9,7): Error: a type synonym (T) is not allowed to replace a type synonym from the refined module (A), even if it denotes the same type
 1 resolution/type errors detected in git-issue-288.dfy

--- a/Test/git-issues/git-issue-852.dfy
+++ b/Test/git-issues/git-issue-852.dfy
@@ -7,9 +7,26 @@ abstract module M0 {
   }
 }
 
-module Q refines M0 {
-  newtype T = ... n:nat | true {
+module Q0 refines M0 {
+  newtype T = n:nat | true {  // error: needs ...
     predicate p() {true}
   }
 }
 
+module Q1 refines M0 {
+  newtype T = ... n:nat | true {
+    predicate p() {true}  // error: p() already has a body in M0
+  }
+}
+
+module Q2 refines M0 {
+  newtype T = ... n:nat | true {
+    predicate p... {true}  // error: p() already has a body in M0
+  }
+}
+
+module Q3 refines M0 {
+  newtype T = ... n:nat | true {
+    predicate p...  // allowed (but what's the point?)
+  }
+}

--- a/Test/git-issues/git-issue-852.dfy.expect
+++ b/Test/git-issues/git-issue-852.dfy.expect
@@ -1,2 +1,4 @@
-git-issue-852.dfy(11,10): Error: a newtype declaration (T) in a refinement module can only replace an opaque type declaration
-1 resolution/type errors detected in git-issue-852.dfy
+git-issue-852.dfy(11,10): Error: to redeclare and refine declaration 'T' from module 'M0', you must use the refining (`...`) notation
+git-issue-852.dfy(18,14): Error: a refining predicate is not allowed to extend/change the body
+git-issue-852.dfy(24,14): Error: a refining predicate is not allowed to extend/change the body
+3 resolution/type errors detected in git-issue-852.dfy

--- a/Test/git-issues/git-issue-864.dfy.expect
+++ b/Test/git-issues/git-issue-864.dfy.expect
@@ -1,3 +1,3 @@
-git-issue-864.dfy(13,8): Error: module M2 redeclares a name T1 from module M1 without indicating refining
+git-issue-864.dfy(13,8): Error: to redeclare and refine declaration 'T1' from module 'M1', you must use the refining (`...`) notation
 git-issue-864.dfy(14,19): Error: unresolved identifier: b
 2 resolution/type errors detected in git-issue-864.dfy

--- a/Test/git-issues/git-issue-981.dfy.expect
+++ b/Test/git-issues/git-issue-981.dfy.expect
@@ -1,5 +1,5 @@
-git-issue-981.dfy(37,9): Error: module BBB redeclares a name E from module AAA without indicating refining
-git-issue-981.dfy(39,9): Error: module BBB redeclares a name M from module AAA without indicating refining
+git-issue-981.dfy(37,9): Error: to redeclare and refine declaration 'E' from module 'AAA', you must use the refining (`...`) notation
+git-issue-981.dfy(39,9): Error: to redeclare and refine declaration 'M' from module 'AAA', you must use the refining (`...`) notation
 git-issue-981.dfy(45,12): Error: no export set 'AA' in module 'AA'
 git-issue-981.dfy(48,20): Error: AA must be an export of BB to be extended
 git-issue-981.dfy(62,19): Error: K must be an export of B to be extended


### PR DESCRIPTION
Also:
* Add many (but surely not yet all) missing refinement checks.
* Allow refining indication (`...`) for opaque types.
* Check for superfluous refining indications.
* Don’t allow type parameters to be renamed, not even for opaque types.
* Reword some error messages, trying to make them clearer.

Fixes #1180