### PR TITLE
fix: Correct hint in error message

### DIFF
--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -6212,7 +6212,7 @@ namespace Microsoft.Dafny {
       } else if (decl.WitnessKind == SubsetTypeDecl.WKind.CompiledZero) {
         var witness = Zero(decl.tok, decl.Var.Type);
         var errMsg = "cannot find witness that shows type is inhabited";
-        var hintMsg = "; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type";
+        var hintMsg = "; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type";
         if (witness == null) {
           witnessCheckBuilder.Add(Assert(decl.tok, Bpl.Expr.False, $"{errMsg}{hintMsg}"));
         } else {

--- a/Test/allocated1/dafny0/Newtypes.dfy.expect
+++ b/Test/allocated1/dafny0/Newtypes.dfy.expect
@@ -1,4 +1,4 @@
-Newtypes.dfy(74,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+Newtypes.dfy(74,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 Newtypes.dfy(76,44): Error: possible division by zero
 Newtypes.dfy(87,13): Error: result of operation might violate newtype constraint for 'char8'
 Newtypes.dfy(95,11): Error: result of operation might violate newtype constraint for 'char8'

--- a/Test/allocated1/dafny0/SubsetTypes.dfy.expect
+++ b/Test/allocated1/dafny0/SubsetTypes.dfy.expect
@@ -63,11 +63,11 @@ SubsetTypes.dfy(318,18): Error: value does not satisfy the subset constraints of
 SubsetTypes.dfy(323,20): Error: value does not satisfy the subset constraints of 'nat'
 SubsetTypes.dfy(329,18): Error: result of operation might violate newtype constraint for 'Nat'
 SubsetTypes.dfy(335,20): Error: result of operation might violate newtype constraint for 'Nat'
-SubsetTypes.dfy(340,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(340,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 SubsetTypes.dfy(341,18): Error: value does not satisfy the subset constraints of 'Nat'
-SubsetTypes.dfy(345,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(345,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 SubsetTypes.dfy(346,18): Error: result of operation might violate newtype constraint for 'Nat'
-SubsetTypes.dfy(350,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(350,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 SubsetTypes.dfy(358,21): Error: possible division by zero
 SubsetTypes.dfy(363,23): Error: possible division by zero
 SubsetTypes.dfy(375,19): Error: value does not satisfy the subset constraints of 'X'
@@ -81,7 +81,7 @@ SubsetTypes.dfy(392,28): Error: value does not satisfy the subset constraints of
 SubsetTypes.dfy(394,28): Error: value does not satisfy the subset constraints of 'int ~> nat'
 SubsetTypes.dfy(396,26): Error: value does not satisfy the subset constraints of 'int ~> X'
 SubsetTypes.dfy(399,9): Error: value does not satisfy the subset constraints of 'nat'
-SubsetTypes.dfy(409,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
-SubsetTypes.dfy(411,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(409,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
+SubsetTypes.dfy(411,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 
 Dafny program verifier finished with 13 verified, 85 errors

--- a/Test/allocated1/dafny0/Termination.dfy.expect
+++ b/Test/allocated1/dafny0/Termination.dfy.expect
@@ -20,6 +20,6 @@ Termination.dfy(806,2): Error: cannot prove termination; try supplying a decreas
 Termination.dfy(1152,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(1168,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(361,46): Error: failure to decrease termination measure
-Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 
 Dafny program verifier finished with 95 verified, 23 errors

--- a/Test/dafny0/GhostAutoInit.dfy.expect
+++ b/Test/dafny0/GhostAutoInit.dfy.expect
@@ -40,7 +40,7 @@ GhostAutoInit.dfy(244,20): Error: variable 'y', which is subject to definite-ass
 GhostAutoInit.dfy(257,23): Error: variable 'm', which is subject to definite-assignment rules, might be used before it has been assigned
 GhostAutoInit.dfy(257,29): Error: variable 'x', which is subject to definite-assignment rules, might be used before it has been assigned
 GhostAutoInit.dfy(257,32): Error: variable 'y', which is subject to definite-assignment rules, might be used before it has been assigned
-GhostAutoInit.dfy(282,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+GhostAutoInit.dfy(282,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 GhostAutoInit.dfy(298,2): Error: A postcondition might not hold on this return path.
 GhostAutoInit.dfy(297,12): Related location: This is the postcondition that might not hold.
 GhostAutoInit.dfy(303,9): Error: value does not satisfy the subset constraints of 'nat'

--- a/Test/dafny0/Newtypes.dfy.expect
+++ b/Test/dafny0/Newtypes.dfy.expect
@@ -1,4 +1,4 @@
-Newtypes.dfy(74,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+Newtypes.dfy(74,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 Newtypes.dfy(76,44): Error: possible division by zero
 Newtypes.dfy(87,13): Error: result of operation might violate newtype constraint for 'char8'
 Newtypes.dfy(95,11): Error: result of operation might violate newtype constraint for 'char8'

--- a/Test/dafny0/NonZeroInitialization.dfy.expect
+++ b/Test/dafny0/NonZeroInitialization.dfy.expect
@@ -6,9 +6,9 @@ NonZeroInitialization.dfy(16,8): Error: trying witness 0: result of operation mi
 NonZeroInitialization.dfy(17,61): Error: result of operation might violate newtype constraint for 'NewSix'
 NonZeroInitialization.dfy(18,46): Error: result of operation might violate newtype constraint for 'NewSix'
 NonZeroInitialization.dfy(19,8): Error: trying witness 0: result of operation might violate newtype constraint for 'NewSix'
-NonZeroInitialization.dfy(37,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+NonZeroInitialization.dfy(37,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 NonZeroInitialization.dfy(38,70): Error: result of operation might violate subset type constraint for 'ListTwo'
-NonZeroInitialization.dfy(39,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+NonZeroInitialization.dfy(39,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 NonZeroInitialization.dfy(53,0): Error: out-parameter 'g', which is subject to definite-assignment rules, might not have been defined at this return point
 NonZeroInitialization.dfy(58,7): Error: unless an initializer is provided for the array elements, a new array of 'Yt<GW>' must have empty size
 

--- a/Test/dafny0/SubsetTypes.dfy.expect
+++ b/Test/dafny0/SubsetTypes.dfy.expect
@@ -63,11 +63,11 @@ SubsetTypes.dfy(318,18): Error: value does not satisfy the subset constraints of
 SubsetTypes.dfy(323,20): Error: value does not satisfy the subset constraints of 'nat'
 SubsetTypes.dfy(329,18): Error: result of operation might violate newtype constraint for 'Nat'
 SubsetTypes.dfy(335,20): Error: result of operation might violate newtype constraint for 'Nat'
-SubsetTypes.dfy(340,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(340,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 SubsetTypes.dfy(341,18): Error: value does not satisfy the subset constraints of 'Nat'
-SubsetTypes.dfy(345,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(345,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 SubsetTypes.dfy(346,18): Error: result of operation might violate newtype constraint for 'Nat'
-SubsetTypes.dfy(350,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(350,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 SubsetTypes.dfy(358,21): Error: possible division by zero
 SubsetTypes.dfy(363,23): Error: possible division by zero
 SubsetTypes.dfy(375,19): Error: value does not satisfy the subset constraints of 'X'
@@ -81,7 +81,7 @@ SubsetTypes.dfy(392,28): Error: value does not satisfy the subset constraints of
 SubsetTypes.dfy(394,28): Error: value does not satisfy the subset constraints of 'int ~> nat'
 SubsetTypes.dfy(396,26): Error: value does not satisfy the subset constraints of 'int ~> X'
 SubsetTypes.dfy(399,9): Error: value does not satisfy the subset constraints of 'nat'
-SubsetTypes.dfy(409,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
-SubsetTypes.dfy(411,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+SubsetTypes.dfy(409,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
+SubsetTypes.dfy(411,7): Error: cannot find witness that shows type is inhabited (only tried 'D'); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 
 Dafny program verifier finished with 13 verified, 85 errors

--- a/Test/dafny0/Termination.dfy.expect
+++ b/Test/dafny0/Termination.dfy.expect
@@ -1,6 +1,6 @@
 Termination.dfy[TerminationRefinement1](441,5): Error: failure to decrease termination measure
 Termination.dfy(361,46): Error: failure to decrease termination measure
-Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 Termination.dfy(108,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(125,2): Error: decreases expression might not decrease
 Termination.dfy(126,16): Error: decreases expression must be bounded below by 0 at end of loop iteration

--- a/Test/dafny4/RollYourOwnArrowType.dfy.expect
+++ b/Test/dafny4/RollYourOwnArrowType.dfy.expect
@@ -1,4 +1,4 @@
-RollYourOwnArrowType.dfy(6,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+RollYourOwnArrowType.dfy(6,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 RollYourOwnArrowType.dfy(141,16): Error: the given witness expression might not satisfy constraint
 RollYourOwnArrowType.dfy(139,21): Related location
 RollYourOwnArrowType.dfy(123,2): Related location

--- a/Test/dafny4/git-issue3.dfy.expect
+++ b/Test/dafny4/git-issue3.dfy.expect
@@ -1,3 +1,3 @@
-git-issue3.dfy(4,8): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue3.dfy(4,8): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/git-issues/git-issue-276a.dfy.expect
+++ b/Test/git-issues/git-issue-276a.dfy.expect
@@ -1,13 +1,13 @@
 git-issue-276a.dfy(23,10): Info: newtype c0 resolves as {:nativeType "byte"} (Detected Range: 0 .. 100)
 git-issue-276a.dfy(25,10): Info: newtype c1 resolves as {:nativeType "byte"} (Detected Range: 0 .. 100)
 git-issue-276a.dfy(26,10): Info: newtype c2 resolves as {:nativeType "byte"} (Detected Range: 0 .. 50)
-git-issue-276a.dfy(5,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(5,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(5,26): Related location
 git-issue-276a.dfy(5,29): Error: possible division by zero
-git-issue-276a.dfy(6,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(6,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(6,26): Related location
 git-issue-276a.dfy(6,29): Error: possible division by zero
-git-issue-276a.dfy(7,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(7,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(7,26): Related location
 git-issue-276a.dfy(7,32): Error: possible division by zero
 git-issue-276a.dfy(8,32): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
@@ -15,26 +15,26 @@ git-issue-276a.dfy(9,35): Error: value to be converted might not fit in bv8
 git-issue-276a.dfy(10,34): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
 git-issue-276a.dfy(11,33): Error: value to be converted might not fit in bv8
 git-issue-276a.dfy(12,41): Error: value to be converted might not fit in bv8
-git-issue-276a.dfy(13,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(13,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(13,27): Related location
 git-issue-276a.dfy(13,39): Error: value to be converted might not fit in char
-git-issue-276a.dfy(14,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(14,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(14,27): Related location
 git-issue-276a.dfy(14,40): Error: real value to be converted might not fit in char
 git-issue-276a.dfy(15,41): Error: the real-based number must be an integer (if you want truncation, apply .Floor to the real-based number)
 git-issue-276a.dfy(16,33): Error: value to be converted might not fit in bv2
-git-issue-276a.dfy(17,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(17,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(17,27): Related location
 git-issue-276a.dfy(17,46): Error: bit-vector value to be converted might not fit in char
 git-issue-276a.dfy(18,41): Error: possible division by zero
 git-issue-276a.dfy(19,41): Error: possible division by zero
-git-issue-276a.dfy(20,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(20,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(20,27): Related location
 git-issue-276a.dfy(20,40): Error: shift amount must be non-negative
-git-issue-276a.dfy(21,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(21,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(21,27): Related location
 git-issue-276a.dfy(21,40): Error: shift amount must be non-negative
-git-issue-276a.dfy(28,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'ghost *' to treat as a possibly empty type
+git-issue-276a.dfy(28,10): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 git-issue-276a.dfy(28,26): Related location
 git-issue-276a.dfy(28,35): Error: index out of range
 


### PR DESCRIPTION
The error message used to say `ghost *` when it should have said `witness *`.