### PR TITLE
Add CSV logger for test results and timing

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -131,9 +131,7 @@ namespace Microsoft.Dafny {
     public bool WarningsAsErrors = false;
     [CanBeNull] private TestGenerationOptions testGenOptions = null;
     public bool ExtractCounterexample = false;
-
-    public string VerificationLoggerConfig = null;
-
+    public List<string> VerificationLoggerConfigs = new();
     // Working around the fact that xmlFilename is private
     public string BoogieXmlFilename = null;
 
@@ -495,7 +493,11 @@ namespace Microsoft.Dafny {
 
         case "verificationLogger":
           if (ps.ConfirmArgumentCount(1)) {
-            VerificationLoggerConfig = args[ps.i];
+            if (args[ps.i] is "trx" or "csv") {
+              VerificationLoggerConfigs.Add(args[ps.i]);
+            } else {
+              InvalidArgumentError(name, ps);
+            }
           }
 
           return true;
@@ -512,7 +514,7 @@ namespace Microsoft.Dafny {
     public override void ApplyDefaultOptions() {
       base.ApplyDefaultOptions();
 
-      if (VerificationLoggerConfig != null) {
+      if (VerificationLoggerConfigs.Any()) {
         if (XmlSink != null) {
           throw new Exception("The /verificationLogger and /xml options cannot be used at the same time.");
         }

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Dafny {
 
         case "verificationLogger":
           if (ps.ConfirmArgumentCount(1)) {
-            if (args[ps.i] is "trx" or "csv") {
+            if (args[ps.i].StartsWith("trx") || args[ps.i].StartsWith("csv")) {
               VerificationLoggerConfigs.Add(args[ps.i]);
             } else {
               InvalidArgumentError(name, ps);

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -972,12 +972,13 @@ namespace Microsoft.Dafny {
     failing assertion. Requires specifying the /mv option as well as
     /proverOpt:0:model_compress=false and /proverOpt:0:model.completion=true.
 /verificationLogger:<configuration string>
-    Logs verification results to the given test result logger.
-    The only currently supported logger is ""trx"", the XML-based format
-    commonly used for test results for .NET languages. You can provide configuration
-    using the same string format as when using the --logger option for dotnet test,
-    such as /verificationLogger:trx;LogFileName=<...>.
-    The exact mapping of verification concepts to the TRX format is
+    Logs verification results to the given test result logger. The currently
+    supported loggers are ""trx"" and ""csv"". The former is the XML-based format
+    commonly used for test results for .NET languages. You can provide
+    configuration using the same string format as when using the --logger
+    option for dotnet test, such as:
+        /verificationLogger:trx;LogFileName=<...>.
+    The exact mapping of verification concepts to the TRX and CSV formats is
     experimental and subject to change!
 {TestGenOptions.Help}
 

--- a/Source/DafnyDriver/BoogieXmlConvertor.cs
+++ b/Source/DafnyDriver/BoogieXmlConvertor.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Dafny {
         EndTime = DateTimeOffset.Parse(endTime)
       };
 
-      if (outcome is "correct" or "valid") {
+      if (outcome == "correct") {
         testResult.Outcome = TestOutcome.Passed;
       } else {
         testResult.Outcome = TestOutcome.Failed;

--- a/Source/DafnyDriver/BoogieXmlConvertor.cs
+++ b/Source/DafnyDriver/BoogieXmlConvertor.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Dafny {
   /// </summary>
   public static class BoogieXmlConvertor {
 
-    public static TestProperty ResourceCountProperty = TestProperty.Register("TestResult.ResourceCount", "TestResult.ResourceCount", typeof(int), typeof(TestResult));
-
     public static void RaiseTestLoggerEvents(string fileName, List<string> loggerConfigs) {
       // Provide just enough configuration for the loggers to work
       var parameters = new Dictionary<string, string> {
@@ -108,7 +106,6 @@ namespace Microsoft.Dafny {
                                        .Single(n => n.Name.LocalName == "conclusion");
       var endTime = conclusionNode.Attribute("endTime")!.Value;
       var duration = float.Parse(conclusionNode.Attribute("duration")!.Value);
-      var resourceCount = conclusionNode.Attribute("resourceCount")?.Value;
       var outcome = conclusionNode.Attribute("outcome")!.Value;
 
       var testCase = TestCaseForEntry(currentFileFragment, name);
@@ -117,10 +114,6 @@ namespace Microsoft.Dafny {
         Duration = TimeSpan.FromMilliseconds((long)(duration * 1000)),
         EndTime = DateTimeOffset.Parse(endTime)
       };
-
-      if (resourceCount != null) {
-        testResult.SetPropertyValue(ResourceCountProperty, int.Parse(resourceCount));
-      }
 
       if (outcome is "correct" or "valid") {
         testResult.Outcome = TestOutcome.Passed;

--- a/Source/DafnyDriver/BoogieXmlConvertor.cs
+++ b/Source/DafnyDriver/BoogieXmlConvertor.cs
@@ -27,16 +27,30 @@ namespace Microsoft.Dafny {
     public static TestProperty ResourceCountProperty = TestProperty.Register("TestResult.ResourceCount", "TestResult.ResourceCount", typeof(int), typeof(TestResult));
 
     public static void RaiseTestLoggerEvents(string fileName, List<string> loggerConfigs) {
-      var events = new LocalTestLoggerEvents();
       // Provide just enough configuration for the loggers to work
       var parameters = new Dictionary<string, string> {
         ["TestRunDirectory"] = Constants.DefaultResultsDirectory
       };
+
+      var events = new LocalTestLoggerEvents();
       foreach (var loggerConfig in loggerConfigs) {
-        if (loggerConfig == "trx") {
+        string loggerName;
+        int semiColonIndex = loggerConfig.IndexOf(";");
+        if (semiColonIndex >= 0) {
+          loggerName = loggerConfig[..semiColonIndex];
+          var parametersList = loggerConfig[(semiColonIndex + 1)..];
+          foreach (string s in parametersList.Split(",")) {
+            var equalsIndex = s.IndexOf("=");
+            parameters.Add(s[..equalsIndex], s[(equalsIndex + 1)..]);
+          };
+        } else {
+          loggerName = loggerConfig;
+        }
+
+        if (loggerName == "trx") {
           var logger = new TrxLogger();
           logger.Initialize(events, parameters);
-        } else if (loggerConfig == "csv") {
+        } else if (loggerName == "csv") {
           var csvLogger = new CSVTestLogger();
           csvLogger.Initialize(events, parameters);
         } else {

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -27,8 +27,20 @@ namespace Microsoft.Dafny {
         const string resultsDir = "TestResults";
         Directory.CreateDirectory(resultsDir); // No-op if the directory already exists
         var dateTime = DateTime.Now.ToString("yyyy-MM-dd_HH_mm_ss");
-        var autoFilename =
-          Path.ChangeExtension(Path.Combine(resultsDir, dateTime), ".csv");
+
+        // Iterate through possible file names to ensure uniqueness, failing after
+        // 65k tries (as in the TRX case).
+        string autoFilename;
+        ushort suffixCounter = 0;
+        do {
+          if (suffixCounter == ushort.MaxValue) {
+            throw new FileNotFoundException("Could not create unique file name for CSV test log.");
+          }
+          autoFilename =
+            Path.ChangeExtension(Path.Combine(resultsDir, dateTime + "-" + suffixCounter.ToString()), ".csv");
+          suffixCounter++;
+        } while (File.Exists(autoFilename));
+
         writer = new StreamWriter(autoFilename);
       }
     }

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -27,13 +27,9 @@ namespace Microsoft.Dafny {
       results.Add(e.Result);
     }
 
-    private int? GetResourceCount(TestResult result) {
-      return result.GetPropertyValue<int?>(BoogieXmlConvertor.ResourceCountProperty, null);
-    }
-
     private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e) {
       var realWriter = writer ?? Console.Out;
-      foreach (var result in results.OrderByDescending(GetResourceCount)) {
+      foreach (var result in results.OrderByDescending(r => r.Duration)) {
         realWriter.WriteLine($"{result.TestCase.DisplayName}, {result.Outcome}, {result.Duration}");
       }
       writer?.Close();

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -34,14 +34,25 @@ namespace Microsoft.Dafny {
         // 65k tries (as in the TRX case).
         string autoFilename;
         ushort suffixCounter = 0;
-        do {
+        while (true) {
           if (suffixCounter == ushort.MaxValue) {
             throw new FileNotFoundException("Could not create unique file name for CSV test log.");
           }
+
           autoFilename =
             Path.ChangeExtension(Path.Combine(resultsDir, dateTime + "-" + suffixCounter.ToString()), ".csv");
           suffixCounter++;
-        } while (File.Exists(autoFilename));
+          try {
+            // Creating the file reserves it for use. It'll be closed here and re-opened below.
+            using (var fs = File.Open(autoFilename, FileMode.CreateNew)) {
+            }
+
+            break;
+          } catch (IOException) {
+            // If creating the file using CreateNew failed, try again with the incremented suffix.
+            continue;
+          }
+        }
 
         writer = new StreamWriter(autoFilename);
         writerFilename = autoFilename;

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,8 +10,8 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 namespace Microsoft.Dafny {
   public class CSVTestLogger : ITestLoggerWithParameters {
 
-    private readonly List<TestResult> results = new();
     private TextWriter writer = null;
+    private readonly ConcurrentBag<TestResult> results = new();
 
     public void Initialize(TestLoggerEvents events, string testRunDirectory) {
     }
@@ -29,8 +30,9 @@ namespace Microsoft.Dafny {
 
     private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e) {
       var realWriter = writer ?? Console.Out;
+      realWriter.WriteLine("TestResult.DisplayName,TestResult.Outcome,TestResult.Duration");
       foreach (var result in results.OrderByDescending(r => r.Duration)) {
-        realWriter.WriteLine($"{result.TestCase.DisplayName}, {result.Outcome}, {result.Duration}");
+        realWriter.WriteLine($"{result.TestCase.DisplayName},{result.Outcome},{result.Duration}");
       }
       writer?.Close();
     }

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace Microsoft.Dafny {
+  public class CSVTestLogger : ITestLoggerWithParameters {
+
+    private readonly List<TestResult> results = new();
+
+    public void Initialize(TestLoggerEvents events, string testRunDirectory) {
+    }
+
+    public void Initialize(TestLoggerEvents events, Dictionary<string, string> parameters) {
+      events.TestResult += TestResultHandler;
+      events.TestRunComplete += TestRunCompleteHandler;
+    }
+
+    private void TestResultHandler(object sender, TestResultEventArgs e) {
+      results.Add(e.Result);
+    }
+
+    private int? GetResourceCount(TestResult result) {
+      return result.GetPropertyValue<int?>(BoogieXmlConvertor.ResourceCountProperty, null);
+    }
+
+    private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e) {
+      foreach (var result in results.OrderByDescending(GetResourceCount)) {
+        Console.Out.WriteLine($"{result.TestCase.DisplayName}, {result.Outcome}, {result.Duration}");
+      }
+    }
+  }
+}

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Dafny {
 
     private readonly ConcurrentBag<TestResult> results = new();
     private TextWriter writer;
+    private string writerFilename;
 
     public void Initialize(TestLoggerEvents events, string testRunDirectory) {
     }
@@ -21,6 +22,7 @@ namespace Microsoft.Dafny {
       events.TestRunComplete += TestRunCompleteHandler;
       if (parameters.TryGetValue("LogFileName", out string filename)) {
         writer = new StreamWriter(filename);
+        writerFilename = filename;
       } else {
         // Auto-generate a file name if none is specified. This uses a
         // similar approach to the TRX logger, but with simpler logic.
@@ -42,6 +44,7 @@ namespace Microsoft.Dafny {
         } while (File.Exists(autoFilename));
 
         writer = new StreamWriter(autoFilename);
+        writerFilename = autoFilename;
       }
     }
 
@@ -56,6 +59,7 @@ namespace Microsoft.Dafny {
       }
 
       writer.Close();
+      Console.Out.WriteLine("Results File: " + Path.GetFullPath(writerFilename));
     }
   }
 }

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
@@ -9,6 +10,7 @@ namespace Microsoft.Dafny {
   public class CSVTestLogger : ITestLoggerWithParameters {
 
     private readonly List<TestResult> results = new();
+    private TextWriter writer = null;
 
     public void Initialize(TestLoggerEvents events, string testRunDirectory) {
     }
@@ -16,6 +18,9 @@ namespace Microsoft.Dafny {
     public void Initialize(TestLoggerEvents events, Dictionary<string, string> parameters) {
       events.TestResult += TestResultHandler;
       events.TestRunComplete += TestRunCompleteHandler;
+      if (parameters.TryGetValue("LogFileName", out string filename)) {
+        writer = new StreamWriter(filename);
+      }
     }
 
     private void TestResultHandler(object sender, TestResultEventArgs e) {
@@ -27,9 +32,11 @@ namespace Microsoft.Dafny {
     }
 
     private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e) {
+      var realWriter = writer ?? Console.Out;
       foreach (var result in results.OrderByDescending(GetResourceCount)) {
-        Console.Out.WriteLine($"{result.TestCase.DisplayName}, {result.Outcome}, {result.Duration}");
+        realWriter.WriteLine($"{result.TestCase.DisplayName}, {result.Outcome}, {result.Duration}");
       }
+      writer?.Close();
     }
   }
 }

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Dafny {
       events.TestResult += TestResultHandler;
       events.TestRunComplete += TestRunCompleteHandler;
       if (parameters.TryGetValue("LogFileName", out string filename)) {
-        writer = filename == "-" ? Console.Out : new StreamWriter(filename);
+        writer = new StreamWriter(filename);
       } else {
         // Auto-generate a file name if none is specified. This uses a
         // similar approach to the TRX logger, but with simpler logic.
@@ -55,9 +55,7 @@ namespace Microsoft.Dafny {
         writer.WriteLine($"{result.TestCase.DisplayName},{result.Outcome},{result.Duration}");
       }
 
-      if (writer != Console.Out) {
-        writer.Close();
-      }
+      writer.Close();
     }
   }
 }

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Dafny {
 
       if (CommandLineOptions.Clo.XmlSink != null) {
         CommandLineOptions.Clo.XmlSink.Close();
-        if (DafnyOptions.O.VerificationLoggerConfig != null) {
-          BoogieXmlConvertor.RaiseTestLoggerEvents(DafnyOptions.O.BoogieXmlFilename, DafnyOptions.O.VerificationLoggerConfig);
+        if (DafnyOptions.O.VerificationLoggerConfigs.Any()) {
+          BoogieXmlConvertor.RaiseTestLoggerEvents(DafnyOptions.O.BoogieXmlFilename, DafnyOptions.O.VerificationLoggerConfigs);
         }
       }
       if (CommandLineOptions.Clo.Wait) {

--- a/Test/logger/CSVLogger.dfy
+++ b/Test/logger/CSVLogger.dfy
@@ -1,0 +1,42 @@
+// RUN: %dafny /verificationLogger:csv;LogFileName="%t.csv" "%s"
+// RUN: %OutputCheck --file-to-check "%t.csv" "%s"
+
+// CHECK: TestResult\.DisplayName,TestResult\.Outcome,TestResult\.Duration
+// CHECK-NEXT: Impl\$\$_module.__default\.ExampleWithSplits\$\$1,Passed,.*
+
+method ExampleWithSplits() returns (y: int)
+  ensures y >= 0
+{
+  var x: int;
+  x := 5;
+  y := 0;
+  while (x > 0)
+    invariant x + y == 5
+    invariant x*x <= 25
+  {
+    x := x - 1;
+    assert {:split_here} (x+y) * (x+y) > 25;
+    y := y + 1;
+    if (x < 3) {
+      assert 2 < 2;
+      assert {:split_here} y*y > 4;
+    }
+    else {
+      assert {:split_here} y*y*y < 8;
+      assert 2 < 2;
+    }
+    assert {:split_here} (x+y) * (x+y) == 25;
+  }
+}
+
+method ExampleWithoutSplits() {
+  assert 1 + 1 == 2;
+  assert 2 + 2 == 4;
+  assert 3 + 3 == 6;
+}
+
+method AnotherExampleWithoutSplits() {
+  assert 1 + 1 == 2;
+  assert 2 + 2 == 4;
+  assert 3 + 3 == 6;
+}


### PR DESCRIPTION
Adds the ability to log proof goal results and timing in CSV format.

Cherry-picked from robin-aws and slightly tweaked.