### PR TITLE
Make singleton datatypes more efficient in Go

### DIFF
--- a/Source/Dafny/Compilers/Compiler-go.cs
+++ b/Source/Dafny/Compilers/Compiler-go.cs
@@ -750,7 +750,11 @@ namespace Microsoft.Dafny {
               var wDtor = wr.NewNamedBlock("func (_this {0}) {1}() {2}", name, FormatDatatypeDestructorName(arg.CompileName), TypeName(arg.Type, wr, arg.tok));
               var n = dtor.EnclosingCtors.Count;
               if (n == 1) {
-                wDtor.WriteLine("return _this.{0}", DatatypeFieldName(arg));
+                if (dt.Ctors.Count == 1) {
+                  wDtor.WriteLine("return _this.{0}", DatatypeFieldName(arg));
+                } else {
+                  wDtor.WriteLine("return _this.Get().({0}).{1}", structOfCtor(dtor.EnclosingCtors[0]), DatatypeFieldName(arg));
+                }
               } else {
                 wDtor = wDtor.NewBlock("switch data := _this.Get().(type)");
                 for (int i = 0; i < n - 1; i++) {


### PR DESCRIPTION
Fixes #1214. I'm not very serious about this implementation, I just wanted to show what I managed to do with a little hacking.

Currently, a simple "record" inductive like `datatype Astruct = A(x: uint64, y: bool)` gets compiled to a Go struct with an interface that only ever has one implementing struct. This creates an unnecessary indirection. This PR replaces that interface with the single constructor's concrete struct type.

The change here is designed to minimize changes to the compiler and share with the case where the datatype has more than one constructor as much as possible. More aggressively for such records we could get rid of the interface type entirely, or also simplify the `String()` and `Equals()` implementations. I've benchmarked this change and it does seem to fix the performance problems I had with the normal Dafny output. It's not huge but I do observe a difference, maybe 5% faster for a regular benchmark that shouldn't be bottlenecked on creating structs; an artificial benchmark that creates a lot of structs goes from 83ns to do a functional update to a struct down to 3ns with this PR.