### PR TITLE
fix: Initialize bound variable of let-such-that with placebo

### DIFF
--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -4474,7 +4474,7 @@ namespace Microsoft.Dafny {
           } else {
             var w = CreateIIFE1(0, e.Body.Type, e.Body.tok, "_let_dummy_" + GetUniqueAstNumber(e), wr);
             foreach (var bv in e.BoundVars) {
-              DeclareLocalVar(IdName(bv), bv.Type, bv.tok, false, DefaultValue(bv.Type, wr, bv.tok, true), w);
+              DeclareLocalVar(IdName(bv), bv.Type, bv.tok, false, PlaceboValue(bv.Type, wr, bv.tok, true), w);
             }
             TrAssignSuchThat(new List<IVariable>(e.BoundVars).ConvertAll(bv => (IVariable)bv), e.RHSs[0], e.Constraint_Bounds, e.tok.line, w, inLetExprBody);
             EmitReturnExpr(e.Body, e.Body.Type, true, w);

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -17656,7 +17656,13 @@ namespace Microsoft.Dafny
           MakeGhostAsNeeded(e.LHSs);
           return UsesSpecFeatures(e.Body);
         } else {
-          return true;  // let-such-that is always ghost
+          Contract.Assert(e.RHSs.Count == 1);
+          if (UsesSpecFeatures(e.RHSs[0])) {
+            foreach (var bv in e.BoundVars) {
+              bv.MakeGhost();
+            }
+          }
+          return UsesSpecFeatures(e.Body);
         }
       } else if (expr is QuantifierExpr) {
         var e = (QuantifierExpr)expr;

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -17655,7 +17655,6 @@ namespace Microsoft.Dafny
         if (e.Exact) {
           MakeGhostAsNeeded(e.LHSs);
           return UsesSpecFeatures(e.Body);
-          //return Contract.Exists(e.RHSs, ee => UsesSpecFeatures(ee)) || UsesSpecFeatures(e.Body);
         } else {
           return true;  // let-such-that is always ghost
         }

--- a/Test/dafny0/ResolutionErrors.dfy
+++ b/Test/dafny0/ResolutionErrors.dfy
@@ -3368,3 +3368,50 @@ module RelaxedAutoInitChecking {
     M(0, NoReferences<Good>());
   }
 }
+
+// --------------- let-such-that ghost regressions ------------------------------
+
+module LetSuchThatGhost {
+  predicate True<T>(t: T) { true }
+
+  function method F<T>(s: set<T>): int
+    requires s != {}
+  {
+    // once, the RHS for p was (bogusly) considered ghost, which made p ghost,
+    // which made this body illegal
+    var p :=
+      var e :| e in s;
+      true;
+    if p then 6 else 8
+  }
+
+  function method G<T>(s: set<T>): int
+    requires s != {}
+  {
+    // again, e and p are both non-ghost
+    var p :=
+      var e :| e in s;
+      e == e;
+    if p then 6 else 8
+  }
+
+  function method H<T>(s: set<T>): int
+    requires s != {}
+  {
+    // here, e is ghost, but p is still not
+    var p :=
+      var e :| e in s && True(e);
+      true;
+    if p then 6 else 8
+  }
+
+  function method I<T>(s: set<T>): int
+    requires s != {}
+  {
+    // here, e is ghost, and therefore so is p
+    var p :=
+      var e :| e in s && True(e);
+      e == e;
+    if p then 6 else 8  // error: p is ghost
+  }
+}

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -527,4 +527,5 @@ ResolutionErrors.dfy(3340,6): Error: type parameter (T) passed to function NoRef
 ResolutionErrors.dfy(3346,9): Error: type parameter (T) passed to function MustBeNonempty must support nonempty (got PossiblyEmpty)
 ResolutionErrors.dfy(3352,9): Error: type parameter (T) passed to function MustBeAutoInit must support auto-initialization (got PossiblyEmpty)
 ResolutionErrors.dfy(3367,9): Error: type parameter (T) passed to function NoReferences must support no references (got Class?)
-524 resolution/type errors detected in ResolutionErrors.dfy
+ResolutionErrors.dfy(3415,7): Error: ghost variables are allowed only in specification contexts
+525 resolution/type errors detected in ResolutionErrors.dfy

--- a/Test/git-issues/git-issue-1185.dfy
+++ b/Test/git-issues/git-issue-1185.dfy
@@ -1,0 +1,31 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+predicate method P(s: set)
+  requires s != {}
+{
+  // In the following line, the let-such-that is compiled by TrExprOpt
+  var e :| e in s;
+  e == e
+}
+
+function method F(s: set): int
+  requires s != {}
+{
+  var p :=
+    // In the following line, the let-such-that is compiled by TrExpr
+    var e :| e in s;
+    e == e;
+  if p then 6 else 8
+}
+
+method Main() {
+  var s := {12, 20};
+  var b := P(s);
+  var x := F(s);
+  print s, " ", b, " ", x, "\n";
+}

--- a/Test/git-issues/git-issue-1185.dfy.expect
+++ b/Test/git-issues/git-issue-1185.dfy.expect
@@ -1,0 +1,14 @@
+
+Dafny program verifier finished with 3 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+{12, 20} true 6
+
+Dafny program verifier did not attempt verification
+{20, 12} true 6
+
+Dafny program verifier did not attempt verification
+{12, 20} true 6
+
+Dafny program verifier did not attempt verification
+{12, 20} true 6


### PR DESCRIPTION
Additionally:

fix: computation of ghost determination for let-such-that expressions

Fixes #1185 