### PR TITLE
Add the missing nlog.config for the Language Server

### DIFF
--- a/Source/DafnyLanguageServer/nlog.config
+++ b/Source/DafnyLanguageServer/nlog.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- XSD manually extracted from package NLog.Schema: https://www.nuget.org/packages/NLog.Schema-->
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+    xsi:schemaLocation="NLog NLog.xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <variable name="layout" value="${longdate}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}" />
+  
+  <targets>
+    <target xsi:type="File" name="file" fileName="${baseDir}/log.txt" layout="${layout}" keepFileOpen="true" />
+    <target xsi:type="Debugger" name="debugger" layout="${layout}"/>
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Warn" writeTo="file" />
+    
+    <logger name="Microsoft.Dafny.LanguageServer.*" minlevel="Info" maxlevel="Info" writeTo="debugger" />
+    <logger name="*" minlevel="Warn" writeTo="debugger" />
+  </rules>
+</nlog>


### PR DESCRIPTION
The language server uses NLog as its logging provider. During the repository merger, the required *nlog.config* file got lost making the language server unable to start. 

As a workaround, the VSCode extension automatically creates an empty file if it's missing. I prefer to remove this workaround for later releases.