### PR TITLE
fix: Check well-formedness of modifies and modify

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -10929,6 +10929,8 @@ namespace Microsoft.Dafny {
       } else if (stmt is ModifyStmt) {
         AddComment(builder, stmt, "modify statement");
         var s = (ModifyStmt)stmt;
+        // check well-formedness of the modifies clauses
+        CheckFrameWellFormed(new WFOptions(), s.Mod.Expressions, locals, builder, etran);
         // check that the modifies is a subset
         CheckFrameSubset(s.Tok, s.Mod.Expressions, null, null, etran, builder, "modify statement may violate context's modifies clause", null);
         // cause the change of the heap according to the given frame
@@ -12135,7 +12137,8 @@ namespace Microsoft.Dafny {
         updatedFrameEtran = etran;
       }
 
-      if (s.Mod.Expressions != null) { // check that the modifies is a subset
+      if (s.Mod.Expressions != null) { // check well-formedness and that the modifies is a subset
+        CheckFrameWellFormed(new WFOptions(), s.Mod.Expressions, locals, builder, etran);
         CheckFrameSubset(s.Tok, s.Mod.Expressions, null, null, etran, builder, "loop modifies clause may violate context's modifies clause", null);
         DefineFrame(s.Tok, s.Mod.Expressions, builder, locals, loopFrameName);
       }

--- a/Test/allocated1/dafny0/DirtyLoops.dfy.expect
+++ b/Test/allocated1/dafny0/DirtyLoops.dfy.expect
@@ -86,19 +86,23 @@ Execution trace:
 DirtyLoops.dfy(70,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon8_LoopHead
-    (0,0): anon8_LoopBody
-    DirtyLoops.dfy(68,3): anon9_Else
-    (0,0): anon10_Then
     (0,0): anon11_Then
+    (0,0): anon3
+    DirtyLoops.dfy(68,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(68,3): anon13_Else
+    (0,0): anon14_Then
+    (0,0): anon15_Then
 DirtyLoops.dfy(72,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon8_LoopHead
-    (0,0): anon8_LoopBody
-    DirtyLoops.dfy(68,3): anon9_Else
-    (0,0): anon10_Then
     (0,0): anon11_Then
+    (0,0): anon3
+    DirtyLoops.dfy(68,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(68,3): anon13_Else
+    (0,0): anon14_Then
+    (0,0): anon15_Then
 DirtyLoops.dfy(82,11): Error: assertion violation
 Execution trace:
     (0,0): anon0

--- a/Test/dafny0/DirtyLoops.dfy.expect
+++ b/Test/dafny0/DirtyLoops.dfy.expect
@@ -107,19 +107,23 @@ Execution trace:
 DirtyLoops.dfy(70,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon8_LoopHead
-    (0,0): anon8_LoopBody
-    DirtyLoops.dfy(68,3): anon9_Else
-    (0,0): anon10_Then
     (0,0): anon11_Then
+    (0,0): anon3
+    DirtyLoops.dfy(68,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(68,3): anon13_Else
+    (0,0): anon14_Then
+    (0,0): anon15_Then
 DirtyLoops.dfy(72,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-    DirtyLoops.dfy(68,3): anon8_LoopHead
-    (0,0): anon8_LoopBody
-    DirtyLoops.dfy(68,3): anon9_Else
-    (0,0): anon10_Then
     (0,0): anon11_Then
+    (0,0): anon3
+    DirtyLoops.dfy(68,3): anon12_LoopHead
+    (0,0): anon12_LoopBody
+    DirtyLoops.dfy(68,3): anon13_Else
+    (0,0): anon14_Then
+    (0,0): anon15_Then
 DirtyLoops.dfy(82,11): Error: assertion violation
 Execution trace:
     (0,0): anon0

--- a/Test/git-issues/git-issue-1252.dfy
+++ b/Test/git-issues/git-issue-1252.dfy
@@ -94,3 +94,14 @@ iterator Iter(c: C?, d: C?)
   reads d.more // error: c may be null (reported twice)
 {
 }
+
+method Fresh() {
+  var c := C.MaybeNew();
+  ghost var b := fresh(c.more); // error: c may be null
+}
+
+method Unchanged(c: C?)
+  modifies c
+{
+  assert unchanged(c.more); // error: c may be null
+}

--- a/Test/git-issues/git-issue-1252.dfy
+++ b/Test/git-issues/git-issue-1252.dfy
@@ -1,0 +1,96 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class C {
+  var more: C?
+  constructor ()
+    ensures more == null || fresh(more)
+  {
+    if * {
+      more := null;
+    } else {
+      more := this;
+    }
+  }
+  static method MaybeNew() returns (c: C?)
+    ensures c == null || (fresh(c) && (c.more == null || fresh(c.more)))
+  {
+    if * {
+      c := new C();
+    } else {
+      c := null;
+    }
+  }
+}
+
+method Test0()
+{
+  var c := C.MaybeNew();
+  // The following once omitted the well-formedness check
+  modify c.more; // error: c may be null
+}
+
+method Test1()
+{
+  var c := C.MaybeNew();
+  // The following once omitted the well-formedness check
+  modify c.more { // error: c may be null
+    if c != null && c.more != null {
+      c.more.more := null;
+    }
+  }
+}
+
+method Test2(c: C?)
+  modifies c.more // error: c may be null
+{
+}
+
+method Test3() {
+  // The following once omitted the well-formedness check
+  modify (if 1/0 > 0 then {} else {}); // error: division by zero
+}
+
+method Test4(n: nat) {
+  var c := C.MaybeNew();
+  var i := 0;
+  while i < n
+    // The following once omitted the well-formedness check
+    modifies c.more // error: c may be null
+  {
+    i := i + 1;
+  }
+}
+
+method Test5(n: nat) {
+  var c := C.MaybeNew();
+  var i := 0;
+  while
+    // The following once omitted the well-formedness check
+    modifies c.more // error: c may be null
+    decreases n - i
+  {
+    case i < n => i := i + 1;
+  }
+}
+
+/*method Test6(n: nat) {
+  var c := C.MaybeNew();
+  for i := 0 to n
+    // The following once omitted the well-formedness check
+    modifies c.more // error: c may be null
+  {
+  }
+   }*/
+
+function method F(c: C?): int
+  reads c, c.more // error: c may be null
+{
+  5
+}
+
+iterator Iter(c: C?, d: C?)
+  modifies c.more // error: c may be null (reported twice)
+  reads d.more // error: c may be null (reported twice)
+{
+}

--- a/Test/git-issues/git-issue-1252.dfy.expect
+++ b/Test/git-issues/git-issue-1252.dfy.expect
@@ -31,5 +31,11 @@ Execution trace:
 git-issue-1252.dfy(87,13): Error: target object may be null
 Execution trace:
     (0,0): anon0
+git-issue-1252.dfy(100,25): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(106,21): Error: target object may be null
+Execution trace:
+    (0,0): anon0
 
-Dafny program verifier finished with 4 verified, 11 errors
+Dafny program verifier finished with 4 verified, 13 errors

--- a/Test/git-issues/git-issue-1252.dfy.expect
+++ b/Test/git-issues/git-issue-1252.dfy.expect
@@ -1,0 +1,35 @@
+git-issue-1252.dfy(93,13): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(94,10): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(93,13): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(94,10): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(30,11): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(37,11): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(45,13): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(51,14): Error: possible division by zero
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(59,15): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(70,15): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+git-issue-1252.dfy(87,13): Error: target object may be null
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 4 verified, 11 errors


### PR DESCRIPTION
Some well-formedness checks for loop `modifies` clauses and `modify` statements were missing. This PR adds them.

Fixes #1252