### PR TITLE
Set flag to use Go pre modules

### DIFF
--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -3443,6 +3443,9 @@ namespace Microsoft.Dafny {
         RedirectStandardError = false,
       };
       psi.EnvironmentVariables["GOPATH"] = GoPath(targetFilename);
+      // Dafny compiles to the old Go package system, whereas Go has moved on to a module
+      // system. Until Dafny's Go compiler catches up, the GO111MODULE variable has to be set.
+      psi.EnvironmentVariables["GO111MODULE"] = "auto";
 
       try {
         using (var process = Process.Start(psi)) {

--- a/Test/comp/manualcompile/lit.local.cfg
+++ b/Test/comp/manualcompile/lit.local.cfg
@@ -26,5 +26,6 @@ config.substitutions.append( ('%binaryDir', binaryDir) )
 current_dir = os.path.join(config.test_source_root, 'comp', 'manualcompile')
 
 config.environment['GOPATH'] = os.path.join(current_dir, 'ManualCompile-go')
+config.environment['GO111MODULE'] = 'auto'
 
 config.environment['CLASSPATH'] = os.path.join(current_dir, 'ManualCompile-java') + ":" + os.path.join( binaryDir, "DafnyRuntime.jar" )


### PR DESCRIPTION
The current version of Go (version 1.16 or later) has a module system. The Dafny compiler for Go still produces code in the old Go packages. To make this work, the environment variable `GO111MODULE` has to be set (to `auto` or to `off`). This PR sets it to `auto`.

Fixes #1156 