### PR TITLE
chore: fix test reports

### DIFF
--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -5,7 +5,8 @@ name: Test Release Downloads
 on:
   release:
     types: [ published ]
-  workflow_dispatch: // For manual testing through the Actions UI
+  # For manual testing through the Actions UI
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,13 +1,14 @@
-name: 'Test Report'
+name: "Test Report"
 on:
   workflow_run:
-    workflows: ['Run XUnit tests', 'Build and Test']
+    workflows:
+      - "Run XUnit tests"
+      - "Build and Test"
     types:
       - completed
 jobs:
   report:
     name: "Download and Publish Test Results"
-    needs: build
     runs-on: ubuntu-latest
     if: always()
 

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -26,5 +26,5 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: Test Results
-          path: 'artifacts/**/*.trx'
+          path: "artifacts/**/*.trx"
           reporter: dotnet-trx


### PR DESCRIPTION
There are error notifications about failures in the CI. The reports of parse errors `on` should go away.