### PR TITLE
Language Server: Support verification timeouts

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -314,7 +314,16 @@ namespace Microsoft.Dafny {
       bplFilename = BoogieProgramSuffix(bplFilename, moduleName);
       stats = null;
       oc = BoogiePipelineWithRerun(boogieProgram, bplFilename, out stats, 1 < Dafny.DafnyOptions.Clo.VerifySnapshots ? programId : null);
-      return (oc == PipelineOutcome.Done || oc == PipelineOutcome.VerificationCompleted) && stats.ErrorCount == 0 && stats.InconclusiveCount == 0 && stats.TimeoutCount == 0 && stats.OutOfResourceCount == 0 && stats.OutOfMemoryCount == 0;
+      return IsBoogieVerified(oc, stats);
+    }
+
+    public static bool IsBoogieVerified(PipelineOutcome outcome, PipelineStatistics statistics) {
+      return (outcome == PipelineOutcome.Done || outcome == PipelineOutcome.VerificationCompleted)
+        && statistics.ErrorCount == 0
+        && statistics.InconclusiveCount == 0
+        && statistics.TimeoutCount == 0
+        && statistics.OutOfResourceCount == 0
+        && statistics.OutOfMemoryCount == 0;
     }
 
     public static bool Boogie(string baseName, IEnumerable<Tuple<string, Bpl.Program>> boogiePrograms, string programId, out Dictionary<string, PipelineStatistics> statss, out PipelineOutcome oc) {

--- a/Source/DafnyLanguageServer.Test/Various/VerificationNotificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/VerificationNotificationTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
+using Microsoft.Dafny.LanguageServer.Language;
 using Microsoft.Dafny.LanguageServer.Workspace.Notifications;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
   [TestClass]
   public class VerificationNotificationTest : DafnyLanguageServerTestBase {
+    private const int MaxTestExecutionTimeMs = 10000;
     private ILanguageClient _client;
     private TestNotificationReceiver _notificationReceiver;
     private IDictionary<string, string> _configuration;
@@ -34,7 +36,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
         : new ConfigurationBuilder().AddInMemoryCollection(_configuration).Build();
     }
 
-    [TestMethod, Timeout(5000)]
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
     public async Task DocumentWithParserErrorsSendsParsingFailedStatus() {
       var source = @"
 method Abs(x: int) returns (y: int)
@@ -56,7 +58,7 @@ method Abs(x: int) returns (y: int)
       Assert.AreEqual(CompilationStatus.ParsingFailed, queueRemainder.Status);
     }
 
-    [TestMethod, Timeout(5000)]
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
     public async Task DocumentWithResolverErrorsSendsResolutionFailedStatus() {
       var source = @"
 method Abs(x: int) returns (y: int)
@@ -78,7 +80,7 @@ method Abs(x: int) returns (y: int)
       Assert.AreEqual(CompilationStatus.ResolutionFailed, queueRemainder.Status);
     }
 
-    [TestMethod, Timeout(5000)]
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
     public async Task DocumentWithoutErrorsSendsCompilationSucceededVerificationStartedAndVerificationSucceededStatuses() {
       var source = @"
 method Abs(x: int) returns (y: int)
@@ -106,7 +108,7 @@ method Abs(x: int) returns (y: int)
       Assert.AreEqual(CompilationStatus.VerificationSucceeded, completed.Status);
     }
 
-    [TestMethod, Timeout(5000)]
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
     public async Task DocumentWithOnlyVerifierErrorsSendsCompilationSucceededVerificationStartedAndVerificationFailedStatuses() {
       var source = @"
 method Abs(x: int) returns (y: int)
@@ -131,8 +133,8 @@ method Abs(x: int) returns (y: int)
       Assert.AreEqual(CompilationStatus.VerificationFailed, completed.Status);
     }
 
-    [TestMethod, Timeout(10000)]
-    public async Task DocumentWithOnlyVerifierTimeoutSendsCompilationSucceededVerificationStartedAndVerificationFailedStatuses() {
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
+    public async Task DocumentWithOnlyCodedVerifierTimeoutSendsCompilationSucceededVerificationStartedAndVerificationFailedStatuses() {
       var source = @"
 lemma {:timeLimit 3} SquareRoot2NotRational(p: nat, q: nat)
   requires p > 0 && q > 0
@@ -148,6 +150,42 @@ lemma {:timeLimit 3} SquareRoot2NotRational(p: nat, q: nat)
     }
   }
 }".TrimStart();
