### PR TITLE
fix(lsp): Fix a concurrency bug in `AddDiagnosticForFile` (Fixes #1651)

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -633,6 +633,9 @@ method t26() { assert false; }
 method t27() { assert false; }
 method t28() { assert false; }
 method t29() { assert false; }".TrimStart();
+      await SetUp(new Dictionary<string, string>() {
+        { $"{VerifierOptions.Section}:{nameof(VerifierOptions.VcsCores)}", "4" }
+      });
       for (int i = 0; i < 100; i++) {
         var documentItem = CreateTestDocument(source, $"test_{i}.dfy");
         client.OpenDocument(documentItem);

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -609,34 +609,15 @@ method t2() { assert true; }
 method t3() { assert true; }
 method t4() { assert true; }
 method t5() { assert true; }
-method t6() { assert true; }
-method t7() { assert true; }
-method t8() { assert true; }
-method t9() { assert true; }
-method t10() { assert true; }
-method t11() { assert true; }
-method t12() { assert true; }
-method t13() { assert true; }
-method t14() { assert true; }
-method t15() { assert true; }
-method t16() { assert true; }
-method t17() { assert true; }
-method t18() { assert true; }
-method t19() { assert true; }
-method t20() { assert true; }
-method t21() { assert true; }
-method t22() { assert true; }
-method t23() { assert true; }
-method t24() { assert true; }
-method t25() { assert false; }
-method t26() { assert false; }
-method t27() { assert false; }
-method t28() { assert false; }
-method t29() { assert false; }".TrimStart();
+method t6() { assert false; }
+method t7() { assert false; }
+method t8() { assert false; }
+method t9() { assert false; }
+method t10() { assert false; }".TrimStart();
       await SetUp(new Dictionary<string, string>() {
         { $"{VerifierOptions.Section}:{nameof(VerifierOptions.VcsCores)}", "4" }
       });
-      for (int i = 0; i < 100; i++) {
+      for (int i = 0; i < 20; i++) {
         var documentItem = CreateTestDocument(source, $"test_{i}.dfy");
         client.OpenDocument(documentItem);
         var report = await diagnosticReceiver.AwaitNextNotificationAsync(CancellationToken);

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -599,5 +599,49 @@ class Test {
       Assert.AreEqual("Related location", relatedInformation[1].Message);
       Assert.AreEqual(new Range((9, 13), (9, 14)), relatedInformation[1].Location.Range);
     }
+
+    [TestMethod]
+    public async Task OpeningDocumentWithMultipleVerificationCoresReturnsStableDiagnostics() {
+      var source = @"
+method t0() { assert true; }
+method t1() { assert true; }
+method t2() { assert true; }
+method t3() { assert true; }
+method t4() { assert true; }
+method t5() { assert true; }
+method t6() { assert true; }
+method t7() { assert true; }
+method t8() { assert true; }
+method t9() { assert true; }
+method t10() { assert true; }
+method t11() { assert true; }
+method t12() { assert true; }
+method t13() { assert true; }
+method t14() { assert true; }
+method t15() { assert true; }
+method t16() { assert true; }
+method t17() { assert true; }
+method t18() { assert true; }
+method t19() { assert true; }
+method t20() { assert true; }
+method t21() { assert true; }
+method t22() { assert true; }
+method t23() { assert true; }
+method t24() { assert true; }
+method t25() { assert false; }
+method t26() { assert false; }
+method t27() { assert false; }
+method t28() { assert false; }
+method t29() { assert false; }".TrimStart();
+      for (int i = 0; i < 100; i++) {
+        var documentItem = CreateTestDocument(source, $"test_{i}.dfy");
+        client.OpenDocument(documentItem);
+        var report = await diagnosticReceiver.AwaitNextNotificationAsync(CancellationToken);
+        var diagnostics = report.Diagnostics.ToArray();
+        Assert.AreEqual(5, diagnostics.Length);
+        Assert.AreEqual("Other", diagnostics[0].Source);
+        Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[0].Severity);
+      }
+    }
   }
 }

--- a/Source/DafnyLanguageServer.Test/Synchronization/OpenDocumentTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/OpenDocumentTest.cs
@@ -53,7 +53,7 @@ function GetConstant() int {
       var document = await Documents.GetDocumentAsync(documentItem.Uri);
       Assert.IsNotNull(document);
       Assert.AreEqual(1, document.Errors.ErrorCount);
-      var message = document.Errors.Diagnostics.First().Value[0];
+      var message = document.Errors.GetDiagnostics(documentItem.Uri)[0];
       Assert.AreEqual(MessageSource.Parser.ToString(), message.Source);
     }
 
@@ -68,7 +68,7 @@ function GetConstant(): int {
       var document = await Documents.GetDocumentAsync(documentItem.Uri);
       Assert.IsNotNull(document);
       Assert.AreEqual(1, document.Errors.ErrorCount);
-      var message = document.Errors.Diagnostics.First().Value[0];
+      var message = document.Errors.GetDiagnostics(documentItem.Uri)[0];
       Assert.AreEqual(MessageSource.Resolver.ToString(), message.Source);
     }
 
@@ -87,7 +87,7 @@ method Recurse(x: int) returns (r: int) {
       var document = await Documents.GetDocumentAsync(documentItem.Uri);
       Assert.IsNotNull(document);
       Assert.AreEqual(1, document.Errors.ErrorCount);
-      var message = document.Errors.Diagnostics.First().Value.First(d => d.Severity!.Value == DiagnosticSeverity.Error);
+      var message = document.Errors.GetDiagnostics(documentItem.Uri).First(d => d.Severity!.Value == DiagnosticSeverity.Error);
       Assert.AreEqual(MessageSource.Other.ToString(), message.Source);
     }
 

--- a/Source/DafnyLanguageServer.Test/Synchronization/SaveDocumentTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/SaveDocumentTest.cs
@@ -134,7 +134,7 @@ method DoIt() {
       var document = await Documents.GetDocumentAsync(documentItem.Uri);
       Assert.IsNotNull(document);
       Assert.AreEqual(1, document.Errors.ErrorCount);
-      var message = document.Errors.Diagnostics.First().Value[0];
+      var message = document.Errors.GetDiagnostics(documentItem.Uri)[0];
       Assert.AreEqual(MessageSource.Other.ToString(), message.Source);
     }
   }

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Dafny.LanguageServer.Language {
           //      A dash means write to the textwriter instead of a file.
           // https://github.com/boogie-org/boogie/blob/b03dd2e4d5170757006eef94cbb07739ba50dddb/Source/VCGeneration/Couterexample.cs#L217
           DafnyOptions.O.ModelViewFile = "-";
-          DafnyOptions.O.VcsCores = GetConfiguredCoreCount(options.Value);
           initialized = true;
           logger.LogTrace("initialized the boogie verifier...");
         }
