### PR TITLE
Fix version of Newtonsoft.Json

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.Extensions.TrxLogger" Version="17.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.11.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
       
     <!-- Locking down versions that would otherwise be downgraded -->
     <PackageReference Include="System.Security.Principal.Windows" Version="4.5.0" />

--- a/Source/DafnyLanguageServer.Test/Unit/NewtonsoftConfiguration.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/NewtonsoftConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
+
+  [TestClass]
+  public class NewtonsoftConfiguration {
+    private string GetLibraryVersion(string csprojFile, string library) {
+      var libraryVersionExtractor = new Regex(
+        $"Include=\"{Regex.Escape(library)}\" Version=\"([^\"]+)\"");
+      var csprojContent = System.IO.File.ReadAllText(csprojFile);
+      var libraryVersion = libraryVersionExtractor.Match(csprojContent);
+      Assert.IsTrue(libraryVersion.Success, $"Could not extract {library}'s version from {csprojFile}");
+      return libraryVersion.Groups[1].ToString();
+    }
+
+    [TestMethod]
+    public void NewtonsoftVersionMatch() {
+      var dlsNewtonsoftVersion = GetLibraryVersion(@"../../../../DafnyLanguageServer/DafnyLanguageServer.csproj", "Newtonsoft.Json");
+      var ddNewtonsoftVersion = GetLibraryVersion(@"../../../../DafnyDriver/DafnyDriver.csproj", "Newtonsoft.Json");
+      Assert.AreEqual(dlsNewtonsoftVersion, ddNewtonsoftVersion, "The versions of Newtonsoft.Json in DafnyLanguageServer and DafnyDriver do not match");
+    }
+  }
+}

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RangeTree" Version="3.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />


### PR DESCRIPTION
This will fix #1722  by expliciting the version of Newtonsoft.json in both DafnyDriver and DafnyLanguageServer.

I added a test in DafnyLanguageServer to ensure the two versions are in sync, to prevent further synchronization problems.