### PR TITLE
Language Server: Add option to set the number of verifier cores

### DIFF
--- a/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
@@ -98,7 +98,9 @@ method Negate(a: int) returns (b: int)
 ".TrimStart();
       var documentItem = CreateTestDocument(source);
       _client.OpenDocument(documentItem);
-      var counterExamples = (await RequestCounterExamples(documentItem.Uri)).ToArray();
+      var counterExamples = (await RequestCounterExamples(documentItem.Uri))
+        .OrderBy(counterExample => counterExample.Position)
+        .ToArray();
       Assert.AreEqual(2, counterExamples.Length);
       Assert.AreEqual((2, 0), counterExamples[0].Position);
       Assert.IsTrue(counterExamples[0].Variables.ContainsKey("y:int"));

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -45,11 +45,19 @@ namespace Microsoft.Dafny.LanguageServer.Language {
           //      A dash means write to the textwriter instead of a file.
           // https://github.com/boogie-org/boogie/blob/b03dd2e4d5170757006eef94cbb07739ba50dddb/Source/VCGeneration/Couterexample.cs#L217
           DafnyOptions.O.ModelViewFile = "-";
+          DafnyOptions.O.VcsCores = GetConfiguredCoreCount(options.Value);
+          DafnyOptions.O.VerifySnapshots = options.Value.Snapshots;
           _initialized = true;
           logger.LogTrace("initialized the boogie verifier...");
         }
         return new DafnyProgramVerifier(logger, options.Value);
       }
+    }
+
+    private static int GetConfiguredCoreCount(VerifierOptions options) {
+      return options.Cores == 0
+        ? Environment.ProcessorCount / 2
+        : Convert.ToInt32(options.Cores);
     }
 
     public async Task<VerificationResult> VerifyAsync(Dafny.Program program, CancellationToken cancellationToken) {

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Dafny.LanguageServer.Language {
           // https://github.com/boogie-org/boogie/blob/b03dd2e4d5170757006eef94cbb07739ba50dddb/Source/VCGeneration/Couterexample.cs#L217
           DafnyOptions.O.ModelViewFile = "-";
           DafnyOptions.O.VcsCores = GetConfiguredCoreCount(options.Value);
-          DafnyOptions.O.VerifySnapshots = options.Value.Snapshots;
           _initialized = true;
           logger.LogTrace("initialized the boogie verifier...");
         }

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     }
 
     private static int GetConfiguredCoreCount(VerifierOptions options) {
-      return options.Cores == 0
+      return options.VcsCores == 0
         ? Environment.ProcessorCount / 2
-        : Convert.ToInt32(options.Cores);
+        : Convert.ToInt32(options.VcsCores);
     }
 
     public async Task<VerificationResult> VerifyAsync(Dafny.Program program, CancellationToken cancellationToken) {

--- a/Source/DafnyLanguageServer/Language/VerifierOptions.cs
+++ b/Source/DafnyLanguageServer/Language/VerifierOptions.cs
@@ -9,7 +9,7 @@
     public const string Section = "verifier";
 
     /// <summary>
-    /// Gets or sets the time limit of the verifier. 0 = no time limit
+    /// Gets or sets the time limit of the verifier (in seconds). 0 = no time limit
     /// </summary>
     public uint TimeLimit { get; set; } = 0;
 

--- a/Source/DafnyLanguageServer/Language/VerifierOptions.cs
+++ b/Source/DafnyLanguageServer/Language/VerifierOptions.cs
@@ -16,6 +16,6 @@
     /// <summary>
     /// Gets or sets that may be used for verification. 0 = automatic.
     /// </summary>
-    public uint Cores { get; set; } = 0;
+    public uint VcsCores { get; set; } = 0;
   }
 }

--- a/Source/DafnyLanguageServer/Language/VerifierOptions.cs
+++ b/Source/DafnyLanguageServer/Language/VerifierOptions.cs
@@ -12,5 +12,15 @@
     /// Gets or sets the time limit of the verifier.
     /// </summary>
     public uint TimeLimit { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets that may be used for verification. 0 = automatic.
+    /// </summary>
+    public uint Cores { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the number of snapshots to retain for caching of boogie. -1 disables snapshots.
+    /// </summary>
+    public int Snapshots { get; set; } = 3;
   }
 }

--- a/Source/DafnyLanguageServer/Language/VerifierOptions.cs
+++ b/Source/DafnyLanguageServer/Language/VerifierOptions.cs
@@ -9,18 +9,13 @@
     public const string Section = "verifier";
 
     /// <summary>
-    /// Gets or sets the time limit of the verifier.
+    /// Gets or sets the time limit of the verifier. 0 = no time limit
     /// </summary>
