### PR TITLE
fix: Compilation of ghost tuple destructors

### DIFF
--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -369,6 +369,11 @@ namespace Microsoft.Dafny {
       return s.StartsWith("_tuple#");
     }
     public const string TupleTypeCtorNamePrefix = "_#Make";  // the printer wants this name prefix to be uniquely recognizable
+
+    public static string TupleTypeCtorName(int dims) {
+      Contract.Assert(0 <= dims);
+      return TupleTypeCtorNamePrefix + dims;
+    }
   }
 
   /// <summary>
@@ -4685,7 +4690,7 @@ namespace Microsoft.Dafny {
         var f = new Formal(Token.NoToken, i.ToString(), new UserDefinedType(Token.NoToken, tp), true, argumentGhostness[i], null, nameForCompilation: compileName);
         formals.Add(f);
       }
-      string ctorName = BuiltIns.TupleTypeCtorNamePrefix + typeArgs.Count;
+      string ctorName = BuiltIns.TupleTypeCtorName(typeArgs.Count);
       var ctor = new DatatypeCtor(Token.NoToken, ctorName, formals, null);
       return new List<DatatypeCtor>() { ctor };
     }

--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Dafny {
 
     public Formal CloneFormal(Formal formal) {
       Formal f = new Formal(Tok(formal.tok), formal.Name, CloneType(formal.Type), formal.InParam, formal.IsGhost,
-        CloneExpr(formal.DefaultValue), formal.IsOld);
+        CloneExpr(formal.DefaultValue), formal.IsOld, formal.IsNameOnly, formal.NameForCompilation);
       return f;
     }
 

