### PR TITLE
fix: typos in Compiler-java.GenericArrayElementLvalue

### DIFF
--- a/Source/Dafny/Compiler-java.cs
+++ b/Source/Dafny/Compiler-java.cs
@@ -1465,7 +1465,7 @@ namespace Microsoft.Dafny{
       public ConcreteSyntaxTree EmitWrite(ConcreteSyntaxTree wr) {
         ConcreteSyntaxTree w;
         if (Indices.Count == 1) {
-          wr.Write($"{FormatTypeDescriptorVariable(ElmtTypeParameter)}.setArrayElement({Array}, {Indices[0]}.intValue(),");
+          wr.Write($"{FormatTypeDescriptorVariable(ElmtTypeParameter)}.setArrayElement({Array}, {Indices[0]},");
           w = wr.Fork();
           wr.Write(")");
         } else {
@@ -1473,6 +1473,7 @@ namespace Microsoft.Dafny{
           w = wr.Fork();
           wr.Write(")");
         }
+        Compiler.EndStmt(wr);
         return w;
       }
     }

--- a/Test/comp/Arrays.dfy
+++ b/Test/comp/Arrays.dfy
@@ -314,6 +314,13 @@ class Cell<T> {
   {
     x, y := arr, arr;
   }
+  method UArray(x: T)
+    modifies arr 
+  {
+    if arr.Length > 0 {
+      arr[0] := x;
+    }
+  }
 }
 
 type ychar = ch | '\0' <= ch <= 'z'

--- a/Test/comp/Arrays.dfy.expect
+++ b/Test/comp/Arrays.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 41 verified, 0 errors
+Dafny program verifier finished with 42 verified, 0 errors
 
 Dafny program verifier did not attempt verification
 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 


### PR DESCRIPTION
This specialization of ILvalue represents an lvalue of the form `a[i]` where a is an array of unknown (that is, parameterized) type. The implementation was missing a call to `EndStmt(wr)` and had an unnecessary call to `intValue()`, and the test suite somehow managed to miss exercising this case.

This is a good case study for being able to measure the code coverage of the regression suite, which will be possible to tackle once we a) move to xUnit to drive the tests and b) stop creating separate `dafny` subprocesses for each test.