### PR TITLE
fix: relative paths in filename

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -642,7 +642,7 @@ namespace Microsoft.Dafny {
 
       string targetFilename = Path.Combine(targetDir, targetBaseName);
 
-      return new TargetPaths(Directory: Path.GetDirectoryName(dafnyProgramName), Filename: targetFilename);
+      return new TargetPaths(Directory: Path.GetDirectoryName(Path.GetFullPath(dafnyProgramName)), Filename: Path.GetFullPath(targetFilename));
     }
 
     static void WriteDafnyProgramToFiles(TargetPaths paths, bool targetProgramHasErrors, string targetProgramText,

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -598,10 +598,13 @@ namespace Microsoft.Dafny {
     #region Compilation
 
     private record TargetPaths(string Directory, string Filename) {
-      private Func<string, string> DeleteDot = p => p == "." ? "" : p;
-      private Func<string, string> AddDot = p => p == "" ? "." : p;
-      public string RelativeDirectory => DeleteDot(Path.GetRelativePath(AddDot(Directory), AddDot(Path.GetDirectoryName(Filename))));
-      public string RelativeFilename => DeleteDot(Path.GetRelativePath(AddDot(Directory), Filename));
+      private static Func<string, string> DeleteDot = p => p == "." ? "" : p;
+      private static Func<string, string> AddDot = p => p == "" ? "." : p;
+      private Func<string, string> RelativeToDirectory =
+        path => DeleteDot(Path.GetRelativePath(AddDot(Directory), path));
+
+      public string RelativeDirectory => RelativeToDirectory(AddDot(Path.GetDirectoryName(Filename)));
+      public string RelativeFilename => RelativeToDirectory(Filename);
       public string SourceDirectory => Path.GetDirectoryName(Filename);
     }
 

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -599,8 +599,9 @@ namespace Microsoft.Dafny {
 
     private record TargetPaths(string Directory, string Filename) {
       private Func<string, string> DeleteDot = p => p == "." ? "" : p;
-      public string RelativeDirectory => DeleteDot(Path.GetRelativePath(Directory, Path.GetDirectoryName(Filename)));
-      public string RelativeFilename => DeleteDot(Path.GetRelativePath(Directory, Filename));
+      private Func<string, string> AddDot = p => p == "" ? "." : p;
+      public string RelativeDirectory => DeleteDot(Path.GetRelativePath(AddDot(Directory), AddDot(Path.GetDirectoryName(Filename))));
+      public string RelativeFilename => DeleteDot(Path.GetRelativePath(AddDot(Directory), Filename));
       public string SourceDirectory => Path.GetDirectoryName(Filename);
     }
 
@@ -642,7 +643,7 @@ namespace Microsoft.Dafny {
 
       string targetFilename = Path.Combine(targetDir, targetBaseName);
 
-      return new TargetPaths(Directory: Path.GetDirectoryName(Path.GetFullPath(dafnyProgramName)), Filename: Path.GetFullPath(targetFilename));
+      return new TargetPaths(Directory: Path.GetDirectoryName(dafnyProgramName), Filename: targetFilename);
     }
 
     static void WriteDafnyProgramToFiles(TargetPaths paths, bool targetProgramHasErrors, string targetProgramText,

--- a/Source/DafnyPipeline.Test/DafnyPipeline.Test.csproj
+++ b/Source/DafnyPipeline.Test/DafnyPipeline.Test.csproj
@@ -28,6 +28,9 @@
     <Content Include="..\..\Binaries\z3\**\*.*" LinkBase="z3">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\Test\dafny0\warnings-as-errors.*" LinkBase="TestFiles\LitTests\LitTest">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Source/DafnyPipeline.Test/DafnyPipeline.Test.csproj
+++ b/Source/DafnyPipeline.Test/DafnyPipeline.Test.csproj
@@ -28,7 +28,7 @@
     <Content Include="..\..\Binaries\z3\**\*.*" LinkBase="z3">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\Test\dafny0\warnings-as-errors.dfy" LinkBase="TestFiles\LitTests\LitTest">
+    <Content Include="..\..\Test\dafny0\warnings-as-errors.dfy">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Source/DafnyPipeline.Test/DafnyPipeline.Test.csproj
+++ b/Source/DafnyPipeline.Test/DafnyPipeline.Test.csproj
@@ -28,7 +28,7 @@
     <Content Include="..\..\Binaries\z3\**\*.*" LinkBase="z3">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\Test\dafny0\warnings-as-errors.*" LinkBase="TestFiles\LitTests\LitTest">
+    <Content Include="..\..\Test\dafny0\warnings-as-errors.dfy" LinkBase="TestFiles\LitTests\LitTest">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Source/DafnyPipeline.Test/RelativePaths.cs
+++ b/Source/DafnyPipeline.Test/RelativePaths.cs
@@ -8,8 +8,7 @@ namespace DafnyPipeline.Test {
   public class RelativePaths {
     [Fact]
     public void Test() {
-      var code = DafnyDriver.ThreadMain(new string[] { "/spillTargetCode:3", "warnings-as-errors.dfy" });
-      Assert.Equal(0, code);
+      Assert.Equal(0, DafnyDriver.ThreadMain(new string[] { "/spillTargetCode:3", "warnings-as-errors.dfy" }));
     }
   }
 }

--- a/Source/DafnyPipeline.Test/RelativePaths.cs
+++ b/Source/DafnyPipeline.Test/RelativePaths.cs
@@ -1,0 +1,17 @@
+using System.IO;
+using Microsoft.Dafny;
+using Xunit;
+
+namespace DafnyPipeline.Test {
+  [Collection("Singleton Test Collection - Resolution")]
+
+  public class RelativePaths {
+    [Fact]
+    public void Test() {
+      Directory.SetCurrentDirectory(Path.Join("TestFiles", "LitTests", "LitTest"));
+      var code = DafnyDriver.ThreadMain(new string[] { "/spillTargetCode:3", "warnings-as-errors.dfy" });
+      Directory.SetCurrentDirectory(Path.Join("..", "..", ".."));
+      Assert.Equal(0, code);
+    }
+  }
+}

--- a/Source/DafnyPipeline.Test/RelativePaths.cs
+++ b/Source/DafnyPipeline.Test/RelativePaths.cs
@@ -8,9 +8,7 @@ namespace DafnyPipeline.Test {
   public class RelativePaths {
     [Fact]
     public void Test() {
-      Directory.SetCurrentDirectory(Path.Join("TestFiles", "LitTests", "LitTest"));
       var code = DafnyDriver.ThreadMain(new string[] { "/spillTargetCode:3", "warnings-as-errors.dfy" });
-      Directory.SetCurrentDirectory(Path.Join("..", "..", ".."));
       Assert.Equal(0, code);
     }
   }


### PR DESCRIPTION
My recent PR #1598 breaks relative paths under certain conditions (e.g. `/spillTargetCode:3`). This one fixes them. Testing this with a lit file is hard, because xUnit and lit have different working directories, so we do it directly in xUnit.