### PR TITLE
fix: Check type equality in override signatures

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -9305,7 +9305,7 @@ namespace Microsoft.Dafny
       }
       CheckOverride_ResolvedParameters(nw.tok, old.Formals, nw.Formals, nw.Name, "function", "parameter", typeMap);
       var oldResultType = Resolver.SubstType(old.ResultType, typeMap);
-      if (!nw.ResultType.Equals(oldResultType)) {
+      if (!nw.ResultType.Equals(oldResultType, true)) {
         reporter.Error(MessageSource.Resolver, nw, "the result type of function '{0}' ({1}) differs from that in the overridden function ({2})",
           nw.Name, nw.ResultType, oldResultType);
       }
@@ -9387,7 +9387,7 @@ namespace Microsoft.Dafny
               parameterKind, n.Name, thing, name);
           } else {
             var oo = Resolver.SubstType(o.Type, typeMap);
-            if (!n.Type.Equals(oo)) {
+            if (!n.Type.Equals(oo, true)) {
               reporter.Error(MessageSource.Resolver, n.tok,
                 "the type of {0} '{1}' is different from the type of the corresponding {0} in trait {2} ('{3}' instead of '{4}')",
                 parameterKind, n.Name, thing, n.Type, oo);

--- a/Test/git-issues/git-issue-1377.dfy
+++ b/Test/git-issues/git-issue-1377.dfy
@@ -1,0 +1,60 @@
+// RUN: %dafny /compile:3 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class Cell {
+  var data: int
+}
+
+trait Trait {
+  function method baz(): Cell
+  function method xyz(): nat
+
+  method M0(n: nat) returns (n': int)
+  method M1(n: int) returns (n': nat)
+  function method F0(n: nat): int
+  function method F1(n: int): nat
+  function method G(x: nat): nat
+}
+
+class Class extends Trait {
+  constructor () {}
+  // regression: the next two method declarations were once allowed
+  function method baz(): Cell? { // error: baz() should not be allowed to widen the result type
+    null
+  }
+  function method xyz(): int { // error: xyz() should not be allowed to widen the result type
+    -4
+  }
+
+  function method baz'(c: Cell): Cell {
+    c
+  }
+  function method xyz'(): nat {
+    15
+  }
+
+  method M0(n: int) returns (n': nat) { n' := 0; } // error (x2): cannot change parameter types in override
+  method M1(n: nat) returns (n': int) { n' := 0; } // error (x2): cannot change parameter types in override
+  function method F0(n: int): nat { 0 } // error (x2): cannot change parameter/result types in override
+  function method F1(n: nat): int { 0 } // error (x2): cannot change parameter/result types in override
+  function method G(x: NatSym): NatSym
+}
+
+type NatSym = nat
+
+method Problem(n: nat) {
+  var e: Trait := new Class();
+
+  if n == 0 {
+    var z := e.baz().data;
+  } else {
+    var y := e.xyz() + 4;
+    var z := 10 / y;
+  }
+}
+
+method Main() {
+  // if Class.baz() and Class.xyz() were allowed, then either of the following calls would cause a crash
+  Problem(0);
+  Problem(1);
+}

--- a/Test/git-issues/git-issue-1377.dfy.expect
+++ b/Test/git-issues/git-issue-1377.dfy.expect
@@ -1,0 +1,11 @@
+git-issue-1377.dfy(22,18): Error: the result type of function 'baz' (Cell?) differs from that in the overridden function (Cell)
+git-issue-1377.dfy(25,18): Error: the result type of function 'xyz' (int) differs from that in the overridden function (nat)
+git-issue-1377.dfy(36,12): Error: the type of in-parameter 'n' is different from the type of the corresponding in-parameter in trait method ('int' instead of 'nat')
+git-issue-1377.dfy(36,29): Error: the type of out-parameter 'n'' is different from the type of the corresponding out-parameter in trait method ('nat' instead of 'int')
+git-issue-1377.dfy(37,12): Error: the type of in-parameter 'n' is different from the type of the corresponding in-parameter in trait method ('nat' instead of 'int')
+git-issue-1377.dfy(37,29): Error: the type of out-parameter 'n'' is different from the type of the corresponding out-parameter in trait method ('int' instead of 'nat')
+git-issue-1377.dfy(38,21): Error: the type of parameter 'n' is different from the type of the corresponding parameter in trait function ('int' instead of 'nat')
+git-issue-1377.dfy(38,18): Error: the result type of function 'F0' (nat) differs from that in the overridden function (int)
+git-issue-1377.dfy(39,21): Error: the type of parameter 'n' is different from the type of the corresponding parameter in trait function ('nat' instead of 'int')
+git-issue-1377.dfy(39,18): Error: the result type of function 'F1' (int) differs from that in the overridden function (nat)
+10 resolution/type errors detected in git-issue-1377.dfy


### PR DESCRIPTION
Previously, the type-equality checks for overriding methods/functions ignored type constraints. With this PR, the proper type equality is used.

Note, one can imagine allowing some co-/contra-variance among the parameters in an override. That would indeed be sound, but it may cause complications in compilation, since target languages may have different rules. Therefore, I suggest we continue to insist on type equality in Dafny. If a strong need for co-/contra-variance comes up, we can consider changing the language.

Fixes #1377 