### PR TITLE
Add missing ghost modifier when printing VarDeclStmt

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -664,7 +664,7 @@ namespace Microsoft.Dafny
 
       } else if (stmt is VarDeclPattern) {
         var s = (VarDeclPattern) stmt;
-        r = new VarDeclPattern(Tok(s.Tok), Tok(s.EndTok), CloneCasePattern(s.LHS), CloneExpr(s.RHS), s.IsAutoGhost);
+        r = new VarDeclPattern(Tok(s.Tok), Tok(s.EndTok), CloneCasePattern(s.LHS), CloneExpr(s.RHS), s.HasGhostModifier);
 
       } else if (stmt is ModifyStmt) {
         var s = (ModifyStmt)stmt;

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2692,7 +2692,7 @@ VarDeclStatement<.out Statement/*!*/ s.>
     Expression<out e, false, true>
 
     ";"
-    (. s = new VarDeclPattern(e.tok, e.tok, pat, e, !isGhost); .)
+    (. s = new VarDeclPattern(e.tok, e.tok, pat, e, isGhost); .)
   )
   .
 

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -7469,13 +7469,13 @@ namespace Microsoft.Dafny {
   {
     public readonly CasePattern<LocalVariable> LHS;
     public readonly Expression RHS;
-    public bool IsAutoGhost;
+    public bool HasGhostModifier;
 
-    public VarDeclPattern(IToken tok, IToken endTok, CasePattern<LocalVariable> lhs, Expression rhs, bool isAutoGhost = false)
+    public VarDeclPattern(IToken tok, IToken endTok, CasePattern<LocalVariable> lhs, Expression rhs, bool hasGhostModifier = true)
       : base(tok, endTok) {
       LHS = lhs;
       RHS = rhs;
-      IsAutoGhost = isAutoGhost;
+      HasGhostModifier = hasGhostModifier;
     }
 
     public override IEnumerable<Expression> SubExpressions {

--- a/Source/Dafny/DafnyMain.cs
+++ b/Source/Dafny/DafnyMain.cs
@@ -89,18 +89,14 @@ namespace Microsoft.Dafny {
 
   public class Main {
 
-      public static void MaybePrintProgram(Program program, string filename, bool afterResolver)
-      {
-          if (filename != null) {
-              TextWriter tw;
-              if (filename == "-") {
-                  tw = System.Console.Out;
-              } else {
-                  tw = new System.IO.StreamWriter(filename);
-              }
-              Printer pr = new Printer(tw, DafnyOptions.O.PrintMode);
-              pr.PrintProgram(program, afterResolver);
-          }
+      public static void MaybePrintProgram(Program program, string filename, bool afterResolver) {
+        if (filename == null) {
+          return;
+        }
+
+        var tw = filename == "-" ? Console.Out : new StreamWriter(filename);
+        var pr = new Printer(tw, DafnyOptions.O.PrintMode);
+        pr.PrintProgram(program, afterResolver);
       }
 
     /// <summary>

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -1522,6 +1522,9 @@ namespace Microsoft.Dafny {
 
       } else if (stmt is VarDeclPattern) {
         var s = (VarDeclPattern)stmt;
+        if (s.HasGhostModifier) {
+          wr.Write("ghost ");
+        }
         wr.Write("var ");
         PrintCasePattern(s.LHS);
         wr.Write(" := ");

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -8353,7 +8353,7 @@ namespace Microsoft.Dafny
               local.MakeGhost();
             }
           }
-          if (!s.IsAutoGhost || mustBeErasable) {
+          if (s.HasGhostModifier || mustBeErasable) {
             s.IsGhost = s.LocalVars.All(v => v.IsGhost);
           } else {
             var spec = resolver.UsesSpecFeatures(s.RHS);

--- a/Test/dafny0/PrettyPrinting.dfy
+++ b/Test/dafny0/PrettyPrinting.dfy
@@ -41,6 +41,7 @@ module B refines A {
 
 module C {
   method For() {
+    ghost var (x, y) := (123, 234);
     var a := new int[100];
     for i := 0 to 100 {
       a[i] := i;

--- a/Test/dafny0/PrettyPrinting.dfy.expect
+++ b/Test/dafny0/PrettyPrinting.dfy.expect
@@ -47,6 +47,8 @@ module C {
 
   method For()
   {
+    ghost var (x, y) := (123, 234);
+
     var a := new int[100];
     for i := 0 to 100 {
       a[i] := i;
@@ -100,10 +102,10 @@ PrettyPrinting.dfy(18,4): Error: skeleton statements are allowed only in refinin
 PrettyPrinting.dfy(18,4): Warning: note, this loop has no body
 PrettyPrinting.dfy(19,4): Error: skeleton statements are allowed only in refining methods
 PrettyPrinting.dfy(33,4): Warning: note, this forall statement has no body
-PrettyPrinting.dfy(51,4): Warning: note, this loop has no body (loop frame: i)
 PrettyPrinting.dfy(52,4): Warning: note, this loop has no body (loop frame: i)
-PrettyPrinting.dfy(53,4): Warning: note, this loop has no body (loop frame: i, a)
-PrettyPrinting.dfy(56,4): Warning: note, this loop has no body (loop frame: i, a)
-PrettyPrinting.dfy(68,4): Warning: note, this loop has no body (loop frame: i)
-PrettyPrinting.dfy(72,16): Error: a possibly infinite loop is allowed only if the enclosing method is declared (with 'decreases *') to be possibly non-terminating
+PrettyPrinting.dfy(53,4): Warning: note, this loop has no body (loop frame: i)
+PrettyPrinting.dfy(54,4): Warning: note, this loop has no body (loop frame: i, a)
+PrettyPrinting.dfy(57,4): Warning: note, this loop has no body (loop frame: i, a)
+PrettyPrinting.dfy(69,4): Warning: note, this loop has no body (loop frame: i)
+PrettyPrinting.dfy(73,16): Error: a possibly infinite loop is allowed only if the enclosing method is declared (with 'decreases *') to be possibly non-terminating
 3 resolution/type errors detected in PrettyPrinting.dfy


### PR DESCRIPTION
Fixes #1280

### Changes
- Add missing ghost modifier when printing VarDeclStmt
- Rename the property `IsAutoGhost` to `HasGhostModifier` and flip the boolean value. LMK if anyone has concerns.