### PR TITLE
chore: fix warnings

### DIFF
--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -128,18 +128,21 @@ class Release:
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
+            "--sc",
             "-c", "Release"])
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyServer", "DafnyServer.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
+            "--sc",
             "-c", "Release"])
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyDriver", "DafnyDriver.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
+            "--sc",
             "-c", "Release"])
 
     def pack(self):

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -128,21 +128,18 @@ class Release:
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "--sc",
             "-c", "Release"])
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyServer", "DafnyServer.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "--sc",
             "-c", "Release"])
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyDriver", "DafnyDriver.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "--sc",
             "-c", "Release"])
 
     def pack(self):

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -122,7 +122,8 @@ class Release:
 
         if path.exists(self.buildDirectory):
             shutil.rmtree(self.buildDirectory)
-        env = { "RUNTIME_IDENTIFIER": self.target }
+        env = dict(os.environ)
+        env["RUNTIME_IDENTIFIER"] = self.target
         run(["make", "--quiet", "clean"])
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyLanguageServer", "DafnyLanguageServer.csproj"),
             "--nologo",

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -130,21 +130,21 @@ class Release:
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "--sc",
+            "--self-contained",
             "-c", "Release"], env)
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyServer", "DafnyServer.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "--sc",
+            "--self-contained",
             "-c", "Release"], env)
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyDriver", "DafnyDriver.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "--sc",
+            "--self-contained",
             "-c", "Release"], env)
 
     def pack(self):

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -122,25 +122,29 @@ class Release:
 
         if path.exists(self.buildDirectory):
             shutil.rmtree(self.buildDirectory)
+        env = { "RUNTIME_IDENTIFIER": self.target }
         run(["make", "--quiet", "clean"])
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyLanguageServer", "DafnyLanguageServer.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "-c", "Release"])
+            "--sc",
+            "-c", "Release"], env)
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyServer", "DafnyServer.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "-c", "Release"])
+            "--sc",
+            "-c", "Release"], env)
         run(["dotnet", "publish", path.join(SOURCE_DIRECTORY, "DafnyDriver", "DafnyDriver.csproj"),
             "--nologo",
             "-f", "net6.0",
             "-o", self.buildDirectory,
             "-r", self.target,
-            "-c", "Release"])
+            "--sc",
+            "-c", "Release"], env)
 
     def pack(self):
         try:
@@ -214,9 +218,9 @@ def download(releases):
         flush("    + {}:".format(release.z3_name), end=' ')
         release.download()
 
-def run(cmd):
+def run(cmd, env=None):
     flush("    + {}...".format(" ".join(cmd)), end=' ')
-    retv = subprocess.call(cmd)
+    retv = subprocess.call(cmd, env)
     if retv != 0:
         flush("failed! (Is Dafny or the Dafny server running?)")
         sys.exit(1)

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -220,7 +220,7 @@ def download(releases):
 
 def run(cmd, env=None):
     flush("    + {}...".format(" ".join(cmd)), end=' ')
-    retv = subprocess.call(cmd, env)
+    retv = subprocess.call(cmd, env=env)
     if retv != 0:
         flush("failed! (Is Dafny or the Dafny server running?)")
         sys.exit(1)

--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -14,6 +14,10 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
+
+  <PropertyGroup Condition="$(RUNTIME_IDENTIFIER) != ''">
+    <RuntimeIdentifier>$(RUNTIME_IDENTIFIER)</RuntimeIdentifier>
+  </PropertyGroup>
     
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.Extensions.TrxLogger" Version="17.0.0" />

--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -15,6 +15,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
+  <!-- Working around some stange behavior in dotnet publish: https://github.com/dotnet/sdk/issues/10566 -->
   <PropertyGroup Condition="$(RUNTIME_IDENTIFIER) != ''">
     <RuntimeIdentifier>$(RUNTIME_IDENTIFIER)</RuntimeIdentifier>
   </PropertyGroup>

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" />
-    <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
+    <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" GlobalPropertiesToRemove="SelfContained" />
+    <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" GlobalPropertiesToRemove="SelfContained" />
     <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
   </ItemGroup>
 

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -34,9 +34,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" GlobalPropertiesToRemove="SelfContained" />
-    <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" GlobalPropertiesToRemove="SelfContained" />
-    <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" GlobalPropertiesToRemove="SelfContained" />
+    <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" />
+    <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
+    <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" GlobalPropertiesToRemove="SelfContained" />
     <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" GlobalPropertiesToRemove="SelfContained" />
-    <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
+    <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" GlobalPropertiesToRemove="SelfContained" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -15,6 +15,10 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(RUNTIME_IDENTIFIER) != ''">
+    <RuntimeIdentifier>$(RUNTIME_IDENTIFIER)</RuntimeIdentifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
   </ItemGroup>

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -15,6 +15,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
+  <!-- Working around some stange behavior in dotnet publish: https://github.com/dotnet/sdk/issues/10566 -->
   <PropertyGroup Condition="$(RUNTIME_IDENTIFIER) != ''">
     <RuntimeIdentifier>$(RUNTIME_IDENTIFIER)</RuntimeIdentifier>
   </PropertyGroup>

--- a/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
+++ b/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
@@ -10,10 +10,10 @@ namespace XUnitExtensions.Lit {
   public class OutputCheckOptions {
 
     [Value(0)]
-    public string CheckFile { get; set; }
+    public string CheckFile { get; set; } = default!;
 
     [Option("file-to-check", Required = true, HelpText = "File to check")]
-    public string FileToCheck { get; set; }
+    public string FileToCheck { get; set; } = default!;
   }
 
   public readonly record struct OutputCheckCommand(OutputCheckOptions options) : ILitCommand {
@@ -41,7 +41,7 @@ namespace XUnitExtensions.Lit {
   }
 
   private record CheckRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public static CheckDirective Parse(string file, int lineNumber, string arguments) {
+    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
       return new CheckRegexp(file, lineNumber, new Regex(arguments));
     }
 
@@ -60,7 +60,7 @@ namespace XUnitExtensions.Lit {
   }
 
   private record CheckLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public static CheckDirective Parse(string file, int lineNumber, string arguments) {
+    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
       return new CheckLiteral(file, lineNumber, arguments);
     }
 


### PR DESCRIPTION
Likely a side effects of moving to `net6.0`. The CI build warnings are caused by the fact that `SelfContained` is no longer implied by specifying a runtime. Making it explicit triggers a problem where the `RuntimeIdentifier` is no longer handed down to included projects. Setting the new environment variable works around that.