--- a/Source/Dafny/Compilers/Compiler-go.cs
+++ b/Source/Dafny/Compilers/Compiler-go.cs
@@ -2414,9 +2414,11 @@ namespace Microsoft.Dafny {
         return SimpleLvalue(wr => {
           wr = EmitCoercionIfNecessary(dtor.Type, expectedType, Bpl.Token.NoToken, wr);
           if (dtor.EnclosingClass is TupleTypeDecl) {
+            Contract.Assert(dtor.CorrespondingFormals.Count == 1);
+            var formal = dtor.CorrespondingFormals[0];
             wr.Write("(*(");
             obj(wr);
-            wr.Write(").IndexInt({0}))", dtor.Name);
+            wr.Write(").IndexInt({0}))", formal.NameForCompilation);
           } else {
             obj(wr);
             wr.Write(".{0}()", FormatDatatypeDestructorName(dtor.CompileName));

--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -3077,8 +3077,9 @@ namespace Microsoft.Dafny {
       } else if (cl is DatatypeDecl dt) {
         var s = FullTypeName(udt);
         var typeargs = "";
-        if (udt.TypeArgs.Count != 0) {
-          typeargs = $"<{BoxedTypeNames(udt.TypeArgs, wr, udt.tok)}>";
+        var nonGhostTypeArgs = SelectNonGhost(cl, udt.TypeArgs);
+        if (nonGhostTypeArgs.Count != 0) {
+          typeargs = $"<{BoxedTypeNames(nonGhostTypeArgs, wr, udt.tok)}>";
         }
         // In an auto-init context (like a field initializer), we may not have
         // access to all the type descriptors, so we can't construct the

--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -1995,7 +1995,7 @@ namespace Microsoft.Dafny {
 
       var dt = ctor.EnclosingDatatype;
       if (dt is TupleTypeDecl tupleDecl) {
-        return DafnyTupleClass(tupleDecl.TypeArgs.Count);
+        return DafnyTupleClass(tupleDecl.NonGhostDims);
       }
       var dtName = IdProtect(dt.CompileName);
       return dt.IsRecordType ? dtName : dtName + "_" + ctor.CompileName;
@@ -3152,7 +3152,7 @@ namespace Microsoft.Dafny {
     protected override void EmitDestructor(string source, Formal dtor, int formalNonGhostIndex, DatatypeCtor ctor, List<Type> typeArgs, Type bvType, ConcreteSyntaxTree wr) {
       string dtorName;
       if (ctor.EnclosingDatatype is TupleTypeDecl) {
-        dtorName = $"dtor__{dtor.Name}()";
+        dtorName = $"dtor__{dtor.NameForCompilation}()";
       } else if (int.TryParse(dtor.Name, out _)) {
         dtorName = $"dtor_{dtor.Name}()";
       } else {

--- a/Source/Dafny/Compilers/Compiler-js.cs
+++ b/Source/Dafny/Compilers/Compiler-js.cs
@@ -1568,7 +1568,9 @@ namespace Microsoft.Dafny {
     protected override ILvalue EmitMemberSelect(Action<ConcreteSyntaxTree> obj, Type objType, MemberDecl member, List<TypeArgumentInstantiation> typeArgs, Dictionary<TypeParameter, Type> typeMap,
       Type expectedType, string/*?*/ additionalCustomParameter, bool internalAccess = false) {
       if (member is DatatypeDestructor dtor && dtor.EnclosingClass is TupleTypeDecl) {
-        return SuffixLvalue(obj, "[{0}]", dtor.Name);
+        Contract.Assert(dtor.CorrespondingFormals.Count == 1);
+        var formal = dtor.CorrespondingFormals[0];
+        return SuffixLvalue(obj, "[{0}]", formal.NameForCompilation);
       } else if (member is SpecialField sf && !(member is ConstantField)) {
         string compiledName, preStr, postStr;
         GetSpecialFieldInfo(sf.SpecialId, sf.IdParam, objType, out compiledName, out preStr, out postStr);

--- a/Source/Dafny/Compilers/Compiler.cs
+++ b/Source/Dafny/Compilers/Compiler.cs
@@ -4158,7 +4158,7 @@ namespace Microsoft.Dafny {
           BoundVar bv = arguments[m];
           // FormalType f0 = ((Dt_Ctor0)source._D).a0;
           var sw = DeclareLocalVar(IdName(bv), bv.Type, bv.Tok, w);
-          EmitDestructor(source, arg, k, ctor, sourceType.TypeArgs, bv.Type, sw);
+          EmitDestructor(source, arg, k, ctor, SelectNonGhost(sourceType.ResolvedClass, sourceType.TypeArgs), bv.Type, sw);
           k++;
         }
       }

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -3017,7 +3017,7 @@ ExtendedPattern<.out ExtendedPattern pat.>
     ")"                                    (. // make sure the tuple type exists
                                               theBuiltIns.TupleType(id, arguments.Count, true);
                                               //use the TupleTypeCtors
-                                              string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;
+                                              string ctor = BuiltIns.TupleTypeCtorName(arguments.Count);
                                               pat = new IdPattern(id, ctor, arguments);
                                            .)
   | IF(IsIdentParen())
@@ -3896,7 +3896,7 @@ ParensExpression<out Expression e>
        var argumentGhostness = ghostness.ToList();
        // make sure the corresponding tuple type exists
        var tmp = theBuiltIns.TupleType(x, args.Count, true, argumentGhostness);
-       e = new DatatypeValue(x, BuiltIns.TupleTypeName(argumentGhostness), BuiltIns.TupleTypeCtorNamePrefix + args.Count, args);
+       e = new DatatypeValue(x, BuiltIns.TupleTypeName(argumentGhostness), BuiltIns.TupleTypeCtorName(args.Count), args);
      }
   .)
   .
@@ -4210,7 +4210,7 @@ CasePattern<.out CasePattern<BoundVar> pat.>
         }
       ]
     ")"                                (. // Parse parenthesis without an identifier as a built in tuple type.
-                                          string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;  //use the TupleTypeCtors
+                                          string ctor = BuiltIns.TupleTypeCtorName(arguments.Count);  //use the TupleTypeCtors
                                           pat = new CasePattern<BoundVar>(id, ctor, arguments);
                                        .)
   | IdentTypeOptional<out bv>          (. // This could be a BoundVar of a parameter-less constructor and we may not know until resolution.
@@ -4253,7 +4253,7 @@ CasePatternLocal<.out CasePattern<LocalVariable> pat, bool isGhost.>
         }
       ]
     ")"                                (. // Parse parenthesis without an identifier as a built in tuple type.
-                                          string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;  //use the TupleTypeCtors
+                                          string ctor = BuiltIns.TupleTypeCtorName(arguments.Count);  //use the TupleTypeCtors
                                           pat = new CasePattern<LocalVariable>(id, ctor, arguments);
                                        .)
   | LocalIdentTypeOptional<out local, isGhost>

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -3014,15 +3014,12 @@ ExtendedPattern<.out ExtendedPattern pat.>
       [ ExtendedPattern<out pat>           (. arguments.Add(pat); .)
       { "," ExtendedPattern<out pat>       (. arguments.Add(pat); .)
       }]
-    ")"                                    (. if (arguments.Count == 1) {
-                                                SemErr(t, "parentheses are not allowed around a pattern");
-                                              } else {
-                                                // make sure the tuple type exists
-                                                theBuiltIns.TupleType(id, arguments.Count, true);
-                                                //use the TupleTypeCtors
-                                                string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;
-                                                pat = new IdPattern(id, ctor, arguments);
-                                               } .)
+    ")"                                    (. // make sure the tuple type exists
+                                              theBuiltIns.TupleType(id, arguments.Count, true);
+                                              //use the TupleTypeCtors
+                                              string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;
+                                              pat = new IdPattern(id, ctor, arguments);
+                                           .)
   | IF(IsIdentParen())
     Ident<out id>                          (. arguments = new List<ExtendedPattern>(); .)
     "("

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -11549,7 +11549,7 @@ namespace Microsoft.Dafny {
           var ctorId = mc.Ctor.Name;
           if (s.Source.Type.AsDatatype is TupleTypeDecl) {
             var tuple = (TupleTypeDecl)s.Source.Type.AsDatatype;
-            ctorId = BuiltIns.TupleTypeCtorNamePrefix + tuple.Dims;
+            ctorId = BuiltIns.TupleTypeCtorName(tuple.Dims);
           }
           if (!ctors.ContainsKey(ctorId)) {
             reporter.Error(MessageSource.Resolver, mc.tok, "member '{0}' does not exist in datatype '{1}'", ctorId, dtd.Name);
@@ -12349,7 +12349,7 @@ namespace Microsoft.Dafny {
 
     private void CheckLinearVarPattern(Type type, IdPattern pat, ResolveOpts opts) {
       if (pat.Arguments != null) {
-        if (pat.Id == BuiltIns.TupleTypeCtorNamePrefix + "1") {
+        if (pat.Id == BuiltIns.TupleTypeCtorName(1)) {
           reporter.Error(MessageSource.Resolver, pat.Tok, "parentheses are not allowed around a pattern");
         } else {
           reporter.Error(MessageSource.Resolver, pat.Tok, "member {0} does not exist in type {1}", pat.Id, type);
@@ -15724,7 +15724,7 @@ namespace Microsoft.Dafny {
           var ctorId = mc.Ctor.Name;
           if (me.Source.Type.AsDatatype is TupleTypeDecl) {
             var tuple = (TupleTypeDecl)me.Source.Type.AsDatatype;
-            ctorId = BuiltIns.TupleTypeCtorNamePrefix + tuple.Dims;
+            ctorId = BuiltIns.TupleTypeCtorName(tuple.Dims);
           }
           if (!ctors.ContainsKey(ctorId)) {
             reporter.Error(MessageSource.Resolver, mc.tok, "member '{0}' does not exist in datatype '{1}'", ctorId, dtd.Name);

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -12349,7 +12349,11 @@ namespace Microsoft.Dafny {
 
     private void CheckLinearVarPattern(Type type, IdPattern pat, ResolveOpts opts) {
       if (pat.Arguments != null) {
-        reporter.Error(MessageSource.Resolver, pat.Tok, "member {0} does not exist in type {1}", pat.Id, type);
+        if (pat.Id == BuiltIns.TupleTypeCtorNamePrefix + "1") {
+          reporter.Error(MessageSource.Resolver, pat.Tok, "parentheses are not allowed around a pattern");
+        } else {
+          reporter.Error(MessageSource.Resolver, pat.Tok, "member {0} does not exist in type {1}", pat.Id, type);
+        }
         return;
       }
 

--- a/Test/dafny0/NestedPatternsA.dfy
+++ b/Test/dafny0/NestedPatternsA.dfy
@@ -3,11 +3,25 @@
 
 datatype List<T> = Nil | Cons(head: T, tail: List<T>)
 
-/* Error: parentheses are not allowed around a pattern */
-method AssertionFailure(xs: List)
+method BadParens0(xs: List)
 {
   match xs
+  case (Nil) => // error: parentheses are not allowed around a pattern
+  case (Cons(h, t)) => // error: parentheses are not allowed around a pattern
+}
+
+method BadParens1(xs: List)
+{
+  match (xs)
+  case (Nil) => // error: parentheses are not allowed around a pattern
+  case (Cons(h, t)) => // error: parentheses are not allowed around a pattern
+}
+
+method Ghost1Tuple(xs: List)
+{
+  // These parentheses in patterns are fine, because they are the syntax of the constructor for a 1-tuple
+  // with 1 ghost component.
+  match (ghost xs)
   case (Nil) =>
   case (Cons(h, t)) =>
 }
-

--- a/Test/dafny0/NestedPatternsA.dfy.expect
+++ b/Test/dafny0/NestedPatternsA.dfy.expect
@@ -1,3 +1,5 @@
-NestedPatternsA.dfy(10,11): Error: parentheses are not allowed around a pattern
-NestedPatternsA.dfy(11,18): Error: parentheses are not allowed around a pattern
-2 parse errors detected in NestedPatternsA.dfy
+NestedPatternsA.dfy(9,7): Error: parentheses are not allowed around a pattern
+NestedPatternsA.dfy(10,7): Error: parentheses are not allowed around a pattern
+NestedPatternsA.dfy(16,7): Error: parentheses are not allowed around a pattern
+NestedPatternsA.dfy(17,7): Error: parentheses are not allowed around a pattern
+4 resolution/type errors detected in NestedPatternsA.dfy

--- a/Test/ghost/Comp.dfy
+++ b/Test/ghost/Comp.dfy
@@ -14,12 +14,31 @@ method Test3(t3: ((ghost int), (ghost int, int), ghost int)) { print "Test3: ", 
 
 method Main() {
   var p := PhantomData(123);
-  var t0 := (ghost 00);
-  var t1 := (ghost 11, 22);
-  var t2 := (33, ghost 44, 55);
-  var t3 := ((ghost 66), (ghost 77, 88), ghost 99);
+  var t0, t1, t2, t3;
   Test0(t0);
   Test1(t1);
   Test2(t2);
   Test3(t3);
+  t0 := (ghost 00);
+  t1 := (ghost 11, 22);
+  t2 := (33, ghost 44, 55);
+  t3 := ((ghost 66), (ghost 77, 88), ghost 99);
+  Test0(t0);
+  Test1(t1);
+  Test2(t2);
+  Test3(t3);
+  TestDestructors();
+}
+
+method TestDestructors() {
+  var u := (100, 200);
+  print u.0, " ", u.1, "\n"; // 100 200
+
+  var a, b, c, d; // will be initialized to default values
+  print a, " ", b, " ", c, " ", d, "\n"; // 
+
+  a := (5, ghost 7, 9);
+  b := (ghost 9, ghost 16, 25, 36);
+  c := (ghost 7, 5);
+  d := (ghost 9, ghost 16, 25);
 }

--- a/Test/ghost/Comp.dfy
+++ b/Test/ghost/Comp.dfy
@@ -41,4 +41,7 @@ method TestDestructors() {
   b := (ghost 9, ghost 16, 25, 36);
   c := (ghost 7, 5);
   d := (ghost 9, ghost 16, 25);
+
+  print a.2, " ", b.2, "\n"; // 9 25
+  print c.1, " ", d.2, "\n"; // 5 25
 }

--- a/Test/ghost/Comp.dfy
+++ b/Test/ghost/Comp.dfy
@@ -28,6 +28,7 @@ method Main() {
   Test2(t2);
   Test3(t3);
   TestDestructors();
+  TestMatchDestructions();
 }
 
 method TestDestructors() {
@@ -44,4 +45,35 @@ method TestDestructors() {
 
   print a.2, " ", b.2, "\n"; // 9 25
   print c.1, " ", d.2, "\n"; // 5 25
+}
+
+method TestMatchDestructions() {
+  var e := (ghost 15);
+  var a := (5, ghost 7, 9);
+  var b := (ghost 9, ghost 16, 25, 36);
+  var c := (ghost 7, 5);
+  var d := (ghost 9, ghost 16, 25);
+
+  // match statements
+
+  match a {
+    case (x, _, y) => print x, " ", y, "\n"; // 5 9
+  }
+  match b {
+    case (_, _, x, y) => print x, " ", y, "\n"; // 25 36
+  }
+  match c {
+    case (_, x) => print x, "\n"; // 5
+  }
+  match d {
+    case (_, _, x) => print x, "\n"; // 25
+  }
+
+  // match expressions
+
+  var aa := match a case (x, _, y) => x + y; // 14
+  var bb := match b case (_, _, x, y) => x + y; // 61
+  var cc := match c case (_, x) => x; // 5
+  var dd := match d case (_, _, x) => x; // 25
+  print aa, " ", bb, " ", cc, " ", dd, "\n";
 }

--- a/Test/ghost/Comp.dfy
+++ b/Test/ghost/Comp.dfy
@@ -56,6 +56,9 @@ method TestMatchDestructions() {
 
   // match statements
 
+  match e {
+    case (_) => print e, "\n"; // ()
+  }
   match a {
     case (x, _, y) => print x, " ", y, "\n"; // 5 9
   }
@@ -71,9 +74,10 @@ method TestMatchDestructions() {
 
   // match expressions
 
+  var ee := match e case (_) => e;
   var aa := match a case (x, _, y) => x + y; // 14
   var bb := match b case (_, _, x, y) => x + y; // 61
   var cc := match c case (_, x) => x; // 5
   var dd := match d case (_, _, x) => x; // 25
-  print aa, " ", bb, " ", cc, " ", dd, "\n";
+  print ee, " ", aa, " ", bb, " ", cc, " ", dd, "\n";
 }

--- a/Test/ghost/Comp.dfy.expect
+++ b/Test/ghost/Comp.dfy.expect
@@ -12,6 +12,8 @@ Test2: (33, 55)
 Test3: ((), (88))
 100 200
 (0, 0) (0, 0) (0) (0)
+9 25
+5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -24,6 +26,8 @@ Test2: (33, 55)
 Test3: ((), (88))
 100 200
 (0, 0) (0, 0) (0) (0)
+9 25
+5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -36,6 +40,8 @@ Test2: (33, 55)
 Test3: ((), (88))
 100 200
 (0, 0) (0, 0) (0) (0)
+9 25
+5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -48,3 +54,5 @@ Test2: (33, 55)
 Test3: ((), (88))
 100 200
 (0, 0) (0, 0) (0) (0)
+9 25
+5 25

--- a/Test/ghost/Comp.dfy.expect
+++ b/Test/ghost/Comp.dfy.expect
@@ -14,6 +14,11 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+5 9
+25 36
+5
+25
+14 61 5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -28,6 +33,11 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+5 9
+25 36
+5
+25
+14 61 5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -42,6 +52,11 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+5 9
+25 36
+5
+25
+14 61 5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -56,3 +71,8 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+5 9
+25 36
+5
+25
+14 61 5 25

--- a/Test/ghost/Comp.dfy.expect
+++ b/Test/ghost/Comp.dfy.expect
@@ -3,24 +3,48 @@ Dafny program verifier finished with 1 verified, 0 errors
 
 Dafny program verifier did not attempt verification
 Test0: ()
-Test1: (22)
-Test2: (33, 55)
-Test3: ((), (88))
-
-Dafny program verifier did not attempt verification
+Test1: (0)
+Test2: (0, 0)
+Test3: ((), (0))
 Test0: ()
 Test1: (22)
 Test2: (33, 55)
 Test3: ((), (88))
+100 200
+(0, 0) (0, 0) (0) (0)
 
 Dafny program verifier did not attempt verification
+Test0: ()
+Test1: (0)
+Test2: (0, 0)
+Test3: ((), (0))
 Test0: ()
 Test1: (22)
 Test2: (33, 55)
 Test3: ((), (88))
+100 200
+(0, 0) (0, 0) (0) (0)
 
 Dafny program verifier did not attempt verification
+Test0: ()
+Test1: (0)
+Test2: (0, 0)
+Test3: ((), (0))
 Test0: ()
 Test1: (22)
 Test2: (33, 55)
 Test3: ((), (88))
+100 200
+(0, 0) (0, 0) (0) (0)
+
+Dafny program verifier did not attempt verification
+Test0: ()
+Test1: (0)
+Test2: (0, 0)
+Test3: ((), (0))
+Test0: ()
+Test1: (22)
+Test2: (33, 55)
+Test3: ((), (88))
+100 200
+(0, 0) (0, 0) (0) (0)

--- a/Test/ghost/Comp.dfy.expect
+++ b/Test/ghost/Comp.dfy.expect
@@ -14,11 +14,12 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+()
 5 9
 25 36
 5
 25
-14 61 5 25
+() 14 61 5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -33,11 +34,12 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+()
 5 9
 25 36
 5
 25
-14 61 5 25
+() 14 61 5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -52,11 +54,12 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+()
 5 9
 25 36
 5
 25
-14 61 5 25
+() 14 61 5 25
 
 Dafny program verifier did not attempt verification
 Test0: ()
@@ -71,8 +74,9 @@ Test3: ((), (88))
 (0, 0) (0, 0) (0) (0)
 9 25
 5 25
+()
 5 9
 25 36
 5
 25
-14 61 5 25
+() 14 61 5 25


### PR DESCRIPTION
This PR fixes the compilation of ghost-tuple destructors, some other compilation issues for Java, and the parsing/resolution of 1-tuple patterns.