### PR TITLE
fix: `lit` has no `%sed`

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -147,6 +147,7 @@ config.substitutions.append( ('%server', serverExecutable) )
 config.substitutions.append( ('%refmanexamples', os.path.join(repositoryRoot, 'docs', 'DafnyRef', 'examples')) )
 config.substitutions.append( ('%os', os.name) )
 config.substitutions.append( ('%ver', ver ) )
+config.substitutions.append( ('%sed', 'sed' ) )
 if os.name == "nt":
     config.available_features = [ 'windows' ]
 elif "Darwin" in ver:


### PR DESCRIPTION
Fixes a regression in the raw `lit` tests introduced in #1540. Not tested on Windows.