### PR TITLE
Swap the names Join and Meet

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -1796,9 +1796,9 @@ namespace Microsoft.Dafny {
 
     /// <summary>
     /// For each i, computes some combination of a[i] and b[i], according to direction[i].
-    /// For a negative direction (Contra), computes Meet(a[i], b[i]), provided this meet exists.
+    /// For a negative direction (Contra), computes Join(a[i], b[i]), provided this join exists.
     /// For a zero direction (Inv), uses a[i], provided a[i] and b[i] are equal.
-    /// For a positive direction (Co), computes Join(a[i], b[i]), provided this join exists.
+    /// For a positive direction (Co), computes Meet(a[i], b[i]), provided this meet exists.
     /// Returns null if any operation fails.
     /// </summary>
     public static List<Type> ComputeExtrema(List<TypeParameter.TPVariance> directions, List<Type> a, List<Type> b, BuiltIns builtIns) {
@@ -1822,7 +1822,7 @@ namespace Microsoft.Dafny {
             return null;
           }
         } else {
-          var t = directions[i] == TypeParameter.TPVariance.Contra ? Meet(a[i], b[i], builtIns) : Join(a[i], b[i], builtIns);
+          var t = directions[i] == TypeParameter.TPVariance.Contra ? Join(a[i], b[i], builtIns) : Meet(a[i], b[i], builtIns);
           if (t == null) {
             return null;
           }
@@ -1833,23 +1833,23 @@ namespace Microsoft.Dafny {
     }
 
     /// <summary>
-    /// Does a best-effort to compute the meet of "a" and "b", returning "null" if not successful.
+    /// Does a best-effort to compute the join of "a" and "b", returning "null" if not successful.
     ///
     /// Since some type parameters may still be proxies, it could be that the returned type is not
-    /// really a meet, so the caller should set up additional constraints that the result is
+    /// really a join, so the caller should set up additional constraints that the result is
     /// assignable to both a and b.
     /// </summary>
-    public static Type Meet(Type a, Type b, BuiltIns builtIns) {
+    public static Type Join(Type a, Type b, BuiltIns builtIns) {
       Contract.Requires(a != null);
       Contract.Requires(b != null);
       Contract.Requires(builtIns != null);
-      var j = MeetX(a, b, builtIns);
+      var j = JoinX(a, b, builtIns);
       if (DafnyOptions.O.TypeInferenceDebug) {
         Console.WriteLine("DEBUG: Meet( {0}, {1} ) = {2}", a, b, j);
       }
       return j;
     }
-    public static Type MeetX(Type a, Type b, BuiltIns builtIns) {
+    public static Type JoinX(Type a, Type b, BuiltIns builtIns) {
       Contract.Requires(a != null);
       Contract.Requires(b != null);
       Contract.Requires(builtIns != null);
@@ -1898,7 +1898,7 @@ namespace Microsoft.Dafny {
       } else if (b is RealVarietiesSupertype) {
         return a.IsNumericBased(NumericPersuasion.Real) ? a : null;
       } else if (a.IsNumericBased()) {
-        // Note, for meet, we choose not to step down to IntVarietiesSupertype or RealVarietiesSupertype
+        // Note, for join, we choose not to step down to IntVarietiesSupertype or RealVarietiesSupertype
         return a.Equals(b) ? a : null;
       } else if (a.IsBitVectorType) {
         return a.Equals(b) ? a : null;
@@ -1909,7 +1909,7 @@ namespace Microsoft.Dafny {
           return null;
         }
         // sets are co-variant in their argument type
-        var typeArg = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArg = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
         return typeArg == null ? null : new SetType(aa.Finite, typeArg);
       } else if (a is MultiSetType) {
         var aa = (MultiSetType)a;
@@ -1918,7 +1918,7 @@ namespace Microsoft.Dafny {
           return null;
         }
         // multisets are co-variant in their argument type
-        var typeArg = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArg = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
         return typeArg == null ? null : new MultiSetType(typeArg);
       } else if (a is SeqType) {
         var aa = (SeqType)a;
@@ -1927,7 +1927,7 @@ namespace Microsoft.Dafny {
           return null;
         }
         // sequences are co-variant in their argument type
-        var typeArg = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArg = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
         return typeArg == null ? null : new SeqType(typeArg);
       } else if (a is MapType) {
         var aa = (MapType)a;
@@ -1936,8 +1936,8 @@ namespace Microsoft.Dafny {
           return null;
         }
         // maps are co-variant in both argument types
-        var typeArgDomain = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
-        var typeArgRange = Meet(a.TypeArgs[1], b.TypeArgs[1], builtIns);
+        var typeArgDomain = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArgRange = Join(a.TypeArgs[1], b.TypeArgs[1], builtIns);
         return typeArgDomain == null || typeArgRange == null ? null : new MapType(aa.Finite, typeArgDomain, typeArgRange);
       } else if (a.IsDatatype) {
         var aa = a.AsDatatype;
@@ -2013,7 +2013,7 @@ namespace Microsoft.Dafny {
             return abNonNullTypes ? UserDefinedType.CreateNonNullType(udtA) : udtA;
           }
           // A and B are classes or traits. They always have object as a common supertype, but they may also both be extending some other
-          // trait.  If such a trait is unique, pick it. (Unfortunately, this makes the meet operation not associative.)
+          // trait.  If such a trait is unique, pick it. (Unfortunately, this makes the join operation not associative.)
           var commonTraits = TopLevelDeclWithMembers.CommonTraits(A, B);
           if (commonTraits.Count == 1) {
             var typeMap = Resolver.TypeSubstitutionMap(A.TypeArgs, a.TypeArgs);
@@ -2030,13 +2030,13 @@ namespace Microsoft.Dafny {
     }
 
     /// <summary>
-    /// Does a best-effort to compute the join of "a" and "b", returning "null" if not successful.
+    /// Does a best-effort to compute the meet of "a" and "b", returning "null" if not successful.
     ///
     /// Since some type parameters may still be proxies, it could be that the returned type is not
-    /// really a join, so the caller should set up additional constraints that the result is
+    /// really a meet, so the caller should set up additional constraints that the result is
     /// assignable to both a and b.
     /// </summary>
-    public static Type Join(Type a, Type b, BuiltIns builtIns) {
+    public static Type Meet(Type a, Type b, BuiltIns builtIns) {
       Contract.Requires(a != null);
       Contract.Requires(b != null);
       Contract.Requires(builtIns != null);
@@ -2048,31 +2048,31 @@ namespace Microsoft.Dafny {
       if (a is UserDefinedType && ((UserDefinedType)a).ResolvedClass is NonNullTypeDecl) {
         joinNeedsNonNullConstraint = true;
         var nnt = (NonNullTypeDecl)((UserDefinedType)a).ResolvedClass;
-        j = JoinX(nnt.RhsWithArgument(a.TypeArgs), b, builtIns);
+        j = MeetX(nnt.RhsWithArgument(a.TypeArgs), b, builtIns);
       } else if (b is UserDefinedType && ((UserDefinedType)b).ResolvedClass is NonNullTypeDecl) {
         joinNeedsNonNullConstraint = true;
         var nnt = (NonNullTypeDecl)((UserDefinedType)b).ResolvedClass;
-        j = JoinX(a, nnt.RhsWithArgument(b.TypeArgs), builtIns);
+        j = MeetX(a, nnt.RhsWithArgument(b.TypeArgs), builtIns);
       } else {
-        j = JoinX(a, b, builtIns);
+        j = MeetX(a, b, builtIns);
       }
       if (j != null && joinNeedsNonNullConstraint && !j.IsNonNullRefType) {
-        // try to make j into a non-null type; if that's not possible, then there is no join
+        // try to make j into a non-null type; if that's not possible, then there is no meet
         var udt = j as UserDefinedType;
         if (udt != null && udt.ResolvedClass is ClassDecl) {
           // add the non-null constraint back in
           j = UserDefinedType.CreateNonNullType(udt);
         } else {
-          // the original a and b have no join
+          // the original a and b have no meet
           j = null;
         }
       }
       if (DafnyOptions.O.TypeInferenceDebug) {
-        Console.WriteLine("DEBUG: Join( {0}, {1} ) = {2}", a, b, j);
+        Console.WriteLine("DEBUG: Meet( {0}, {1} ) = {2}", a, b, j);
       }
       return j;
     }
-    public static Type JoinX(Type a, Type b, BuiltIns builtIns) {
+    public static Type MeetX(Type a, Type b, BuiltIns builtIns) {
       Contract.Requires(a != null);
       Contract.Requires(b != null);
       Contract.Requires(builtIns != null);
@@ -2087,8 +2087,8 @@ namespace Microsoft.Dafny {
       var n = towerA.Count;
       Contract.Assert(1 <= n);  // guaranteed by GetTowerOfSubsetTypes
       if (towerA.Count < towerB.Count) {
-        // B is strictly taller. The join exists only if towerA[n-1] is a supertype of towerB[n-1], and
-        // then the join is "b".
+        // B is strictly taller. The meet exists only if towerA[n-1] is a supertype of towerB[n-1], and
+        // then the meet is "b".
         return Type.IsSupertype(towerA[n - 1], towerB[n - 1]) ? b : null;
       }
       Contract.Assert(towerA.Count == towerB.Count);
@@ -2110,7 +2110,7 @@ namespace Microsoft.Dafny {
           }
           return new UserDefinedType(udtA.tok, udtA.Name, udtA.ResolvedClass, typeArgs);
         } else {
-          // The two subset types do not have the same head, so there is no join
+          // The two subset types do not have the same head, so there is no meet
           return null;
         }
       }
@@ -2137,7 +2137,7 @@ namespace Microsoft.Dafny {
           return null;
         }
         // sets are co-variant in their argument type
-        var typeArg = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArg = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
         return typeArg == null ? null : new SetType(aa.Finite, typeArg);
       } else if (a is MultiSetType) {
         var aa = (MultiSetType)a;
@@ -2146,7 +2146,7 @@ namespace Microsoft.Dafny {
           return null;
         }
         // multisets are co-variant in their argument type
-        var typeArg = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArg = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
         return typeArg == null ? null : new MultiSetType(typeArg);
       } else if (a is SeqType) {
         var aa = (SeqType)a;
@@ -2155,7 +2155,7 @@ namespace Microsoft.Dafny {
           return null;
         }
         // sequences are co-variant in their argument type
-        var typeArg = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArg = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
         return typeArg == null ? null : new SeqType(typeArg);
       } else if (a is MapType) {
         var aa = (MapType)a;
@@ -2164,8 +2164,8 @@ namespace Microsoft.Dafny {
           return null;
         }
         // maps are co-variant in both argument types
-        var typeArgDomain = Join(a.TypeArgs[0], b.TypeArgs[0], builtIns);
-        var typeArgRange = Join(a.TypeArgs[1], b.TypeArgs[1], builtIns);
+        var typeArgDomain = Meet(a.TypeArgs[0], b.TypeArgs[0], builtIns);
+        var typeArgRange = Meet(a.TypeArgs[1], b.TypeArgs[1], builtIns);
         return typeArgDomain == null || typeArgRange == null ? null : new MapType(aa.Finite, typeArgDomain, typeArgRange);
       } else if (a.IsDatatype) {
         var aa = a.AsDatatype;
@@ -2195,9 +2195,9 @@ namespace Microsoft.Dafny {
         Contract.Assert(((ArrowType)a).ResolvedClass == ((ArrowType)b).ResolvedClass);
         var directions = new List<TypeParameter.TPVariance>();
         for (int i = 0; i < arity; i++) {
-          directions.Add(TypeParameter.TPVariance.Contra);  // arrow types are contra-variant in the argument types, so compute meets of these
+          directions.Add(TypeParameter.TPVariance.Contra);  // arrow types are contra-variant in the argument types, so compute joins of these
         }
-        directions.Add(TypeParameter.TPVariance.Co);  // arrow types are co-variant in the result type, so compute the join of these
+        directions.Add(TypeParameter.TPVariance.Co);  // arrow types are co-variant in the result type, so compute the meet of these
         var typeArgs = ComputeExtrema(directions, a.TypeArgs, b.TypeArgs, builtIns);
         if (typeArgs == null) {
           return null;


### PR DESCRIPTION
Swap the names Join and Meet so joining two types returns a type that contains at least as many elements as the maximum of the elements in each separate type, and meeting two types returns a type that contains at most the minimum of the elements in each separate type.

Consistently swapped the names Join and Meet by finding references with the regex `(\Wjoin[s]?\W)|(\Wmeet[s]?\W)`