### PR TITLE
Proposal to re-enable C++ tests

### DIFF
--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -73,6 +73,31 @@ private:
    iterator end_;
 };
 
+// Workaround the fact that Apple's clang and g++ print nullptr as 0x0,
+// while Linux's g++ prints it as 0
+template<typename T>
+void dafny_print(T x) {
+  std::cout << x;
+}
+
+template<typename T>
+void dafny_print(T* x) {
+  if (x == nullptr) {
+    std::cout << "NULL";
+  } else {
+    std::cout << x;
+  }
+}
+
+template<typename T>
+void dafny_print(std::shared_ptr<T> x) {
+  if (x == nullptr) {
+    std::cout << "NULL";
+  } else {
+    std::cout << x;
+  }
+}
+
 /*********************************************************
  *  DEFAULTS                                             *
  *********************************************************/

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -2377,6 +2377,9 @@ namespace Microsoft.Dafny {
       if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
         warnings += " -Wno-unknown-warning-option";
       }
+      if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+        warnings += " -Wunused-but-set-variable";
+      }
       var args = warnings + $" -g -std=c++17 -I{codebase} -o {exeName} {targetFilename}";
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", args) {

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -1218,7 +1218,7 @@ namespace Microsoft.Dafny {
     // ----- Statements -------------------------------------------------------------
 
     protected override void EmitPrintStmt(ConcreteSyntaxTree wr, Expression arg) {
-      wr.Write("std::cout << (");
+      wr.Write("dafny_print(");
       TrExpr(arg, wr, false);
       wr.WriteLine(");");
     }

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Diagnostics.Contracts;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Bpl = Microsoft.Boogie;
 
 namespace Microsoft.Dafny {
@@ -2369,7 +2370,14 @@ namespace Microsoft.Dafny {
       var codebase = System.IO.Path.GetDirectoryName(assemblyLocation);
       Contract.Assert(codebase != null);
       var exeName = ComputeExeName(targetFilename);
-      var args = $"-g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy -Wno-unknown-warning-option -std=c++17 -I{codebase} -o {exeName} {targetFilename}";
+      var warnings = "-Wall -Wextra -Wpedantic -Wno-unused-variable";
+      if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+        warnings += " -Wno-deprecated-copy";
+      }
+      if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+        warnings += " -Wno-unknown-warning-option";
+      }
+      var args = warnings + $" -g -std=c++17 -I{codebase} -o {exeName} {targetFilename}";
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", args) {
         CreateNoWindow = true,

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -2378,7 +2378,7 @@ namespace Microsoft.Dafny {
         warnings += " -Wno-unknown-warning-option";
       }
       if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-        warnings += " -Wunused-but-set-variable";
+        warnings += " -Wno-unused-but-set-variable";
       }
       var args = warnings + $" -g -std=c++17 -I{codebase} -o {exeName} {targetFilename}";
       compilationResult = null;

--- a/Test/c++/maps.dfy.expect
+++ b/Test/c++/maps.dfy.expect
@@ -32,10 +32,10 @@ Keys membership 4: This is expected
 0 2 0
 0 0 1
 0 1 1 1
-jack wendy 0x0
-jack 0x0 0x0
+jack wendy NULL
+jack NULL NULL
 ronald ronald 0
 1 1 1 0
-jack wendy 0x0
-jack 0x0 0x0
+jack wendy NULL
+jack NULL NULL
 ronald ronald 0

--- a/Test/c++/maps.dfy.expect
+++ b/Test/c++/maps.dfy.expect
@@ -32,10 +32,10 @@ Keys membership 4: This is expected
 0 2 0
 0 0 1
 0 1 1 1
-jack wendy 0
-jack 0 0
+jack wendy 0x0
+jack 0x0 0x0
 ronald ronald 0
 1 1 1 0
-jack wendy 0
-jack 0 0
+jack wendy 0x0
+jack 0x0 0x0
 ronald ronald 0

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -23,7 +23,7 @@ config.suffixes = ['.dfy']
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
-config.excludes = ['Inputs', 'sandbox', 'c++']
+config.excludes = ['Inputs', 'sandbox']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
I'd like to suggest we re-enable the tests in `Test/c++` as part of the CI, assuming the CI run for this PR succeeds.  That would help catch issues like those fixed in #1233.