### PR TITLE
chore(ci): Lock previous version of dotnet 

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -25,7 +25,6 @@ jobs:
             ]
         ## Size of the following array must match --num-shards in lit command
         shard: [1, 2, 3, 4, 5]
-        ##shard: [1, 2, 3]
         include:
         - os:                  'ubuntu-latest'
           os_for_build:        'ubuntu'

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup dotnet 5.0
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: '5.0.x' # SDK Version for building Dafny; x will use the latest version of the 5.0 channel
+        dotnet-version: '5.0.203' # See https://github.com/dafny-lang/dafny/issues/1238
     - name: C++ for ubuntu 16.04
       if: matrix.os == 'ubuntu-16.04'
       run: |


### PR DESCRIPTION
See https://github.com/dafny-lang/dafny/issues/1238 (which should still be fixed properly)