### PR TITLE
Use default output directory for DafnyServer

### DIFF
--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -7,7 +7,6 @@
       <DefineConstants>TRACE</DefineConstants>
       <PackageVersion>1.1.0</PackageVersion>
       <TargetFramework>net6.0</TargetFramework>
-      <OutputPath>..\..\Binaries\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">


### PR DESCRIPTION
On multiple other branches we're getting the following build errors:

```
/home/runner/.dotnet/sdk/6.0.101/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(172,5): error MSB4018: System.IO.IOException: The process cannot access the file '/home/runner/work/dafny/dafny/dafny/Binaries/net6.0/linux-x64/DafnyServer.deps.json' because it is being used by another process. 
```

and

```
Error: /Users/runner/.dotnet/sdk/6.0.101/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(550,5): error NETSDK1177: Failed to sign apphost with error code 0: /Users/runner/work/dafny/dafny/dafny/Source/DafnyServer/obj/Release/net6.0/osx-x64/apphost: No such file or directory [/Users/runner/work/dafny/dafny/dafny/Source/DafnyServer/DafnyServer.csproj]
```

Both relate to DafnyServer, and DafnyServer is one of two projects that have a custom OutputPath. Let's see if removing the OutputPath resolves these issues.

Not that the following .NET 6.0 change likely relates to the second problem: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/apphost-generated-for-macos

