### PR TITLE
fix: Location of generated files in C++

### DIFF
--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2407,7 +2407,7 @@ namespace Microsoft.Dafny {
     public override bool RunTargetProgram(string dafnyProgramName, string targetProgramText, string/*?*/ callToMain, string targetFilename, ReadOnlyCollection<string> otherFileNames,
       object compilationResult, TextWriter outputWriter) {
       var exeName = ComputeExeName(targetFilename);
-      var psi = new ProcessStartInfo(exeName) {
+      var psi = new ProcessStartInfo($"{Path.GetDirectoryName(Path.GetFullPath(targetFilename))}/{exeName}") {
         CreateNoWindow = true,
         UseShellExecute = false,
         RedirectStandardOutput = true,

--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2364,7 +2364,7 @@ namespace Microsoft.Dafny {
 
     // ----- Target compilation and execution -------------------------------------------------------------
     private string ComputeExeName(string targetFilename) {
-      return Path.GetFileNameWithoutExtension(targetFilename) + ".exe";
+      return Path.ChangeExtension(Path.GetFullPath(targetFilename), "exe");
     }
 
     public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string/*?*/ callToMain, string/*?*/ targetFilename, ReadOnlyCollection<string> otherFileNames,
@@ -2373,7 +2373,6 @@ namespace Microsoft.Dafny {
       Contract.Assert(assemblyLocation != null);
       var codebase = System.IO.Path.GetDirectoryName(assemblyLocation);
       Contract.Assert(codebase != null);
-      var exeName = ComputeExeName(targetFilename);
       var warnings = "-Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy";
       if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
         warnings += " -Wno-unknown-warning-option";
@@ -2381,7 +2380,7 @@ namespace Microsoft.Dafny {
       if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
         warnings += " -Wno-unused-but-set-variable";
       }
-      var args = warnings + $" -g -std=c++17 -I {codebase} -o {Path.GetDirectoryName(Path.GetFullPath(targetFilename))}/{exeName} {targetFilename}";
+      var args = warnings + $" -g -std=c++17 -I {codebase} -o {ComputeExeName(targetFilename)} {targetFilename}";
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", args) {
         CreateNoWindow = true,
@@ -2406,8 +2405,7 @@ namespace Microsoft.Dafny {
 
     public override bool RunTargetProgram(string dafnyProgramName, string targetProgramText, string/*?*/ callToMain, string targetFilename, ReadOnlyCollection<string> otherFileNames,
       object compilationResult, TextWriter outputWriter) {
-      var exeName = ComputeExeName(targetFilename);
-      var psi = new ProcessStartInfo($"{Path.GetDirectoryName(Path.GetFullPath(targetFilename))}/{exeName}") {
+      var psi = new ProcessStartInfo(ComputeExeName(targetFilename)) {
         CreateNoWindow = true,
         UseShellExecute = false,
         RedirectStandardOutput = true,

--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2381,7 +2381,7 @@ namespace Microsoft.Dafny {
       if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
         warnings += " -Wno-unused-but-set-variable";
       }
-      var args = warnings + $" -g -std=c++17 -I {codebase} -o {exeName} {targetFilename}";
+      var args = warnings + $" -g -std=c++17 -I {codebase} -o {Path.GetDirectoryName(Path.GetFullPath(targetFilename))}/{exeName} {targetFilename}";
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", args) {
         CreateNoWindow = true,

--- a/Test/comp/compile1quiet/CompileRunQuietly.dfy
+++ b/Test/comp/compile1quiet/CompileRunQuietly.dfy
@@ -11,7 +11,7 @@
 // RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/CompileRunQuietly-java CompileRunQuietly >> "%t"
 
 // RUN: %dafny /compileTarget:cpp "%s" >> "%t"
-// RUN: CompileRunQuietly.exe >> "%t"
+// RUN: %S/CompileRunQuietly.exe >> "%t"
 
  // RUN: %diff "%s.expect" "%t"
 

--- a/Test/comp/compile1quiet/CompileRunQuietly.dfy
+++ b/Test/comp/compile1quiet/CompileRunQuietly.dfy
@@ -11,7 +11,7 @@
 // RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/CompileRunQuietly-java CompileRunQuietly >> "%t"
 
 // RUN: %dafny /compileTarget:cpp "%s" >> "%t"
-// RUN: ls %S
+// RUN: ls %S 1>&2
 // RUN: %S/CompileRunQuietly.exe >> "%t"
 
  // RUN: %diff "%s.expect" "%t"

--- a/Test/comp/compile1quiet/CompileRunQuietly.dfy
+++ b/Test/comp/compile1quiet/CompileRunQuietly.dfy
@@ -11,6 +11,7 @@
 // RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/CompileRunQuietly-java CompileRunQuietly >> "%t"
 
 // RUN: %dafny /compileTarget:cpp "%s" >> "%t"
+// RUN: ls %S
 // RUN: %S/CompileRunQuietly.exe >> "%t"
 
  // RUN: %diff "%s.expect" "%t"

--- a/Test/comp/compile1quiet/CompileRunQuietly.dfy
+++ b/Test/comp/compile1quiet/CompileRunQuietly.dfy
@@ -11,7 +11,6 @@
 // RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/CompileRunQuietly-java CompileRunQuietly >> "%t"
 
 // RUN: %dafny /compileTarget:cpp "%s" >> "%t"
-// RUN: ls %S 1>&2
 // RUN: %S/CompileRunQuietly.exe >> "%t"
 
  // RUN: %diff "%s.expect" "%t"

--- a/Test/comp/compile1verbose/CompileAndThenRun.dfy
+++ b/Test/comp/compile1verbose/CompileAndThenRun.dfy
@@ -11,7 +11,7 @@
 // RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/CompileAndThenRun-java CompileAndThenRun >> "%t"
 
 // RUN: %dafny /compileVerbose:1 /compileTarget:cpp "%s" >> "%t"
-// RUN: CompileAndThenRun.exe >> "%t"
+// RUN: %S/CompileAndThenRun.exe >> "%t"
 
 // RUN: %diff "%s.expect" "%t"
 

--- a/Test/comp/manualcompile/ManualCompile.dfy
+++ b/Test/comp/manualcompile/ManualCompile.dfy
@@ -14,7 +14,7 @@
 
 // RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:cpp "%s" >> "%t"
 // RUN: g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -std=c++17 -I %binaryDir -o ManualCompile.exe %S/ManualCompile.cpp
-// RUN: ManualCompile.exe >> "%t"
+// RUN: %S/ManualCompile.exe >> "%t"
 
 // RUN: %diff "%s.expect" "%t"
 

--- a/Test/comp/manualcompile/ManualCompile.dfy
+++ b/Test/comp/manualcompile/ManualCompile.dfy
@@ -13,7 +13,7 @@
 // RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/ManualCompile-java ManualCompile >> "%t"
 
 // RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:cpp "%s" >> "%t"
-// RUN: g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -std=c++17 -I %binaryDir -o ManualCompile.exe %S/ManualCompile.cpp
+// RUN: g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -std=c++17 -I %binaryDir -o %S/ManualCompile.exe %S/ManualCompile.cpp
 // RUN: %S/ManualCompile.exe >> "%t"
 
 // RUN: %diff "%s.expect" "%t"

--- a/Test/comp/manualcompile/ManualCompile.dfy
+++ b/Test/comp/manualcompile/ManualCompile.dfy
@@ -6,7 +6,7 @@
 // RUN: node %S/ManualCompile.js >> "%t"
 
 // RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"
-// RUN: env GOPATH=%S/ManualCompile-go go run %S/ManualCompile-go/src/ManualCompile.go >> "%t"
+// RUN: env GO111MODULE=auto GOPATH=%S/ManualCompile-go go run %S/ManualCompile-go/src/ManualCompile.go >> "%t"
 
 // RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:java "%s" >> "%t"
 // RUN: javac -cp %binaryDir/DafnyRuntime.jar:%S/ManualCompile-java %S/ManualCompile-java/ManualCompile.java %S/ManualCompile-java/*/*.java

--- a/Test/comp/manualcompile/lit.local.cfg
+++ b/Test/comp/manualcompile/lit.local.cfg
@@ -21,3 +21,5 @@ if lit.util.which('g++') == None:
   config.unsupported = True
 
 current_dir = os.path.join(config.test_source_root, 'comp', 'manualcompile')
+
+config.environment['GO111MODULE'] = 'auto'

--- a/Test/comp/manualcompile/lit.local.cfg
+++ b/Test/comp/manualcompile/lit.local.cfg
@@ -21,5 +21,3 @@ if lit.util.which('g++') == None:
   config.unsupported = True
 
 current_dir = os.path.join(config.test_source_root, 'comp', 'manualcompile')
-
-config.environment['GO111MODULE'] = 'auto'


### PR DESCRIPTION
PR #680 uncovers some problems with file locations, but fails to address them entirely. Those changes break some tests when run directly with `lit`. This change should provide a more general solution.