### PR TITLE
fix: Account for types of bound variables in let-such-that translation

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -14145,18 +14145,21 @@ namespace Microsoft.Dafny {
       if (e.getTranslationDesugaring(this) == null) {
         // For let-such-that expression:
         //   var x:X, y:Y :| P(x,y,g); F(...)
-        // where g has type G, declare a function for each bound variable:
-        //   function $let$x(G): X;
-        //   function $let$y(G): Y;
-        //   function $let_canCall(G): bool;
+        // where
+        //   - g has type G, and
+        //   - tt* denotes the list of type variables in the types X and Y and expression F(...),
+        // declare a function for each bound variable:
+        //   function $let$x(Ty*, G): X;
+        //   function $let$y(Ty*, G): Y;
+        //   function $let_canCall(Ty*, G): bool;
         // and add an axiom about these functions:
-        //   axiom (forall g:G ::
-        //            { $let$x(g) }
-        //            { $let$y(g) }
-        //            $let$_canCall(g)) ==>
-        //            P($let$x(g), $let$y(g), g));
+        //   axiom (forall tt*:Ty*, g:G ::
+        //            { $let$x(tt*, g) }
+        //            { $let$y(tt*, g) }
+        //            $let$_canCall(tt*, g)) ==>
+        //            P($let$x(tt*, g), $let$y(tt*, g), g));
         // and create the desugaring:
-        //   var x:X, y:Y := $let$x(g), $let$y(g); F(...)
+        //   var x:X, y:Y := $let$x(tt*, g), $let$y(tt*, g); F(...)
         if (e is SubstLetExpr) {
           // desugar based on the original letexpr.
           var expr = (SubstLetExpr)e;
@@ -14166,7 +14169,8 @@ namespace Microsoft.Dafny {
           var orgInfo = letSuchThatExprInfo[orgExpr];
           letSuchThatExprInfo.Add(expr, new LetSuchThatExprInfo(orgInfo, this, expr.substMap, expr.typeMap));
         } else {
-          // First, determine "g" as a list of Dafny variables FVs plus possibly this, $Heap, and old($Heap)
+          // First, determine "g" as a list of Dafny variables FVs plus possibly this, $Heap, and old($Heap),
+          // and determine "tt*" as a list of Dafny type variables
           LetSuchThatExprInfo info;
           {
             var FVs = new HashSet<IVariable>();
@@ -14174,10 +14178,11 @@ namespace Microsoft.Dafny {
             var FVsHeapAt = new HashSet<Label>();
             Type usesThis = null;
             ComputeFreeVariables(e.RHSs[0], FVs, ref usesHeap, ref usesOldHeap, FVsHeapAt, ref usesThis);
+            var FTVs = new HashSet<TypeParameter>();
             foreach (var bv in e.BoundVars) {
               FVs.Remove(bv);
+              ComputeFreeTypeVariables(bv.Type, FTVs);
             }
-            var FTVs = new HashSet<TypeParameter>();
             ComputeFreeTypeVariables(e.RHSs[0], FTVs);
             info = new LetSuchThatExprInfo(e.tok, letSuchThatExprInfo.Count, FVs.ToList(), FTVs.ToList(), usesHeap, usesOldHeap, FVsHeapAt, usesThis, currentDeclaration);
             letSuchThatExprInfo.Add(e, info);

--- a/Test/git-issues/git-issue-1256.dfy
+++ b/Test/git-issues/git-issue-1256.dfy
@@ -21,3 +21,40 @@ method False()
   assert x == y; // error
   assert x == z; // error
 }
+
+// -----
+
+class C<X(0)> {
+  static predicate P<Y>(n: nat, y: Y)
+
+  static function F(k: nat, x: X): nat
+    requires P(k, x)
+  {
+    var n :| 0 <= n && P(n, x);
+    n
+  }
+
+  static function G(p: (nat, X) -> bool, k: nat, x: X): nat
+    requires p(k, x)
+  {
+    var n :| 0 <= n && p(n, x);
+    n
+  }
+
+  static const c: X
+
+  static function H(Q: (nat, bool) -> bool, k: nat): nat
+    requires Q(k, true)
+  {
+    var n :| 0 <= n && Q(n, c == c);
+    n
+  }
+
+  static function S<Y>(y: Y): set<Y> { {y} }
+
+  static function I(x: X): nat
+  {
+    var n :| 0 <= n && x in set z | z in S(x);
+    if x in S(x) then n else n + 1
+  }
+}

--- a/Test/git-issues/git-issue-1256.dfy
+++ b/Test/git-issues/git-issue-1256.dfy
@@ -1,0 +1,23 @@
+// RUN: %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function f<X(0)>(): X
+{
+  var x: X :| true;
+  x
+}
+
+type low_int = t | 0 <= t < 256
+type high_int = t | 1000 <= t < 2000 witness 1000
+
+method False()
+  // Regression: the following postcondition was once provable
+  ensures false
+{
+  var x: int := f();
+  var y: low_int := f();
+  var z: high_int := f();
+  // Regression: the following assertions were once provable
+  assert x == y; // error
+  assert x == z; // error
+}

--- a/Test/git-issues/git-issue-1256.dfy.expect
+++ b/Test/git-issues/git-issue-1256.dfy.expect
@@ -5,4 +5,4 @@ git-issue-1256.dfy(22,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
 
-Dafny program verifier finished with 3 verified, 2 errors
+Dafny program verifier finished with 7 verified, 2 errors

--- a/Test/git-issues/git-issue-1256.dfy.expect
+++ b/Test/git-issues/git-issue-1256.dfy.expect
@@ -1,0 +1,8 @@
+git-issue-1256.dfy(21,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+git-issue-1256.dfy(22,11): Error: assertion violation
+Execution trace:
+    (0,0): anon0
+
+Dafny program verifier finished with 3 verified, 2 errors


### PR DESCRIPTION
Fixes #1256