### PR TITLE
Fix: Build Java integer types using valueOf

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -3385,7 +3385,7 @@ namespace Microsoft.Dafny{
         var numberval = "intValue()";
         if (nativeType == "Byte" || nativeType == "Short")
           numberval = $"{nativeType.ToLower()}Value()";
-        wEnum.WriteLine($"for (java.math.BigInteger j = lo; j.compareTo(hi) < 0; j.add(java.math.BigInteger.ONE)) {{ arr.add(new {nativeType}(j.{numberval})); }}");
+        wEnum.WriteLine($"for (java.math.BigInteger j = lo; j.compareTo(hi) < 0; j.add(java.math.BigInteger.ONE)) {{ arr.add({nativeType}.valueOf(j.{numberval})); }}");
         wEnum.WriteLine("return arr;");
       }
       if (nt.WitnessKind == SubsetTypeDecl.WKind.Compiled) {


### PR DESCRIPTION
This PR fixes  #1257 by modifying the Java compiler to remove a deprecation warning that breaks some tests when using recent Java versions. I tested it on my system with openjdk version "1.8.0_282".
