### PR TITLE
fix(lsp): Catch didChange errors as event/telemetry notifications

### DIFF
--- a/Source/DafnyLanguageServer/Workspace/ITelemetryPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/ITelemetryPublisher.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.Dafny.LanguageServer.Language;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.Dafny.LanguageServer.Workspace {
+  /// <summary>
+  /// Implementations of this interface are responsible to publish telemetry events
+  /// of a <see cref="DafnyDocument"/> to the LSP client.
+  /// </summary>
+  public interface ITelemetryPublisher {
+    protected enum TelemetryEventKind {
+      UpdateComplete,
+      UnhandledException
+    }
+
+    /// <summary>
+    /// Publish a telemetry event.
+    /// </summary>
+    /// <param name="kind">The kind of telemetry event.</param>
+    /// <param name="evt">The telemetry event.</param>
+    protected void PublishTelemetry(TelemetryEventKind kind, object? evt);
+
+    /// <summary>
+    /// Signal the completion of a document update.
+    /// </summary>
+    public void PublishUpdateComplete() {
+      PublishTelemetry(TelemetryEventKind.UpdateComplete, null);
+    }
+
+    /// <summary>
+    /// Signal an unhandled error.
+    /// </summary>
+    public void PublishUnhandledException(Exception e) {
+      PublishTelemetry(TelemetryEventKind.UnhandledException, e.ToString());
+    }
+  }
+}

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         .AddSingleton<IRelocator, Relocator>()
         .AddSingleton<ISymbolGuesser, SymbolGuesser>()
         .AddSingleton<ICompilationStatusNotificationPublisher, CompilationStatusNotificationPublisher>()
-        .AddSingleton<IDiagnosticPublisher, DiagnosticPublisher>();
+        .AddSingleton<ITelemetryPublisher, TelemetryPublisher>();
     }
 
     private static TextDocumentLoader CreateTextDocumentLoader(IServiceProvider services) {

--- a/Source/DafnyLanguageServer/Workspace/TelemetryPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/TelemetryPublisher.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Dafny.LanguageServer.Util;
+using Microsoft.Dafny.LanguageServer.Workspace.Notifications;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System.Collections.Generic;
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace Microsoft.Dafny.LanguageServer.Workspace {
+  public class TelemetryPublisher : ITelemetryPublisher {
+    private readonly ILanguageServerFacade languageServer;
+
+    public TelemetryPublisher(ILanguageServerFacade languageServer) {
+      this.languageServer = languageServer;
+    }
+
+    void ITelemetryPublisher.PublishTelemetry(ITelemetryPublisher.TelemetryEventKind kind, object? evt) {
+      languageServer.Window.SendTelemetryEvent(new TelemetryEventParams() {
+        ExtensionData = new Dictionary<string, object> {
+          {"kind", kind.ToString()},
+          {"data", evt ?? new Dictionary<string, object>()}
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
Previously errors were caught in a try/catch block in `HandleUpdateAndPublishDiagnostics`, but this stopped being the case after https://github.com/dafny-lang/dafny/pull/1666.

The event/telemetry notification is useful for debugging, and maybe that's in fact what we should use instead of the current custom notifications?


FWIW, I think that the current code is as safe as the previous one, but I'm not sure that it's actually safe; see the FIXME that I added.