### PR TITLE
fix: docs: Remove TypeMembers from subset types

### DIFF
--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -1119,19 +1119,6 @@ SynonymTypeDecl_ =
    { TypeParameterCharacteristics }
    [ GenericParameters ]
    "=" Type
-   [ TypeMembers ]
-
-TypeMembers =
-  "{"
-  {
-    { DeclModifier }
-    ClassMemberDecl(allowConstructors: false,
-                    isValueType: true,
-                    moduleLevelDecl: false,
-                    isWithinAbstractModule: module.IsAbstract)
-  }
-  "}"
-
 ````
 
 A _type synonym_ declaration:
@@ -1176,6 +1163,17 @@ OpaqueTypeDecl_ =
    { TypeParameterCharacteristics }
    [ GenericParameters ]
    [ TypeMembers ]
+
+TypeMembers =
+  "{"
+  {
+    { DeclModifier }
+    ClassMemberDecl(allowConstructors: false,
+                    isValueType: true,
+                    moduleLevelDecl: false,
+                    isWithinAbstractModule: module.IsAbstract)
+  }
+  "}"
 ````
 
 An opaque type is a special case of a type synonym that is underspecified.  Such


### PR DESCRIPTION
The documentation previously, and incorrectly, said that subset types can have type members. This PR fixes that.

Fixes #1719