### PR TITLE
fix: Meaningful nested tokens for quantifier splitting.

### DIFF
--- a/Source/Dafny/Triggers/QuantifierSplitter.cs
+++ b/Source/Dafny/Triggers/QuantifierSplitter.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Dafny.Triggers {
           stream = SplitExpr(body, BinaryExpr.Opcode.And);
         }
         foreach (var e in stream) {
-          var tok = new NestedToken(quantifier.tok, e.tok);
+          var tok = new NestedToken(quantifier.tok, e.tok, "in sub-expression at");
           yield return new ForallExpr(tok, quantifier.BodyEndTok, ((ForallExpr)quantifier).TypeArgs, quantifier.BoundVars, quantifier.Range, e, TriggerUtils.CopyAttributes(quantifier.Attributes)) { Type = quantifier.Type, Bounds = quantifier.Bounds };
         }
       } else if (quantifier is ExistsExpr) {
@@ -86,7 +86,7 @@ namespace Microsoft.Dafny.Triggers {
           stream = SplitExpr(body, BinaryExpr.Opcode.Or);
         }
         foreach (var e in stream) {
-          var tok = new NestedToken(quantifier.tok, e.tok);
+          var tok = body?.tok == e.tok ? quantifier.tok : new NestedToken(quantifier.tok, e.tok, "in sub-expression at");
           yield return new ExistsExpr(tok, quantifier.BodyEndTok, ((ExistsExpr)quantifier).TypeArgs, quantifier.BoundVars, quantifier.Range, e, TriggerUtils.CopyAttributes(quantifier.Attributes)) { Type = quantifier.Type, Bounds = quantifier.Bounds };
         }
       } else {

--- a/Source/DafnyPipeline.Test/InterMethodVerificationStability.cs
+++ b/Source/DafnyPipeline.Test/InterMethodVerificationStability.cs
@@ -149,7 +149,7 @@ method M(heap: object)
 -         y#7_0 := LitInt(0);
 +         j#7_0 := LitInt(0);
 ";
-      Assert.Equal(expectedDiff, diff);
+      Assert.Equal(expectedDiff, diff.Replace("\r\n", "\n"));
     }
 
     string GetDiff(string before, string after) {

--- a/Source/DafnyPipeline.Test/InterMethodVerificationStability.cs
+++ b/Source/DafnyPipeline.Test/InterMethodVerificationStability.cs
@@ -149,7 +149,7 @@ method M(heap: object)
 -         y#7_0 := LitInt(0);
 +         j#7_0 := LitInt(0);
 ";
-      Assert.Equal(expectedDiff, diff.Replace("\r\n", "\n"));
+      Assert.Equal(expectedDiff.Replace("\r\n", "\n"), diff.Replace("\r\n", "\n"));
     }
 
     string GetDiff(string before, string after) {

--- a/Test/allocated1/dafny0/DiscoverBounds.dfy.expect
+++ b/Test/allocated1/dafny0/DiscoverBounds.dfy.expect
@@ -1,8 +1,8 @@
-DiscoverBounds.dfy(32,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(32,33)
-DiscoverBounds.dfy(33,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(33,33)
-DiscoverBounds.dfy(34,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(34,36)
-DiscoverBounds.dfy(35,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(35,39)
-DiscoverBounds.dfy(36,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(36,42)
+DiscoverBounds.dfy(32,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(33,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(34,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(35,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(36,7): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 7 verified, 0 errors
 0

--- a/Test/allocated1/dafny0/InSetComprehension.dfy.expect
+++ b/Test/allocated1/dafny0/InSetComprehension.dfy.expect
@@ -11,7 +11,7 @@ InSetComprehension.dfy(39,16): Info: Not generating triggers for "Id(u)". Note t
 InSetComprehension.dfy(76,13): Info: Selected triggers: {x in si}
 InSetComprehension.dfy(78,13): Info: Selected triggers: {y in ti}
 InSetComprehension.dfy(81,13): Info: Selected triggers: {n in si}
-InSetComprehension.dfy(82,5): Info: Selected triggers: {si[i]} Trigger position: InSetComprehension.dfy(82,37)
+InSetComprehension.dfy(82,5): Info: Selected triggers: {si[i]}
 InSetComprehension.dfy(53,24): Info: Selected triggers: {x in elems}
 InSetComprehension.dfy(51,25): Info: Selected triggers: {x in elems}
 InSetComprehension.dfy(67,24): Info: Selected triggers: {x in elems}

--- a/Test/allocated1/dafny0/LetExpr.dfy.expect
+++ b/Test/allocated1/dafny0/LetExpr.dfy.expect
@@ -1,5 +1,5 @@
-LetExpr.dfy(45,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy(45,39)
-LetExpr.dfy(206,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy(206,30)
+LetExpr.dfy(45,2): Warning: /!\ No terms found to trigger on.
+LetExpr.dfy(206,4): Warning: /!\ No terms found to trigger on.
 LetExpr.dfy(340,18): Error: value does not satisfy the subset constraints of 'nat'
 LetExpr.dfy(344,13): Error: value does not satisfy the subset constraints of 'nat'
 LetExpr.dfy(390,33): Error: assertion violation
@@ -15,7 +15,7 @@ LetExpr.dfy(323,11): Error: to be compilable, the value of a let-such-that expre
 LetExpr.dfy(109,22): Error: assertion violation
 
 Dafny program verifier finished with 37 verified, 13 errors
-LetExpr.dfy.tmp.dprint.dfy(281,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy.tmp.dprint.dfy(283,8)
-LetExpr.dfy.tmp.dprint.dfy(46,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy.tmp.dprint.dfy(47,12)
+LetExpr.dfy.tmp.dprint.dfy(281,4): Warning: /!\ No terms found to trigger on.
+LetExpr.dfy.tmp.dprint.dfy(46,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier did not attempt verification

--- a/Test/allocated1/dafny0/Matrix-OOB.dfy.expect
+++ b/Test/allocated1/dafny0/Matrix-OOB.dfy.expect
@@ -3,5 +3,6 @@ Matrix-OOB.dfy(11,26): Error: index 0 out of range
 Matrix-OOB.dfy(11,26): Error: index 1 out of range
 Matrix-OOB.dfy(12,0): Error: A postcondition might not hold on this return path.
 Matrix-OOB.dfy(11,10): Related location: This is the postcondition that might not hold.
+Matrix-OOB.dfy(11,33): Related location
 
 Dafny program verifier finished with 0 verified, 3 errors

--- a/Test/allocated1/dafny0/Matrix-OOB.dfy.expect
+++ b/Test/allocated1/dafny0/Matrix-OOB.dfy.expect
@@ -1,8 +1,7 @@
-Matrix-OOB.dfy(11,10): Info: Selected triggers: {m[i, j]} Trigger position: Matrix-OOB.dfy(11,33)
+Matrix-OOB.dfy(11,10): Info: Selected triggers: {m[i, j]}
 Matrix-OOB.dfy(11,26): Error: index 0 out of range
 Matrix-OOB.dfy(11,26): Error: index 1 out of range
 Matrix-OOB.dfy(12,0): Error: A postcondition might not hold on this return path.
 Matrix-OOB.dfy(11,10): Related location: This is the postcondition that might not hold.
-Matrix-OOB.dfy(11,33): Related location
 
 Dafny program verifier finished with 0 verified, 3 errors

--- a/Test/allocated1/dafny0/SmallTests.dfy.expect
+++ b/Test/allocated1/dafny0/SmallTests.dfy.expect
@@ -1,4 +1,4 @@
-SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found. Potential trigger not suitable: SmallTests.dfy(549,48)
+SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy(34,11): Error: index out of range
 SmallTests.dfy(65,35): Error: possible division by zero
 SmallTests.dfy(66,50): Error: possible division by zero
@@ -51,6 +51,6 @@ SmallTests.dfy(703,9): Error: cannot establish the existence of LHS values that 
 SmallTests.dfy(716,8): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
 
 Dafny program verifier finished with 51 verified, 46 errors
-SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found. Potential trigger not suitable: SmallTests.dfy.tmp.dprint.dfy(451,48)
+SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found.
 
 Dafny program verifier did not attempt verification

--- a/Test/allocated1/dafny0/TriggerInPredicate.dfy.expect
+++ b/Test/allocated1/dafny0/TriggerInPredicate.dfy.expect
@@ -1,4 +1,4 @@
-TriggerInPredicate.dfy(6,32): Info: Not generating triggers for "A(x, y) && z". Trigger position: TriggerInPredicate.dfy(6,63)
+TriggerInPredicate.dfy(6,32): Info: Not generating triggers for "A(x, y) && z".
 TriggerInPredicate.dfy(9,20): Info: Some instances of this call cannot safely be inlined.
 TriggerInPredicate.dfy(9,20): Info: Some instances of this call cannot safely be inlined.
 

--- a/Test/dafny0/DiscoverBounds.dfy.expect
+++ b/Test/dafny0/DiscoverBounds.dfy.expect
@@ -1,8 +1,8 @@
-DiscoverBounds.dfy(32,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(32,33)
-DiscoverBounds.dfy(33,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(33,33)
-DiscoverBounds.dfy(34,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(34,36)
-DiscoverBounds.dfy(35,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(35,39)
-DiscoverBounds.dfy(36,7): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: DiscoverBounds.dfy(36,42)
+DiscoverBounds.dfy(32,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(33,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(34,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(35,7): Warning: /!\ No terms found to trigger on.
+DiscoverBounds.dfy(36,7): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 7 verified, 0 errors
 0

--- a/Test/dafny0/InSetComprehension.dfy.expect
+++ b/Test/dafny0/InSetComprehension.dfy.expect
@@ -15,6 +15,6 @@ InSetComprehension.dfy(39,16): Info: Not generating triggers for "Id(u)". Note t
 InSetComprehension.dfy(76,13): Info: Selected triggers: {x in si}
 InSetComprehension.dfy(78,13): Info: Selected triggers: {y in ti}
 InSetComprehension.dfy(81,13): Info: Selected triggers: {n in si}
-InSetComprehension.dfy(82,5): Info: Selected triggers: {si[i]} Trigger position: InSetComprehension.dfy(82,37)
+InSetComprehension.dfy(82,5): Info: Selected triggers: {si[i]}
 
 Dafny program verifier finished with 8 verified, 0 errors

--- a/Test/dafny0/LetExpr.dfy.expect
+++ b/Test/dafny0/LetExpr.dfy.expect
@@ -1,5 +1,5 @@
-LetExpr.dfy(206,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy(206,30)
-LetExpr.dfy(45,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy(45,39)
+LetExpr.dfy(206,4): Warning: /!\ No terms found to trigger on.
+LetExpr.dfy(45,2): Warning: /!\ No terms found to trigger on.
 LetExpr.dfy(340,18): Error: value does not satisfy the subset constraints of 'nat'
 LetExpr.dfy(344,13): Error: value does not satisfy the subset constraints of 'nat'
 LetExpr.dfy(390,33): Error: assertion violation
@@ -15,7 +15,7 @@ LetExpr.dfy(313,11): Error: assertion violation
 LetExpr.dfy(323,11): Error: to be compilable, the value of a let-such-that expression must be uniquely determined
 
 Dafny program verifier finished with 37 verified, 13 errors
-LetExpr.dfy.tmp.dprint.dfy(97,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy.tmp.dprint.dfy(99,8)
-LetExpr.dfy.tmp.dprint.dfy(289,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: LetExpr.dfy.tmp.dprint.dfy(290,12)
+LetExpr.dfy.tmp.dprint.dfy(97,4): Warning: /!\ No terms found to trigger on.
+LetExpr.dfy.tmp.dprint.dfy(289,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier did not attempt verification

--- a/Test/dafny0/Matrix-OOB.dfy.expect
+++ b/Test/dafny0/Matrix-OOB.dfy.expect
@@ -1,4 +1,4 @@
-Matrix-OOB.dfy(11,10): Info: Selected triggers: {m[i, j]} Trigger position: Matrix-OOB.dfy(11,33)
+Matrix-OOB.dfy(11,10): Info: Selected triggers: {m[i, j]}
 Matrix-OOB.dfy(11,26): Error: index 0 out of range
 Matrix-OOB.dfy(11,26): Error: index 1 out of range
 Matrix-OOB.dfy(12,0): Error: A postcondition might not hold on this return path.

--- a/Test/dafny0/SmallTests.dfy.expect
+++ b/Test/dafny0/SmallTests.dfy.expect
@@ -1,4 +1,4 @@
-SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found. Potential trigger not suitable: SmallTests.dfy(549,48)
+SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy(909,14): Error: target object may be null
 SmallTests.dfy(901,14): Error: target object may be null
 SmallTests.dfy(34,11): Error: index out of range
@@ -53,6 +53,6 @@ SmallTests.dfy(703,9): Error: cannot establish the existence of LHS values that 
 SmallTests.dfy(716,8): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
 
 Dafny program verifier finished with 56 verified, 48 errors
-SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found. Potential trigger not suitable: SmallTests.dfy.tmp.dprint.dfy(451,48)
+SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found.
 
 Dafny program verifier did not attempt verification

--- a/Test/dafny0/TriggerInPredicate.dfy.expect
+++ b/Test/dafny0/TriggerInPredicate.dfy.expect
@@ -1,4 +1,4 @@
-TriggerInPredicate.dfy(6,32): Info: Not generating triggers for "A(x, y) && z". Trigger position: TriggerInPredicate.dfy(6,63)
+TriggerInPredicate.dfy(6,32): Info: Not generating triggers for "A(x, y) && z".
 TriggerInPredicate.dfy(9,20): Info: Some instances of this call cannot safely be inlined.
 TriggerInPredicate.dfy(9,20): Info: Some instances of this call cannot safely be inlined.
 

--- a/Test/dafny0/Wellfounded.dfy.expect
+++ b/Test/dafny0/Wellfounded.dfy.expect
@@ -1,5 +1,5 @@
-Wellfounded.dfy(49,14): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Wellfounded.dfy(49,26)
-Wellfounded.dfy(77,5): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Wellfounded.dfy(77,17)
+Wellfounded.dfy(49,14): Warning: /!\ No terms found to trigger on.
+Wellfounded.dfy(77,5): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 3 verified, 0 errors
 M(d, d) = 10

--- a/Test/dafny0/snapshots/Snapshots5.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots5.run.dfy.expect
@@ -1,7 +1,7 @@
-Snapshots5.v0.dfy(10,12): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v0.dfy(10,36)
-Snapshots5.v0.dfy(13,10): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v0.dfy(13,34)
-Snapshots5.v0.dfy(20,12): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v0.dfy(20,36)
-Snapshots5.v0.dfy(26,11): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v0.dfy(26,35)
+Snapshots5.v0.dfy(10,12): Warning: /!\ No terms found to trigger on.
+Snapshots5.v0.dfy(13,10): Warning: /!\ No terms found to trigger on.
+Snapshots5.v0.dfy(20,12): Warning: /!\ No terms found to trigger on.
+Snapshots5.v0.dfy(26,11): Warning: /!\ No terms found to trigger on.
 Processing command (at Snapshots5.v0.dfy(3,4)) assert (forall<alpha> $o: ref, $f: Field alpha :: false ==> $_Frame[$o, $f]);
   >>> DoNothingToAssert
 Processing command (at Snapshots5.v0.dfy(10,40)) assert (forall b#1_1: bool :: true ==> b#1_1 || !b#1_1) || 0 != 0;
@@ -14,11 +14,11 @@ Processing command (at Snapshots5.v0.dfy(20,40)) assert (forall b#3_1: bool :: t
   >>> DoNothingToAssert
 
 Dafny program verifier finished with 1 verified, 0 errors
-Snapshots5.v1.dfy(10,12): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v1.dfy(10,36)
-Snapshots5.v1.dfy(13,10): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v1.dfy(13,34)
-Snapshots5.v1.dfy(20,12): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v1.dfy(20,30)
-Snapshots5.v1.dfy(22,10): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v1.dfy(22,28)
-Snapshots5.v1.dfy(27,11): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Snapshots5.v1.dfy(27,35)
+Snapshots5.v1.dfy(10,12): Warning: /!\ No terms found to trigger on.
+Snapshots5.v1.dfy(13,10): Warning: /!\ No terms found to trigger on.
+Snapshots5.v1.dfy(20,12): Warning: /!\ No terms found to trigger on.
+Snapshots5.v1.dfy(22,10): Warning: /!\ No terms found to trigger on.
+Snapshots5.v1.dfy(27,11): Warning: /!\ No terms found to trigger on.
 Processing command (at Snapshots5.v1.dfy(3,4)) assert (forall<alpha> $o: ref, $f: Field alpha :: false ==> $_Frame[$o, $f]);
   >>> MarkAsFullyVerified
 Processing command (at Snapshots5.v1.dfy(10,40)) assert (forall b#1_1: bool :: true ==> b#1_1 || !b#1_1) || 0 != 0;

--- a/Test/dafny3/InductionVsCoinduction.dfy.expect
+++ b/Test/dafny3/InductionVsCoinduction.dfy.expect
@@ -1,3 +1,3 @@
-InductionVsCoinduction.dfy(81,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: InductionVsCoinduction.dfy(69,36)
+InductionVsCoinduction.dfy(81,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 15 verified, 0 errors

--- a/Test/dafny3/Streams.dfy.expect
+++ b/Test/dafny3/Streams.dfy.expect
@@ -1,4 +1,4 @@
-Streams.dfy(65,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Streams.dfy(70,20)
-Streams.dfy(105,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Streams.dfy(110,30)
+Streams.dfy(65,2): Warning: /!\ No terms found to trigger on.
+Streams.dfy(105,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 37 verified, 0 errors

--- a/Test/dafny4/Ackermann.dfy.expect
+++ b/Test/dafny4/Ackermann.dfy.expect
@@ -1,5 +1,5 @@
-Ackermann.dfy(163,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Ackermann.dfy(147,12)
-Ackermann.dfy(181,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: Ackermann.dfy(129,21)
+Ackermann.dfy(163,4): Warning: /!\ No terms found to trigger on.
+Ackermann.dfy(181,4): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 15 verified, 0 errors
 Ack(3, 4) = 125

--- a/Test/dafny4/git-issue1.dfy.expect
+++ b/Test/dafny4/git-issue1.dfy.expect
@@ -1,4 +1,4 @@
-git-issue1.dfy(15,11): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue1.dfy(15,27)
-git-issue1.dfy(16,11): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue1.dfy(16,27)	
+git-issue1.dfy(15,11): Warning: /!\ No terms found to trigger on.
+git-issue1.dfy(16,11): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/dafny4/git-issue18.dfy.expect
+++ b/Test/dafny4/git-issue18.dfy.expect
@@ -1,3 +1,3 @@
-git-issue18.dfy(7,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue18.dfy(8,10)
+git-issue18.dfy(7,4): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/dafny4/git-issue22.dfy.expect
+++ b/Test/dafny4/git-issue22.dfy.expect
@@ -1,3 +1,3 @@
-git-issue22.dfy(6,4): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue22.dfy(6,18)
+git-issue22.dfy(6,4): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/dafny4/git-issue92.dfy.expect
+++ b/Test/dafny4/git-issue92.dfy.expect
@@ -1,3 +1,3 @@
-git-issue92.dfy(6,19): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue92.dfy(6,32)
+git-issue92.dfy(6,19): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/dafny4/git-issue96.dfy.expect
+++ b/Test/dafny4/git-issue96.dfy.expect
@@ -1,4 +1,4 @@
 git-issue96.dfy(14,21): Warning: For expression "0 <= i && i < j && j < 5 ==> s[_t#0] == s[i]":
-   /!\ No trigger covering all quantified variables found. Potential trigger not suitable: git-issue96.dfy(15,36)
+   /!\ No trigger covering all quantified variables found. In sub-expression at git-issue96.dfy(15,36)
 
 Dafny program verifier finished with 4 verified, 0 errors

--- a/Test/git-issues/git-issue-1207.dfy.expect
+++ b/Test/git-issues/git-issue-1207.dfy.expect
@@ -1,8 +1,8 @@
-git-issue-1207.dfy(17,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-1207.dfy(17,42)
-git-issue-1207.dfy(29,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-1207.dfy(29,44)
-git-issue-1207.dfy(41,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-1207.dfy(41,52)
-git-issue-1207.dfy(47,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-1207.dfy(47,42)
-git-issue-1207.dfy(48,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-1207.dfy(48,42)
+git-issue-1207.dfy(17,9): Warning: /!\ No terms found to trigger on.
+git-issue-1207.dfy(29,9): Warning: /!\ No terms found to trigger on.
+git-issue-1207.dfy(41,9): Warning: /!\ No terms found to trigger on.
+git-issue-1207.dfy(47,9): Warning: /!\ No terms found to trigger on.
+git-issue-1207.dfy(48,9): Warning: /!\ No terms found to trigger on.
 git-issue-1207.dfy(10,9): Error: assertion violation
 git-issue-1207.dfy(11,9): Error: assertion violation
 git-issue-1207.dfy(14,9): Error: assertion violation

--- a/Test/git-issues/git-issue-851.dfy.expect
+++ b/Test/git-issues/git-issue-851.dfy.expect
@@ -1,18 +1,18 @@
-git-issue-851.dfy(116,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(116,19)
-git-issue-851.dfy(144,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(144,41)
-git-issue-851.dfy(150,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(150,36)
-git-issue-851.dfy(156,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(156,36)
+git-issue-851.dfy(116,9): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(144,13): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(150,13): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(156,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(162,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(168,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(174,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(180,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(186,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(192,13): Warning: /!\ No terms found to trigger on.
-git-issue-851.dfy(211,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(211,32)
-git-issue-851.dfy(217,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(217,36)
-git-issue-851.dfy(223,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(223,36)
-git-issue-851.dfy(229,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(229,36)
-git-issue-851.dfy(235,13): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: git-issue-851.dfy(235,36)
+git-issue-851.dfy(211,13): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(217,13): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(223,13): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(229,13): Warning: /!\ No terms found to trigger on.
+git-issue-851.dfy(235,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(241,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(247,13): Warning: /!\ No terms found to trigger on.
 git-issue-851.dfy(253,13): Warning: /!\ No terms found to trigger on.

--- a/Test/hofs/SumSum.dfy.expect
+++ b/Test/hofs/SumSum.dfy.expect
@@ -1,4 +1,4 @@
-SumSum.dfy(77,2): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: SumSum.dfy(80,43)
-SumSum.dfy(106,6): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: SumSum.dfy(108,36)
+SumSum.dfy(77,2): Warning: /!\ No terms found to trigger on.
+SumSum.dfy(106,6): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 19 verified, 0 errors

--- a/Test/server/simple-session.transcript.expect
+++ b/Test/server/simple-session.transcript.expect
@@ -128,7 +128,7 @@ transcript(10,27): Error: invalid LogicalExpression
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
   [1 proof obligation]  error
@@ -140,14 +140,14 @@ Execution trace:
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
   [1 proof obligation]  verified
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -159,14 +159,14 @@ transcript(12,0): Error: invalid UpdateStmt
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
   [1 proof obligation]  verified
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -230,10 +230,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(38,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -253,10 +253,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(38,35)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Info: Selected triggers: {x' * x'}
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -279,10 +279,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -316,10 +316,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -346,10 +346,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -371,10 +371,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -418,10 +418,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -464,10 +464,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...
@@ -489,10 +489,10 @@ transcript(5,0): Warning: module-level methods are always non-instance, so the '
 transcript(15,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(24,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
 transcript(33,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
-transcript(10,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(10,35)
-transcript(20,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(20,35)
-transcript(29,9): Info: Selected triggers: {x' * x'} Trigger position: transcript(29,35)
-transcript(38,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: transcript(38,37)
+transcript(10,9): Info: Selected triggers: {x' * x'}
+transcript(20,9): Info: Selected triggers: {x' * x'}
+transcript(29,9): Info: Selected triggers: {x' * x'}
+transcript(38,9): Warning: /!\ No terms found to trigger on.
 
 Verifying Impl$$_module.__default.M_k ...
 Retrieving cached verification result for implementation Impl$$_module.__default.M_k...

--- a/Test/triggers/auto-triggers-fix-an-issue-listed-in-the-ironclad-notebook.dfy.expect
+++ b/Test/triggers/auto-triggers-fix-an-issue-listed-in-the-ironclad-notebook.dfy.expect
@@ -1,4 +1,4 @@
 auto-triggers-fix-an-issue-listed-in-the-ironclad-notebook.dfy(21,11): Info: Selected triggers:
-   {HashtableLookup(h2, k)}, {HashtableLookup(h1, k)} Trigger position: auto-triggers-fix-an-issue-listed-in-the-ironclad-notebook.dfy(21,45)
+   {HashtableLookup(h2, k)}, {HashtableLookup(h1, k)}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/constructors-cause-matching-loops.dfy.expect
+++ b/Test/triggers/constructors-cause-matching-loops.dfy.expect
@@ -1,6 +1,6 @@
 constructors-cause-matching-loops.dfy(10,9): Info: Selected triggers: {Succ(s)}
  Rejected triggers:
    {f(s)} (may loop with "f(Succ(s))")
-   {f(Succ(s))} (more specific than {Succ(s)}) Trigger position: constructors-cause-matching-loops.dfy(10,40)
+   {f(Succ(s))} (more specific than {Succ(s)})
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/function-applications-are-triggers.dfy.expect
+++ b/Test/triggers/function-applications-are-triggers.dfy.expect
@@ -1,9 +1,9 @@
-function-applications-are-triggers.dfy(9,9): Info: Selected triggers: {P.requires(f)} Trigger position: function-applications-are-triggers.dfy(9,35)
+function-applications-are-triggers.dfy(9,9): Info: Selected triggers: {P.requires(f)}
 function-applications-are-triggers.dfy(10,9): Info: Selected triggers:
-   {f(10)}, {f.requires(10)}, {P(f)} Trigger position: function-applications-are-triggers.dfy(10,44)
+   {f(10)}, {f.requires(10)}, {P(f)}
 function-applications-are-triggers.dfy(11,9): Info: Selected triggers:
-   {f(10)}, {f.requires(10)} Trigger position: function-applications-are-triggers.dfy(13,19)
+   {f(10)}, {f.requires(10)}
 function-applications-are-triggers.dfy(12,5): Info: Selected triggers:
-   {g(x)}, {f(x)}, {g.requires(x)}, {f.requires(x)} Trigger position: function-applications-are-triggers.dfy(12,57)
+   {g(x)}, {f(x)}, {g.requires(x)}, {f.requires(x)}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/large-quantifiers-dont-break-dafny.dfy.expect
+++ b/Test/triggers/large-quantifiers-dont-break-dafny.dfy.expect
@@ -1,4 +1,4 @@
 large-quantifiers-dont-break-dafny.dfy(60,9): Info: Selected triggers:
-   {P49(x)}, {P48(x)}, {P47(x)}, {P46(x)}, {P45(x)}, {P44(x)}, {P43(x)}, {P42(x)}, {P41(x)}, {P40(x)}, {P39(x)}, {P38(x)}, {P37(x)}, {P36(x)}, {P35(x)}, {P34(x)}, {P33(x)}, {P32(x)}, {P31(x)}, {P30(x)}, {P29(x)}, {P28(x)}, {P27(x)}, {P26(x)}, {P25(x)}, {P24(x)}, {P23(x)}, {P22(x)}, {P21(x)}, {P20(x)}, {P19(x)}, {P18(x)}, {P17(x)}, {P16(x)}, {P15(x)}, {P14(x)}, {P13(x)}, {P12(x)}, {P11(x)}, {P10(x)}, {P9(x)}, {P8(x)}, {P7(x)}, {P6(x)}, {P5(x)}, {P4(x)}, {P3(x)}, {P2(x)}, {P1(x)}, {P0(x)} Trigger position: large-quantifiers-dont-break-dafny.dfy(60,509)
+   {P49(x)}, {P48(x)}, {P47(x)}, {P46(x)}, {P45(x)}, {P44(x)}, {P43(x)}, {P42(x)}, {P41(x)}, {P40(x)}, {P39(x)}, {P38(x)}, {P37(x)}, {P36(x)}, {P35(x)}, {P34(x)}, {P33(x)}, {P32(x)}, {P31(x)}, {P30(x)}, {P29(x)}, {P28(x)}, {P27(x)}, {P26(x)}, {P25(x)}, {P24(x)}, {P23(x)}, {P22(x)}, {P21(x)}, {P20(x)}, {P19(x)}, {P18(x)}, {P17(x)}, {P16(x)}, {P15(x)}, {P14(x)}, {P13(x)}, {P12(x)}, {P11(x)}, {P10(x)}, {P9(x)}, {P8(x)}, {P7(x)}, {P6(x)}, {P5(x)}, {P4(x)}, {P3(x)}, {P2(x)}, {P1(x)}, {P0(x)}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/let-expressions.dfy.expect
+++ b/Test/triggers/let-expressions.dfy.expect
@@ -1,6 +1,6 @@
-let-expressions.dfy(6,8): Info: Selected triggers: {s[i]} Trigger position: let-expressions.dfy(6,37)
-let-expressions.dfy(7,8): Info: Selected triggers: {s[i]} Trigger position: let-expressions.dfy(7,37)
-let-expressions.dfy(8,8): Info: Selected triggers: {s[_t#0], s[i]} Trigger position: let-expressions.dfy(8,44)
-let-expressions.dfy(9,8): Info: Selected triggers: {s[_t#0], s[i]} Trigger position: let-expressions.dfy(9,44)
+let-expressions.dfy(6,8): Info: Selected triggers: {s[i]}
+let-expressions.dfy(7,8): Info: Selected triggers: {s[i]}
+let-expressions.dfy(8,8): Info: Selected triggers: {s[_t#0], s[i]}
+let-expressions.dfy(9,8): Info: Selected triggers: {s[_t#0], s[i]}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/loop-detection-is-not-too-strict.dfy.expect
+++ b/Test/triggers/loop-detection-is-not-too-strict.dfy.expect
@@ -1,15 +1,15 @@
 loop-detection-is-not-too-strict.dfy(15,9): Info: Selected triggers:
-   {P(y, x)}, {P(x, y)} Trigger position: loop-detection-is-not-too-strict.dfy(15,42)
+   {P(y, x)}, {P(x, y)}
 loop-detection-is-not-too-strict.dfy(18,9): Info: Selected triggers:
-   {P(y, x)}, {P(x, y)} Trigger position: loop-detection-is-not-too-strict.dfy(18,42)
-loop-detection-is-not-too-strict.dfy(21,9): Info: Selected triggers: {P(x, _t#0), P(x, y)} Trigger position: loop-detection-is-not-too-strict.dfy(21,42)
-loop-detection-is-not-too-strict.dfy(26,9): Info: Selected triggers: {Q(x)} Trigger position: loop-detection-is-not-too-strict.dfy(26,37)
-loop-detection-is-not-too-strict.dfy(27,9): Info: Selected triggers: {Q(x)} Trigger position: loop-detection-is-not-too-strict.dfy(27,37)
+   {P(y, x)}, {P(x, y)}
+loop-detection-is-not-too-strict.dfy(21,9): Info: Selected triggers: {P(x, _t#0), P(x, y)}
+loop-detection-is-not-too-strict.dfy(26,9): Info: Selected triggers: {Q(x)}
+loop-detection-is-not-too-strict.dfy(27,9): Info: Selected triggers: {Q(x)}
 loop-detection-is-not-too-strict.dfy(28,9): Info: Selected triggers:
-   {P(x, z)}, {P(x, 1)} Trigger position: loop-detection-is-not-too-strict.dfy(28,40)
-loop-detection-is-not-too-strict.dfy(33,9): Info: Selected triggers: {Q(x)} Trigger position: loop-detection-is-not-too-strict.dfy(33,37)
-loop-detection-is-not-too-strict.dfy(34,9): Info: Selected triggers: {Q(x)} Trigger position: loop-detection-is-not-too-strict.dfy(34,37)
-loop-detection-is-not-too-strict.dfy(36,9): Info: Selected triggers: {Q(_t#0), Q(x)} Trigger position: loop-detection-is-not-too-strict.dfy(36,37)
-loop-detection-is-not-too-strict.dfy(40,9): Info: Selected triggers: {Q(_t#0), Q(x)} Trigger position: loop-detection-is-not-too-strict.dfy(40,38)
+   {P(x, z)}, {P(x, 1)}
+loop-detection-is-not-too-strict.dfy(33,9): Info: Selected triggers: {Q(x)}
+loop-detection-is-not-too-strict.dfy(34,9): Info: Selected triggers: {Q(x)}
+loop-detection-is-not-too-strict.dfy(36,9): Info: Selected triggers: {Q(_t#0), Q(x)}
+loop-detection-is-not-too-strict.dfy(40,9): Info: Selected triggers: {Q(_t#0), Q(x)}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/loop-detection-looks-at-ranges-too.dfy.expect
+++ b/Test/triggers/loop-detection-looks-at-ranges-too.dfy.expect
@@ -1,4 +1,4 @@
-loop-detection-looks-at-ranges-too.dfy(11,17): Info: Selected triggers: {P(_t#0), P(x)} Trigger position: loop-detection-looks-at-ranges-too.dfy(11,41)
-loop-detection-looks-at-ranges-too.dfy(13,17): Info: Selected triggers: {P(x), P(_t#0)} Trigger position: loop-detection-looks-at-ranges-too.dfy(13,43)
+loop-detection-looks-at-ranges-too.dfy(11,17): Info: Selected triggers: {P(_t#0), P(x)}
+loop-detection-looks-at-ranges-too.dfy(13,17): Info: Selected triggers: {P(x), P(_t#0)}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/loop-detection-messages--unit-tests.dfy.expect
+++ b/Test/triggers/loop-detection-messages--unit-tests.dfy.expect
@@ -1,28 +1,28 @@
 loop-detection-messages--unit-tests.dfy(11,9): Info: Selected triggers: {f(f(i))}
- Rejected triggers: {f(i)} (may loop with "f(f(i))") Trigger position: loop-detection-messages--unit-tests.dfy(11,36)
-loop-detection-messages--unit-tests.dfy(12,9): Info: Selected triggers: {f(_t#0), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(12,36)
-loop-detection-messages--unit-tests.dfy(13,9): Info: Selected triggers: {f(_t#0), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(13,52)
+ Rejected triggers: {f(i)} (may loop with "f(f(i))")
+loop-detection-messages--unit-tests.dfy(12,9): Info: Selected triggers: {f(_t#0), f(i)}
+loop-detection-messages--unit-tests.dfy(13,9): Info: Selected triggers: {f(_t#0), f(i)}
 loop-detection-messages--unit-tests.dfy(15,9): Info: For expression "false ==> f(i) == f(_t#0)":
-   Selected triggers: {f(_t#0), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(15,36)
+   Selected triggers: {f(_t#0), f(i)} in sub-expression at loop-detection-messages--unit-tests.dfy(15,36)
 loop-detection-messages--unit-tests.dfy(15,9): Info: For expression "false ==> f(i) == g(i)":
    Selected triggers:
-     {g(i)}, {f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(15,54)
+     {g(i)}, {f(i)} in sub-expression at loop-detection-messages--unit-tests.dfy(15,54)
 loop-detection-messages--unit-tests.dfy(16,9): Info: For expression "false ==> f(i) == f(_t#0)":
-   Selected triggers: {f(_t#0), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(16,36)
+   Selected triggers: {f(_t#0), f(i)} in sub-expression at loop-detection-messages--unit-tests.dfy(16,36)
 loop-detection-messages--unit-tests.dfy(16,9): Info: For expression "false ==> f(i) == f(i)":
-   Selected triggers: {f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(16,54)
+   Selected triggers: {f(i)} in sub-expression at loop-detection-messages--unit-tests.dfy(16,54)
 loop-detection-messages--unit-tests.dfy(17,9): Info: For expression "false ==> f(i) == f(_t#0)":
-   Selected triggers: {f(_t#0), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(17,52)
+   Selected triggers: {f(_t#0), f(i)} in sub-expression at loop-detection-messages--unit-tests.dfy(17,52)
 loop-detection-messages--unit-tests.dfy(17,9): Info: For expression "false ==> f(i) == f(i)":
-   Selected triggers: {f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(17,70)
-loop-detection-messages--unit-tests.dfy(19,9): Info: Selected triggers: {f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(19,36)
-loop-detection-messages--unit-tests.dfy(20,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: loop-detection-messages--unit-tests.dfy(20,38)
-loop-detection-messages--unit-tests.dfy(21,9): Info: Not generating triggers for "false ==> f(i + 1) == 0". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead. Trigger position: loop-detection-messages--unit-tests.dfy(21,60)
-loop-detection-messages--unit-tests.dfy(23,9): Info: Selected triggers: {f(j), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(23,44)
-loop-detection-messages--unit-tests.dfy(24,9): Warning: /!\ No trigger covering all quantified variables found. Potential trigger not suitable: loop-detection-messages--unit-tests.dfy(24,44)
-loop-detection-messages--unit-tests.dfy(25,9): Info: Selected triggers: {g(j), f(i)} Trigger position: loop-detection-messages--unit-tests.dfy(25,44)
-loop-detection-messages--unit-tests.dfy(26,9): Warning: /!\ No trigger covering all quantified variables found. Potential trigger not suitable: loop-detection-messages--unit-tests.dfy(26,44)
-loop-detection-messages--unit-tests.dfy(27,9): Info: Not generating triggers for "false ==> f(i) == f(i)". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead. Trigger position: loop-detection-messages--unit-tests.dfy(27,66)
-loop-detection-messages--unit-tests.dfy(28,9): Info: Not generating triggers for "false ==> f(i) == f(i)". Trigger position: loop-detection-messages--unit-tests.dfy(28,66)
+   Selected triggers: {f(i)} in sub-expression at loop-detection-messages--unit-tests.dfy(17,70)
+loop-detection-messages--unit-tests.dfy(19,9): Info: Selected triggers: {f(i)}
+loop-detection-messages--unit-tests.dfy(20,9): Warning: /!\ No terms found to trigger on.
+loop-detection-messages--unit-tests.dfy(21,9): Info: Not generating triggers for "false ==> f(i + 1) == 0". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead.
+loop-detection-messages--unit-tests.dfy(23,9): Info: Selected triggers: {f(j), f(i)}
+loop-detection-messages--unit-tests.dfy(24,9): Warning: /!\ No trigger covering all quantified variables found.
+loop-detection-messages--unit-tests.dfy(25,9): Info: Selected triggers: {g(j), f(i)}
+loop-detection-messages--unit-tests.dfy(26,9): Warning: /!\ No trigger covering all quantified variables found.
+loop-detection-messages--unit-tests.dfy(27,9): Info: Not generating triggers for "false ==> f(i) == f(i)". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead.
+loop-detection-messages--unit-tests.dfy(28,9): Info: Not generating triggers for "false ==> f(i) == f(i)".
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/looping-is-hard-to-decide-modulo-equality.dfy.expect
+++ b/Test/triggers/looping-is-hard-to-decide-modulo-equality.dfy.expect
@@ -1,10 +1,10 @@
 looping-is-hard-to-decide-modulo-equality.dfy(21,9): Info: Selected triggers:
    {h(h(c, j), j)}, {h(c, i)}, {c in sc}
- Rejected triggers: {h(c, j)} (may loop with "h(h(c, j), j)") Trigger position: looping-is-hard-to-decide-modulo-equality.dfy(21,47)
+ Rejected triggers: {h(c, j)} (may loop with "h(h(c, j), j)")
 looping-is-hard-to-decide-modulo-equality.dfy(26,9): Info: Selected triggers: {f(x)}
- Rejected triggers: {g(f(x))} (more specific than {f(x)}) Trigger position: looping-is-hard-to-decide-modulo-equality.dfy(26,34)
+ Rejected triggers: {g(f(x))} (more specific than {f(x)})
 looping-is-hard-to-decide-modulo-equality.dfy(31,9): Info: Selected triggers:
    {old(f(f(c)))}, {f(c)}, {c in sc}
- Rejected triggers: {old(f(c))} (may loop with "old(f(f(c)))") Trigger position: looping-is-hard-to-decide-modulo-equality.dfy(31,44)
+ Rejected triggers: {old(f(c))} (may loop with "old(f(f(c)))")
 
 Dafny program verifier finished with 3 verified, 0 errors

--- a/Test/triggers/matrix-accesses-are-triggers.dfy.expect
+++ b/Test/triggers/matrix-accesses-are-triggers.dfy.expect
@@ -1,4 +1,4 @@
-matrix-accesses-are-triggers.dfy(7,11): Info: Selected triggers: {m[j, _t#0], m[i, j]} Trigger position: matrix-accesses-are-triggers.dfy(7,77)
+matrix-accesses-are-triggers.dfy(7,11): Info: Selected triggers: {m[j, _t#0], m[i, j]}
 matrix-accesses-are-triggers.dfy(7,81): Error: index 0 out of range
 matrix-accesses-are-triggers.dfy(7,86): Error: index 1 out of range
 

--- a/Test/triggers/nested-quantifiers-all-get-triggers.dfy.expect
+++ b/Test/triggers/nested-quantifiers-all-get-triggers.dfy.expect
@@ -1,4 +1,4 @@
-nested-quantifiers-all-get-triggers.dfy(8,17): Info: Selected triggers: {x in s} Trigger position: nested-quantifiers-all-get-triggers.dfy(8,55)
-nested-quantifiers-all-get-triggers.dfy(8,59): Info: Selected triggers: {y in s} Trigger position: nested-quantifiers-all-get-triggers.dfy(8,84)
+nested-quantifiers-all-get-triggers.dfy(8,17): Info: Selected triggers: {x in s}
+nested-quantifiers-all-get-triggers.dfy(8,59): Info: Selected triggers: {y in s}
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/triggers/old-is-a-special-case-for-triggers.dfy.expect
+++ b/Test/triggers/old-is-a-special-case-for-triggers.dfy.expect
@@ -1,22 +1,22 @@
 old-is-a-special-case-for-triggers.dfy(15,10): Info: Selected triggers:
-   {old(f(c))}, {c in sc} Trigger position: old-is-a-special-case-for-triggers.dfy(15,42)
+   {old(f(c))}, {c in sc}
 old-is-a-special-case-for-triggers.dfy(20,10): Info: Selected triggers:
    {old(f(f(c)))}, {f(c)}, {c in sc}
- Rejected triggers: {old(f(c))} (may loop with "old(f(f(c)))") Trigger position: old-is-a-special-case-for-triggers.dfy(20,45)
+ Rejected triggers: {old(f(c))} (may loop with "old(f(f(c)))")
 old-is-a-special-case-for-triggers.dfy(21,10): Info: Selected triggers:
    {f(g(c))}, {g(f(c))}, {old(f(g(c)))}, {old(g(f(c)))}, {old(f(f(c)))}, {c in sc}
  Rejected triggers:
    {g(c)} (may loop with "g(f(c))")
    {f(c)} (may loop with "f(g(c))")
    {old(g(c))} (may loop with "old(g(f(c)))")
-   {old(f(c))} (may loop with "old(f(f(c)))", "old(f(g(c)))") Trigger position: old-is-a-special-case-for-triggers.dfy(21,107)
+   {old(f(c))} (may loop with "old(f(f(c)))", "old(f(g(c)))")
 old-is-a-special-case-for-triggers.dfy(25,10): Info: Selected triggers:
    {old(f(c))}, {f(c)}, {c in sc}
- Rejected triggers: {old(g(f(c)))} (more specific than {old(f(c))}) Trigger position: old-is-a-special-case-for-triggers.dfy(25,45)
+ Rejected triggers: {old(g(f(c)))} (more specific than {old(f(c))})
 old-is-a-special-case-for-triggers.dfy(26,10): Info: Selected triggers:
    {old(f(c))}, {f(c)}, {c in sc}
  Rejected triggers:
    {g(f(c))} (more specific than {f(c)})
-   {old(g(f(c)))} (more specific than {old(f(c))}) Trigger position: old-is-a-special-case-for-triggers.dfy(26,74)
+   {old(g(f(c)))} (more specific than {old(f(c))})
 
 Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/triggers/redundancy-detection-is-bidirectional.dfy.expect
+++ b/Test/triggers/redundancy-detection-is-bidirectional.dfy.expect
@@ -1,12 +1,12 @@
 redundancy-detection-is-bidirectional.dfy(13,9): Info: Selected triggers:
-   {R(x), Q(y)}, {P(x, y)} Trigger position: redundancy-detection-is-bidirectional.dfy(13,51)
+   {R(x), Q(y)}, {P(x, y)}
 redundancy-detection-is-bidirectional.dfy(14,9): Info: Selected triggers:
-   {R(x), Q(y)}, {P(x, y)} Trigger position: redundancy-detection-is-bidirectional.dfy(14,51)
+   {R(x), Q(y)}, {P(x, y)}
 redundancy-detection-is-bidirectional.dfy(15,9): Info: Selected triggers:
-   {P(x, y)}, {R(x), Q(y)} Trigger position: redundancy-detection-is-bidirectional.dfy(15,48)
-redundancy-detection-is-bidirectional.dfy(25,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)} Trigger position: redundancy-detection-is-bidirectional.dfy(25,83)
-redundancy-detection-is-bidirectional.dfy(26,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)} Trigger position: redundancy-detection-is-bidirectional.dfy(26,83)
-redundancy-detection-is-bidirectional.dfy(27,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)} Trigger position: redundancy-detection-is-bidirectional.dfy(27,83)
-redundancy-detection-is-bidirectional.dfy(28,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)} Trigger position: redundancy-detection-is-bidirectional.dfy(28,80)
+   {P(x, y)}, {R(x), Q(y)}
+redundancy-detection-is-bidirectional.dfy(25,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)}
+redundancy-detection-is-bidirectional.dfy(26,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)}
+redundancy-detection-is-bidirectional.dfy(27,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)}
+redundancy-detection-is-bidirectional.dfy(28,9): Info: Selected triggers: {SS(z, w), RR(y, v), QQ(x, u)}
 
 Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/triggers/regression-tests.dfy.expect
+++ b/Test/triggers/regression-tests.dfy.expect
@@ -1,4 +1,4 @@
 regression-tests.dfy(15,4): Info: ==
-regression-tests.dfy(16,5): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: regression-tests.dfy(16,17)
+regression-tests.dfy(16,5): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/triggers/set-construction-is-a-good-trigger.dfy.expect
+++ b/Test/triggers/set-construction-is-a-good-trigger.dfy.expect
@@ -1,5 +1,5 @@
-set-construction-is-a-good-trigger.dfy(8,11): Info: Selected triggers: {[y]} Trigger position: set-construction-is-a-good-trigger.dfy(8,25)
-set-construction-is-a-good-trigger.dfy(9,11): Info: Selected triggers: {{y}} Trigger position: set-construction-is-a-good-trigger.dfy(9,26)
-set-construction-is-a-good-trigger.dfy(10,11): Info: Selected triggers: {multiset{y}} Trigger position: set-construction-is-a-good-trigger.dfy(10,27)
+set-construction-is-a-good-trigger.dfy(8,11): Info: Selected triggers: {[y]}
+set-construction-is-a-good-trigger.dfy(9,11): Info: Selected triggers: {{y}}
+set-construction-is-a-good-trigger.dfy(10,11): Info: Selected triggers: {multiset{y}}
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/triggers/some-proofs-only-work-without-autoTriggers.dfy.expect
+++ b/Test/triggers/some-proofs-only-work-without-autoTriggers.dfy.expect
@@ -1,9 +1,9 @@
-some-proofs-only-work-without-autoTriggers.dfy(19,11): Info: Selected triggers: {x in a} Trigger position: some-proofs-only-work-without-autoTriggers.dfy(19,36)
-some-proofs-only-work-without-autoTriggers.dfy(20,11): Info: Selected triggers: {x in a[..|a|]} Trigger position: some-proofs-only-work-without-autoTriggers.dfy(20,43)
-some-proofs-only-work-without-autoTriggers.dfy(27,11): Info: Selected triggers: {x in a} Trigger position: some-proofs-only-work-without-autoTriggers.dfy(27,36)
-some-proofs-only-work-without-autoTriggers.dfy(28,11): Info: Selected triggers: {a[i]} Trigger position: some-proofs-only-work-without-autoTriggers.dfy(28,44)
-some-proofs-only-work-without-autoTriggers.dfy(31,11): Info: Selected triggers: {x in a[..3]} Trigger position: some-proofs-only-work-without-autoTriggers.dfy(31,39)
-some-proofs-only-work-without-autoTriggers.dfy(33,11): Info: Selected triggers: {x in a[..2]} Trigger position: some-proofs-only-work-without-autoTriggers.dfy(33,39)
+some-proofs-only-work-without-autoTriggers.dfy(19,11): Info: Selected triggers: {x in a}
+some-proofs-only-work-without-autoTriggers.dfy(20,11): Info: Selected triggers: {x in a[..|a|]}
+some-proofs-only-work-without-autoTriggers.dfy(27,11): Info: Selected triggers: {x in a}
+some-proofs-only-work-without-autoTriggers.dfy(28,11): Info: Selected triggers: {a[i]}
+some-proofs-only-work-without-autoTriggers.dfy(31,11): Info: Selected triggers: {x in a[..3]}
+some-proofs-only-work-without-autoTriggers.dfy(33,11): Info: Selected triggers: {x in a[..2]}
 some-proofs-only-work-without-autoTriggers.dfy(20,11): Error: assertion violation
 some-proofs-only-work-without-autoTriggers.dfy(28,11): Error: assertion violation
 some-proofs-only-work-without-autoTriggers.dfy(33,11): Error: assertion violation

--- a/Test/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy.expect
+++ b/Test/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy.expect
@@ -1,78 +1,78 @@
-some-terms-do-not-look-like-the-triggers-they-match.dfy(12,17): Info: Selected triggers: {s[_t#0], s[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(12,72)
+some-terms-do-not-look-like-the-triggers-they-match.dfy(12,17): Info: Selected triggers: {s[_t#0], s[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(15,17): Info: For expression "x in s ==> s[_t#0] > 0":
-   Selected triggers: {s[_t#0], s[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(15,70)
+   Selected triggers: {s[_t#0], s[x]} in sub-expression at some-terms-do-not-look-like-the-triggers-they-match.dfy(15,70)
 some-terms-do-not-look-like-the-triggers-they-match.dfy(15,17): Info: For expression "x in s ==> _t#0 !in s":
-   Selected triggers: {s[_t#0], s[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(15,81)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(24,18): Info: Selected triggers: {x in s + t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(24,45)
+   Selected triggers: {s[_t#0], s[x]} in sub-expression at some-terms-do-not-look-like-the-triggers-they-match.dfy(15,81)
+some-terms-do-not-look-like-the-triggers-they-match.dfy(24,18): Info: Selected triggers: {x in s + t}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(25,18): Info: Selected triggers:
-   {x in t}, {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(25,51)
+   {x in t}, {x in s}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(26,18): Info: Selected triggers: {x in s + t}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(27,18): Info: Selected triggers:
    {x in t}, {x in s}, {x in s + t}
-some-terms-do-not-look-like-the-triggers-they-match.dfy(31,18): Info: Selected triggers: {x in s * t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(31,45)
+some-terms-do-not-look-like-the-triggers-they-match.dfy(31,18): Info: Selected triggers: {x in s * t}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(32,18): Info: Selected triggers:
-   {x in t}, {x in s}, {x in s * t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(32,65)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(36,18): Info: Selected triggers: {x in s - t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(36,45)
+   {x in t}, {x in s}, {x in s * t}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(36,18): Info: Selected triggers: {x in s - t}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(37,18): Info: Selected triggers:
-   {x in t}, {x in s}, {x in s - t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(37,66)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(43,20): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(43,51)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(44,20): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(44,53)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(49,20): Info: Selected triggers: {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(49,43)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(50,20): Info: Selected triggers: {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(50,45)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(55,18): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(55,58)
+   {x in t}, {x in s}, {x in s - t}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(43,20): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(44,20): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(49,20): Info: Selected triggers: {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(50,20): Info: Selected triggers: {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(55,18): Warning: /!\ No terms found to trigger on.
 some-terms-do-not-look-like-the-triggers-they-match.dfy(55,36): Info: Selected triggers: {y in s}
-some-terms-do-not-look-like-the-triggers-they-match.dfy(56,18): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(56,30)
+some-terms-do-not-look-like-the-triggers-they-match.dfy(56,18): Warning: /!\ No terms found to trigger on.
 some-terms-do-not-look-like-the-triggers-they-match.dfy(56,39): Info: Selected triggers: {y in s}
-some-terms-do-not-look-like-the-triggers-they-match.dfy(58,18): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(58,30)
+some-terms-do-not-look-like-the-triggers-they-match.dfy(58,18): Warning: /!\ No terms found to trigger on.
 some-terms-do-not-look-like-the-triggers-they-match.dfy(58,41): Info: Selected triggers: {y in s}
-some-terms-do-not-look-like-the-triggers-they-match.dfy(59,18): Info: Selected triggers: {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(59,43)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(60,18): Info: Selected triggers: {x in F(s)} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(60,46)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(67,18): Info: Selected triggers: {(s + t)[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(67,45)
+some-terms-do-not-look-like-the-triggers-they-match.dfy(59,18): Info: Selected triggers: {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(60,18): Info: Selected triggers: {x in F(s)}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(67,18): Info: Selected triggers: {(s + t)[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(68,18): Info: Selected triggers:
-   {t[x]}, {s[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(68,51)
+   {t[x]}, {s[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(71,11): Info: Selected triggers:
-   {t[x]}, {s[x]}, {(s + t)[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(71,34)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(75,18): Info: Selected triggers: {(s * t)[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(75,45)
+   {t[x]}, {s[x]}, {(s + t)[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(75,18): Info: Selected triggers: {(s * t)[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(76,18): Info: Selected triggers:
-   {t[x]}, {s[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(76,51)
+   {t[x]}, {s[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(79,17): Info: Selected triggers:
-   {t[x]}, {s[x]}, {(s * t)[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(79,64)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(83,18): Info: Selected triggers: {(s - t)[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(83,45)
+   {t[x]}, {s[x]}, {(s * t)[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(83,18): Info: Selected triggers: {(s - t)[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(84,18): Info: Selected triggers:
-   {t[x]}, {s[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(84,56)
+   {t[x]}, {s[x]}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(86,11): Info: Selected triggers:
-   {t[x]}, {s[x]}, {(s - t)[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(86,34)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(92,20): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(92,59)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(93,20): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(93,61)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(98,20): Info: Selected triggers: {ms[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(98,44)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(99,20): Info: Selected triggers: {ms[x]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(99,46)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(106,18): Info: Selected triggers: {x in s + t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(106,45)
+   {t[x]}, {s[x]}, {(s - t)[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(92,20): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(93,20): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(98,20): Info: Selected triggers: {ms[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(99,20): Info: Selected triggers: {ms[x]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(106,18): Info: Selected triggers: {x in s + t}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(107,18): Info: Selected triggers:
-   {x in t}, {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(107,51)
+   {x in t}, {x in s}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(110,6): Info: Selected triggers:
-   {x in t}, {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(111,18)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(121,18): Info: Selected triggers: {x in [2, 3, 5]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(121,49)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(122,18): Info: Selected triggers: {x in [2, 3, 5]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(122,51)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(128,18): Info: Selected triggers: {x in s + t} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(128,45)
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(121,18): Info: Selected triggers: {x in [2, 3, 5]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(122,18): Info: Selected triggers: {x in [2, 3, 5]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(128,18): Info: Selected triggers: {x in s + t}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(129,18): Info: Selected triggers:
-   {x in t}, {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(129,51)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(133,18): Info: Selected triggers: {x in s - u} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(133,45)
+   {x in t}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(133,18): Info: Selected triggers: {x in s - u}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(134,18): Info: Selected triggers:
-   {x in u}, {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(134,52)
+   {x in u}, {x in s}
 some-terms-do-not-look-like-the-triggers-they-match.dfy(137,6): Info: Selected triggers:
-   {x in u}, {x in s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(138,18)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(148,18): Info: Selected triggers: {x in map[2 := 20, 3 := 30, 5 := 50]} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(148,70)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(149,18): Info: Selected triggers: {x in F(map[2 := 20, 3 := 30, 5 := 50])} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(149,73)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(156,12): Info: Selected triggers: {x <= s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(156,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(157,12): Info: Selected triggers: {x <= s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(157,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(158,12): Info: Selected triggers: {x >= s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(158,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(159,12): Info: Selected triggers: {x >= s} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(159,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(161,12): Info: Selected triggers: {x <= ms} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(161,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(162,12): Info: Selected triggers: {x <= ms} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(162,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(163,12): Info: Selected triggers: {x >= ms} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(163,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(164,12): Info: Selected triggers: {x >= ms} Trigger position: some-terms-do-not-look-like-the-triggers-they-match.dfy(164,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(166,12): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(166,26)
-some-terms-do-not-look-like-the-triggers-they-match.dfy(167,12): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: some-terms-do-not-look-like-the-triggers-they-match.dfy(167,26)
+   {x in u}, {x in s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(148,18): Info: Selected triggers: {x in map[2 := 20, 3 := 30, 5 := 50]}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(149,18): Info: Selected triggers: {x in F(map[2 := 20, 3 := 30, 5 := 50])}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(156,12): Info: Selected triggers: {x <= s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(157,12): Info: Selected triggers: {x <= s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(158,12): Info: Selected triggers: {x >= s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(159,12): Info: Selected triggers: {x >= s}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(161,12): Info: Selected triggers: {x <= ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(162,12): Info: Selected triggers: {x <= ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(163,12): Info: Selected triggers: {x >= ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(164,12): Info: Selected triggers: {x >= ms}
+some-terms-do-not-look-like-the-triggers-they-match.dfy(166,12): Warning: /!\ No terms found to trigger on.
+some-terms-do-not-look-like-the-triggers-they-match.dfy(167,12): Warning: /!\ No terms found to trigger on.
 some-terms-do-not-look-like-the-triggers-they-match.dfy(152,9): Error: assertion violation
 
 Dafny program verifier finished with 4 verified, 1 error

--- a/Test/triggers/splitting-picks-the-right-tokens.dfy.expect
+++ b/Test/triggers/splitting-picks-the-right-tokens.dfy.expect
@@ -1,5 +1,5 @@
-splitting-picks-the-right-tokens.dfy(9,11): Info: Selected triggers: {Id(x)} Trigger position: splitting-picks-the-right-tokens.dfy(9,37)
-splitting-picks-the-right-tokens.dfy(16,11): Info: Selected triggers: {Id(x)} Trigger position: splitting-picks-the-right-tokens.dfy(16,39)
+splitting-picks-the-right-tokens.dfy(9,11): Info: Selected triggers: {Id(x)}
+splitting-picks-the-right-tokens.dfy(16,11): Info: Selected triggers: {Id(x)}
 splitting-picks-the-right-tokens.dfy(20,12): Error: A precondition for this call might not hold.
 splitting-picks-the-right-tokens.dfy(16,11): Related location: This is the precondition that might not hold.
 splitting-picks-the-right-tokens.dfy(16,39): Related location

--- a/Test/triggers/splitting-triggers-recovers-expressivity.dfy.expect
+++ b/Test/triggers/splitting-triggers-recovers-expressivity.dfy.expect
@@ -8,18 +8,18 @@ splitting-triggers-recovers-expressivity.dfy(33,11): Info: Selected triggers: {Q
  Rejected triggers: {P(j)} (may loop with "P(j + 1)")
 splitting-triggers-recovers-expressivity.dfy(44,10): Info: For expression "P(i) || !Q(i)":
    Selected triggers:
-     {Q(i)}, {P(i)} Trigger position: splitting-triggers-recovers-expressivity.dfy(44,51)
+     {Q(i)}, {P(i)} in sub-expression at splitting-triggers-recovers-expressivity.dfy(44,51)
 splitting-triggers-recovers-expressivity.dfy(44,10): Info: For expression "P(i + 1)":
    Selected triggers: {Q(i)}
-   Rejected triggers: {P(i)} (may loop with "P(i + 1)") Trigger position: splitting-triggers-recovers-expressivity.dfy(44,69)
+   Rejected triggers: {P(i)} (may loop with "P(i + 1)") in sub-expression at splitting-triggers-recovers-expressivity.dfy(44,69)
 splitting-triggers-recovers-expressivity.dfy(49,11): Info: For expression "j >= 0 ==> P(j)":
    Selected triggers:
-     {Q(j)}, {P(j)} Trigger position: splitting-triggers-recovers-expressivity.dfy(49,64)
+     {Q(j)}, {P(j)} in sub-expression at splitting-triggers-recovers-expressivity.dfy(49,64)
 splitting-triggers-recovers-expressivity.dfy(49,11): Info: For expression "j >= 0 ==> Q(j) ==> P(j + 1)":
    Selected triggers: {Q(j)}
-   Rejected triggers: {P(j)} (may loop with "P(j + 1)") Trigger position: splitting-triggers-recovers-expressivity.dfy(49,78)
+   Rejected triggers: {P(j)} (may loop with "P(j + 1)") in sub-expression at splitting-triggers-recovers-expressivity.dfy(49,78)
 splitting-triggers-recovers-expressivity.dfy(58,11): Info: Selected triggers:
-   {P(i)}, {Q(i)} Trigger position: splitting-triggers-recovers-expressivity.dfy(58,80)
+   {P(i)}, {Q(i)}
 splitting-triggers-recovers-expressivity.dfy(12,63): Error: A postcondition might not hold on this return path.
 splitting-triggers-recovers-expressivity.dfy(12,10): Related location: This is the postcondition that might not hold.
 splitting-triggers-recovers-expressivity.dfy(19,15): Error: A postcondition might not hold on this return path.

--- a/Test/triggers/splitting-triggers-yields-better-precondition-related-errors.dfy.expect
+++ b/Test/triggers/splitting-triggers-yields-better-precondition-related-errors.dfy.expect
@@ -1,5 +1,5 @@
-splitting-triggers-yields-better-precondition-related-errors.dfy(7,11): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: splitting-triggers-yields-better-precondition-related-errors.dfy(7,25)
-splitting-triggers-yields-better-precondition-related-errors.dfy(15,11): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: splitting-triggers-yields-better-precondition-related-errors.dfy(15,25)
+splitting-triggers-yields-better-precondition-related-errors.dfy(7,11): Warning: /!\ No terms found to trigger on.
+splitting-triggers-yields-better-precondition-related-errors.dfy(15,11): Warning: /!\ No terms found to trigger on.
 splitting-triggers-yields-better-precondition-related-errors.dfy(11,3): Error: A precondition for this call might not hold.
 splitting-triggers-yields-better-precondition-related-errors.dfy(7,11): Related location: This is the precondition that might not hold.
 splitting-triggers-yields-better-precondition-related-errors.dfy(7,25): Related location

--- a/Test/triggers/suppressing-warnings-behaves-properly.dfy.expect
+++ b/Test/triggers/suppressing-warnings-behaves-properly.dfy.expect
@@ -1,14 +1,14 @@
-suppressing-warnings-behaves-properly.dfy(10,9): Warning: /!\ No terms found to trigger on. Potential trigger not suitable: suppressing-warnings-behaves-properly.dfy(10,33)
-suppressing-warnings-behaves-properly.dfy(11,9): Info: (Suppressed warning) No terms found to trigger on. Potential trigger not suitable: suppressing-warnings-behaves-properly.dfy(11,43)
-suppressing-warnings-behaves-properly.dfy(12,9): Info: Not generating triggers for "n >= 0 || n < 0". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead. Trigger position: suppressing-warnings-behaves-properly.dfy(12,55)
-suppressing-warnings-behaves-properly.dfy(14,9): Info: Selected triggers: {f(n)} Trigger position: suppressing-warnings-behaves-properly.dfy(14,46)
+suppressing-warnings-behaves-properly.dfy(10,9): Warning: /!\ No terms found to trigger on.
+suppressing-warnings-behaves-properly.dfy(11,9): Info: (Suppressed warning) No terms found to trigger on.
+suppressing-warnings-behaves-properly.dfy(12,9): Info: Not generating triggers for "n >= 0 || n < 0". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead.
+suppressing-warnings-behaves-properly.dfy(14,9): Info: Selected triggers: {f(n)}
 suppressing-warnings-behaves-properly.dfy(15,9): Warning: Selected triggers: {f(n)}
- /!\ There is no warning here to suppress. Trigger position: suppressing-warnings-behaves-properly.dfy(15,56)
-suppressing-warnings-behaves-properly.dfy(16,9): Info: Not generating triggers for "(n != 0) == f(n) || true". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead. Trigger position: suppressing-warnings-behaves-properly.dfy(16,68)
+ /!\ There is no warning here to suppress.
+suppressing-warnings-behaves-properly.dfy(16,9): Info: Not generating triggers for "(n != 0) == f(n) || true". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead.
 suppressing-warnings-behaves-properly.dfy(18,9): Info: Selected triggers:
-   {g(n), f(_t#0)}, {f(_t#0), f(n)} Trigger position: suppressing-warnings-behaves-properly.dfy(18,52)
+   {g(n), f(_t#0)}, {f(_t#0), f(n)}
 suppressing-warnings-behaves-properly.dfy(19,9): Warning: Selected triggers: {f(n)}
- /!\ There is no warning here to suppress. Trigger position: suppressing-warnings-behaves-properly.dfy(19,56)
-suppressing-warnings-behaves-properly.dfy(20,9): Info: Not generating triggers for "(n != 0) == f(n) || true". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead. Trigger position: suppressing-warnings-behaves-properly.dfy(20,68)
+ /!\ There is no warning here to suppress.
+suppressing-warnings-behaves-properly.dfy(20,9): Info: Not generating triggers for "(n != 0) == f(n) || true". Note that {:autotriggers false} can cause instabilities. Consider using {:nowarn}, {:matchingloop} (not great either), or a manual trigger instead.
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/triggers-prevent-some-inlining.dfy.expect
+++ b/Test/triggers/triggers-prevent-some-inlining.dfy.expect
@@ -1,4 +1,4 @@
-triggers-prevent-some-inlining.dfy(17,2): Info: Selected triggers: {sum(a, b)} Trigger position: triggers-prevent-some-inlining.dfy(17,33)
+triggers-prevent-some-inlining.dfy(17,2): Info: Selected triggers: {sum(a, b)}
 triggers-prevent-some-inlining.dfy(24,10): Info: Some instances of this call cannot safely be inlined.
 triggers-prevent-some-inlining.dfy(25,10): Info: Some instances of this call cannot safely be inlined.
 triggers-prevent-some-inlining.dfy(24,10): Info: Some instances of this call cannot safely be inlined.

--- a/Test/triggers/useless-triggers-are-removed.dfy.expect
+++ b/Test/triggers/useless-triggers-are-removed.dfy.expect
@@ -3,15 +3,15 @@ useless-triggers-are-removed.dfy(16,11): Info: Selected triggers: {f(x)}
    {h(g(f(x)))} (more specific than {g(f(x))}, {f(x)})
    {g(h(f(x)))} (more specific than {h(f(x))}, {f(x)})
    {h(f(x))} (more specific than {f(x)})
-   {g(f(x))} (more specific than {f(x)}) Trigger position: useless-triggers-are-removed.dfy(16,79)
+   {g(f(x))} (more specific than {f(x)})
 useless-triggers-are-removed.dfy(20,11): Info: Selected triggers: {f(f(x))}
- Rejected triggers: {f(x)} (may loop with "f(f(x))") Trigger position: useless-triggers-are-removed.dfy(20,33)
+ Rejected triggers: {f(x)} (may loop with "f(f(x))")
 useless-triggers-are-removed.dfy(23,11): Info: Selected triggers:
    {g(f(x)), g(y)}, {f(y), f(x)}
  Rejected triggers:
    {g(y), f(x)} (may loop with "g(f(y))", "g(f(x))")
    {g(f(x)), g(f(y))} (more specific than {g(f(x)), f(y)}, {g(f(y)), f(x)}, {f(y), f(x)})
    {g(f(x)), f(y)} (more specific than {f(y), f(x)})
-   {g(f(y)), f(x)} (more specific than {f(y), f(x)}) Trigger position: useless-triggers-are-removed.dfy(23,58)
+   {g(f(y)), f(x)} (more specific than {f(y), f(x)})
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/triggers/wf-checks-use-the-original-quantifier.dfy.expect
+++ b/Test/triggers/wf-checks-use-the-original-quantifier.dfy.expect
@@ -1,6 +1,6 @@
 wf-checks-use-the-original-quantifier.dfy(26,11): Info: Selected triggers: {f(n)}
- Rejected triggers: {P(f(n))} (more specific than {f(n)}) Trigger position: wf-checks-use-the-original-quantifier.dfy(26,30)
+ Rejected triggers: {P(f(n))} (more specific than {f(n)})
 wf-checks-use-the-original-quantifier.dfy(27,11): Info: Selected triggers:
-   {c'.x, c.x}, {c'.x, c in s}, {c.x, c' in s}, {c' in s, c in s} Trigger position: wf-checks-use-the-original-quantifier.dfy(27,51)
+   {c'.x, c.x}, {c'.x, c in s}, {c.x, c' in s}, {c' in s, c in s}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/tutorial/maximum.dfy.expect
+++ b/Test/tutorial/maximum.dfy.expect
@@ -1,7 +1,7 @@
-maximum.dfy(11,10): Info: Selected triggers: {values[i]} Trigger position: maximum.dfy(11,52)
-maximum.dfy(18,14): Info: Selected triggers: {values[j]} Trigger position: maximum.dfy(18,51)
-maximum.dfy(28,27): Info: Selected triggers: {values[i]} Trigger position: maximum.dfy(28,69)
-maximum.dfy(29,27): Info: Selected triggers: {values[i]} Trigger position: maximum.dfy(29,69)
+maximum.dfy(11,10): Info: Selected triggers: {values[i]}
+maximum.dfy(18,14): Info: Selected triggers: {values[j]}
+maximum.dfy(28,27): Info: Selected triggers: {values[i]}
+maximum.dfy(29,27): Info: Selected triggers: {values[i]}
 maximum.dfy(15,2): Info: decreases |values| - idx
 
 Dafny program verifier finished with 4 verified, 0 errors


### PR DESCRIPTION
This fixes the problem unveiled in #1695: The related locations were not about the trigger positions, but about sub-expressions.

* fix: If there was no splitting (i.e. the body of the comprehension is the same as the considered sub-expression), this PR also simply REMOVES the extra message about the considered sub-expression which did not bring any extra information
* feat: If there is splitting (info message starting with "For expression"), this PR ensures that it indicates the position of the sub-expression being considered, with a properly capitalized nominal phrase.
* chore: One fix for a Windows test (InferMethodVerificationStability.cs) (unrelated to this PR, but since I had to run all the tests I saw that one was not working locally)