### PR TITLE
Set default time limit of five minutes per procedure

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -124,6 +124,9 @@ dafnyExecutable += ' -countVerificationErrors:0'
 dafnyExecutable += ' -compileVerbose:0'
 dafnyExecutable += ' /errorTrace:0'
 
+# Set a default time limit, to catch cases where verification time runs off the rails
+dafnyExecutable += ' /timeLimit:60'
+
 # Allow user to provide extra arguments to Dafny
 dafnyParams = lit_config.params.get('dafny_params','')
 if len(dafnyParams) > 0:

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -125,7 +125,7 @@ dafnyExecutable += ' -compileVerbose:0'
 dafnyExecutable += ' /errorTrace:0'
 
 # Set a default time limit, to catch cases where verification time runs off the rails
-dafnyExecutable += ' /timeLimit:60'
+dafnyExecutable += ' /timeLimit:300'
 
 # Allow user to provide extra arguments to Dafny
 dafnyParams = lit_config.params.get('dafny_params','')


### PR DESCRIPTION
This is a guard against cases where verification of test cases still succeeds but takes far longer, such as the recent reverted #1351. Ideally it can be tightened and made more precise over time, perhaps on a per-file basis.