### PR TITLE
fix: Better error reporting for type mismatch

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -13546,10 +13546,16 @@ namespace Microsoft.Dafny {
           callee.IsStatic ? null : s.Receiver);
         // type check the out-parameter arguments (in-parameters were type checked as part of ResolveActualParameters)
         for (int i = 0; i < callee.Outs.Count && i < s.Lhs.Count; i++) {
-          var it = callee.Outs[i].Type;
+          var outFormal = callee.Outs[i];
+          var it = outFormal.Type;
           Type st = SubstType(it, typeMap);
           var lhs = s.Lhs[i];
-          AddAssignableConstraint(s.Tok, lhs.Type, st, "incorrect type of method out-parameter" + (callee.Outs.Count == 1 ? "" : " " + i) + " (expected {1}, got {0})");
+          AddAssignableConstraint(
+            s.Tok, lhs.Type, st, "incorrect type of method out-parameter" +
+                                 (callee.Outs.Count == 1 ? "" : " " + i) +
+                                 (outFormal is ImplicitFormal || !outFormal.HasName
+                                   ? "" : "named '" + outFormal.Name + "'") +
+                                 " (expected {1}, got {0})");
         }
         for (int i = 0; i < s.Lhs.Count; i++) {
           var lhs = s.Lhs[i];
@@ -16806,7 +16812,7 @@ namespace Microsoft.Dafny {
               formals = new List<Formal>();
               for (var i = 0; i < fnType.Args.Count; i++) {
                 var argType = fnType.Args[i];
-                var formal = new Formal(e.tok, "_#p" + i, argType, true, false, null);
+                var formal = new ImplicitFormal(e.tok, "_#p" + i, argType, true, false);
                 formals.Add(formal);
               }
             }
@@ -16942,7 +16948,7 @@ namespace Microsoft.Dafny {
           if (formals.Count != 1) {
             what += " " + j;
           }
-          if (formal.HasName) {
+          if (formal.HasName && !(formal is ImplicitFormal)) {
             what += " named '" + formal.Name + "'";
           }
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -13554,7 +13554,7 @@ namespace Microsoft.Dafny {
             s.Tok, lhs.Type, st, "incorrect type of method out-parameter" +
                                  (callee.Outs.Count == 1 ? "" : " " + i) +
                                  (outFormal is ImplicitFormal || !outFormal.HasName
-                                   ? "" : "named '" + outFormal.Name + "'") +
+                                   ? "" : " named '" + outFormal.Name + "'") +
                                  " (expected {1}, got {0})");
         }
         for (int i = 0; i < s.Lhs.Count; i++) {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -16942,6 +16942,10 @@ namespace Microsoft.Dafny {
           if (formals.Count != 1) {
             what += " " + j;
           }
+          if (formal.HasName) {
+            what += " named '" + formal.Name + "'";
+          }
+
           AddAssignableConstraint(callTok, SubstType(formal.Type, typeMap), b.Actual.Type, "incorrect type of " + what + " (expected {0}, found {1})");
         } else if (formal.DefaultValue != null) {
           // Note, in the following line, "substMap" is passed in, but it hasn't been fully filled in until the

--- a/Test/dafny0/BitvectorResolution.dfy.expect
+++ b/Test/dafny0/BitvectorResolution.dfy.expect
@@ -8,7 +8,7 @@ BitvectorResolution.dfy(38,6): Error: RHS (of type bv67) not assignable to LHS (
 BitvectorResolution.dfy(39,6): Error: RHS (of type bv67) not assignable to LHS (of type int)
 BitvectorResolution.dfy(40,15): Error: type of right argument to << (real) must be an integer-numeric or bitvector type
 BitvectorResolution.dfy(41,15): Error: type of right argument to << (SmallReal) must be an integer-numeric or bitvector type
-BitvectorResolution.dfy(42,25): Error: incorrect type of function argument (expected nat, found real)
-BitvectorResolution.dfy(43,25): Error: incorrect type of function argument (expected nat, found SmallReal)
+BitvectorResolution.dfy(42,25): Error: incorrect type of function argument named 'w' (expected nat, found real)
+BitvectorResolution.dfy(43,25): Error: incorrect type of function argument named 'w' (expected nat, found SmallReal)
 BitvectorResolution.dfy(110,19): Error: the type of this expression is underspecified
 13 resolution/type errors detected in BitvectorResolution.dfy

--- a/Test/dafny0/Coinductive.dfy.expect
+++ b/Test/dafny0/Coinductive.dfy.expect
@@ -32,8 +32,8 @@ Coinductive.dfy(296,4): Error: this call does not type check, because the contex
 Coinductive.dfy(299,4): Error: this call does not type check, because the context uses a _k parameter of type nat whereas the callee uses a _k parameter of type ORDINAL
 Coinductive.dfy(307,13): Error: this call does not type check, because the context uses a _k parameter of type nat whereas the callee uses a _k parameter of type ORDINAL
 Coinductive.dfy(313,13): Error: this call does not type check, because the context uses a _k parameter of type ORDINAL whereas the callee uses a _k parameter of type nat
-Coinductive.dfy(323,5): Error: incorrect type of prefix lemma in-parameter 0 named '_k' (expected nat, found ORDINAL)
-Coinductive.dfy(329,5): Error: incorrect type of prefix lemma in-parameter 0 named '_k' (expected ORDINAL, found int)
+Coinductive.dfy(323,5): Error: incorrect type of prefix lemma in-parameter 0 (expected nat, found ORDINAL)
+Coinductive.dfy(329,5): Error: incorrect type of prefix lemma in-parameter 0 (expected ORDINAL, found int)
 Coinductive.dfy(355,19): Error: a greatest predicate can be called recursively only in positive positions and cannot sit inside an unbounded existential quantifier
 Coinductive.dfy(355,44): Error: a greatest predicate can be called recursively only in positive positions and cannot sit inside an unbounded existential quantifier
 Coinductive.dfy(358,19): Error: a greatest predicate can be called recursively only in positive positions and cannot sit inside an unbounded existential quantifier

--- a/Test/dafny0/Coinductive.dfy.expect
+++ b/Test/dafny0/Coinductive.dfy.expect
@@ -32,8 +32,8 @@ Coinductive.dfy(296,4): Error: this call does not type check, because the contex
 Coinductive.dfy(299,4): Error: this call does not type check, because the context uses a _k parameter of type nat whereas the callee uses a _k parameter of type ORDINAL
 Coinductive.dfy(307,13): Error: this call does not type check, because the context uses a _k parameter of type nat whereas the callee uses a _k parameter of type ORDINAL
 Coinductive.dfy(313,13): Error: this call does not type check, because the context uses a _k parameter of type ORDINAL whereas the callee uses a _k parameter of type nat
-Coinductive.dfy(323,5): Error: incorrect type of prefix lemma in-parameter 0 (expected nat, found ORDINAL)
-Coinductive.dfy(329,5): Error: incorrect type of prefix lemma in-parameter 0 (expected ORDINAL, found int)
+Coinductive.dfy(323,5): Error: incorrect type of prefix lemma in-parameter 0 named '_k' (expected nat, found ORDINAL)
+Coinductive.dfy(329,5): Error: incorrect type of prefix lemma in-parameter 0 named '_k' (expected ORDINAL, found int)
 Coinductive.dfy(355,19): Error: a greatest predicate can be called recursively only in positive positions and cannot sit inside an unbounded existential quantifier
 Coinductive.dfy(355,44): Error: a greatest predicate can be called recursively only in positive positions and cannot sit inside an unbounded existential quantifier
 Coinductive.dfy(358,19): Error: a greatest predicate can be called recursively only in positive positions and cannot sit inside an unbounded existential quantifier

--- a/Test/dafny0/IteratorResolution.dfy.expect
+++ b/Test/dafny0/IteratorResolution.dfy.expect
@@ -1,7 +1,7 @@
 IteratorResolution.dfy(64,9): Error: LHS of assignment must denote a mutable field
 IteratorResolution.dfy(84,13): Error: when allocating an object of type 'GenericIteratorResult', one of its constructor methods must be called
 IteratorResolution.dfy(69,18): Error: arguments must have comparable types (got _T0 and int)
-IteratorResolution.dfy(86,16): Error: incorrect type of constructor in-parameter (expected bool, found int)
+IteratorResolution.dfy(86,16): Error: incorrect type of constructor in-parameter named 't' (expected bool, found int)
 IteratorResolution.dfy(81,19): Error: RHS (of type bool) not assignable to LHS (of type int)
 IteratorResolution.dfy(22,9): Error: LHS of assignment must denote a mutable field
 IteratorResolution.dfy(24,9): Error: LHS of assignment must denote a mutable field

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -44,8 +44,8 @@ ResolutionErrors.dfy(354,18): Error: arguments must have comparable types (got i
 ResolutionErrors.dfy(355,18): Error: arguments must have comparable types (got DTD_List and int)
 ResolutionErrors.dfy(369,17): Error: ghost variables are allowed only in specification contexts
 ResolutionErrors.dfy(393,7): Error: incorrect type of method in-parameter 1 (expected GenericClass<int>, found GenericClass<bool>) (non-variant type parameter would require int = bool)
-ResolutionErrors.dfy(407,13): Error: incorrect type of datatype constructor argument 0 (expected _T0, found int)
-ResolutionErrors.dfy(408,9): Error: incorrect type of datatype constructor argument 0 (expected _T0, found int)
+ResolutionErrors.dfy(407,13): Error: incorrect type of datatype constructor argument 0 named 'hd' (expected _T0, found int)
+ResolutionErrors.dfy(408,9): Error: incorrect type of datatype constructor argument 0 named 'hd' (expected _T0, found int)
 ResolutionErrors.dfy(417,8): Error: all lines in a calculation must have the same type (got int after bool)
 ResolutionErrors.dfy(421,8): Error: all lines in a calculation must have the same type (got int after bool)
 ResolutionErrors.dfy(424,8): Error: first argument to ==> must be of type bool (instead got int)

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -43,7 +43,7 @@ ResolutionErrors.dfy(356,27): Error: arguments must have comparable types (got b
 ResolutionErrors.dfy(354,18): Error: arguments must have comparable types (got int and DTD_List)
 ResolutionErrors.dfy(355,18): Error: arguments must have comparable types (got DTD_List and int)
 ResolutionErrors.dfy(369,17): Error: ghost variables are allowed only in specification contexts
-ResolutionErrors.dfy(393,7): Error: incorrect type of method in-parameter 1 (expected GenericClass<int>, found GenericClass<bool>) (non-variant type parameter would require int = bool)
+ResolutionErrors.dfy(393,7): Error: incorrect type of method in-parameter 1 named 'b' (expected GenericClass<int>, found GenericClass<bool>) (non-variant type parameter would require int = bool)
 ResolutionErrors.dfy(407,13): Error: incorrect type of datatype constructor argument 0 named 'hd' (expected _T0, found int)
 ResolutionErrors.dfy(408,9): Error: incorrect type of datatype constructor argument 0 named 'hd' (expected _T0, found int)
 ResolutionErrors.dfy(417,8): Error: all lines in a calculation must have the same type (got int after bool)

--- a/Test/dafny0/TypeTests.dfy.expect
+++ b/Test/dafny0/TypeTests.dfy.expect
@@ -1,10 +1,10 @@
-TypeTests.dfy(9,14): Error: incorrect type of function argument 0 (expected C, found D)
-TypeTests.dfy(9,14): Error: incorrect type of function argument 1 (expected D, found C)
-TypeTests.dfy(10,14): Error: incorrect type of function argument 0 (expected C, found int)
-TypeTests.dfy(10,14): Error: incorrect type of function argument 1 (expected D, found int)
-TypeTests.dfy(16,16): Error: incorrect type of method in-parameter (expected int, found bool)
-TypeTests.dfy(16,16): Error: incorrect type of method out-parameter 1 (expected C, got int)
-TypeTests.dfy(17,12): Error: incorrect type of method out-parameter 1 (expected C, got int)
+TypeTests.dfy(9,14): Error: incorrect type of function argument 0 named 'c' (expected C, found D)
+TypeTests.dfy(9,14): Error: incorrect type of function argument 1 named 'd' (expected D, found C)
+TypeTests.dfy(10,14): Error: incorrect type of function argument 0 named 'c' (expected C, found int)
+TypeTests.dfy(10,14): Error: incorrect type of function argument 1 named 'd' (expected D, found int)
+TypeTests.dfy(16,16): Error: incorrect type of method in-parameter named 'x' (expected int, found bool)
+TypeTests.dfy(16,16): Error: incorrect type of method out-parameter 1 named 'c' (expected C, got int)
+TypeTests.dfy(17,12): Error: incorrect type of method out-parameter 1 named 'c' (expected C, got int)
 TypeTests.dfy(45,6): Error: Duplicate local-variable name: z
 TypeTests.dfy(47,6): Error: Duplicate local-variable name: x
 TypeTests.dfy(50,8): Error: Duplicate local-variable name: x
@@ -28,7 +28,7 @@ TypeTests.dfy(179,6): Error: cannot assign to non-ghost variable in a ghost cont
 TypeTests.dfy(180,9): Error: cannot assign to non-ghost variable in a ghost context
 TypeTests.dfy(198,10): Error: incorrect type of datatype constructor argument (expected int -> Dt<int>, found int -> int) (covariant type parameter 1 would require int <: Dt<int>)
 TypeTests.dfy(204,10): Error: incorrect type of datatype constructor argument (expected ? -> Dt<?>, found Dt<?> -> Dt<?>) (contravariance for type parameter0 expects ? <: Dt<?>)
-TypeTests.dfy(211,10): Error: incorrect type of function argument (expected ?, found set<?>)
+TypeTests.dfy(211,10): Error: incorrect type of function argument named 'x' (expected ?, found set<?>)
 TypeTests.dfy(222,9): Error: assignment to array element is not allowed in this context, because this is a ghost method
 TypeTests.dfy(229,11): Error: because of cyclic dependencies among constructor argument types, no instances of datatype 'A' can be constructed
 TypeTests.dfy(230,11): Error: because of cyclic dependencies among constructor argument types, no instances of datatype 'B' can be constructed

--- a/Test/dafny0/UserSpecifiedTypeParameters.dfy.expect
+++ b/Test/dafny0/UserSpecifiedTypeParameters.dfy.expect
@@ -8,6 +8,6 @@ UserSpecifiedTypeParameters.dfy(46,22): Error: Undeclared top-level type or type
 UserSpecifiedTypeParameters.dfy(46,26): Error: Undeclared top-level type or type parameter: c (did you forget to qualify a name or declare a module import 'opened'?)
 UserSpecifiedTypeParameters.dfy(46,18): Error: variable 'a' does not take any type parameters
 UserSpecifiedTypeParameters.dfy(46,30): Error: non-function expression (of type int) is called with parameters
-UserSpecifiedTypeParameters.dfy(77,15): Error: incorrect type of lemma in-parameter (expected A, found int)
-UserSpecifiedTypeParameters.dfy(89,14): Error: incorrect type of function argument (expected A, found int)
+UserSpecifiedTypeParameters.dfy(77,15): Error: incorrect type of lemma in-parameter named 'y' (expected A, found int)
+UserSpecifiedTypeParameters.dfy(89,14): Error: incorrect type of function argument named 'y' (expected A, found int)
 12 resolution/type errors detected in UserSpecifiedTypeParameters.dfy

--- a/Test/exceptions/TypecheckErrors.dfy.expect
+++ b/Test/exceptions/TypecheckErrors.dfy.expect
@@ -1,12 +1,12 @@
-TypecheckErrors.dfy(7,28): Error: incorrect type of method in-parameter (expected nat, found string)
-TypecheckErrors.dfy(8,28): Error: incorrect type of method in-parameter (expected nat, found string)
+TypecheckErrors.dfy(7,28): Error: incorrect type of method in-parameter named 'n' (expected nat, found string)
+TypecheckErrors.dfy(8,28): Error: incorrect type of method in-parameter named 'n' (expected nat, found string)
 TypecheckErrors.dfy(14,8): Error: Duplicate local-variable name: a
 TypecheckErrors.dfy(16,8): Error: Duplicate local-variable name: b
 TypecheckErrors.dfy(39,10): Error: member IsFailure does not exist in BadOutcome1?, in :- statement
 TypecheckErrors.dfy(43,10): Error: member 'PropagateFailure' does not exist in trait 'BadOutcome2'
 TypecheckErrors.dfy(43,10): Error: The right-hand side of ':-', which is of type 'BadOutcome2?', must have members 'IsFailure()', 'PropagateFailure()', and 'Extract()'
 TypecheckErrors.dfy(47,10): Error: number of lhs (1) must be one less than number of rhs (1) for a rhs type (BadOutcome3?) without member Extract
-TypecheckErrors.dfy(51,22): Error: incorrect type of method in-parameter (expected string, found int)
+TypecheckErrors.dfy(51,22): Error: incorrect type of method in-parameter named 'msg' (expected string, found int)
 TypecheckErrors.dfy(71,4): Error: member IsFailure does not exist in BadVoidOutcome1?, in :- statement
 TypecheckErrors.dfy(75,4): Error: member 'PropagateFailure' does not exist in trait 'BadVoidOutcome2'
 TypecheckErrors.dfy(75,4): Error: The right-hand side of ':-', which is of type 'BadVoidOutcome2?', must have members 'IsFailure()', 'PropagateFailure()', but not 'Extract()'

--- a/Test/git-issues/git-issue-283g.dfy.expect
+++ b/Test/git-issues/git-issue-283g.dfy.expect
@@ -1,6 +1,6 @@
 git-issue-283g.dfy(20,21): Error: the type of the pattern (int) does not agree with the match expression (string)
 git-issue-283g.dfy(19,34): Error: arguments must have comparable types (got seq<char> and int)
-git-issue-283g.dfy(35,7): Error: incorrect type of datatype constructor argument (expected int, found real)
+git-issue-283g.dfy(35,7): Error: incorrect type of datatype constructor argument named 'value' (expected int, found real)
 git-issue-283g.dfy(41,14): Error: the type of the pattern (int) does not agree with the match expression (real)
 git-issue-283g.dfy(40,8): Error: arguments must have comparable types (got real and int)
 git-issue-283g.dfy(50,4): Warning: this branch is redundant

--- a/Test/git-issues/git-issue-484.dfy.expect
+++ b/Test/git-issues/git-issue-484.dfy.expect
@@ -1,6 +1,6 @@
 git-issue-484.dfy(10,6): Error: type of corresponding source/RHS (int) does not match type of bound variable (MyInt)
 git-issue-484.dfy(19,6): Error: type of corresponding source/RHS (real) does not match type of bound variable (MyInt)
-git-issue-484.dfy(23,2): Error: incorrect type of datatype constructor argument (expected MyInt, found int)
+git-issue-484.dfy(23,2): Error: incorrect type of datatype constructor argument named 'b' (expected MyInt, found int)
 git-issue-484.dfy(34,6): Error: type of corresponding source/RHS (int) does not match type of bound variable (byte)
-git-issue-484.dfy(40,2): Error: incorrect type of datatype constructor argument (expected byte, found int)
+git-issue-484.dfy(40,2): Error: incorrect type of datatype constructor argument named 'b' (expected byte, found int)
 5 resolution/type errors detected in git-issue-484.dfy

--- a/Test/git-issues/git-issue-750.dfy.expect
+++ b/Test/git-issues/git-issue-750.dfy.expect
@@ -1,5 +1,5 @@
 git-issue-750.dfy(8,4): Error: RHS (of type array<nat>) not assignable to LHS (of type array<int>) (nonvariance for type parameter expects int = nat)
 git-issue-750.dfy(9,4): Error: RHS (of type array<int>) not assignable to LHS (of type array<nat>) (nonvariance for type parameter expects nat = int)
-git-issue-750.dfy(10,4): Error: incorrect type of method in-parameter 0 (expected array<nat>, found array<int>) (nonvariance for type parameter expects nat = int)
-git-issue-750.dfy(10,4): Error: incorrect type of method in-parameter 1 (expected array<int>, found array<nat>) (nonvariance for type parameter expects int = nat)
+git-issue-750.dfy(10,4): Error: incorrect type of method in-parameter 0 named 'x' (expected array<nat>, found array<int>) (nonvariance for type parameter expects nat = int)
+git-issue-750.dfy(10,4): Error: incorrect type of method in-parameter 1 named 'y' (expected array<int>, found array<nat>) (nonvariance for type parameter expects int = nat)
 4 resolution/type errors detected in git-issue-750.dfy

--- a/Test/hofs/ResolveError.dfy.expect
+++ b/Test/hofs/ResolveError.dfy.expect
@@ -6,8 +6,8 @@ ResolveError.dfy(36,21): Error: wrong number of arguments (function 'requires' e
 ResolveError.dfy(39,18): Error: wrong number of arguments (function 'reads' expects 1, got 2)
 ResolveError.dfy(31,16): Error: arguments must have comparable types (got int and bool)
 ResolveError.dfy(33,12): Error: incorrect type of function application argument (expected int, found bool)
-ResolveError.dfy(34,21): Error: incorrect type of function argument (expected int, found bool)
-ResolveError.dfy(37,18): Error: incorrect type of function argument (expected int, found bool)
+ResolveError.dfy(34,21): Error: incorrect type of function argument named 'x0' (expected int, found bool)
+ResolveError.dfy(37,18): Error: incorrect type of function argument named 'x0' (expected int, found bool)
 ResolveError.dfy(35,25): Error: arguments must have comparable types (got bool and int)
 ResolveError.dfy(38,22): Error: arguments must have comparable types (got set<object?> and int)
 ResolveError.dfy(47,18): Error: Precondition must be boolean (got int)
@@ -19,5 +19,5 @@ ResolveError.dfy(68,24): Error: unresolved identifier: _
 ResolveError.dfy(86,6): Error: RHS (of type ((int, bool)) -> real) not assignable to LHS (of type (int, bool) -> real)
 ResolveError.dfy(101,6): Error: RHS (of type (()) -> real) not assignable to LHS (of type () -> real)
 ResolveError.dfy(102,6): Error: RHS (of type () -> real) not assignable to LHS (of type (()) -> real)
-ResolveError.dfy(91,15): Error: incorrect type of method in-parameter 0 (expected int -> ?, found (int, bool) -> real)
+ResolveError.dfy(91,15): Error: incorrect type of method in-parameter 0 named 'r' (expected int -> ?, found (int, bool) -> real)
 22 resolution/type errors detected in ResolveError.dfy


### PR DESCRIPTION
Fixes issue #1648

Before:

```cs
datatype Foo = Foo(nat, x: nat)
function Bar(baz: string): Foo {
  Foo(baz, baz) // incorrect type of datatype constructor argument 0 (expected nat, found string)
                // incorrect type of datatype constructor argument 1 (expected nat, found string)
}
datatype Foo3 = Foo3(x: nat)
function Bar3(baz: string): Foo3 {
  Foo3(baz) // incorrect type of datatype constructor argument (expected nat, found string)
}
```

After:

```cs
datatype Foo = Foo(nat, x: nat)
function Bar(baz: string): Foo {
  Foo(baz, baz) // incorrect type of datatype constructor argument 0 (expected nat, found string)
                // incorrect type of datatype constructor argument 1 named 'x' (expected nat, found string)
}
datatype Foo3 = Foo3(x: nat)
function Bar3(baz: string): Foo3 {
  Foo3(baz) // incorrect type of datatype constructor argument named 'x' (expected nat, found string)
}
```

Unchanged:
```cs
datatype Foo2 = Foo2(nat)
function Bar2(baz: string): Foo2 {
  Foo2(baz) // incorrect type of datatype constructor argument (expected nat, found string)
}
```

I fixed various tests that already cover all of the examples above so there is no need for new tests.