### PR TITLE
Add /warningsAsErrors

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Dafny {
     public int Allocated = 3;
     public bool UseStdin = false;
     public bool ShowSnippets = false;
+    public bool WarningsAsErrors = false;
     [CanBeNull] private TestGenerationOptions testGenOptions = null;
 
     public virtual TestGenerationOptions TestGenOptions =>
@@ -410,6 +411,10 @@ namespace Microsoft.Dafny {
             }
             return true;
           }
+
+        case "warningsAsErrors":
+          WarningsAsErrors = true;
+          return true;
       }
 
       // Unless this is an option for test generation, defer to superclass
@@ -860,6 +865,8 @@ $@"
     or type definitions during translation.
 /stdin
     Read standard input and treat it as an input .dfy file.
+/warningsAsErrors
+    Treat warnings as errors.
 {TestGenOptions.Help}
 
 Dafny generally accepts Boogie options and passes these on to Boogie. However,

--- a/Source/Dafny/Reporting.cs
+++ b/Source/Dafny/Reporting.cs
@@ -98,7 +98,11 @@ namespace Microsoft.Dafny {
     public void Warning(MessageSource source, IToken tok, string msg) {
       Contract.Requires(tok != null);
       Contract.Requires(msg != null);
-      Message(source, ErrorLevel.Warning, tok, msg);
+      if (DafnyOptions.O.WarningsAsErrors) {
+        Error(source, tok, msg);
+      } else {
+        Message(source, ErrorLevel.Warning, tok, msg);
+      }
     }
 
     public void Deprecated(MessageSource source, IToken tok, string msg, params object[] args) {

--- a/Test/dafny0/warnings-as-errors.dfy
+++ b/Test/dafny0/warnings-as-errors.dfy
@@ -1,0 +1,5 @@
+// RUN: %dafny /compile:0 /print:"%t.print" /dprint:"%t.dprint" /warnShadowing /warningsAsErrors "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+method f(x: int) {
+  var x := 0;
+}

--- a/Test/dafny0/warnings-as-errors.dfy.expect
+++ b/Test/dafny0/warnings-as-errors.dfy.expect
@@ -1,0 +1,2 @@
+warnings-as-errors.dfy(4,6): Error: Shadowed local-variable name: x
+1 resolution/type errors detected in warnings-as-errors.dfy


### PR DESCRIPTION
It's sometimes useful to be able to fail a CI pipeline on warnings. While there are not many warnings in Dafny, we have a particular use case for failing on `/warnShadowing`.

When trying to create the commit, I ran into an error where pre-commit/dotnet-format asked for .NET 6.0. I now have changed the pre-commit hook to use the local installation of `dotnet-format` as defined in the manifest at https://github.com/dafny-lang/dafny/blob/master/Source/dotnet-tools.json.
Using the local version of `dotnet-format` is suggested in https://github.com/dotnet/format/pull/1352/commits/2d9ee97f1e9723c7b2227d808fd6f367d34f4c51

To run the version from the manifest I had to change the working directory in the pre-commit hook, which I did via `bash -c`. I assume that that doesn't work on Windows.