### PR TITLE
Remove DafnyPrelude.bpl from special packaging list

### DIFF
--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -47,7 +47,7 @@ Z3_INTERESTING_FILES = ["LICENSE.txt", "bin/*"]
 ## On unix systems, which Dafny files should be marked as executable? (Glob syntax; Z3's permissions are preserved)
 UNIX_EXECUTABLES = ["dafny", "dafny-server"]
 
-ETCs = ["DafnyPrelude.bpl", "DafnyRuntime.js", "DafnyRuntime.go", "DafnyRuntime.jar", "DafnyRuntime.h"]
+ETCs = ["DafnyRuntime.js", "DafnyRuntime.go", "DafnyRuntime.jar", "DafnyRuntime.h"]
 
 # Constants
 


### PR DESCRIPTION
This was moved out of `Binaries` and into the DafnyPipeline project by #1467, and therefore is already being packaged along with all other "normal" dependencies, and doesn't need special-casing in this script.