### PR TITLE
Resolving plugin support

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -137,6 +137,9 @@ namespace Microsoft.Dafny {
     // Working around the fact that xmlFilename is private
     public string BoogieXmlFilename = null;
 
+    // invariant: All strings of this list are non-empty
+    public readonly List<string> CompilerBackends = new();
+
     public virtual TestGenerationOptions TestGenOptions =>
       testGenOptions ??= new TestGenerationOptions();
 
@@ -227,6 +230,16 @@ namespace Microsoft.Dafny {
             int verbosity = 0;
             if (ps.GetNumericArgument(ref verbosity, 2)) {
               CompileVerbose = verbosity == 1;
+            }
+
+            return true;
+          }
+
+        case "compiler": {
+            if (ps.ConfirmArgumentCount(1)) {
+              if (args[ps.i].Length > 0) {
+                CompilerBackends.AddRange(args[ps.i].Split(',').Where(s => s.Length > 0));
+              }
             }
 
             return true;
@@ -804,6 +817,9 @@ namespace Microsoft.Dafny {
     Note that the C++ backend has various limitations (see Docs/Compilation/Cpp.md).
     This includes lack of support for BigIntegers (aka int), most higher order
     functions, and advanced features like traits or co-inductive types.
+/compiler:<assemblies>
+    (experimental) List of comma-separated DLLs or assemblies that contain at least one
+    instantiatable class extending Microsoft.Dafny.IRewriter
 /Main:<name>
     The (fully-qualified) name of the method to use as the executable entry point.
     Default is the method with the {{:main}} atrribute, or else the method named 'Main'.

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -818,7 +818,7 @@ namespace Microsoft.Dafny {
     This includes lack of support for BigIntegers (aka int), most higher order
     functions, and advanced features like traits or co-inductive types.
 /compiler:<assemblies>
-    (experimental) List of comma-separated DLLs or assemblies that contain at least one
+    (experimental) List of comma-separated paths to assemblies that contain at least one
     instantiatable class extending Microsoft.Dafny.IRewriter
 /Main:<name>
     The (fully-qualified) name of the method to use as the executable entry point.

--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Dafny {
     public string BoogieXmlFilename = null;
 
     // invariant: All strings of this list are non-empty
-    public readonly List<string> CompilerBackends = new();
+    public List<string> CompilerBackends = new();
 
     public virtual TestGenerationOptions TestGenOptions =>
       testGenOptions ??= new TestGenerationOptions();

--- a/Source/Dafny/RefinementTransformer.cs
+++ b/Source/Dafny/RefinementTransformer.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Dafny {
     public ModuleSignature RefinedSig;  // the intention is to use this field only after a successful PreResolve
     private ModuleSignature refinedSigOpened;
 
-    internal override void PreResolve(ModuleDefinition m) {
+    public override void PreResolve(ModuleDefinition m) {
       if (m.RefinementQId?.Decl != null) { // There is a refinement parent and it resolved OK
         RefinedSig = m.RefinementQId.Sig;
 
@@ -485,7 +485,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    internal override void PostResolve(ModuleDefinition m) {
+    public override void PostResolve(ModuleDefinition m) {
       if (m == moduleUnderConstruction) {
         while (this.postTasks.Count != 0) {
           var a = postTasks.Dequeue();

--- a/Source/Dafny/Reporting.cs
+++ b/Source/Dafny/Reporting.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Dafny {
   }
 
   public abstract class BatchErrorReporter : ErrorReporter {
-    private readonly Dictionary<ErrorLevel, List<ErrorMessage>> allMessages;
+    protected readonly Dictionary<ErrorLevel, List<ErrorMessage>> allMessages;
 
     protected BatchErrorReporter() {
       ErrorsOnly = false;

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Dafny {
         foreach (var assemblyPath in DafnyOptions.O.CompilerBackends) {
           Assembly compilerBackend;
           try {
-            compilerBackend = Assembly.Load(assemblyPath);
+            compilerBackend = Assembly.LoadFrom(assemblyPath);
           } catch (ArgumentException) {
             reporter.Error(MessageSource.Resolver, Token.NoToken, $"Compiler backend paths cannot be empty.");
             continue;

--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Dafny {
       this.reporter = reporter;
     }
 
-    internal virtual void PreResolve(ModuleDefinition m) {
+    virtual void PreResolve(ModuleDefinition m) {
       Contract.Requires(m != null);
     }
 
-    internal virtual void PostResolve(ModuleDefinition m) {
+    virtual void PostResolve(ModuleDefinition m) {
       Contract.Requires(m != null);
     }
 

--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Dafny {
       this.reporter = reporter;
     }
 
-    virtual void PreResolve(ModuleDefinition m) {
+    public virtual void PreResolve(ModuleDefinition m) {
       Contract.Requires(m != null);
     }
 
-    virtual void PostResolve(ModuleDefinition m) {
+    public virtual void PostResolve(ModuleDefinition m) {
       Contract.Requires(m != null);
     }
 

--- a/Source/Dafny/Rewriter.cs
+++ b/Source/Dafny/Rewriter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(reporter != null);
     }
 
-    internal override void PostResolve(ModuleDefinition m) {
+    public override void PostResolve(ModuleDefinition m) {
       var splitter = new Triggers.QuantifierSplitter();
       foreach (var decl in ModuleDefinition.AllCallables(m.TopLevelDecls)) {
         splitter.Visit(decl);
@@ -82,7 +82,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(reporter != null);
     }
 
-    internal override void PostResolve(ModuleDefinition m) {
+    public override void PostResolve(ModuleDefinition m) {
       var forallvisiter = new ForAllStmtVisitor(reporter);
       foreach (var decl in ModuleDefinition.AllCallables(m.TopLevelDecls)) {
         forallvisiter.Visit(decl, true);
@@ -456,7 +456,7 @@ namespace Microsoft.Dafny {
       this.builtIns = builtIns;
     }
 
-    internal override void PreResolve(ModuleDefinition m) {
+    public override void PreResolve(ModuleDefinition m) {
       foreach (var d in m.TopLevelDecls) {
         bool sayYes = true;
         if (d is ClassDecl && Attributes.ContainsBool(d.Attributes, "autocontracts", ref sayYes) && sayYes) {
@@ -543,7 +543,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    internal override void PostResolve(ModuleDefinition m) {
+    public override void PostResolve(ModuleDefinition m) {
       foreach (var d in m.TopLevelDecls) {
         bool sayYes = true;
         if (d is ClassDecl && Attributes.ContainsBool(d.Attributes, "autocontracts", ref sayYes) && sayYes) {
@@ -910,7 +910,7 @@ namespace Microsoft.Dafny {
       revealOriginal = new Dictionary<Method, Function>();
     }
 
-    internal override void PreResolve(ModuleDefinition m) {
+    public override void PreResolve(ModuleDefinition m) {
       foreach (var d in m.TopLevelDecls) {
         if (d is TopLevelDeclWithMembers) {
           ProcessOpaqueClassFunctions((TopLevelDeclWithMembers)d);
@@ -918,7 +918,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    internal override void PostResolve(ModuleDefinition m) {
+    public override void PostResolve(ModuleDefinition m) {
       foreach (var decl in ModuleDefinition.AllCallables(m.TopLevelDecls)) {
         if (decl is Lemma || decl is TwoStateLemma) {
           var lem = (Method)decl;
@@ -1053,7 +1053,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(reporter != null);
     }
 
-    internal override void PostResolve(ModuleDefinition m) {
+    public override void PostResolve(ModuleDefinition m) {
       var components = m.CallGraph.TopologicallySortedComponents();
 
       foreach (var scComponent in components) {  // Visit the call graph bottom up, so anything we call already has its prequisites calculated
@@ -1416,7 +1416,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(reporter != null);
     }
 
-    internal override void PreResolve(ModuleDefinition m) {
+    public override void PreResolve(ModuleDefinition m) {
       var declarations = m.TopLevelDecls;
 
       foreach (var d in declarations) {
@@ -1481,7 +1481,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(reporter != null);
     }
 
-    internal override void PreResolve(ModuleDefinition m) {
+    public override void PreResolve(ModuleDefinition m) {
       foreach (var d in m.TopLevelDecls) {
         if (d is TopLevelDeclWithMembers tld) {
           foreach (MemberDecl member in tld.Members) {

--- a/Source/DafnyLanguageServer.Test/Unit/TextDocumentLoaderTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/TextDocumentLoaderTest.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
   [TestClass]
@@ -20,6 +21,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
     private Mock<ICompilationStatusNotificationPublisher> notificationPublisher;
     private TextDocumentLoader textDocumentLoader;
     private Mock<ILoggerFactory> logger;
+    private Mock<IOptions<CompilerOptions>> compilerOptions;
 
     [TestInitialize]
     public void SetUp() {
@@ -30,6 +32,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
       ghostStateDiagnosticCollector = new();
       notificationPublisher = new();
       logger = new Mock<ILoggerFactory>();
+      compilerOptions = new Mock<IOptions<CompilerOptions>>();
       textDocumentLoader = TextDocumentLoader.Create(
         parser.Object,
         symbolResolver.Object,
@@ -37,7 +40,8 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
         symbolTableFactory.Object,
         ghostStateDiagnosticCollector.Object,
         notificationPublisher.Object,
-        logger.Object
+        logger.Object,
+        compilerOptions.Object
       );
     }
 

--- a/Source/DafnyLanguageServer/Language/CompilerOptions.cs
+++ b/Source/DafnyLanguageServer/Language/CompilerOptions.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Dafny.LanguageServer.Language {
+  /// <summary>
+  /// Options for the resolution and compilation pipeline
+  /// </summary>
+  public class CompilerOptions {
+    /// <summary>
+    /// The IConfiguration section of the compiler options.
+    /// </summary>
+    public const string Section = "Compiler";
+
+    /// <summary>
+    /// Gets or sets which backends will be targeted so that their resolver can run before verification.
+    /// </summary>
+    public string Backends { get; set; } = "";
+  }
+}

--- a/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       return services
         .Configure<VerifierOptions>(configuration.GetSection(VerifierOptions.Section))
         .Configure<GhostOptions>(configuration.GetSection(GhostOptions.Section))
+        .Configure<CompilerOptions>(configuration.GetSection(CompilerOptions.Section))
         .AddSingleton<IDafnyParser>(serviceProvider => DafnyLangParser.Create(serviceProvider.GetRequiredService<ILogger<DafnyLangParser>>()))
         .AddSingleton<ISymbolResolver, DafnyLangSymbolResolver>()
         .AddSingleton<IProgramVerifier>(CreateVerifier)

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -75,3 +75,12 @@ Options provided through the command line have higher priority than the options 
 # Default: true (mark the statements)
 --ghost:markStatements=true
 ```
+
+### Compilation Backends
+
+```sh
+# Provides a comma-separated list of paths to assemblies
+# that contain an instantiatable IRewrite that is used during resolution
+# Default: "" (nothing extra is loaded)
+--compiler:backends=
+```

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Server;
 using System;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// <summary>
@@ -44,7 +45,8 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         services.GetRequiredService<ISymbolTableFactory>(),
         services.GetRequiredService<IGhostStateDiagnosticCollector>(),
         services.GetRequiredService<ICompilationStatusNotificationPublisher>(),
-        services.GetRequiredService<ILoggerFactory>()
+        services.GetRequiredService<ILoggerFactory>(),
+        services.GetRequiredService<IOptions<CompilerOptions>>()
       );
     }
   }

--- a/Source/DafnyPipeline.Test/ExternalResolverTest.cs
+++ b/Source/DafnyPipeline.Test/ExternalResolverTest.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Microsoft.Dafny;
+
+namespace DafnyPipeline.Test;
+
+[Collection("External Resolver plug-in tests")]
+public class ExternalResolverTest {
+  /// <summary>
+  /// This method creates a library and returns the path to that library.
+  /// The library extends an IRewriter so that we can verify that Dafny invokes it if provided in argument.
+  /// </summary>
+  public async Task<string> GetLibrary(string code) {
+    var temp = Path.GetTempFileName();
+    var compilation = CSharpCompilation.Create("tempAssembly");
+    var standardLibraries = new List<string>()
+    {
+      "DafnyPipeline",
+      "System.Runtime",
+      "Boogie.Core"
+    };
+    compilation = compilation.AddReferences(standardLibraries.Select(fileName =>
+        MetadataReference.CreateFromFile(Assembly.Load(fileName).Location)))
+      .AddReferences(
+        MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location))
+      .WithOptions(
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+      );
+    var syntaxTree = CSharpSyntaxTree.ParseText(code);
+    compilation = compilation.AddSyntaxTrees(syntaxTree);
+    var assemblyPath = $"{temp}.dll";
+    var result = compilation.Emit(assemblyPath);
+
+    var configuration = JsonSerializer.Serialize(
+      new {
+        runtimeOptions = new {
+          tfm = "net6.0",
+          framework = new {
+            name = "Microsoft.NETCore.App",
+            version = "6.0.0",
+            rollForward = "LatestMinor"
+          }
+        }
+      }, new JsonSerializerOptions() { WriteIndented = true });
+    await File.WriteAllTextAsync(temp + ".runtimeconfig.json", configuration + Environment.NewLine);
+
+    Assert.True(result.Success, string.Join("\n", result.Diagnostics.Select(d => d.ToString())));
+    return assemblyPath;
+  }
+
+  class CollectionErrorReporter : BatchErrorReporter {
+    public string GetLastErrorMessage() {
+      return allMessages[ErrorLevel.Error][0].message;
+    }
+  }
+
+  [Fact]
+  public async void EnsureItIsPossibleToPluginIRewriter() {
+    var library = await GetLibrary(@"
+      using Microsoft.Dafny;
+      public class ErrorRewriter: IRewriter {
+        public ErrorRewriter(ErrorReporter reporter) : base(reporter)
+        {}
+
+        public override void PostResolve(ModuleDefinition m) {
+          reporter.Error(MessageSource.Compiler, m.tok, ""Impossible to continue"");
+        }
+      }");
+
+    var reporter = new CollectionErrorReporter();
+    var options = new DafnyOptions(reporter);
+    options.CompilerBackends.Add(library);
+    DafnyOptions.Install(options);
+
+    var programString = "function test(): int { 1 }";
+    ModuleDecl module = new LiteralModuleDecl(new DefaultModuleDecl(), null);
+    Microsoft.Dafny.Type.ResetScopes();
+    BuiltIns builtIns = new BuiltIns();
+    Parser.Parse(programString, "virtual", "virtual", module, builtIns, reporter);
+    var dafnyProgram = new Program("programName", module, builtIns, reporter);
+    Main.Resolve(dafnyProgram, reporter);
+
+    Assert.Equal(1, reporter.Count(ErrorLevel.Error));
+    Assert.Equal("Impossible to continue", reporter.GetLastErrorMessage());
+  }
+}


### PR DESCRIPTION
This PR opens up the Dafny Rewriting steps to any external assembly. Namely:

*Dafny pipeline*
* I added in DafnyOptions the option `CompilerBackends`, which takes a list of strings
* In the `Resolver`, when it gather all internal `IRewrite` interfaces, it now loads all the assemblies from `DafnyOptions.O.CompilerBackends` and extract every IRewriter from them, and add them to the list of `rewriters` I fires errors appropriately depending on whether it cannot find the file, the file fails to load, or the file does not have the right version. I'm not sure how to ensure compatibility with version though.
* I added a test in DafnyPipeline.Test that verifies it can load a dummy `IRewriter` (credits to @keyboardDrummer  for the code to do so with the CSharpCompiler which I heavily copied)  and it is correctly during resolution.

*Dafny driver*:
* I added the command option `/compiler:` which takes a comma-separated list of paths to assemblies (I could chose another symbol than comma to separate if preferred), and fills in the option `CompilerBackends` with it.

*Dafny language server*
* To ensure any error in loading such assembly is visible in the VSCode extension, I created a routine that fetches the first non-trivial token, which is used to report the error, rather than `Token.NoToken`
* I added an option to the `DafnyLanguageServer`, namely `--compiler:backends=` which serves the same purpose as the `/compiler:` option of Dafny above. This option can be launched in VSCode by adding `"dafny.languageServerLaunchArgs": ["--compiler:backends=absolute_path_to_resolver.dll"]` to the `settings.json`
* Rather than modifying the settings.json that way, I also updated the VSCode extension so that one can provide this argument in the settings rather the settings.sjon. Will update soon with a link.