-    public uint TimeLimit { get; set; } = 10;
+    public uint TimeLimit { get; set; } = 0;
 
     /// <summary>
     /// Gets or sets that may be used for verification. 0 = automatic.
     /// </summary>
     public uint Cores { get; set; } = 0;
-
-    /// <summary>
-    /// Gets or sets the number of snapshots to retain for caching of boogie. -1 disables snapshots.
-    /// </summary>
-    public int Snapshots { get; set; } = 3;
   }
 }

--- a/Source/DafnyLanguageServer/Language/VerifierOptions.cs
+++ b/Source/DafnyLanguageServer/Language/VerifierOptions.cs
@@ -11,6 +11,6 @@
     /// <summary>
     /// Gets or sets the time limit of the verifier.
     /// </summary>
-    public uint TimeLimit { get; set; } = 0;
+    public uint TimeLimit { get; set; } = 10;
   }
 }

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -61,5 +61,5 @@ Options provided through the command line have higher priority than the options 
 
 # Sets the maximum number of virtual cores to use. 
 # Default: 0 (use half of the available virtual cores).
---verifier:cores=0
+--verifier:vcscores=0
 ```

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -52,18 +52,6 @@ Options provided through the command line have higher priority than the options 
 --documents:verify=onchange
 ```
 
-It is possible to change the moment when a document is verified by providing the `--documents:verify` command-line argument. The options are:
-
-- *never* - Never verifies the document.
-- *onchange* (default) - Verifies the document with each change.
-- *onsave* - Verifies the document each time it is saved.
-
-For example, to launch DafnyLS to only verify upon saving the document, use the following command:
-
-```sh
-dotnet DafnyLanguageServer.dll --documents:verify=onsave
-```
-
 ### Verifier
 
 ```sh

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -55,9 +55,9 @@ Options provided through the command line have higher priority than the options 
 ### Verifier
 
 ```sh
-# Sets maximum execution time for verifications
+# Sets maximum execution time (in seconds) for verifications
 # Default: 0 (no time limit)
---verifier:timeout=0
+--verifier:timelimit=0
 
 # Sets the maximum number of virtual cores to use. 
 # Default: 0 (use half of the available virtual cores).

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -68,14 +68,10 @@ dotnet DafnyLanguageServer.dll --documents:verify=onsave
 
 ```sh
 # Sets maximum execution time for verifications
-# Default: 10
---verifier:timeout=10
+# Default: 0 (no time limit)
+--verifier:timeout=0
 
 # Sets the maximum number of virtual cores to use. 
 # Default: 0 (use half of the available virtual cores).
 --verifier:cores=0
-
-# How many verification snapshots boogie can make.
-# Default: 3
---verifier:snapshots=3
 ```

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -19,7 +19,38 @@ dotnet DafnyLanguageServer.dll
 
 ## Configuration
 
+The language server can be configured using the `DafnyLanguageServer.appsettings.json` file as well as using CLI arguments.
+
+For example, if you want to configure the automatic verification through the command line:
+
+```sh
+dotnet DafnyLanguageServer.dll --documents:verify=onsave
+```
+
+Or using the `DafnyLanguageServer.appsettings.json` configuration file:
+
+```json
+{
+  "Documents": {
+    "Verify": "onsave"
+  }
+}
+```
+
+Options provided through the command line have higher priority than the options provided within `DafnyLanguageServer.appsettings.json`.
+
+
 ### Documents
+
+```sh
+# Sets when the automatic verification should be applied.
+# Options:
+# - never - Never verifies the document.
+# - onchange - Verifies the document with each change.
+# - onsave - Verifies the document each time it is saved.
+# default: onchange
+--documents:verify=onchange
+```
 
 It is possible to change the moment when a document is verified by providing the `--documents:verify` command-line argument. The options are:
 
@@ -35,9 +66,16 @@ dotnet DafnyLanguageServer.dll --documents:verify=onsave
 
 ### Verifier
 
-
-You may specify a verification time limit (in seconds) using `--verifier:timeout`. For example, for a timeout of three seconds start the language server as follows:
-
 ```sh
-dotnet DafnyLanguageServer.dll --verifier:timeout=3
+# Sets maximum execution time for verifications
+# Default: 10
+--verifier:timeout=10
+
+# Sets the maximum number of virtual cores to use. 
+# Default: 0 (use half of the available virtual cores).
+--verifier:cores=0
+
+# How many verification snapshots boogie can make.
+# Default: 3
+--verifier:snapshots=3
 ```


### PR DESCRIPTION
This PR enables users to set the number of cores the verifier may use. The implementation deals the value 0 the same as *DafnyServer*: Use half of the available virtual cores.

The new option is `--verifier:cores=0`.

Furthermore, I've revised the documentation for better readability of the available options.