### PR TITLE
fix: Fixed the escaper to simplify the plugin syntax

### DIFF
--- a/Source/DafnyLanguageServer.Test/Various/PluginsAdvancedTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/PluginsAdvancedTest.cs
@@ -19,7 +19,7 @@ public class PluginsAdvancedTest : PluginsTestBase {
     "PluginsAdvancedTest";
 
   protected override string[] CommandLineArgument =>
-    new[] { $@"--dafny:plugins:0=""{LibraryPath},force you""" };
+    new[] { $@"--dafny:plugins:0={LibraryPath},force you" };
 
   [TestMethod]
   public async Task EnsureErrorMessageCanBeComplexAndTakeIntoAccountConfiguration() {
@@ -35,7 +35,7 @@ method {:test} myMethodWrongName() {
     var resolutionReport = await DiagnosticReceiver.AwaitNextNotificationAsync(CancellationToken.None);
     Assert.AreEqual(documentItem.Uri, resolutionReport.Uri);
     var diagnostics = resolutionReport.Diagnostics.ToArray();
-    Assert.AreEqual(1, DafnyOptions.O.Plugins.Count, "Too many plugins loaded");
+    Assert.AreEqual(1, DafnyOptions.O.Plugins.Count, "Not exactly 1 plugin loaded");
     Assert.AreEqual(1, diagnostics.Length, LibraryPath + " did not raise an error.");
     Assert.AreEqual("Please declare a method {:test} named myMethod_test that will call myMethod, you", diagnostics[0].Message);
     Assert.AreEqual(new Range((1, 17), (1, 25)), diagnostics[0].Range);

--- a/Source/DafnyLanguageServer.Test/Various/PluginsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/PluginsTest.cs
@@ -18,7 +18,7 @@ public class PluginsTest : PluginsTestBase {
     "PluginsTest";
 
   protected override string[] CommandLineArgument =>
-    new[] { $@"--dafny:plugins:0=""{LibraryPath},\""because\\ whatever\""""" };
+    new[] { $@"--dafny:plugins:0={LibraryPath},""because\\ \""whatever""" };
 
   [TestMethod]
   public async Task EnsureItIsPossibleToLoadAPluginWithArguments() {
@@ -28,9 +28,9 @@ public class PluginsTest : PluginsTestBase {
     var resolutionReport = await DiagnosticReceiver.AwaitNextNotificationAsync(CancellationToken.None);
     Assert.AreEqual(documentItem.Uri, resolutionReport.Uri);
     var diagnostics = resolutionReport.Diagnostics.ToArray();
-    Assert.AreEqual(DafnyOptions.O.Plugins.Count, 1, "Too many plugins loaded");
+    Assert.AreEqual(DafnyOptions.O.Plugins.Count, 1, "Not exactly 1 plugin loaded");
     Assert.AreEqual(1, diagnostics.Length, LibraryPath + " did not raise an error.");
-    Assert.AreEqual("Impossible to continue because\\ whatever", diagnostics[0].Message);
+    Assert.AreEqual("Impossible to continue because\\ \"whatever", diagnostics[0].Message);
     Assert.AreEqual(new Range((0, 9), (0, 13)), diagnostics[0].Range);
   }
 

--- a/Source/DafnyLanguageServer/README.md
+++ b/Source/DafnyLanguageServer/README.md
@@ -79,12 +79,17 @@ Options provided through the command line have higher priority than the options 
 ### Plugins
 
 ```sh
-# Provides a path to assemblies and optional space-separated command-line arguments after a commo.
-# Easier to use via VSCode's Settings interface (no need to escape inner double quotes)
+# Provides a path to assemblies and optional space-separated command-line arguments after a comma.
 # Repeat with --dafny:plugins:0=... --dafny:plugins:1=... for multiple plugins.
---dafny:plugins:0=example.dll
---dafny:plugins:0=example2.dll,oneArgument
-"--dafny:plugins:0=\"example2.dll,\\\"firstArgument with space\\\" secondArgument\""
+--dafny:plugins:0=path\to\example.dll
+--dafny:plugins:0=path/to/example2.dll,oneArgument
+--dafny:plugins:0=example3.dll,"firstArgument with \" space and quote" secondArgument
+
+# On the command-line, you'd use the following escapes for the first and third examples:
+"--dafny:plugins:0=path\\to\\example.dll"
+"--dafny:plugins:0=example3.dll,\"firstArgument with \\\" space and quote\" secondArgument"
+
+# For just the dafny executable, replace `--dafny:plugins:X` by `--plugin:` that you can repeat.
 ```
 
 #### About plugins


### PR DESCRIPTION
This PR makes the plugin syntax with arguments and escape simpler by only unescaping plugin arguments.
It leaves to the caller the responsibility of providing the right arguments.