### PR TITLE
Add document symbols to support outline

### DIFF
--- a/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Progress;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
+  [TestClass]
+  public class DocumentSymbolTest : DafnyLanguageServerTestBase {
+    private ILanguageClient client;
+
+    [TestInitialize]
+    public async Task SetUp() {
+      client = await InitializeClient();
+    }
+
+    private IRequestProgressObservable<IEnumerable<SymbolInformationOrDocumentSymbol>, SymbolInformationOrDocumentSymbolContainer> RequestDocumentSymbol(TextDocumentItem documentItem) {
+      return client.RequestDocumentSymbol(
+        new DocumentSymbolParams {
+          TextDocument = documentItem.Uri,
+        },
+        CancellationToken
+      );
+    }
+
+    [TestMethod]
+    public async Task LoadCorrectDocumentCreatesSymbols() {
+      var source = @"
+class Y {
+  var z: nat;
+
+  method DoIt() returns (x: int) {
+  }
+
+  method CallIt() returns () {
+    var x := DoIt();
+  }
+}".TrimStart();
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      
+      var classSymbol = (await RequestDocumentSymbol(documentItem).AsTask()).Single().DocumentSymbol;
+      var classChildren = classSymbol.Children.ToArray();
+      Assert.AreEqual("Y", classSymbol.Name);
+      Assert.AreEqual(new Range((0, 6), (9, 0)), classSymbol.Range);
+      Assert.AreEqual(SymbolKind.Class, classSymbol.Kind);
+      Assert.AreEqual(3, classChildren.Length);
+
+      var fieldSymbol = classChildren[0];
+      Assert.AreEqual("z", fieldSymbol.Name);
+      Assert.AreEqual(new Range((1, 6), (1, 7)), fieldSymbol.Range);
+      Assert.AreEqual(SymbolKind.Field, fieldSymbol.Kind);
+      Assert.AreEqual(0, fieldSymbol.Children.Count());
+
+      var methodDoItSymbol = classChildren[1];
+      var methodDoItChildren = methodDoItSymbol.Children.ToArray();
+      Assert.AreEqual("DoIt", methodDoItSymbol.Name);
+      Assert.AreEqual(new Range((3, 9), (4, 2)), methodDoItSymbol.Range);
+      Assert.AreEqual(SymbolKind.Method, methodDoItSymbol.Kind);
+      Assert.AreEqual(1, methodDoItChildren.Length);
+
+      var outParameterSymbol = methodDoItChildren[0];
+      Assert.AreEqual("x", outParameterSymbol.Name);
+      Assert.AreEqual(new Range((3, 25), (3, 26)), outParameterSymbol.Range);
+      Assert.AreEqual(SymbolKind.Variable, outParameterSymbol.Kind);
+      Assert.AreEqual(0, outParameterSymbol.Children.Count());
+
+      var methodCallItSymbol = classChildren[2];
+      var methodCallItChildren = methodCallItSymbol.Children.ToArray();
+      Assert.AreEqual("CallIt", methodCallItSymbol.Name);
+      Assert.AreEqual(new Range((6, 9), (8, 2)), methodCallItSymbol.Range);
+      Assert.AreEqual(SymbolKind.Method, methodCallItSymbol.Kind);
+      Assert.AreEqual(1, methodCallItChildren.Length);
+
+      var localVariableSymbol = methodCallItChildren[0];
+      Assert.AreEqual("x", localVariableSymbol.Name);
+      Assert.AreEqual(new Range((7, 8), (7, 9)), localVariableSymbol.Range);
+      Assert.AreEqual(SymbolKind.Variable, localVariableSymbol.Kind);
+      Assert.AreEqual(0, localVariableSymbol.Children.Count());
+    }
+  }
+}

--- a/Source/DafnyLanguageServer/Handlers/DafnyDocumentSymbolHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyDocumentSymbolHandler.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       }
       var visitor = new LspSymbolGeneratingVisitor(document.SymbolTable, cancellationToken);
       var symbols = visitor.Visit(document.SymbolTable.CompilationUnit)
-        .WithCancellation(cancellationToken)
         .Select(symbol => new SymbolInformationOrDocumentSymbol(symbol))
         .ToArray();
       return symbols;

--- a/Source/DafnyLanguageServer/Handlers/DafnyDocumentSymbolHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyDocumentSymbolHandler.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       }
       var visitor = new LspSymbolGeneratingVisitor(document.SymbolTable, cancellationToken);
       var symbols = visitor.Visit(document.SymbolTable.CompilationUnit)
+        .WithCancellation(cancellationToken)
         .Select(symbol => new SymbolInformationOrDocumentSymbol(symbol))
         .ToArray();
       return symbols;

--- a/Source/DafnyLanguageServer/Handlers/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Handlers/LanguageServerExtensions.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
     public static LanguageServerOptions WithDafnyHandlers(this LanguageServerOptions options) {
       return options
         .WithHandler<DafnyTextDocumentHandler>()
-        // TODO Disabled since its functionallity cannot be observed in VS Code (yet).
-        //.WithHandler<DafnyDocumentSymbolHandler>()
+        .WithHandler<DafnyDocumentSymbolHandler>()
         .WithHandler<DafnyHoverHandler>()
         .WithHandler<DafnyDefinitionHandler>()
         .WithHandler<DafnyCompletionHandler>()

--- a/Source/DafnyLanguageServer/Language/Symbols/LspSymbolGeneratingVisitor.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/LspSymbolGeneratingVisitor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
 
     private IEnumerable<DocumentSymbol> CreateSymbolsOfEntryDocument(ILocalizableSymbol symbol, Boogie.IToken token, SymbolKind kind) {
       var children = symbol.Children.SelectMany(Visit);
-      if (!IsPartOfEntryDocument(token)) {
+      if (!IsPartOfEntryDocument(token) || token.line == 0) {
         return children;
       }
       var documentSymbol = new DocumentSymbol {

--- a/Source/DafnyLanguageServer/Language/Symbols/LspSymbolGeneratingVisitor.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/LspSymbolGeneratingVisitor.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
       var documentSymbol = new DocumentSymbol {
         Name = symbol.Name,
         Kind = kind,
-        Detail = symbol.GetDetailText(cancellationToken),
         Children = children.ToArray()
       };
       if (symbolTable.TryGetLocationOf(symbol, out var location)) {


### PR DESCRIPTION
This PR enables support for document outlines and the breadcrumb navigation at the top of the editor.

![image](https://user-images.githubusercontent.com/18049310/135870441-4a31cc07-5407-4dda-8f10-6c1830e79fd6.png)