### PR TITLE
Fix build dotnet 5.0.300

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup dotnet 5.0
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: '5.0.203' # See https://github.com/dafny-lang/dafny/issues/1238
+        dotnet-version: '5.0.x' # SDK Version for building Dafny; x will use the latest version of the 5.0 channel
     - name: C++ for ubuntu 16.04
       if: matrix.os == 'ubuntu-16.04'
       run: |

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Dafny.LanguageServer</RootNamespace>
     <OutputPath>..\..\Binaries\</OutputPath>
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -8,7 +8,6 @@
       <PackageVersion>1.1.0</PackageVersion>
       <TargetFramework>net5.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
-      <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -8,6 +8,7 @@
       <PackageVersion>1.1.0</PackageVersion>
       <TargetFramework>net5.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
+      <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">


### PR DESCRIPTION
This PR attempts to work with new build error [NETSDK1150](https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/5.0/referencing-executable-generates-error) introduced in .NET 5.0.300.

The PR undoes the temporary fix provided in PR #1237 

Fixes #1238
