### PR TITLE
chore: Retry failed `dotnet publish`

### DIFF
--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -125,6 +125,7 @@ class Release:
         retv = 1
         MAX_RETRYS = 3
         while(i < MAX_RETRYS and retv != 0):
+            i += 1
             retv = subprocess.call(["dotnet", "publish", projectPath,
                 "--nologo",
                 "-f", "net6.0",

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -121,24 +121,23 @@ class Release:
         env = dict(os.environ)
         env["RUNTIME_IDENTIFIER"] = self.target
         flush("   + Publishing " + project)
-        i = 0
-        retv = 1
-        MAX_RETRYS = 3
-        while(i < MAX_RETRYS and retv != 0):
-            i += 1
-            retv = subprocess.call(["dotnet", "publish", projectPath,
+        remaining = 3
+        exitStatus = 1
+        while 0 < remaining and exitStatus != 0:
+            remaining -= 1
+            exitStatus = subprocess.call(["dotnet", "publish", projectPath,
                 "--nologo",
                 "-f", "net6.0",
                 "-o", self.buildDirectory,
                 "-r", self.target,
                 "--self-contained",
                 "-c", "Release"], env=env)
-            if retv != 0:
-                if i == MAX_RETRYS:
+            if exitStatus != 0:
+                if remaining == 0:
                     flush("failed! (Is Dafny or the Dafny server running?)")
                     sys.exit(1)
                 else:
-                   flush("failed! (Retrying another %i time(s))" % (MAX_RETRYS - i))
+                   flush("failed! (Retrying another %s)" % ("time" if remaining == 1 else "%i times" % remaining))
         flush("done!")
 
     def build(self):

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -117,7 +117,6 @@ class Release:
         return fpath.replace(os.path.sep, '/')
 
     def run_publish(self, project):
-        projectPath = path.join(SOURCE_DIRECTORY, project, project + ".csproj")
         env = dict(os.environ)
         env["RUNTIME_IDENTIFIER"] = self.target
         flush("   + Publishing " + project)
@@ -125,7 +124,7 @@ class Release:
         exitStatus = 1
         while 0 < remaining and exitStatus != 0:
             remaining -= 1
-            exitStatus = subprocess.call(["dotnet", "publish", projectPath,
+            exitStatus = subprocess.call(["dotnet", "publish", path.join(SOURCE_DIRECTORY, project, project + ".csproj"),
                 "--nologo",
                 "-f", "net6.0",
                 "-o", self.buildDirectory,

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -137,7 +137,7 @@ class Release:
                     flush("failed! (Is Dafny or the Dafny server running?)")
                     sys.exit(1)
                 else:
-                   flush("failed! (Retrying another %i time(s))" % MAX_RETRYS - i)
+                   flush("failed! (Retrying another %i time(s))" % (MAX_RETRYS - i))
         flush("done!")
 
     def build(self):


### PR DESCRIPTION
The `dotnet publish` command is somewhat flaky for us, which becomes a problem when it's part of 20 required tasks. To avoid a single failure blocking our builds, we will now retry a failed invocation up to two times.