### PR TITLE
fix: Do ambiguity-resolving type-equality test only on visible types

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -1784,9 +1784,14 @@ namespace Microsoft.Dafny
                   var dk = ResolveAlias(kv.Value);
                   ok = dd == dk;
                 } else {
-                  var dType = UserDefinedType.FromTopLevelDecl(d.tok, d);
-                  var vType = UserDefinedType.FromTopLevelDecl(kv.Value.tok, kv.Value);
-                  ok = dType.Equals(vType, true);
+                  // It's okay if "d" and "kv.Value" denote the same type. This can happen, for example,
+                  // if both are type synonyms for "int".
+                  var scope = Type.GetScope();
+                  if (d.IsVisibleInScope(scope) && kv.Value.IsVisibleInScope(scope)) {
+                    var dType = UserDefinedType.FromTopLevelDecl(d.tok, d);
+                    var vType = UserDefinedType.FromTopLevelDecl(kv.Value.tok, kv.Value);
+                    ok = dType.Equals(vType, true);
+                  }
                 }
                 if (!ok) {
                   sig.TopLevels[kv.Key] = AmbiguousTopLevelDecl.Create(moduleDef, d, kv.Value);
@@ -16929,7 +16934,7 @@ namespace Microsoft.Dafny
     public static string GhostPrefix(bool isGhost) {
       return isGhost ? "ghost " : "";
     }
-    
+
     /// <summary>
     /// Try to make "expr" compilable (in particular, mark LHSs of a let-expression as ghosts if
     /// the corresponding RHS is ghost), and then report errors for every part that would prevent

--- a/Test/git-issues/git-issue-1347.dfy
+++ b/Test/git-issues/git-issue-1347.dfy
@@ -1,0 +1,31 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Foo {
+  datatype T = TX()
+  datatype U = U
+  datatype V = TV()
+  datatype W0 = W0()
+  datatype W1 = W1()
+}
+
+module Bar {
+  datatype T = TY()
+  datatype U = U
+  function V(): int
+  datatype W0 = W0
+  datatype W1 = W1
+}
+
+module Consumer {
+  import opened Foo
+  import opened Bar
+
+  type W0 = Foo.W0
+  type W1 = Bar.W1
+
+  // The following export set once caused a crash in Dafny, because of the
+  // ambiguously import-opened T (and U).
+  export
+    provides Foo, Bar
+}

--- a/Test/git-issues/git-issue-1347.dfy.expect
+++ b/Test/git-issues/git-issue-1347.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Fixes #1347