@@ -65,9 +64,10 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         var errorReporter = (DiagnosticErrorReporter)program.reporter;
         var printer = new ModelCapturingOutputPrinter(logger, errorReporter);
         ExecutionEngine.printer = printer;
-        // Do not set the time limit within the construction/statically. It will break some VerificationNotificationTest unit tests
-        // since we change the configured time limit depending on the test.
+        // Do not set these settings within the object's construction. It will break some tests within
+        // VerificationNotificationTest and DiagnosticsTest that rely on updating these settings.
         DafnyOptions.O.TimeLimit = options.TimeLimit;
+        DafnyOptions.O.VcsCores = GetConfiguredCoreCount(options);
         var translated = Translator.Translate(program, errorReporter, new Translator.TranslatorFlags { InsertChecksums = true });
         bool verified = true;
         foreach (var (_, boogieProgram) in translated) {

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       try {
         // Return a fresh list to avoid concurrency issues
         return new List<Diagnostic>(diagnostics.GetValueOrDefault(documentUri) ?? Enumerable.Empty<Diagnostic>());
-      } finally {
+      }
+      finally {
         rwLock.ExitReadLock();
       }
     }
@@ -105,7 +106,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       rwLock.EnterReadLock();
       try {
         return counts.GetValueOrDefault(ToSeverity(level), 0);
-      } finally {
+      }
+      finally {
         rwLock.ExitReadLock();
       }
     }
@@ -116,7 +118,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         var severity = item.Severity!.Value; // All our diagnostics have a severity.
         counts[severity] = counts.GetValueOrDefault(severity, 0) + 1;
         diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>()).Add(item);
-      } finally {
+      }
+      finally {
         rwLock.ExitWriteLock();
       }
     }

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -98,10 +98,9 @@ namespace Microsoft.Dafny.LanguageServer.Language {
 
     private void AddDiagnosticForFile(Diagnostic item, DocumentUri documentUri) {
       lock (syncObject) {
-        var fileDiagnostics = diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>());
         var severity = item.Severity!.Value; // All our diagnostics have a severity.
         counts[severity] = counts.GetValueOrDefault(severity, 0) + 1;
-        fileDiagnostics.Add(item);
+        diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>()).Add(item);
       }
     }
 

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -92,10 +92,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     }
 
     public override int Count(ErrorLevel level) {
-      if (counts.TryGetValue(ToSeverity(level), out var count)) {
-        return count;
-      }
-      return 0;
+      return counts.GetValueOrDefault(ToSeverity(level), 0);
     }
 
     private void AddDiagnosticForFile(Diagnostic item, DocumentUri documentUri) {
@@ -103,8 +100,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         var fileDiagnostics = diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>());
 
         var severity = item.Severity!.Value; // All our diagnostics have a severity.
