### PR TITLE
Update use-local-boogie.sh

### DIFF
--- a/Scripts/use-local-boogie.sh
+++ b/Scripts/use-local-boogie.sh
@@ -2,5 +2,5 @@ BOOGIE_PATH="Source/boogie/"
 allDlls=("Boogie.AbsInt.dll" "Boogie.BaseTypes.dll" "Boogie.CodeContractsExtender.dll" "Boogie.Concurrency.dll" "Boogie.Core.dll" "Boogie.ExecutionEngine.dll" "Boogie.Graph.dll" "Boogie.Houdini.dll" "Boogie.Model.dll" "Boogie.Predication.dll" "Boogie.Provers.SMTLib.dll" "Boogie.VCExpr.dll" "Boogie.VCGeneration.dll" "BoogieDriver.dll" "System.Configuration.ConfigurationManager.dll" "System.Runtime.Caching.dll" "System.Security.Cryptography.ProtectedData.dll" "System.Security.Permissions.dll")
 for t in "${allDlls[@]}"
 do
-	cp "${BOOGIE_PATH}Source/BoogieDriver/bin/Debug/netcoreapp3.1/${t}" Binaries/
+	cp "${BOOGIE_PATH}Source/BoogieDriver/bin/Debug/net5.0/${t}" Binaries/
 done


### PR DESCRIPTION
Boogie now uses 5.0 dotnet, so we should update the folder we are copying from.