### PR TITLE
Fix for issue #1495

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -12990,7 +12990,7 @@ namespace Microsoft.Dafny {
         var lhsResolved = s.Lhss[0].Resolved;
         // Make a new unresolved expression
         if (lhsResolved is MemberSelectExpr lexr) {
-          Expression id = makeTemp("recv", s, codeContext, lexr.Obj);
+          Expression id = lexr.Obj is ThisExpr ? lexr.Obj : makeTemp("recv", s, codeContext, lexr.Obj);
           var lex = lhsExtract as ExprDotName; // might be just a NameSegment
           lhsExtract = new ExprDotName(lexr.tok, id, lexr.MemberName, lex == null ? null : lex.OptTypeArguments);
         } else if (lhsResolved is SeqSelectExpr lseq) {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -12990,7 +12990,7 @@ namespace Microsoft.Dafny {
         var lhsResolved = s.Lhss[0].Resolved;
         // Make a new unresolved expression
         if (lhsResolved is MemberSelectExpr lexr) {
-          Expression id = lexr.Obj is ThisExpr ? lexr.Obj : makeTemp("recv", s, codeContext, lexr.Obj);
+          Expression id = Expression.AsThis(lexr.Obj) != null ? lexr.Obj : makeTemp("recv", s, codeContext, lexr.Obj);
           var lex = lhsExtract as ExprDotName; // might be just a NameSegment
           lhsExtract = new ExprDotName(lexr.tok, id, lexr.MemberName, lex == null ? null : lex.OptTypeArguments);
         } else if (lhsResolved is SeqSelectExpr lseq) {

--- a/Test/git-issues/git-issue1495.dfy
+++ b/Test/git-issues/git-issue1495.dfy
@@ -1,0 +1,21 @@
+// RUN: %dafny /compile:0 /rprint:"%t.rprint" "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+include "../libraries/src/Wrappers.dfy"
+import opened Wrappers
+
+datatype Bar = Bar(i: string)
+function method ParseBar(s: string): Result<Bar, string> {
+   Success(Bar(s))
+}
+
+class Foo {
+  const bar: Bar
+
+  constructor (
+    barLike: string
+  )
+    requires ParseBar(barLike).Success?
+  {
+      this.bar :- assert ParseBar(barLike);
+  }
+}

--- a/Test/git-issues/git-issue1495.dfy
+++ b/Test/git-issues/git-issue1495.dfy
@@ -16,6 +16,80 @@ class Foo {
   )
     requires ParseBar(barLike).Success?
   {
-      this.bar :- assert ParseBar(barLike);
+     // Before (this) was assigned to a temporary variable.
+     (this).bar :- assert ParseBar(barLike);
   }
+}
+
+// The fix for above should not remove the temporary variable.
+// The following test should still pass.
+class Wrapper {
+  var arg: string
+  constructor() {
+    arg := "default";
+  }
+}
+
+class Foo2 {
+  var leftWrapper: Wrapper;
+  var rightWrapper: Wrapper;
+  var currentWrapper: Wrapper;
+  var isCurrentWrapperLeft: bool;
+  ghost var Repr: set<object>;
+
+  constructor () ensures Valid() && fresh(Repr - {this}) && isCurrentWrapperLeft {
+    leftWrapper := new Wrapper();
+    rightWrapper := new Wrapper();
+    currentWrapper := leftWrapper;
+    isCurrentWrapperLeft := true;
+    Repr := {this, leftWrapper, rightWrapper};
+  }
+
+  predicate Valid() reads this {
+    (if isCurrentWrapperLeft then
+      currentWrapper == leftWrapper
+    else currentWrapper == rightWrapper) &&
+    Repr == {this, leftWrapper, rightWrapper}
+  }
+
+  method getNextValue() returns (s: Result<string, string>) 
+    requires Valid()
+    ensures Valid()
+    ensures if old(isCurrentWrapperLeft) then currentWrapper == rightWrapper else currentWrapper == leftWrapper
+    ensures isCurrentWrapperLeft == !old(isCurrentWrapperLeft)
+    ensures if old(isCurrentWrapperLeft) then s == Success("left") else s == Failure("no next value")
+    ensures old(leftWrapper) == leftWrapper
+    ensures old(rightWrapper) == rightWrapper
+    modifies this
+  {
+    if(isCurrentWrapperLeft) {
+      currentWrapper := rightWrapper;
+      isCurrentWrapperLeft := false;
+      s := Success("left");
+    } else {
+      currentWrapper := leftWrapper;
+      isCurrentWrapperLeft := true;
+      s := Failure("no next value");
+    }
+  }
+
+  method update() returns (r: Result<string, string>)
+      requires Valid()
+      ensures Valid()
+      ensures old(isCurrentWrapperLeft) ==> r == Success("Assigned everything")
+      ensures old(isCurrentWrapperLeft) ==> leftWrapper.arg == "left"
+      ensures old(isCurrentWrapperLeft) ==> currentWrapper == rightWrapper
+      modifies Repr {
+    currentWrapper.arg :- getNextValue();
+    // currentWrapper becomes rightWrapper after getNextValue, but leftWrapper.arg receives the new value
+    r := Success("Assigned everything");
+  }
+}
+
+method Main()
+{
+  var foo2: Foo2 := new Foo2();
+  var updated: Result<string, string> := foo2.update();
+  assert updated == Success("Assigned everything");
+  assert foo2.leftWrapper.arg == "left";
 }

--- a/Test/git-issues/git-issue1495.dfy
+++ b/Test/git-issues/git-issue1495.dfy
@@ -11,9 +11,7 @@ function method ParseBar(s: string): Result<Bar, string> {
 class Foo {
   const bar: Bar
 
-  constructor (
-    barLike: string
-  )
+  constructor (barLike: string)
     requires ParseBar(barLike).Success?
   {
      // Before (this) was assigned to a temporary variable.
@@ -31,13 +29,15 @@ class Wrapper {
 }
 
 class Foo2 {
-  var leftWrapper: Wrapper;
-  var rightWrapper: Wrapper;
-  var currentWrapper: Wrapper;
-  var isCurrentWrapperLeft: bool;
-  ghost var Repr: set<object>;
+  var leftWrapper: Wrapper
+  var rightWrapper: Wrapper
+  var currentWrapper: Wrapper
+  var isCurrentWrapperLeft: bool
+  ghost var Repr: set<object>
 
-  constructor () ensures Valid() && fresh(Repr - {this}) && isCurrentWrapperLeft {
+  constructor ()
+    ensures Valid() && fresh(Repr - {this}) && isCurrentWrapperLeft
+  {
     leftWrapper := new Wrapper();
     rightWrapper := new Wrapper();
     currentWrapper := leftWrapper;
@@ -45,7 +45,9 @@ class Foo2 {
     Repr := {this, leftWrapper, rightWrapper};
   }
 
-  predicate Valid() reads this {
+  predicate Valid()
+    reads this
+  {
     (if isCurrentWrapperLeft then
       currentWrapper == leftWrapper
     else currentWrapper == rightWrapper) &&
@@ -74,12 +76,13 @@ class Foo2 {
   }
 
   method update() returns (r: Result<string, string>)
-      requires Valid()
-      ensures Valid()
-      ensures old(isCurrentWrapperLeft) ==> r == Success("Assigned everything")
-      ensures old(isCurrentWrapperLeft) ==> leftWrapper.arg == "left"
-      ensures old(isCurrentWrapperLeft) ==> currentWrapper == rightWrapper
-      modifies Repr {
+    requires Valid()
+    ensures Valid()
+    ensures old(isCurrentWrapperLeft) ==> r == Success("Assigned everything")
+    ensures old(isCurrentWrapperLeft) ==> leftWrapper.arg == "left"
+    ensures old(isCurrentWrapperLeft) ==> currentWrapper == rightWrapper
+    modifies Repr
+  {
     currentWrapper.arg :- getNextValue();
     // currentWrapper becomes rightWrapper after getNextValue, but leftWrapper.arg receives the new value
     r := Success("Assigned everything");

--- a/Test/git-issues/git-issue1495.dfy.expect
+++ b/Test/git-issues/git-issue1495.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue1495.dfy.expect
+++ b/Test/git-issues/git-issue1495.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 8 verified, 0 errors


### PR DESCRIPTION
This PR fixes the issue of mentioned in #1495.

The problem came from

    this.arg :- assert X
 
 that was translated to 
 
     var tmpObj = this;
     ....
     tmpObj.arg := ...
 
This translation might make sense if instead of "this" we had another field which might point to another object after X executes (i.e. if X is a method with side effects). However, in the `this` case (or this in parentheses), the object is guaranteed to be the same, so we don't need and should not do this temporary assignment, so that there is no alias of this during initialization of constants.

This PR reproduces the bug for #1495 as well as adds a case that would fail if we did not do the temporary assignment.