-        counts.TryGetValue(severity, out var count);
-        counts[severity] = count + 1;
+        counts[severity] = counts.GetValueOrDefault(severity, 0) + 1;
         fileDiagnostics.Add(item);
       }
     }

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -99,12 +99,14 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     }
 
     private void AddDiagnosticForFile(Diagnostic item, DocumentUri documentUri) {
-      var fileDiagnostics = diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>());
+      lock (this) {
+        var fileDiagnostics = diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>());
 
-      var severity = item.Severity!.Value; // All our diagnostics have a severity.
-      counts.TryGetValue(severity, out var count);
-      counts[severity] = count + 1;
-      fileDiagnostics.Add(item);
+        var severity = item.Severity!.Value; // All our diagnostics have a severity.
+        counts.TryGetValue(severity, out var count);
+        counts[severity] = count + 1;
+        fileDiagnostics.Add(item);
+      }
     }
 
     private DocumentUri GetDocumentUriOrDefault(IToken token) {

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     private readonly DocumentUri entryDocumentUri;
     private readonly Dictionary<DocumentUri, List<Diagnostic>> diagnostics = new();
     private readonly Dictionary<DiagnosticSeverity, int> counts = new();
+    private static readonly object syncObject = new();
 
     public IReadOnlyDictionary<DocumentUri, List<Diagnostic>> Diagnostics => diagnostics;
 
@@ -96,9 +97,8 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     }
 
     private void AddDiagnosticForFile(Diagnostic item, DocumentUri documentUri) {
-      lock (this) {
+      lock (syncObject) {
         var fileDiagnostics = diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>());
-
         var severity = item.Severity!.Value; // All our diagnostics have a severity.
         counts[severity] = counts.GetValueOrDefault(severity, 0) + 1;
         fileDiagnostics.Add(item);

--- a/Source/DafnyLanguageServer/Workspace/DiagnosticPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/DiagnosticPublisher.cs
@@ -49,10 +49,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     private static IEnumerable<Diagnostic> GetDiagnostics(DafnyDocument document) {
       // Only report errors of the entry-document.
-      if (document.Errors.Diagnostics.TryGetValue(document.GetFilePath(), out var diagnostics)) {
-        return diagnostics;
-      }
-      return Enumerable.Empty<Diagnostic>();
+      return document.Errors.GetDiagnostics(document.GetFilePath());
     }
   }
 }


### PR DESCRIPTION
Sending a didOpen message to the server produces roughly the following call tree:

    └┬─DocumentDatabase.OpenDocumentAsync
     └┬─DocumentDatabase.OpenAndVerifyAsync
      └┬─DocumentDatabase.LoadAndVerifyAsync
       └┬─TextDocumentLoader.VerifyAsync
        └┬─TextDocumentLoader.VerifyInternal
         └┬─DafnyProgramVerifier.Verify
          ├┬─DafnyProgramVerifier.VerifyWithBoogie
          │└┬─ExecutionEngine.InferAndVerify
          │ └┬─ExecutionEngine.VerifyImplementation
          │  └─ ExecutionEngine.ProcessErrors
          └┬─(Callback) ModelCapturingOutputPrinter.WriteErrorInformation
           └┬─DiagnosticErrorReporter.ReportBoogieError
            └─ DiagnosticErrorReporter.AddDiagnosticForFile

There can be multiple concurrent calls to `AddDiagnosticForFile`, but the code doesn't protect the datastructures that this function touches from concurrent modifications.  Hence we can observe traces like this:

    [lsp] Verifying t26: Enter WriteErrorInformation
    [lsp] Verifying t27: Enter WriteErrorInformation
    [lsp] Verifying t25: Enter WriteErrorInformation
    [lsp] Verifying t25: Exit WriteErrorInformation
    [lsp] Verifying t26: Exit WriteErrorInformation
    [lsp] Verifying t27: Exit WriteErrorInformation

Which in turn cause issues with the call to `diagnostics.GetOrCreate`, since we are in `didOpen`:

    diagnostics.GetOrCreate(documentUri, () => new List<Diagnostic>());

There's probably also an issue with the increment to count, since it's not atomic:

    counts.TryGetValue(severity, out var count);
    counts[severity] = count + 1;

In fact, even the call to `fileDiagnostics.Add(item)` is probably unsafe, since that's not a concurrent collection.

I'm confident with the diagnosis, but I'm not confident with the fix: @camrein, do you have an intuition for the right fix, and for which other methods of this class should be protected against concurrent access?

I'd also appreciate tips on how we might test this.  It was caught by the differential tester that I'm working on.

* DiagnosticErrorReporter.cs (AddDiagnosticForFile): Wrap function body in a lock to avoid concurrent updates.