### PR TITLE
Exit, don't crash, upon underlying compiler failure

### DIFF
--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -2363,7 +2363,8 @@ namespace Microsoft.Dafny {
       }
       proc.WaitForExit();
       if (proc.ExitCode != 0) {
-        throw new Exception($"Error while compiling C++ files. Process exited with exit code {proc.ExitCode}");
+        outputWriter.WriteLine($"Error while compiling C++ files. Process exited with exit code {proc.ExitCode}");
+        return false;
       }
       return true;
     }
@@ -2389,7 +2390,8 @@ namespace Microsoft.Dafny {
       }
       proc.WaitForExit();
       if (proc.ExitCode != 0) {
-        throw new Exception($"Error while running C++ file {targetFilename}. Process exited with exit code {proc.ExitCode}");
+        outputWriter.WriteLine($"Error while running C++ file {targetFilename}. Process exited with exit code {proc.ExitCode}");
+        return false;
       }
       return true;
     }

--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -2188,7 +2188,8 @@ namespace Microsoft.Dafny{
       }
       proc.WaitForExit();
       if (proc.ExitCode != 0) {
-        throw new Exception($"Error while compiling Java files. Process exited with exit code {proc.ExitCode}");
+        outputWriter.WriteLine($"Error while compiling Java files. Process exited with exit code {proc.ExitCode}");
+        return false;
       }
       return true;
     }
@@ -2212,7 +2213,8 @@ namespace Microsoft.Dafny{
       }
       proc.WaitForExit();
       if (proc.ExitCode != 0) {
-        throw new Exception($"Error while running Java file {targetFilename}. Process exited with exit code {proc.ExitCode}");
+        outputWriter.WriteLine($"Error while running Java file {targetFilename}. Process exited with exit code {proc.ExitCode}");
+        return false;
       }
       return true;
     }

--- a/Test/git-issues/git-issue-1129.dfy
+++ b/Test/git-issues/git-issue-1129.dfy
@@ -1,0 +1,32 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" > "%t".abyss
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" > "%t".abyss
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" > "%t".abyss
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" > "%t".abyss
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cpp "%s" > "%t".abyss
+// RUN: %diff "%s.expect" "%t"
+
+// Without providing extern code for the :extern C, Dafny will output
+// target-compiler error messages when asked to compile this program.
+// Some of the compilers had then thrown an exception, which caused
+// Dafny to crash. That doesn't seem very friendly. The fix is to
+// just print the error and exit, without crashing.
+//
+// Errors reported by the underlying compiler may contain absolute
+// path names. These are annoying to have in .expect files. Therefore,
+// the output from the Dafny invocations above are piped into the
+// abyss. This testing still detects any crash.
+
+module A {
+  import B
+  datatype D = D(test: B.C)
+}
+
+module B {
+  class {:extern} C {
+    constructor {:extern} (name: string)
+  }
+}
+
+method Main() {
+}

--- a/Test/git-issues/git-issue-1129.dfy.expect
+++ b/Test/git-issues/git-issue-1129.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
When Dafny is asked to compile a program, it generates target code and calls an underlying compiler. That underlying compiler may fail, e.g., if there's a bug in Dafny and Dafny ends up generating malformed code, or if the user Dafny program contains `:extern` declarations that don't lead to provided code. In those situations, it seems polite to output any errors generated by the underlying compiler and then exit the Dafny tool.

Previously, Dafny had in some such cases thrown an exception, which caused the Dafny tool to crash. This is not so polite. This PR replaces such exception throwing with the printing of an error message and exiting (without crashing).

Fixes #1129 