### PR TITLE
Language Server: Load documents on a dedicated thread

### DIFF
--- a/Source/DafnyLanguageServer.Test/Various/StabilityTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/StabilityTest.cs
@@ -42,5 +42,19 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
       await _client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       Assert.IsTrue(Documents.TryGetDocument(documentItem.Uri, out var _));
     }
+
+    [TestMethod]
+    [Timeout(MaxTestExecutionTimeMs)]
+    public async Task StrongNestingDoesNotCauseStackOverlfow() {
+      // Without a sufficiently large stack, the following code causes a stack overflow:
+      // https://github.com/dafny-lang/dafny/issues/1447
+      const string source = @"
+method NestedExpression() {
+  assert var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; var three := 3; true;
+}";
+      var documentItem = CreateTestDocument(source);
+      await _client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      Assert.IsTrue(Documents.TryGetDocument(documentItem.Uri, out var _));
+    }
   }
 }

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.Language {
   /// <summary>
@@ -47,8 +46,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       }
     }
 
-    public async Task<Dafny.Program> ParseAsync(TextDocumentItem document, ErrorReporter errorReporter, CancellationToken cancellationToken) {
-      await _mutex.WaitAsync(cancellationToken);
+    public Dafny.Program Parse(TextDocumentItem document, ErrorReporter errorReporter, CancellationToken cancellationToken) {
+      _mutex.Wait(cancellationToken);
       try {
         // Ensure that the statically kept scopes are empty when parsing a new document.
         Type.ResetScopes();

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.Language {
   /// <summary>
@@ -59,8 +58,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         : Convert.ToInt32(options.VcsCores);
     }
 
-    public async Task<VerificationResult> VerifyAsync(Dafny.Program program, CancellationToken cancellationToken) {
-      await _mutex.WaitAsync(cancellationToken);
+    public VerificationResult Verify(Dafny.Program program, CancellationToken cancellationToken) {
+      _mutex.Wait(cancellationToken);
       try {
         // The printer is responsible for two things: It logs boogie errors and captures the counter example model.
         var errorReporter = (DiagnosticErrorReporter)program.reporter;

--- a/Source/DafnyLanguageServer/Language/IDafnyParser.cs
+++ b/Source/DafnyLanguageServer/Language/IDafnyParser.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.Dafny;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.Language {
   /// <summary>
@@ -20,6 +18,6 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// <returns>The parsed document represented as a dafny program.</returns>
     /// <exception cref="System.OperationCanceledException">Thrown when the cancellation was requested before completion.</exception>
     /// <exception cref="System.ObjectDisposedException">Thrown if the cancellation token was disposed before the completion.</exception>
-    Task<Microsoft.Dafny.Program> ParseAsync(TextDocumentItem textDocument, ErrorReporter errorReporter, CancellationToken cancellationToken);
+    Dafny.Program Parse(TextDocumentItem textDocument, ErrorReporter errorReporter, CancellationToken cancellationToken);
   }
 }

--- a/Source/DafnyLanguageServer/Language/IProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/IProgramVerifier.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.Language {
   /// <summary>
@@ -14,6 +13,6 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// <returns>The result of the verification run.</returns>
     /// <exception cref="System.OperationCanceledException">Thrown when the cancellation was requested before completion.</exception>
     /// <exception cref="System.ObjectDisposedException">Thrown if the cancellation token was disposed before the completion.</exception>
-    Task<VerificationResult> VerifyAsync(Dafny.Program program, CancellationToken cancellationToken);
+    VerificationResult Verify(Dafny.Program program, CancellationToken cancellationToken);
   }
 }

--- a/Source/DafnyLanguageServer/Language/Symbols/DafnyLangSymbolResolver.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/DafnyLangSymbolResolver.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   /// <summary>
@@ -20,11 +19,11 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
       _logger = logger;
     }
 
-    public async Task<CompilationUnit> ResolveSymbolsAsync(TextDocumentItem textDocument, Dafny.Program program, CancellationToken cancellationToken) {
+    public CompilationUnit ResolveSymbols(TextDocumentItem textDocument, Dafny.Program program, CancellationToken cancellationToken) {
       // TODO The resolution requires mutual exclusion since it sets static variables of classes like Microsoft.Dafny.Type.
       //      Although, the variables are marked "ThreadStatic" - thus it might not be necessary. But there might be
       //      other classes as well.
-      await _resolverMutex.WaitAsync(cancellationToken);
+      _resolverMutex.Wait(cancellationToken);
       try {
         if (!RunDafnyResolver(textDocument, program)) {
           // We cannot proceeed without a successful resolution. Due to the contracts in dafny-lang, we cannot

--- a/Source/DafnyLanguageServer/Language/Symbols/ISymbolResolver.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/ISymbolResolver.cs
@@ -1,6 +1,5 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public interface ISymbolResolver {
@@ -13,6 +12,6 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
     /// <returns>The generated symbol table.</returns>
     /// <exception cref="System.OperationCanceledException">Thrown when the cancellation was requested before completion.</exception>
     /// <exception cref="System.ObjectDisposedException">Thrown if the cancellation token was disposed before the completion.</exception>
-    Task<CompilationUnit> ResolveSymbolsAsync(TextDocumentItem textDocument, Microsoft.Dafny.Program program, CancellationToken cancellationToken);
+    CompilationUnit ResolveSymbols(TextDocumentItem textDocument, Microsoft.Dafny.Program program, CancellationToken cancellationToken);
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Dafny.LanguageServer.Language;
+using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Server;
+using System;
 
 namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// <summary>
@@ -24,11 +26,21 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         .Configure<DocumentOptions>(configuration.GetSection(DocumentOptions.Section))
         .AddSingleton<IDocumentDatabase, DocumentDatabase>()
         .AddSingleton<IDafnyParser>(serviceProvider => DafnyLangParser.Create(serviceProvider.GetRequiredService<ILogger<DafnyLangParser>>()))
-        .AddSingleton<ITextDocumentLoader, TextDocumentLoader>()
+        .AddSingleton<ITextDocumentLoader>(CreateTextDocumentLoader)
         .AddSingleton<IDiagnosticPublisher, DiagnosticPublisher>()
         .AddSingleton<IDocumentUpdater, DocumentUpdater>()
         .AddSingleton<ISymbolGuesser, SymbolGuesser>()
         .AddSingleton<ICompilationStatusNotificationPublisher, CompilationStatusNotificationPublisher>();
+    }
+
+    private static TextDocumentLoader CreateTextDocumentLoader(IServiceProvider services) {
+      return TextDocumentLoader.Create(
+        services.GetRequiredService<IDafnyParser>(),
+        services.GetRequiredService<ISymbolResolver>(),
+        services.GetRequiredService<IProgramVerifier>(),
+        services.GetRequiredService<ISymbolTableFactory>(),
+        services.GetRequiredService<ICompilationStatusNotificationPublisher>()
+      );
     }
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     private readonly Thread loadThread;
     private readonly BlockingCollection<LoadRequest> loadRequests = new();
-    private readonly CancellationTokenSource loadCancellationToken = new();
 
     private TextDocumentLoader(
       IDafnyParser parser,
@@ -65,7 +64,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     private void LoadLoop() {
       for(; ;) {
-        var request = loadRequests.Take(loadCancellationToken.Token);
+        var request = loadRequests.Take();
         var document = LoadInternal(request);
         request.Document.SetResult(document);
       }

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// Text document loader implementation that offloads the whole procedure on one dedicated
   /// thread with a stack size of 256MB.
   /// </summary>
+  /// <remarks>
+  /// The increased stack size is necessary to solve the issue https://github.com/dafny-lang/dafny/issues/1447.
+  /// </remarks>
   public class TextDocumentLoader : ITextDocumentLoader {
     // 256MB
     private const int MaxStackSize = 0x10000000;

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     private void Run() {
-      for (; ; ) {
-        var request = loadRequests.Take();
+      foreach (var request in loadRequests.GetConsumingEnumerable()) {
         var document = LoadInternal(request);
         request.Document.SetResult(document);
       }

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -63,12 +63,13 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     private void LoadLoop() {
       for(; ;) {
         var request = loadRequests.Take(loadCancellationToken.Token);
-        var document = LoadInternal(request.TextDocument, request.Verify, request.CancellationToken);
+        var document = LoadInternal(request);
         request.Document.SetResult(document);
       }
     }
 
-    public DafnyDocument LoadInternal(TextDocumentItem textDocument, bool verify, CancellationToken cancellationToken) {
+    private DafnyDocument LoadInternal(LoadRequest loadRequest) {
+      var (textDocument, verify, cancellationToken) = loadRequest;
       var errorReporter = new DiagnosticErrorReporter(textDocument.Uri);
       var program = parser.Parse(textDocument, errorReporter, cancellationToken);
       if (errorReporter.HasErrors) {


### PR DESCRIPTION
The language server crashes in cases where sources have strongly nested statements with a stack overflow. The Dafny compiler fixed the issue by launching a thread with a sufficiently large stack. This PR adapts the language server to make use of the same mechanism as proposed in #1447.

This issue solves the following issues: #1447, #1213, and https://github.com/dafny-lang/ide-vscode/issues/40

Since we now have a thread that is responsible for document loading, I removed the asynchronous code that is no longer needed.