### PR TITLE
chore: Try to download Z3 5 times instead of just once

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Upcoming
 
-- fix: Dafny with JavaScript target not producing any output on Windows (https://github.com/dafny-lang/dafny/pull/1824)
+- fix: No output when compiling to JavaScript on Windows (https://github.com/dafny-lang/dafny/pull/1824)
+
 
 # 3.4.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Upcoming
 
+- fix: Dafny with JavaScript target not producing any output on Windows (https://github.com/dafny-lang/dafny/pull/1824)
 
 # 3.4.1
 

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -24,6 +24,8 @@ import ntpath
 Z3_RELEASES_URL = "https://api.github.com/repos/Z3Prover/z3/releases/tags/Z3-4.8.5"
 ## How do we extract info from the name of a Z3 release file?
 Z3_RELEASE_REGEXP = re.compile(r"^(?P<directory>z3-[0-9a-z\.]+-(?P<platform>x86|x64)-(?P<os>[a-z0-9\.\-]+)).zip$", re.IGNORECASE)
+## How many times we allow ourselves to try to download Z3
+Z3_MAX_DOWNLOAD_ATTEMPTS = 5
 
 ## Allowed Dafny release names
 DAFNY_RELEASE_REGEX = re.compile("\\d+\\.\\d+\\.\\d+(-[\w\d_-]+)?$")
@@ -106,19 +108,16 @@ class Release:
             print("cached!")
         else:
             flush("downloading {:.2f}MB...".format(self.MB), end=' ')
-            maxTries = 5
-            while maxTries > 0:
+            for currentAttempt in range(Z3_MAX_DOWNLOAD_ATTEMPTS):
                 try:
                     with request.urlopen(self.url) as reader:
                         with open(self.z3_zip, mode="wb") as writer:
                             writer.write(reader.read())
-                    break
+                    flush("done!")
                 except (http.client.IncompleteRead) as e:
-                    maxTries -= 1
-                    if maxTries == 0:
+                    if currentAttempt == Z3_MAX_DOWNLOAD_ATTEMPTS - 1:
                         raise
-                    continue
-            flush("done!")
+            
 
     @staticmethod
     def zipify_path(fpath):

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -114,7 +114,7 @@ class Release:
                         with open(self.z3_zip, mode="wb") as writer:
                             writer.write(reader.read())
                     flush("done!")
-                except (http.client.IncompleteRead) as e:
+                except http.client.IncompleteRead as e:
                     if currentAttempt == Z3_MAX_DOWNLOAD_ATTEMPTS - 1:
                         raise
             

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -114,6 +114,7 @@ class Release:
                         with open(self.z3_zip, mode="wb") as writer:
                             writer.write(reader.read())
                     flush("done!")
+                    break
                 except http.client.IncompleteRead as e:
                     if currentAttempt == Z3_MAX_DOWNLOAD_ATTEMPTS - 1:
                         raise

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -116,7 +116,7 @@ class Release:
                 except (http.client.IncompleteRead) as e:
                     maxTries -= 1
                     if maxTries == 0:
-                        throw e
+                        raise
                     continue
             flush("done!")
 

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -106,9 +106,18 @@ class Release:
             print("cached!")
         else:
             flush("downloading {:.2f}MB...".format(self.MB), end=' ')
-            with request.urlopen(self.url) as reader:
-                with open(self.z3_zip, mode="wb") as writer:
-                    writer.write(reader.read())
+            maxTries = 5
+            while maxTries > 0:
+                try:
+                    with request.urlopen(self.url) as reader:
+                        with open(self.z3_zip, mode="wb") as writer:
+                            writer.write(reader.read())
+                    break
+                except (http.client.IncompleteRead) as e:
+                    maxTries -= 1
+                    if maxTries == 0:
+                        throw e;
+                    continue;
             flush("done!")
 
     @staticmethod

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -116,8 +116,8 @@ class Release:
                 except (http.client.IncompleteRead) as e:
                     maxTries -= 1
                     if maxTries == 0:
-                        throw e;
-                    continue;
+                        throw e
+                    continue
             flush("done!")
 
     @staticmethod


### PR DESCRIPTION
**Problem**
In one fo my last PR, the CI was not able to download Z3 in only 1 of the 15 instances.
This happens regularly (like, 1 time over 5) over an entire CI. Assuming that there are 10 runs every day, I don't want this problem to happen more than once a year.

**Solution**
With 5 tries, this problem will happen only 1 time every 3125, so that should get us covered.

**Original exception**

```
The date in version.cs does not agree with today's date: 40216 vs. 40215
12
The version number in version.cs does not agree with the given version: 0.0.0 vs. 3.4.1
13
Creating release files for release "0.0.0-CI" and internal version information: 3.4.1.40215
14
* Finding and downloading Z3 releases
15
  - Getting information about latest release
16
    + Selecting z3-4.8.5-x64-debian-8.11.zip (35.66MB, 35658053)
17
    + Selecting z3-4.8.5-x64-osx-10.14.2.zip (30.06MB, 30064624)
18
    + Selecting z3-4.8.5-x64-ubuntu-14.04.zip (34.44MB, 34441090)
19
    + Selecting z3-4.8.5-x64-ubuntu-16.04.zip (36.22MB, 36216249)
20
    + Selecting z3-4.8.5-x64-win.zip (14.11MB, 14112529)
21
    + Rejecting z3-4.8.5-x86-win.zip
22
  - Downloading 1 z3 archives
23
Traceback (most recent call last):
24
  File "/Users/runner/work/dafny/dafny/dafny/Scripts/package.py", line 302, in <module>
25
    main()
26
    + z3-4.8.5-x64-osx-10.14.2.zip: downloading 30.06MB... 
27
  File "/Users/runner/work/dafny/dafny/dafny/Scripts/package.py", line 296, in main
28
    download(releases)
29
  File "/Users/runner/work/dafny/dafny/dafny/Scripts/package.py", line 223, in download
30
    release.download()
31
  File "/Users/runner/work/dafny/dafny/dafny/Scripts/package.py", line 111, in download
32
    writer.write(reader.read())
33
  File "/Users/runner/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/http/client.py", line 481, in read
34
    s = self._safe_read(self.length)
35
  File "/Users/runner/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/http/client.py", line 632, in _safe_read
36
    raise IncompleteRead(data, amt-len(data))
37
http.client.IncompleteRead: IncompleteRead(8388608 bytes read, 21676016 more expected)
38
```