### PR TITLE
feat!: Named-only parameters

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1422,14 +1422,15 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
   .
 
 /*------------------------------------------------------------------------*/
-GIdentType<bool allowGhostKeyword, bool allowNewKeyword,
-           out IToken/*!*/ id, out Type/*!*/ ty, out bool isGhost, out bool isOld>
+GIdentType<bool allowGhostKeyword, bool allowNewKeyword, bool allowNameOnlyKeyword,
+           out IToken/*!*/ id, out Type/*!*/ ty, out bool isGhost, out bool isOld, out bool isNameOnly>
 /* isGhost always returns as false if allowGhostKeyword is false */
 = (. Contract.Ensures(Contract.ValueAtReturn(out id)!=null);
      Contract.Ensures(Contract.ValueAtReturn(out ty)!=null);
-     isGhost = false; isOld = allowNewKeyword; .)
+     isGhost = false; isOld = allowNewKeyword; isNameOnly = false; .)
   { "ghost"                    (. if (allowGhostKeyword) { isGhost = true; } else { SemErr(t, "formal cannot be declared 'ghost' in this context"); } .)
   | "new"                      (. if (allowNewKeyword) { isOld = false; } else { SemErr(t, "formal cannot be declared 'new' in this context"); } .)
+  | "nameonly"                 (. if (allowNameOnlyKeyword) { isNameOnly = true; } else { SemErr(t, "formal cannot be declared 'nameonly' in this context"); } .)
   }
   IdentType<out id, out ty, false>
   .
@@ -1480,15 +1481,17 @@ IdentTypeOptional<out BoundVar var>
   (. var = new BoundVar(id, id.val, optType == null ? new InferredTypeProxy() : optType); .)
   .
 
-TypeIdentOptional<out IToken/*!*/ id, out string/*!*/ identName, out Type/*!*/ ty, out bool isGhost, out Expression defaultValue>
+TypeIdentOptional<out IToken/*!*/ id, out string/*!*/ identName, out Type/*!*/ ty, out bool isGhost, out Expression defaultValue, out bool isNameOnly>
 = (.Contract.Ensures(Contract.ValueAtReturn(out id)!=null);
      Contract.Ensures(Contract.ValueAtReturn(out ty)!=null);
      Contract.Ensures(Contract.ValueAtReturn(out identName)!=null);
      string name = null; id = Token.NoToken; ty = new BoolType()/*dummy*/; isGhost = false;
+     IToken nameonlyToken = null;
      defaultValue = null;
   .)
