### PR TITLE
Use Boogie 2.9.3

### DIFF
--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.2" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <!-- Boogie dependency -->
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.2" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Boogie 2.9.3 has corrected support for `:split_here` and support for `:focus`. With this PR, these can be used directly from Dafny. A Dafny PR that makes use of these automatically is coming soon.