### PR TITLE
Fix timeLimitMultiplier by having it generate internal annotations

### DIFF
--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -1511,16 +1511,21 @@ namespace Microsoft.Dafny
                       var arg = attr.Args[0] as LiteralExpr;
                       System.Numerics.BigInteger value = (System.Numerics.BigInteger)arg.Value;
                       if (value.Sign > 0) {
+                        int current_limit = 0;
+                        string name = "";
                         if (DafnyOptions.O.ResourceLimit > 0) {
                           // Interpret this as multiplying the resource limit
-                          int current_limit = DafnyOptions.O.ResourceLimit;
-                          attr.Args[0] = new LiteralExpr(attr.Args[0].tok, value * current_limit);
-                          attr.Name = "rlimit";
+                          current_limit = DafnyOptions.O.ResourceLimit;
+                          name = "rlimit";
                         } else {
                           // Interpret this as multiplying the time limit
-                          int current_limit = DafnyOptions.O.TimeLimit > 0 ? DafnyOptions.O.TimeLimit : 10;  // Default to 10 seconds
-                          attr.Args[0] = new LiteralExpr(attr.Args[0].tok, value * current_limit);
-                          attr.Name = "timeLimit";
+                          current_limit = DafnyOptions.O.TimeLimit > 0 ? DafnyOptions.O.TimeLimit : 10;  // Default to 10 seconds
+                          name = "timeLimit";
+                        }
+                        Expression newArg = new LiteralExpr(attr.Args[0].tok, value * current_limit);
+                        member.Attributes = new Attributes("_" + name, new List<Expression>() { newArg }, attrs);
+                        if (Attributes.Contains(attrs, name)) {
+                          reporter.Warning(MessageSource.Rewriter, member.tok, "timeLimitMultiplier annotation overrides " + name + " annotation");
                         }
                       }
                     }

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -16645,11 +16645,16 @@ namespace Microsoft.Dafny {
 
       public Bpl.QKeyValue TrAttributes(Attributes attrs, string skipThisAttribute) {
         Bpl.QKeyValue kv = null;
+        bool hasNewTimeLimit = Attributes.Contains(attrs, "_timeLimit");
+        bool hasNewRLimit = Attributes.Contains(attrs, "_rlimit");
         foreach (var attr in attrs.AsEnumerable()) {
           if (attr.Name == skipThisAttribute
            || attr.Name == "axiom"  // Dafny's axiom attribute clashes with Boogie's axiom keyword
            || attr.Name == "fuel"   // Fuel often uses function names as arguments, which adds extra axioms unnecessarily
            || (DafnyOptions.O.DisallowExterns && (attr.Name == "extern" || attr.Name == "dllimport")) // omit the extern attribute when /noExterns option is specified.
+           || attr.Name == "timeLimitMultiplier"  // This is a Dafny-specific attribute
+           || (attr.Name == "timeLimit" && hasNewTimeLimit)
+           || (attr.Name == "rlimit" && hasNewRLimit)
              ) {
             continue;
           }
@@ -16665,7 +16670,14 @@ namespace Microsoft.Dafny {
               parms.Add(e);
             }
           }
-          kv = new Bpl.QKeyValue(Token.NoToken, attr.Name, parms, kv);
+
+          var name = attr.Name;
+          if (name == "_timeLimit") {
+            name = "timeLimit";
+          } else if (name == "_rlimit") {
+            name = "rlimit";
+          }
+          kv = new Bpl.QKeyValue(Token.NoToken, name, parms, kv);
         }
         return kv;
       }

--- a/Test/git-issues/git-issue-1224.dfy
+++ b/Test/git-issues/git-issue-1224.dfy
@@ -1,0 +1,8 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+abstract module SlowPoke {
+  lemma {:timeLimitMultiplier 4} SlowLemma()
+}
+
+module SlowChild refines SlowPoke { }

--- a/Test/git-issues/git-issue-1224.dfy.expect
+++ b/Test/git-issues/git-issue-1224.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
The internal annotations are used instead of overwriting the original timeLimitMultiplier annotation.  Closes #1224.

I added a test file, but it doesn't directly check for the issue in #1224.  One way to do so would be to diff the result of `/rprint`, but that will make this test very sensitive to any changes to the pretty printer.  I'm open to other suggestions.