### PR TITLE
Language Server: Option to set the severity of info messages

### DIFF
--- a/Source/DafnyLanguageServer/DafnyLanguageServer.cs
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Dafny.LanguageServer {
 
     public static LanguageServerOptions WithDafnyLanguageServer(this LanguageServerOptions options, IConfiguration configuration) {
       return options
-        .WithDafnyLanguage()
+        .WithDafnyLanguage(configuration)
         .WithDafnyWorkspace(configuration)
         .WithDafnyHandlers()
         .OnInitialize(InitializeAsync)

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     private const MessageSource verifierMessageSource = MessageSource.Other;
 
     private readonly DocumentUri entryDocumentUri;
+    private readonly DiagnosticOptions diagnosticOptions;
     private readonly Dictionary<DocumentUri, List<Diagnostic>> diagnostics = new();
     private readonly Dictionary<DiagnosticSeverity, int> counts = new();
 
@@ -19,11 +20,13 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// Creates a new instance with the given uri of the entry document.
     /// </summary>
     /// <param name="entryDocumentUri">The entry document's uri.</param>
+    /// <param name="diagnosticOptions">The configuration for the reported diagnostics.</param>
     /// <remarks>
     /// The uri of the entry document is necessary to report general compiler errors as part of this document.
     /// </remarks>
-    public DiagnosticErrorReporter(DocumentUri entryDocumentUri) {
+    public DiagnosticErrorReporter(DocumentUri entryDocumentUri, DiagnosticOptions diagnosticOptions) {
       this.entryDocumentUri = entryDocumentUri;
+      this.diagnosticOptions = diagnosticOptions;
     }
 
     public void ReportBoogieError(ErrorInformation error) {
@@ -97,11 +100,11 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         : token.GetDocumentUri();
     }
 
-    private static DiagnosticSeverity ToSeverity(ErrorLevel level) {
+    private DiagnosticSeverity ToSeverity(ErrorLevel level) {
       return level switch {
         ErrorLevel.Error => DiagnosticSeverity.Error,
         ErrorLevel.Warning => DiagnosticSeverity.Warning,
-        ErrorLevel.Info => DiagnosticSeverity.Information,
+        ErrorLevel.Info => diagnosticOptions.InfoSeverity,
         _ => throw new ArgumentException($"unknown error level {level}", nameof(level))
       };
     }

--- a/Source/DafnyLanguageServer/Language/DiagnosticOptions.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticOptions.cs
@@ -1,0 +1,18 @@
+﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.Dafny.LanguageServer.Language {
+  /// <summary>
+  /// Options for diagnostics reported to the LSP client.
+  /// </summary>
+  public class DiagnosticOptions {
+    /// <summary>
+    /// The IConfiguration section of the document options.
+    /// </summary>
+    public const string Section = "Diagnostic";
+
+    /// <summary>
+    /// Gets or sets the severity of info messages produced by the Dafny compiler.
+    /// </summary>
+    public DiagnosticSeverity InfoSeverity { get; set; } = DiagnosticSeverity.Information;
+  }
+}

--- a/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Dafny.LanguageServer.Language.Symbols;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Server;
@@ -12,13 +13,15 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// Registers all services necessary to manage the dafny language.
     /// </summary>
     /// <param name="options">The language server where the workspace services should be registered to.</param>
+    /// <param name="configuration">The configuration object holding the server configuration.</param>
     /// <returns>The language server enriched with the dafny workspace services.</returns>
-    public static LanguageServerOptions WithDafnyLanguage(this LanguageServerOptions options) {
-      return options.WithServices(services => services.WithDafnyLanguage());
+    public static LanguageServerOptions WithDafnyLanguage(this LanguageServerOptions options, IConfiguration configuration) {
+      return options.WithServices(services => services.WithDafnyLanguage(configuration));
     }
 
-    private static IServiceCollection WithDafnyLanguage(this IServiceCollection services) {
+    private static IServiceCollection WithDafnyLanguage(this IServiceCollection services, IConfiguration configuration) {
       return services
+        .Configure<DiagnosticOptions>(configuration.GetSection(DiagnosticOptions.Section))
         .AddSingleton<IDafnyParser>(serviceProvider => DafnyLangParser.Create(serviceProvider.GetRequiredService<ILogger<DafnyLangParser>>()))
         .AddSingleton<ISymbolResolver, DafnyLangSymbolResolver>()
         .AddSingleton<IProgramVerifier>(serviceProvider => DafnyProgramVerifier.Create(serviceProvider.GetRequiredService<ILogger<DafnyProgramVerifier>>()))

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -30,3 +30,10 @@ For example, to launch DafnyLS to only verify upon saving the document, use the 
 ```sh
 dotnet DafnyLanguageServer.dll --documents:verify=onsave
 ```
+
+Another option is specifying the severity of the information messages reported by the Dafny compiler using `--diagnostic:infoseverity`. The options are:
+
+- *Error*
+- *Warning*
+- *Information* (default)
+- *Hint*

--- a/Source/DafnyLanguageServer/Workspace/DocumentOptions.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentOptions.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Linq;
-using Microsoft.Boogie;
+﻿using Microsoft.Boogie;
+using System;
 
 namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// <summary>


### PR DESCRIPTION
This PR enables users to change the severity of information messages (such as *tail recursive*) as requested in https://github.com/dafny-lang/ide-vscode/issues/42. 