### PR TITLE
fix(lsp): Do not mark the bodies of lemmas as ghost.

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/GhostDiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/GhostDiagnosticsTest.cs
@@ -69,6 +69,25 @@ class C {
     }
 
     [TestMethod]
+    public async Task OpeningFlawlessDocumentOnlyContainingLemmasWithGhostMarkStatementsDoesNotMarkAnything() {
+      var source = @"
+class C {
+  lemma Test(x: int) {
+    var y := 0;
+    y := x;
+  }
+}".TrimStart();
+      await SetUp(new Dictionary<string, string>() {
+        { $"{GhostOptions.Section}:{nameof(GhostOptions.MarkStatements)}", "true" }
+      });
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var report = await diagnosticReceiver.AwaitNextNotificationAsync(CancellationToken);
+      var diagnostics = report.Diagnostics.ToArray();
+      Assert.AreEqual(0, diagnostics.Length);
+    }
+
+    [TestMethod]
     public async Task OpeningFlawlessDocumentWithGhostMarkStatementsMarksGhostVariableDeclarations() {
       var source = @"
 class C {

--- a/Source/DafnyLanguageServer/Language/GhostStateDiagnosticCollector.cs
+++ b/Source/DafnyLanguageServer/Language/GhostStateDiagnosticCollector.cs
@@ -47,6 +47,12 @@ namespace Microsoft.Dafny.LanguageServer.Language {
 
       public override void VisitUnknown(object node, IToken token) { }
 
+      public override void Visit(Method method) {
+        if (method is not Lemma) {
+          base.Visit(method);
+        }
+      }
+
       public override void Visit(Statement statement) {
         cancellationToken.ThrowIfCancellationRequested();
         if (IsGhostStatementToMark(statement)) {


### PR DESCRIPTION
Resolves https://github.com/dafny-lang/ide-vscode/issues/126 by explicitly excluding lemmas when traversing the AST to collect ghost statements.

Taking this a step further: Since @RustanLeino couldn't always reproduce the issue, I suspect there's more than just lemmas being highlighted.

I have two things in mind that could lead to the situation that the bug is not easily reproducible:
[GhostStateDiagnosticCollector](https://github.com/dafny-lang/dafny/blob/master/Source/DafnyLanguageServer/Language/GhostStateDiagnosticCollector.cs) runs even when the resolution failed. See [TextDocumentLoader](https://github.com/dafny-lang/dafny/blob/master/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs#L128-L129). The reported ghost statement in the AST might be incorrect due to this. The fix would be quite easy here: Only report ghost states for documents that resolved successfully. However, if that was the case, the error should surface not only within lemmas.

The other thing that might be worth a thought is the situation when the document moves into *migrated* state. That happens when the currently processed change is being canceled by a newer change. The language server then relocates the symbol table as well as the diagnostics according to this change (see [DocumentDatabase](https://github.com/dafny-lang/dafny/blob/master/Source/DafnyLanguageServer/Workspace/DocumentDatabase.cs#L139-L144)). We'd either need to relocate the ghost diagnostics or discard them. Otherwise, I believe they might show invalid locations.