+      var documentItem = CreateTestDocument(source);
+      _client.OpenDocument(documentItem);
+      var compilation = await _notificationReceiver.AwaitNextCompilationStatusAsync(CancellationToken);
+      Assert.AreEqual(documentItem.Uri, compilation.Uri);
+      Assert.AreEqual(documentItem.Version, compilation.Version);
+      Assert.AreEqual(CompilationStatus.CompilationSucceeded, compilation.Status);
+      var started = await _notificationReceiver.AwaitNextCompilationStatusAsync(CancellationToken);
+      Assert.AreEqual(documentItem.Uri, started.Uri);
+      Assert.AreEqual(documentItem.Version, started.Version);
+      Assert.AreEqual(CompilationStatus.VerificationStarted, started.Status);
+      var completed = await _notificationReceiver.AwaitNextCompilationStatusAsync(CancellationToken);
+      Assert.AreEqual(documentItem.Uri, completed.Uri);
+      Assert.AreEqual(documentItem.Version, completed.Version);
+      Assert.AreEqual(CompilationStatus.VerificationFailed, completed.Status);
+    }
+
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
+    public async Task DocumentWithOnlyConfiguredVerifierTimeoutSendsCompilationSucceededVerificationStartedAndVerificationFailedStatuses() {
+      var source = @"
+lemma SquareRoot2NotRational(p: nat, q: nat)
+  requires p > 0 && q > 0
+  ensures (p * p) !=  2 * (q * q)
+{ 
+  if (p * p) ==  2 * (q * q) {
+    calc == {
+      (2 * q - p) * (2 * q - p);
+      4 * q * q + p * p - 4 * p * q;
+      {assert 2 * q * q == p * p;}
+      2 * q * q + 2 * p * p - 4 * p * q;
+      2 * (p - q) * (p - q);
+    }
+  }
+}".TrimStart();
+      await SetUp(new Dictionary<string, string>() {
+        { $"{VerifierOptions.Section}:{nameof(VerifierOptions.TimeLimit)}", "3" }
+      });
       var documentItem = CreateTestDocument(source);
       _client.OpenDocument(documentItem);
       var compilation = await _notificationReceiver.AwaitNextCompilationStatusAsync(CancellationToken);

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.cs
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Dafny.LanguageServer {
 
     public static LanguageServerOptions WithDafnyLanguageServer(this LanguageServerOptions options, IConfiguration configuration) {
       return options
-        .WithDafnyLanguage()
+        .WithDafnyLanguage(configuration)
         .WithDafnyWorkspace(configuration)
         .WithDafnyHandlers()
         .OnInitialize(InitializeAsync)

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" />
     <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
     <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
   </ItemGroup>

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -85,17 +85,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       using (cancellationToken.Register(() => CancelVerification(uniqueId))) {
         var statistics = new PipelineStatistics();
         var outcome = ExecutionEngine.InferAndVerify(program, statistics, uniqueId, error => { }, uniqueId);
-        return IsVerified(outcome, statistics);
+        return DafnyDriver.IsBoogieVerified(outcome, statistics);
       }
-    }
-
-    private static bool IsVerified(PipelineOutcome outcome, PipelineStatistics statistics) {
-      return (outcome == PipelineOutcome.Done || outcome == PipelineOutcome.VerificationCompleted)
-        && statistics.ErrorCount == 0
-        && statistics.InconclusiveCount == 0
-        && statistics.TimeoutCount == 0
-        && statistics.OutOfResourceCount == 0
-        && statistics.OutOfMemoryCount == 0;
     }
 
     private void CancelVerification(string requestId) {

--- a/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.Dafny.LanguageServer.Language.Symbols;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OmniSharp.Extensions.LanguageServer.Server;
+using System;
 
 namespace Microsoft.Dafny.LanguageServer.Language {
   /// <summary>
@@ -12,18 +15,27 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// Registers all services necessary to manage the dafny language.
     /// </summary>
     /// <param name="options">The language server where the workspace services should be registered to.</param>
+    /// <param name="configuration">The language server configuration.</param>
     /// <returns>The language server enriched with the dafny workspace services.</returns>
-    public static LanguageServerOptions WithDafnyLanguage(this LanguageServerOptions options) {
-      return options.WithServices(services => services.WithDafnyLanguage());
+    public static LanguageServerOptions WithDafnyLanguage(this LanguageServerOptions options, IConfiguration configuration) {
+      return options.WithServices(services => services.WithDafnyLanguage(configuration));
     }
 
-    private static IServiceCollection WithDafnyLanguage(this IServiceCollection services) {
+    private static IServiceCollection WithDafnyLanguage(this IServiceCollection services, IConfiguration configuration) {
       return services
+        .Configure<VerifierOptions>(configuration.GetSection(VerifierOptions.Section))
         .AddSingleton<IDafnyParser>(serviceProvider => DafnyLangParser.Create(serviceProvider.GetRequiredService<ILogger<DafnyLangParser>>()))
         .AddSingleton<ISymbolResolver, DafnyLangSymbolResolver>()
-        .AddSingleton<IProgramVerifier>(serviceProvider => DafnyProgramVerifier.Create(serviceProvider.GetRequiredService<ILogger<DafnyProgramVerifier>>()))
+        .AddSingleton<IProgramVerifier>(CreateVerifier)
         .AddSingleton<ISymbolTableFactory, SymbolTableFactory>()
         .AddSingleton<IDiagnosticPublisher, DiagnosticPublisher>();
+    }
+
+    private static DafnyProgramVerifier CreateVerifier(IServiceProvider serviceProvider) {
+      return DafnyProgramVerifier.Create(
+        serviceProvider.GetRequiredService<ILogger<DafnyProgramVerifier>>(),
+        serviceProvider.GetRequiredService<IOptions<VerifierOptions>>()
+      );
     }
   }
 }

--- a/Source/DafnyLanguageServer/Language/VerificationResult.cs
+++ b/Source/DafnyLanguageServer/Language/VerificationResult.cs
@@ -2,11 +2,8 @@
   /// <summary>
   /// Data class to expose the program verification results.
   /// </summary>
+  /// <param name="Verified"><c>true</c> if the program was successfuly verified.</param>
   /// <param name="SerializedCounterExamples">The counter examples to disprove the program's correctness, serialized to a string.</param>
-  public record VerificationResult(string? SerializedCounterExamples) {
-    /// <summary>
-    /// <c>true</c> if the program was successfuly verified. <c>false</c> if the program has verification errors.
-    /// </summary>
-    public bool Verified => SerializedCounterExamples == null;
+  public record VerificationResult(bool Verified, string? SerializedCounterExamples) {
   }
 }

--- a/Source/DafnyLanguageServer/Language/VerifierOptions.cs
+++ b/Source/DafnyLanguageServer/Language/VerifierOptions.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Dafny.LanguageServer.Language {
+  /// <summary>
+  /// Options for the verifier.
+  /// </summary>
+  public class VerifierOptions {
+    /// <summary>
+    /// The IConfiguration section of the verifier options.
+    /// </summary>
+    public const string Section = "verifier";
+
+    /// <summary>
+    /// Gets or sets the time limit of the verifier.
+    /// </summary>
+    public uint TimeLimit { get; set; } = 0;
+  }
+}

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -19,6 +19,8 @@ dotnet DafnyLanguageServer.dll
 
 ## Configuration
 
+### Documents
+
 It is possible to change the moment when a document is verified by providing the `--documents:verify` command-line argument. The options are:
 
 - *never* - Never verifies the document.
@@ -29,4 +31,13 @@ For example, to launch DafnyLS to only verify upon saving the document, use the 
 
 ```sh
 dotnet DafnyLanguageServer.dll --documents:verify=onsave
+```
+
+### Verifier
+
+
+You may specify a verification time limit (in seconds) using `--verifier:timeout`. For example, for a timeout of three seconds start the language server as follows:
+
+```sh
+dotnet DafnyLanguageServer.dll --verifier:timeout=3
 ```


### PR DESCRIPTION
Fix for #1426. I've created the public method `DafnyDriver.IsBoogieVerified` to ensure that the language server and compiler tread verifier results equally.
Additionally, I've added the possibility to set the default verification timeout using the `--verifier:timeout=n` CLI argument. While applying this change I've observed that *DafnyServer* uses a [default timeout of 10](https://github.com/dafny-lang/dafny/blob/a01e754d10ba06f397f35dc87f48ca1e7be1c4a2/Source/DafnyServer/Utilities.cs#L51). Does it make sense to use this default as well within the Language Server?