### PR TITLE
Update the dotnet format command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
 repos:
--   repo: https://github.com/dotnet/format
-    rev: v5.1.225507
+-   repo: local
     hooks:
     -   id: dotnet-format
-        entry: dotnet-format Source/Dafny.sln -w --
+        name: dotnet-format
+        language: system
+        entry: bash -c 'cd Source && dotnet tool run dotnet-format Dafny.sln -w --'
+        types_or: ["c#"]
         


### PR DESCRIPTION
When trying to create a commit, I ran into an error where pre-commit/dotnet-format asked for .NET 6.0, due to a recent change to `dotnet-format`. I have changed the `pre-commit` hook to use the local installation of `dotnet-format` as defined in the manifest at https://github.com/dafny-lang/dafny/blob/master/Source/dotnet-tools.json.
Using the local version of `dotnet-format` is suggested in dotnet/format@2d9ee97

To run the version from the manifest I had to change the working directory in the `pre-commit` hook, which I did via `bash -c`. I assume that that doesn't work on Windows. 

- An alternative would be to require a global installation of `dotnet-format` via `dotnet tool install -g dotnet-format` (maybe in the Makefile?). I think one doesn't need to switch the working directory in that case.
- Another alternative could be to find a different way to switch the working directory to run `dotnet tool run dotnet-format ...`
- Another alternative could be to switch to .NET 6.0, but so far only prerelease versions of it are available, so I think that it's too early for this.