### PR TITLE
Remove pre-commit as a dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,0 @@
-repos:
--   repo: local
-    hooks:
-    -   id: dotnet-format
-        name: dotnet-format
-        language: system
-        entry: dotnet tool run dotnet-format --folder -w --include
-        types_or: ["c#"]

--- a/Scripts/pre-commit
+++ b/Scripts/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+        against=HEAD
+else
+        # Initial commit: diff against an empty tree object
+        against=$(git hash-object -t tree /dev/null)
+fi
+
+#Run dotnet-format on the changed dafny sources
+dotnet_format=$(git diff --cached --name-only --diff-filter=ACMR -z $against | grep -a '^Source.*.cs$' | xargs -0 dotnet tool run dotnet-format --folder -w --include)
+
+#Abort on fail (likely no dotnet-format)
+if (( $? > 0 ));
+then
+        exit 1
+fi
+
+#Eval dotnet-format output
+if (( $(echo "$dotnet_format" | wc -l) > 2));
+then
+        cat <<\EOF
+Error: Staged file(s) violate the formatting rules.
+
+Fortunately, we took the liberty to fix that.
+
+All that is left to do, is to *add the changes* and recommit.
+EOF
+        exit 1
+fi


### PR DESCRIPTION
I propose replacing our current setup of having the dependency `pre-commit` run in local mode, with a direct git hook. All the user has to do is to symlink the script into .git/hooks during the initial setup.

`ln -s "$PWD/Scripts/pre-commit" .git/hooks/pre-commit`

The script runs `dotnet-format` on the staged files and aborts the commit if the formatter changes those files. In that case, the user is encouraged to add the changes to the commit, but rerunning `git commit` without any changes will still work.