### PR TITLE
fix: Add synonym axiom for function handles

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -3746,7 +3746,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    void AddLayerSynonymAxiom(Function f) {
+    void AddLayerSynonymAxiom(Function f, bool forHandle = false) {
       Contract.Requires(f != null);
       Contract.Requires(f.IsFuelAware());
       Contract.Requires(sink != null && predef != null);
@@ -3788,15 +3788,18 @@ namespace Microsoft.Dafny {
         args1.Add(s);
         args0.Add(s);
       }
-      foreach (var p in f.Formals) {
-        bv = new Bpl.BoundVariable(p.tok, new Bpl.TypedIdent(p.tok, p.AssignUniqueName(f.IdGenerator), TrType(p.Type)));
-        formals.Add(bv);
-        s = new Bpl.IdentifierExpr(f.tok, bv);
-        args1.Add(s);
-        args0.Add(s);
+      if (!forHandle) {
+        foreach (var p in f.Formals) {
+          bv = new Bpl.BoundVariable(p.tok, new Bpl.TypedIdent(p.tok, p.AssignUniqueName(f.IdGenerator), TrType(p.Type)));
+          formals.Add(bv);
+          s = new Bpl.IdentifierExpr(f.tok, bv);
+          args1.Add(s);
+          args0.Add(s);
+        }
       }
 
-      var funcID = new Bpl.FunctionCall(new Bpl.IdentifierExpr(f.tok, f.FullSanitizedName, TrType(f.ResultType)));
+      var name = forHandle ? f.FullSanitizedName + "#Handle" : f.FullSanitizedName;
+      var funcID = new Bpl.FunctionCall(new Bpl.IdentifierExpr(f.tok, name, TrType(f.ResultType)));
       var funcAppl1 = new Bpl.NAryExpr(f.tok, funcID, args1);
       var funcAppl0 = new Bpl.NAryExpr(f.tok, funcID, args0);
 
@@ -8631,6 +8634,7 @@ namespace Microsoft.Dafny {
         if (f.IsFuelAware()) {
           Bpl.Expr ly; vars.Add(BplBoundVar("$ly", predef.LayerType, out ly)); args.Add(ly);
           formals.Add(BplFormalVar(null, predef.LayerType, true));
+          AddLayerSynonymAxiom(f, true);
         }
 
         Func<List<Bpl.Expr>, List<Bpl.Expr>> SnocSelf = x => x;

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -3773,7 +3773,7 @@ namespace Microsoft.Dafny {
         args1.Add(s);
         args0.Add(s);
       }
-      if (AlwaysUseHeap || f.ReadsHeap) {
+      if (!forHandle && (AlwaysUseHeap || f.ReadsHeap)) {
         bv = new Bpl.BoundVariable(f.tok, new Bpl.TypedIdent(f.tok, predef.HeapVarName, predef.HeapType));
         formals.Add(bv);
         s = new Bpl.IdentifierExpr(f.tok, bv);

--- a/Test/git-issues/git-issue-1250.dfy
+++ b/Test/git-issues/git-issue-1250.dfy
@@ -1,0 +1,56 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// This file contains the automatic proofs of two nice properties about Fibonacci-like numbers.
+// The theorems were inspired by singingbanana's video https://www.youtube.com/watch?v=CWhcUea5GNc.
+//
+// The attempt to prove them discovered issue 1250, for which this file contains regression tests.
+// In particular, the proof obligations marked with a (*) below did not verify before the issue-1250 fix.
+
+const A: int
+const B: int
+
+function Fib(n: nat): int {
+  if n == 0 then A
+  else if n == 1 then B
+  else Fib(n - 2) + Fib(n - 1)
+}
+
+// Sum f(i) for i from 0 through n (inclusive)
+function Sum(n: nat, f: nat -> int): int {
+  f(n) + if n == 0 then 0 else Sum(n - 1, f)
+}
+
+lemma Eleven()
+  ensures Sum(9, Fib) == 11 * Fib(6)
+{
+}
+
+lemma FibSum(n: nat)
+  ensures Sum(n, Fib) == Fib(n + 2) - Fib(1) // (*)
+{
+}
+
+lemma {:induction false} FibSumManual(n: nat)
+  ensures Sum(n, Fib) == Fib(n + 2) - Fib(1) // (*)
+{
+  if n == 0 {
+  } else {
+    calc {
+      Sum(n, Fib);
+    ==  // def. Sum
+      Fib(n) + Sum(n - 1, Fib);
+    ==  { FibSumManual(n - 1); }
+      Fib(n) + Fib(n - 1 + 2) - Fib(1);
+    ==
+      Fib(n) + Fib(n + 1) - Fib(1);
+    ==  // def. Fib
+      Fib(n + 2) - Fib(1);
+    }
+    assert Sum(n, Fib) == Fib(n + 2) - Fib(1); // (*)
+    assert Sum(n, Fib) == Fib(n + 2) - Fib(1); // (*)
+
+    assert Sum(n, Fib) == Sum(n, Fib);
+  }
+  assert Sum(n, Fib) == Fib(n + 2) - Fib(1); // (*)
+}

--- a/Test/git-issues/git-issue-1250.dfy.expect
+++ b/Test/git-issues/git-issue-1250.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 8 verified, 0 errors

--- a/Test/hofs/Naked.dfy
+++ b/Test/hofs/Naked.dfy
@@ -68,3 +68,37 @@ module ReadsGenerics {
     { (a, b) }
   }
 }
+
+module TwoStateFunctions {
+  method Apply(ghost f: int -> int, x: int) returns (ghost y: int)
+    ensures y == f(x)
+  {
+    y := f(x);
+  }
+
+  class Cell {
+    var data: int
+
+    twostate function F(x: int): int {
+      old(data) + x
+    }
+  }
+
+  method Caller(c: Cell)
+    requires c.data == 9
+    modifies c
+  {
+    c.data := c.data + 1;
+    label L:
+    assert c.F(11) == 20;
+
+    var y := Apply(c.F, 11);
+    assert y == 20;
+
+    assert c.F@L(11) == 21;
+    y := Apply(u => c.F@L(u), 11);
+    assert y == 21;
+
+    assert c.F(100) == 0; // error
+  }
+}

--- a/Test/hofs/Naked.dfy.expect
+++ b/Test/hofs/Naked.dfy.expect
@@ -53,5 +53,9 @@ Execution trace:
 Naked.dfy(67,12): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Execution trace:
     (0,0): anon0
+Naked.dfy(102,20): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+    Naked.dfy(99,16): anon5_Else
 
-Dafny program verifier finished with 2 verified, 14 errors
+Dafny program verifier finished with 5 verified, 15 errors


### PR DESCRIPTION
This PR fixes a problem that had caused confusing behavior when trying to work with functions as values. In particular, the problem caused various different occurrences of the same function name to be unequal in the eyes of the verifier.

Fixes #1250