### PR TITLE
docs: remove HTML text & correct typo

### DIFF
--- a/docs/DafnyRef/README.md
+++ b/docs/DafnyRef/README.md
@@ -20,7 +20,7 @@ Some care must be taken to enable both modes of rendering.
 
 In addition, some textual search and replace operations are implemented
 (see the Makefile) to perform section numbering uniformly and to adjust a few
-pother aspects that are dissimilar between the pdf and online versions.
+other aspects that are dissimilar between the pdf and online versions.
 
 GitHub pages are rendered (converted from markdown to html) using Jekyll.
 The result is a single, long html page.

--- a/docs/OnlineTutorial/guide.md
+++ b/docs/OnlineTutorial/guide.md
@@ -787,9 +787,6 @@ method Testing() {
 function max(a: int, b: int): int { ... }
 ```
 
-</div>
-
-
 One caveat of functions is that not only can they appear in
 annotations, they can only appear in annotations. One cannot write:
 


### PR DESCRIPTION
2 small changes:
1. Removing "</div>" text from the [Dafny online guide](https://dafny-lang.github.io/dafny/OnlineTutorial/guide) (ctrl+F "One caveat of functions is that" to find the errant text.)
2. Correct a typo from "pother" to "other" in the docs/DafnyRef/README.md

**_Before change:_**
![image](https://user-images.githubusercontent.com/5581093/142961273-11f9a7a0-c0fc-489c-af3d-a9634911e33a.png)

**_After change:_**
![image](https://user-images.githubusercontent.com/5581093/142961291-5f20b21f-1b3e-479c-b53d-5bd9372ea2ec.png)
