### PR TITLE
Why do we disallow "decreases *" on function (methods)?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
-default: parser runtime boogie exe
+default: parser boogie exe
 
-all: runtime boogie exe refman
+all: boogie exe refman
 
 exe:
 	(cd ${DIR} ; dotnet build Source/Dafny.sln ) ## includes parser

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2244,7 +2244,7 @@ FunctionDecl<DeclModifierData dmod, out Function/*!*/ f>
   )
 
   (. decreases = isLeastPredicate || isGreatestPredicate ? null : new List<Expression/*!*/>(); .)
-  FunctionSpec<reqs, reads, ens, decreases>
+  FunctionSpec<reqs, reads, ens, decreases, !isFunctionMethod>
   (. IToken byMethodTok = null; BlockStmt byMethodBody = null; .)
   [ FunctionBody<out body, out bodyStart, out bodyEnd, out byMethodTok, out byMethodBody>
     (. if (byMethodBody != null) {
@@ -2304,7 +2304,7 @@ FunctionDecl<DeclModifierData dmod, out Function/*!*/ f>
   .
 
 /*------------------------------------------------------------------------*/
-FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!*/>/*!*/ reads, List<AttributedExpression/*!*/>/*!*/ ens, List<Expression/*!*/> decreases.>
+FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!*/>/*!*/ reads, List<AttributedExpression/*!*/>/*!*/ ens, List<Expression/*!*/> decreases, bool IsGhost.>
 = (. Contract.Requires(cce.NonNullElements(reqs));
      Contract.Requires(cce.NonNullElements(reads));
      Contract.Requires(decreases == null || cce.NonNullElements(decreases));
@@ -2319,7 +2319,7 @@ FunctionSpec<.List<AttributedExpression/*!*/>/*!*/ reqs, List<FrameExpression/*!
          decreases = new List<Expression/*!*/>();
        }
     .)
-    DecreasesClause<decreases, ref attrs, false, false>
+    DecreasesClause<decreases, ref attrs, !IsGhost, false>
   }
   .
 


### PR DESCRIPTION
I get that it's unsound, and arguably it's worth on methods than on functions, but we do allow `{:verify false}` on functions and function methods.

The problem with `{:verify false}` is that it disables too much; it would be nice to be able to turn off just termination checks.