### PR TITLE
Add pre-commit hook for dotnet-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,7 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3  # Use the ref you want to point at
+-   repo: https://github.com/dotnet/format
+    rev: v5.1.225507
     hooks:
-    -   id: trailing-whitespace
-        exclude: >  # exclude generated files, third-party files, and .expect files
-            (?x)^(
-                Source/Dafny/Parser\.cs|
-                Source/Dafny/Scanner\.cs|
-                Docs/DafnyRef/madoko\.css|
-                Docs/DafnyRef/css\.sty|
-                Docs/DafnyRef/out/DafnyRef\.html|
-                third_party/Coco/.*|
-                Test/.*\.expect
-            )$
+    -   id: dotnet-format
+        entry: dotnet-format Source/Dafny.sln -w --
+        


### PR DESCRIPTION
This PR tries to address this comment: https://github.com/dafny-lang/dafny/pull/1389#issuecomment-905957211


### Caveats
`pre-commit run` takes about 5s with this change.

The generated .cs files have valid whitespace so I didn't add them to an exclude list.

I tried using the `--include` argument of `dotnet-format` to only get the changed files to be formatted but couldn't get that to work, and it wasn't faster to run anyways.

### Testing

Verified that when having bad whitespace in the staging area, `pre-commit run` resolves that.