-  [ "ghost"                            (. isGhost = true; .)
-  ]
+  { "ghost"                            (. isGhost = true; .)
+  | "nameonly"                         (. nameonlyToken = t; .)
+  }
   ( TypeAndToken<out id, out ty, false>
     [ ":"
       (. /* try to convert ty to an identifier */
@@ -1509,8 +1512,13 @@ TypeIdentOptional<out IToken/*!*/ id, out string/*!*/ identName, out Type/*!*/ t
   )
   (. if (name != null) {
        identName = name;
+       isNameOnly = nameonlyToken != null;
      } else {
        identName = "#" + anonymousIds++;
+       if (nameonlyToken != null) {
+         SemErr(nameonlyToken, "use of the 'nameonly' modifier must be accompanied with a parameter name");
+       }
+       isNameOnly = false;
      }
   .)
   .
@@ -1876,15 +1884,16 @@ Formals<.bool incoming, bool allowGhostKeyword, bool allowNewKeyword, List<Forma
      bool isGhost;
      bool isOld;
      Expression defaultValue;
+     bool isNameOnly;
   .)
   "("
   [
-    GIdentType<allowGhostKeyword, allowNewKeyword, out id, out ty, out isGhost, out isOld>
+    GIdentType<allowGhostKeyword, allowNewKeyword, incoming, out id, out ty, out isGhost, out isOld, out isNameOnly>
     ParameterDefaultValue<incoming, out defaultValue>
-                 (. formals.Add(new Formal(id, id.val, ty, incoming, isGhost, defaultValue, isOld)); .)
-    { "," GIdentType<allowGhostKeyword, allowNewKeyword, out id, out ty, out isGhost, out isOld>
+                 (. formals.Add(new Formal(id, id.val, ty, incoming, isGhost, defaultValue, isOld, isNameOnly)); .)
+    { "," GIdentType<allowGhostKeyword, allowNewKeyword, incoming, out id, out ty, out isGhost, out isOld, out isNameOnly>
     ParameterDefaultValue<incoming, out defaultValue>
-                 (. formals.Add(new Formal(id, id.val, ty, incoming, isGhost, defaultValue, isOld)); .)
+                 (. formals.Add(new Formal(id, id.val, ty, incoming, isGhost, defaultValue, isOld, isNameOnly)); .)
     }
   ]
   ")"
@@ -1907,11 +1916,14 @@ ParameterDefaultValue<bool incoming, out Expression defaultValue>
 FormalsOptionalIds<.List<Formal/*!*/>/*!*/ formals.>
 = (. Contract.Requires(cce.NonNullElements(formals));
      IToken/*!*/ id;  Type/*!*/ ty;  string/*!*/ name;  bool isGhost;  Expression/*?*/ defaultValue;
+     bool isNameOnly;
   .)
   "("
   [
-    TypeIdentOptional<out id, out name, out ty, out isGhost, out defaultValue>        (. formals.Add(new Formal(id, name, ty, true, isGhost, defaultValue)); .)
-    { "," TypeIdentOptional<out id, out name, out ty, out isGhost, out defaultValue>  (. formals.Add(new Formal(id, name, ty, true, isGhost, defaultValue)); .)
+    TypeIdentOptional<out id, out name, out ty, out isGhost, out defaultValue, out isNameOnly>
+            (. formals.Add(new Formal(id, name, ty, true, isGhost, defaultValue, false, isNameOnly)); .)
+    { "," TypeIdentOptional<out id, out name, out ty, out isGhost, out defaultValue, out isNameOnly>
+            (. formals.Add(new Formal(id, name, ty, true, isGhost, defaultValue, false, isNameOnly)); .)
     }
   ]
   ")"
@@ -2132,14 +2144,8 @@ FunctionDecl<DeclModifierData dmod, out Function/*!*/ f>
       ":"
       (  IF(FollowedByColon())
          "("
-           (.
-              IToken resultId;
-              Type ty;
-              bool isGhost;
-              bool isOld;
-           .)
-           GIdentType<false, false, out resultId, out ty, out isGhost, out isOld>
-           (. Contract.Assert(!isGhost && !isOld);
+           GIdentType<false, false, false, out var resultId, out var ty, out var isGhost, out var isOld, out var isNameOnly>
+           (. Contract.Assert(!isGhost && !isOld && !isNameOnly);
               result = new Formal(resultId, resultId.val, ty, false, false, null, false);
            .)
          ")"

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -6061,16 +6061,19 @@ namespace Microsoft.Dafny {
     }
     public readonly bool IsOld;
     public readonly Expression DefaultValue;
+    public readonly bool IsNameOnly;
 
-    public Formal(IToken tok, string name, Type type, bool inParam, bool isGhost, Expression defaultValue, bool isOld = false)
+    public Formal(IToken tok, string name, Type type, bool inParam, bool isGhost, Expression defaultValue, bool isOld = false, bool isNameOnly = false)
       : base(tok, name, type, isGhost) {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
       Contract.Requires(type != null);
       Contract.Requires(inParam || defaultValue == null);
+      Contract.Requires(!isNameOnly || (inParam && !name.StartsWith("#")));
       InParam = inParam;
       IsOld = isOld;
       DefaultValue = defaultValue;
+      IsNameOnly = isNameOnly;
     }
 
     public bool HasName {

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -1008,6 +1008,10 @@ namespace Microsoft.Dafny {
       if (f.IsGhost) {
         wr.Write("ghost ");
       }
+      if (f.IsNameOnly) {
+        Contract.Assert(f.HasName);
+        wr.Write("nameonly ");
+      }
       if (f.HasName) {
         wr.Write("{0}: ", f.DisplayName);
       }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -16585,8 +16585,13 @@ namespace Microsoft.Dafny
         } else if (!stillAcceptingPositionalArguments) {
           reporter.Error(MessageSource.Resolver, arg.tok, "a positional argument is not allowed to follow named arguments");
         } else if (j < formals.Count) {
-          // use the name of formal corresponding to this positional argument
-          var pname = formals[j].Name;
+          // use the name of formal corresponding to this positional argument, unless the parameter is named-only
+          var formal = formals[j];
+          var pname = formal.Name;
+          if (formal.IsNameOnly) {
+            reporter.Error(MessageSource.Resolver, arg.tok,
+              $"parameter '{pname}' must be passed using a name bindings; it cannot be passed positionally");
+          }
           Contract.Assert(namesToActuals[pname] == null); // we expect this, since we've only filled parameters positionally so far
           namesToActuals[pname] = binding;
         } else {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -9652,6 +9652,7 @@ namespace Microsoft.Dafny
 
       var dependencies = new Graph<IVariable>();
       var allowMoreRequiredParameters = true;
+      var allowNamelessParameters = true;
       foreach (var formal in formals) {
         var d = formal.DefaultValue;
         if (d != null) {
@@ -9662,7 +9663,13 @@ namespace Microsoft.Dafny
             dependencies.AddEdge(formal, v);
           }
         } else if (!allowMoreRequiredParameters) {
-          reporter.Error(MessageSource.Resolver, formal.tok, "all required parameters must precede any optional parameters");
+          reporter.Error(MessageSource.Resolver, formal.tok, "a required parameter must precede all optional parameters");
+        }
+        if (!allowNamelessParameters && !formal.HasName) {
+          reporter.Error(MessageSource.Resolver, formal.tok, "a nameless parameter must precede all nameonly parameters");
+        }
+        if (formal.IsNameOnly) {
+          allowNamelessParameters = false;
         }
       }
       SolveAllTypeConstraints();
@@ -16590,7 +16597,7 @@ namespace Microsoft.Dafny
           var pname = formal.Name;
           if (formal.IsNameOnly) {
             reporter.Error(MessageSource.Resolver, arg.tok,
-              $"parameter '{pname}' must be passed using a name bindings; it cannot be passed positionally");
+              $"nameonly parameter '{pname}' must be passed using a name binding; it cannot be passed positionally");
           }
           Contract.Assert(namesToActuals[pname] == null); // we expect this, since we've only filled parameters positionally so far
           namesToActuals[pname] = binding;

--- a/Test/dafny0/ParameterResolution.dfy.expect
+++ b/Test/dafny0/ParameterResolution.dfy.expect
@@ -52,11 +52,11 @@ ParameterResolution.dfy(198,37): Error: type parameter 'X' (inferred to be '?') 
 ParameterResolution.dfy(193,21): Error: type parameter 'X' (inferred to be '?') in the function call to 'F' could not be determined
 ParameterResolution.dfy(194,13): Error: type parameter 'X' (inferred to be '?') in the function call to 'F' could not be determined
 ParameterResolution.dfy(196,23): Error: type parameter 'X' (inferred to be '?') in the function call to 'F' could not be determined
-ParameterResolution.dfy(202,37): Error: all required parameters must precede any optional parameters
-ParameterResolution.dfy(203,29): Error: all required parameters must precede any optional parameters
-ParameterResolution.dfy(203,29): Error: all required parameters must precede any optional parameters
-ParameterResolution.dfy(204,27): Error: all required parameters must precede any optional parameters
-ParameterResolution.dfy(205,37): Error: all required parameters must precede any optional parameters
+ParameterResolution.dfy(202,37): Error: a required parameter must precede all optional parameters
+ParameterResolution.dfy(203,29): Error: a required parameter must precede all optional parameters
+ParameterResolution.dfy(203,29): Error: a required parameter must precede all optional parameters
+ParameterResolution.dfy(204,27): Error: a required parameter must precede all optional parameters
+ParameterResolution.dfy(205,37): Error: a required parameter must precede all optional parameters
 ParameterResolution.dfy(211,23): Error: old expressions are not allowed in this context
 ParameterResolution.dfy(213,32): Error: old expressions are not allowed in this context
 ParameterResolution.dfy(216,32): Error: old expressions are not allowed in this context
@@ -73,4 +73,29 @@ ParameterResolution.dfy(252,21): Error: Duplicate parameter name: x
 ParameterResolution.dfy(259,11): Error: default-value expressions for parameters contain a cycle: x -> x
 ParameterResolution.dfy(260,35): Error: unresolved identifier: _k
 ParameterResolution.dfy(261,26): Error: unresolved identifier: _k
-75 resolution/type errors detected in ParameterResolution.dfy
+ParameterResolution.dfy(284,30): Error: a required parameter must precede all optional parameters
+ParameterResolution.dfy(285,39): Error: a required parameter must precede all optional parameters
+ParameterResolution.dfy(286,34): Error: a nameless parameter must precede all nameonly parameters
+ParameterResolution.dfy(290,21): Error: nameonly parameter 'c' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(297,26): Error: nameonly parameter 'c' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(301,34): Error: a positional argument is not allowed to follow named arguments
+ParameterResolution.dfy(305,23): Error: nameonly parameter 'b' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(308,28): Error: the binding named 'unknown' does not correspond to any formal parameter
+ParameterResolution.dfy(312,19): Error: a positional argument is not allowed to follow named arguments
+ParameterResolution.dfy(313,11): Error: nameonly parameter 'b' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(313,16): Error: the parameter named 'b' is already given positionally
+ParameterResolution.dfy(314,21): Error: duplicate binding for parameter name 'b'
+ParameterResolution.dfy(323,16): Error: nameonly parameter 'b' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(328,15): Error: wrong number of arguments (least predicate 'LP' expects at least 2, got 1)
+ParameterResolution.dfy(329,15): Error: no actual argument passed for least predicate argument 'b'
+ParameterResolution.dfy(333,36): Error: the parameter named 'a' is already given positionally
+ParameterResolution.dfy(336,21): Error: nameonly parameter 'u' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(337,29): Error: a positional argument is not allowed to follow named arguments
+ParameterResolution.dfy(337,12): Error: no actual argument passed for constructor in-parameter 'x'
+ParameterResolution.dfy(340,37): Error: duplicate binding for parameter name 'x'
+ParameterResolution.dfy(343,12): Error: unresolved identifier: a
+ParameterResolution.dfy(351,15): Error: nameonly parameter '900' must be passed using a name binding; it cannot be passed positionally
+ParameterResolution.dfy(355,15): Error: the binding named '0900' does not correspond to any formal parameter
+ParameterResolution.dfy(355,9): Error: no actual argument passed for datatype constructor argument '900'
+ParameterResolution.dfy(356,25): Error: the binding named '90_0' does not correspond to any formal parameter
+100 resolution/type errors detected in ParameterResolution.dfy

--- a/Test/dafny0/ParseErrors.dfy
+++ b/Test/dafny0/ParseErrors.dfy
@@ -169,3 +169,22 @@ newtype Pos = x | 0 < x witness 1
 type Opaque {
   var x: int  // error: mutable field not allowed in opaque type
 }
+
+// ------------------------- nameonly parameters ------------------------------
+
+module NameOnlyParameters {
+  // name-less datatype fields
+  datatype D =
+    | D0(int, nameonly int) // error: nameonly modifier must be followed by parameter name
+    | D1(int, nameonly int, real) // error: nameonly modifier must be followed by parameter name
+    | D2(int, nameonly x: int)
+  // named function results
+  function F(nameonly y: int): int
+  function G(y: int): (nameonly r: int) // error: 'nameonly' unexpected here
+  // out-parameters
+  method M(nameonly x: int) returns (y: int)
+  method N(x: int) returns (nameonly y: int) // error: 'nameonly' not allowed here
+  // yield-parameters
+  iterator Iter0(nameonly x: int) yields (y: int)
+  iterator Iter0(x: int) yields (nameonly y: int) // error: 'nameonly' not allowed here
+}

--- a/Test/dafny0/ParseErrors.dfy.expect
+++ b/Test/dafny0/ParseErrors.dfy.expect
@@ -41,4 +41,9 @@ ParseErrors.dfy(156,22): Error: a set comprehension with more than one bound var
 ParseErrors.dfy(163,2): Error: mutable fields are not allowed in value types
 ParseErrors.dfy(167,2): Error: mutable fields are not allowed in value types
 ParseErrors.dfy(170,2): Error: mutable fields are not allowed in value types
-43 parse errors detected in ParseErrors.dfy
+ParseErrors.dfy(178,14): Error: use of the 'nameonly' modifier must be accompanied with a parameter name
+ParseErrors.dfy(179,14): Error: use of the 'nameonly' modifier must be accompanied with a parameter name
+ParseErrors.dfy(183,23): Error: closeparen expected
+ParseErrors.dfy(186,28): Error: formal cannot be declared 'nameonly' in this context
+ParseErrors.dfy(189,33): Error: formal cannot be declared 'nameonly' in this context
+48 parse errors detected in ParseErrors.dfy

--- a/docs/DafnyRef/Expressions.md
+++ b/docs/DafnyRef/Expressions.md
@@ -1455,7 +1455,9 @@ Positional arguments must be given before any named arguments.
 Positional arguments are passed to the formals in the corresponding
 position. Named arguments are passed to the formal of the given
 name. Named arguments can be given out of order from how the corresponding
-formal parameters are declared. The list of bindings for a call must
+formal parameters are declared. A formal declared with the modifier
+`nameonly` is not allowed to be passed positionally.
+The list of bindings for a call must
 provide exactly one value for every required parameter and at most one
 value for each optional parameter, and must never name
 non-existent formals. Any optional parameter that is not given a value
@@ -1467,7 +1469,8 @@ The formal parameters of a method, constructor in a class, iterator,
 function, or datatype constructor can be declared with an expression
 denoting a _default value_. This makes the parameter _optional_,
 as opposed to _required_. All required parameters must be declared
-before any optional parameters.
+before any optional parameters. All nameless parameters in a datatype
+constructor must be declared before any `nameonly` parameters.
 
 The default-value expression for a parameter is allowed to mention the
 other parameters, including `this` (for instance methods and instance

--- a/docs/DafnyRef/Grammar.md
+++ b/docs/DafnyRef/Grammar.md
@@ -301,7 +301,7 @@ reservedword =
     "int" | "invariant" | "is" | "iset" | "iterator" |
     "label" | "lemma" | "map" | "match" | "method" |
     "modifies" | "modify" | "module" | "multiset" |
-    "nat" | "new" | "newtype" | "null" |
+    "nameonly" | "nat" | "new" | "newtype" | "null" |
     "object" | "object?" | "old" | "opened" | "ORDINAL"
     "predicate" | "print" | "provides" |
     "reads" | "real" | "refines" | "requires" | "return" |
@@ -512,16 +512,17 @@ A `CIdentType` is used for a `const` declaration. The Type is optional because i
 the initializer.
 
 ````grammar
-GIdentType(allowGhostKeyword, allowNewKeyword, allowDefault) =
-    [ "ghost" | "new" ] IdentType
+GIdentType(allowGhostKeyword, allowNewKeyword, allowNameOnlyKeyword, allowDefault) =
+    { "ghost" | "new" | "nameonly" } IdentType
     [ ":=" Expression(allowLemma: true, allowLambda: true) ]
 ````
 A ``GIdentType`` is a typed entity declaration optionally preceded by `ghost` or `new`. The _ghost_
 qualifier means the entity is only used during verification and not in the generated code.
 Ghost variables are useful for abstractly representing internal state in specifications.
-If `allowGhostKeyword` is false then `ghost` is not allowed.
-If `allowNewKeyword` is false then `new` is not allowed.
-If `allowDefault` is false then `:= Expression` is not allowed.
+If `allowGhostKeyword` is false, then `ghost` is not allowed.
+If `allowNewKeyword` is false, then `new` is not allowed.
+If `allowNameOnlyKeyword` is false, then `nameonly` is not allowed.
+If `allowDefault` is false, then `:= Expression` is not allowed.
 
 ````grammar
 LocalIdentTypeOptional = WildIdent [ ":" Type ]
@@ -539,12 +540,13 @@ may be inferred from the context. Examples are in pattern matching or quantifier
 
 ````grammar
 TypeIdentOptional =
-    [ "ghost" ] [ NoUSIdentOrDigits ":" ] Type
+    { "ghost" | "nameonly" } [ NoUSIdentOrDigits ":" ] Type
     [ ":=" Expression(allowLemma: true, allowLambda: true) ]
 ````
 ``TypeIdentOptional``s are used in ``FormalsOptionalIds``. This represents situations
 where a type is given but there may not be an identifier. The default-value expression
 `:= Expression` is allowed only if `NoUSIdentOrDigits :` is also provided.
+If modifier `nameonly` is given, then `NoUSIdentOrDigits` must also be used.
 
 ````grammar
 FormalsOptionalIds = "(" [ TypeIdentOptional

--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -1635,8 +1635,8 @@ in [Section 18.3](#sec-coinduction). // TODO - check this is the correct referen
 
 ````grammar
 Formals(allowGhostKeyword, allowNewKeyword, allowDefault) =
-  "(" [ GIdentType(allowGhostKeyword, allowNewKeyword, allowDefault)
-        { "," GIdentType(allowGhostKeyword, allowNewKeyword, allowDefault) }
+  "(" [ GIdentType(allowGhostKeyword, allowNewKeyword, allowNameOnlyKeyword: true, allowDefault)
+        { "," GIdentType(allowGhostKeyword, allowNewKeyword, allowNameOnlyKeyword: true, allowDefault) }
       ]
   ")"
 ````
@@ -1940,6 +1940,7 @@ FunctionSignature_(allowGhostKeyword, allowNewKeyword) =
   ( Type
   | "(" GIdentType(allowGhostKeyword: false,
                    allowNewKeyword: false,
+                   allowNameOnlyKeyword: false,
                    allowDefault: false)
     ")"
   )


### PR DESCRIPTION
This PR introduces parameters that must be passed via a name binding, as requested by https://github.com/dafny-lang/dafny/issues/1243. That is, these parameters are not allowed to be passed positionally.

To indicate that a formal parameter is of this form, declare it with the new `nameonly` modifier. This is a new keyword, which makes this PR a breaking change. (But other than the new keyword, this PR is backward compatible.)