### PR TITLE
Update to Boogie 2.9.6

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <!-- Boogie dependency -->
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.4" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.6" />
   </ItemGroup>
 
 </Project>

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -124,7 +124,7 @@ index 4934fa8d..64a5a976 100644
  
    <!-- Boogie dependency -->
    <ItemGroup>
--    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.4" />
+-    <PackageReference Include="Boogie.ExecutionEngine" Version="2.9.6" />
 +    <ProjectReference Include="..\..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
    </ItemGroup>
  


### PR DESCRIPTION
Resolves the warnings that were previously created in the `build Dafny with local Boogie` task.