### PR TITLE
Language Server: Change the info severity to hint

### DIFF
--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       return level switch {
         ErrorLevel.Error => DiagnosticSeverity.Error,
         ErrorLevel.Warning => DiagnosticSeverity.Warning,
-        ErrorLevel.Info => DiagnosticSeverity.Information,
+        ErrorLevel.Info => DiagnosticSeverity.Hint,
         _ => throw new ArgumentException($"unknown error level {level}", nameof(level))
       };
     }


### PR DESCRIPTION
As discussed in #1415: Rather than introducing further code complexity with an option, this PR reduces the severity of Dafny information messages to hint. This will reduce the visual noise within VSCode as follows.

Before:
![image](https://user-images.githubusercontent.com/18049310/133083482-42e3e7b6-e209-4eb4-b3ce-e5b506a4dac9.png)


After: Users now see three dots in place of the squiggles. Furthermore, the messages are no longer listed as "Problems".
![image](https://user-images.githubusercontent.com/18049310/133083278-8d0d0fa3-39b9-4352-8968-f1aaa591ecca.png)



