### PR TITLE
Fix multiple occurrences of same key in map for Go and JS

### DIFF
--- a/Binaries/DafnyRuntime.go
+++ b/Binaries/DafnyRuntime.go
@@ -1417,22 +1417,6 @@ func NewMapBuilder() *MapBuilder {
   return new(MapBuilder)
 }
 
-// Add adds a key and value to the map being built.
-func (mb *MapBuilder) Add(k, v interface{}) *MapBuilder {
-  modifyingIdx := -1
-  for i, e := range *mb {
-    if AreEqual(e.key, k) {
-      modifyingIdx = i
-    }
-  }
-  if modifyingIdx == -1 {
-    *mb = append(*mb, mapElt{k, v})
-  } else {
-    (*mb)[modifyingIdx] = mapElt{k, v}
-  }
-  return mb
-}
-
 // ToMap gets the map out of the map builder.
 func (mb *MapBuilder) ToMap() Map {
   return Map{*mb}
@@ -1491,6 +1475,19 @@ func (m Map) Contains(key interface{}) bool {
 // Update returns a new Map which associates the given key and value.
 func (m Map) Update(key, value interface{}) Map {
   ans := m.clone()
+  i, found := ans.findIndex(key)
+  if found {
+    ans.elts[i] = mapElt{key, value}
+  } else {
+    ans.elts = append(ans.elts, mapElt{key, value})
+  }
+  return ans
+}
+
+// Similar to Update, but make the modification in-place.
+// Meant to be used in the map constructor.
+func (m Map) UpdateUnsafe(key, value interface{}) Map {
+  ans := m
   i, found := ans.findIndex(key)
   if found {
     ans.elts[i] = mapElt{key, value}

--- a/Binaries/DafnyRuntime.go
+++ b/Binaries/DafnyRuntime.go
@@ -1419,7 +1419,17 @@ func NewMapBuilder() *MapBuilder {
 
 // Add adds a key and value to the map being built.
 func (mb *MapBuilder) Add(k, v interface{}) *MapBuilder {
-  *mb = append(*mb, mapElt{k, v})
+  modifyingIdx := -1
+  for i, e := range *mb {
+    if AreEqual(e.key, k) {
+      modifyingIdx = i
+    }
+  }
+  if modifyingIdx == -1 {
+    *mb = append(*mb, mapElt{k, v})
+  } else {
+    (*mb)[modifyingIdx] = mapElt{k, v}
+  }
   return mb
 }
 

--- a/Binaries/DafnyRuntime.js
+++ b/Binaries/DafnyRuntime.js
@@ -600,6 +600,14 @@ let _dafny = (function() {
       m[i] = [k, v];
       return m;
     }
+    // Similar to update, but make the modification in-place.
+    // Meant to be used in the map constructor.
+    updateUnsafe(k, v) {
+      let m = this;
+      let i = m.findIndex(k);
+      m[i] = [k, v];
+      return m;
+    }
     equals(other) {
       if (this === other) {
         return true;

--- a/Source/Dafny/Compiler-go.cs
+++ b/Source/Dafny/Compiler-go.cs
@@ -3360,15 +3360,14 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitMapDisplay(MapType mt, Bpl.IToken tok, List<ExpressionPair> elements, bool inLetExprBody, ConcreteSyntaxTree wr) {
-      wr.Write("_dafny.NewMapBuilder()");
+      wr.Write("_dafny.NewMapBuilder().ToMap()");
       foreach (ExpressionPair p in elements) {
-        wr.Write(".Add(");
+        wr.Write(".UpdateUnsafe(");
         TrExpr(p.A, wr, inLetExprBody);
         wr.Write(", ");
         TrExpr(p.B, wr, inLetExprBody);
         wr.Write(')');
       }
-      wr.Write(".ToMap()");
     }
 
     protected override void EmitSetBuilder_New(ConcreteSyntaxTree wr, SetComprehension e, string collectionName) {

--- a/Source/Dafny/Compiler-js.cs
+++ b/Source/Dafny/Compiler-js.cs
@@ -2282,18 +2282,14 @@ namespace Microsoft.Dafny {
     }
 
     protected override void EmitMapDisplay(MapType mt, Bpl.IToken tok, List<ExpressionPair> elements, bool inLetExprBody, ConcreteSyntaxTree wr) {
-      wr.Write($"{DafnyMapClass}.of(");
-      string sep = "";
+      wr.Write($"{DafnyMapClass}.Empty.slice()");
       foreach (ExpressionPair p in elements) {
-        wr.Write(sep);
-        wr.Write("[");
+        wr.Write(".updateUnsafe(");
         TrExpr(p.A, wr, inLetExprBody);
         wr.Write(",");
         TrExpr(p.B, wr, inLetExprBody);
-        wr.Write("]");
-        sep = ", ";
+        wr.Write(")");
       }
-      wr.Write(")");
     }
 
     protected override void EmitSetBuilder_New(ConcreteSyntaxTree wr, SetComprehension e, string collectionName) {

--- a/Test/comp/Collections.dfy
+++ b/Test/comp/Collections.dfy
@@ -244,6 +244,7 @@ method Maps() {
   print "items: ", items, "\n";
 
   TestMapMergeSubtraction();
+  TestMapMultiOccurrences();
 }
 
 method TestMapMergeSubtraction() {
@@ -362,6 +363,13 @@ method TestNullsAmongValues() {
   print p[0].name, " ", p[1].name, " ", p[20], "\n";  // jack wendy null
   print q[0].name, " ", q[199], " ", q[20], "\n";  // jack null null
   print r[0].name, " ", r[198].name, " ", 20 in r, "\n";  // ronald ronald false
+}
+
+method TestMapMultiOccurrences() {
+  var a := map[1 := 1, 1 := 2];
+  print "Map multiple occurrences test", "\n";
+  print "  length: ", |a|, "\n";
+  print "  self-equal: ", a == a, "\n";
 }
 
 // -------------------------------------------------------------------------------------------

--- a/Test/comp/Collections.dfy.expect
+++ b/Test/comp/Collections.dfy.expect
@@ -92,6 +92,9 @@ true true true false
 jack wendy null
 jack null null
 ronald ronald false
+Map multiple occurrences test
+  length: 1
+  self-equal: true
 2: 0 1 1
 3: 0 1 2
 There are 0 occurrences of 58 in the multiset
@@ -207,6 +210,9 @@ true true true false
 jack wendy null
 jack null null
 ronald ronald false
+Map multiple occurrences test
+  length: 2
+  self-equal: true
 2: 0 1 1
 3: 0 1 2
 There are 0 occurrences of 58 in the multiset
@@ -322,6 +328,9 @@ true true true false
 jack wendy null
 jack null null
 ronald ronald false
+Map multiple occurrences test
+  length: 1
+  self-equal: true
 2: 0 1 1
 3: 0 1 2
 There are 0 occurrences of 58 in the multiset
@@ -437,6 +446,9 @@ true true true false
 jack wendy null
 jack null null
 ronald ronald false
+Map multiple occurrences test
+  length: 1
+  self-equal: true
 2: 0 1 1
 3: 0 1 2
 There are 0 occurrences of 58 in the multiset

--- a/Test/comp/Collections.dfy.expect
+++ b/Test/comp/Collections.dfy.expect
@@ -211,7 +211,7 @@ jack wendy null
 jack null null
 ronald ronald false
 Map multiple occurrences test
-  length: 2
+  length: 1
   self-equal: true
 2: 0 1 1
 3: 0 1 2


### PR DESCRIPTION
Attempting to enforce the invariant that keys are all distinct.

The distinction check changes the time complexity of a map display expression of size n to O(n^2). A better data structure is required to be more efficient.

Fix #1367