### PR TITLE
Report timeouts in IDE to fix #1710

### DIFF
--- a/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
@@ -181,6 +181,9 @@ lemma {:timeLimit 3} SquareRoot2NotRational(p: nat, q: nat)
       Assert.AreEqual(documentItem.Uri, completed.Uri);
       Assert.AreEqual(documentItem.Version, completed.Version);
       Assert.AreEqual(CompilationStatus.VerificationFailed, completed.Status);
+      var document = await Documents.GetVerifiedDocumentAsync(documentItem.Uri);
+      Assert.IsNotNull(document);
+      Assert.IsTrue(document.Errors.GetDiagnostics(documentItem.Uri)[0].Message.Contains("timed out"));
     }
 
     [TestMethod, Timeout(MaxTestExecutionTimeMs)]

--- a/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyProgramVerifier.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       using (cancellationToken.Register(() => CancelVerification(uniqueId))) {
         try {
           var statistics = new PipelineStatistics();
-          var outcome = ExecutionEngine.InferAndVerify(program, statistics, uniqueId, error => { }, uniqueId);
+          var outcome = ExecutionEngine.InferAndVerify(program, statistics, uniqueId, null, uniqueId);
           return Main.IsBoogieVerified(outcome, statistics);
         } catch (Exception e) when (e is not OperationCanceledException) {
           if (!cancellationToken.IsCancellationRequested) {


### PR DESCRIPTION
I couldn't figure out from the history of the repo why we were passing a no-op resolver instead of null, but passing `errors => { }` instead of `null` hits this code in Boogie: https://github.com/boogie-org/boogie/blob/6251cd8ae3a87866f31d705fe8c30ed57c053dab/Source/ExecutionEngine/ExecutionEngine.cs#L1594-L1609 and hence we don't get a diagnostic.