### PR TITLE
fix: missing targetFilename leads to wrong location of generated files

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -601,7 +601,7 @@ namespace Microsoft.Dafny {
       private Func<string, string> DeleteDot = p => p == "." ? "" : p;
       public string RelativeDirectory => DeleteDot(Path.GetRelativePath(Directory, Path.GetDirectoryName(Filename)));
       public string RelativeFilename => DeleteDot(Path.GetRelativePath(Directory, Filename));
-      public string SourceDirectory => DeleteDot(Path.GetDirectoryName(Filename));
+      public string SourceDirectory => Path.GetDirectoryName(Filename);
     }
 
     private static TargetPaths GenerateLocations(Compiler compiler, string dafnyProgramName) {

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Dafny {
       public string SourceDirectory => Path.GetDirectoryName(Filename);
     }
 
-    private static TargetPaths GenerateLocations(Compiler compiler, string dafnyProgramName) {
+    private static TargetPaths GenerateTargetPaths(Compiler compiler, string dafnyProgramName) {
       string targetExtension;
       string baseName = Path.GetFileNameWithoutExtension(dafnyProgramName);
       string targetBaseDir = "";
@@ -761,7 +761,7 @@ namespace Microsoft.Dafny {
       compiler.Coverage.WriteLegendFile();
 
       // blurt out the code to a file, if requested, or if other target-language files were specified on the command line.
-      var paths = GenerateLocations(compiler, dafnyProgramName);
+      var paths = GenerateTargetPaths(compiler, dafnyProgramName);
       if (DafnyOptions.O.SpillTargetCode > 0 || otherFileNames.Count > 0 || (invokeCompiler && !compiler.SupportsInMemoryCompilation) ||
           (invokeCompiler && compiler.TextualTargetIsExecutable && !DafnyOptions.O.RunAfterCompile)) {
         WriteDafnyProgramToFiles(paths, targetProgramHasErrors, targetProgramText, callToMain, otherFiles, outputWriter);

--- a/Test/comp/compile1quiet/CompileRunQuietly.dfy
+++ b/Test/comp/compile1quiet/CompileRunQuietly.dfy
@@ -1,5 +1,5 @@
 // RUN: %dafny /compileTarget:cs "%s" > "%t"
-// RUN: dotnet CompileRunQuietly.dll >> "%t"
+// RUN: dotnet %S/CompileRunQuietly.dll >> "%t"
 
 // RUN: %dafny /compileTarget:js "%s" >> "%t"
 // RUN: node %S/CompileRunQuietly.js >> "%t"

--- a/Test/comp/compile1verbose/CompileAndThenRun.dfy
+++ b/Test/comp/compile1verbose/CompileAndThenRun.dfy
@@ -1,5 +1,5 @@
 // RUN: %dafny /compileVerbose:1 /compileTarget:cs "%s" > "%t"
-// RUN: dotnet CompileAndThenRun.dll >> "%t"
+// RUN: dotnet %S/CompileAndThenRun.dll >> "%t"
 
 // RUN: %dafny /compileVerbose:1 /compileTarget:js "%s" >> "%t"
 // RUN: node %S/CompileAndThenRun.js >> "%t"


### PR DESCRIPTION
In certain situations (e.g. compiling C# with `/spillTargetCode:0`), no `targetFilename` is generated. Failure to provide one, leads to all artefact being placed in the working directory, not the input file's.