### PR TITLE
Fix: Lower C# runtime version to 7.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 - feat: The keyword syntax for functions will change in Dafny version 4. The new command-line option `/functionSyntax` (see `/help`) allows early adoption of the new syntax. (https://github.com/dafny-lang/dafny/pull/1832)
 - fix: No warning "File contains no code" if a file only contains a submodule (https://github.com/dafny-lang/dafny/pull/1840)
 - fix: export-reveals of function-by-method now allows the function body to be ghost (https://github.com/dafny-lang/dafny/pull/1855)
+- fix: Dafnyruntime's c# language version explicitly set to 7.1 to stay backward compatible. (https://github.com/dafny-lang/dafny/pull/1877)
 
 
 # 3.4.2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 - feat: The keyword syntax for functions will change in Dafny version 4. The new command-line option `/functionSyntax` (see `/help`) allows early adoption of the new syntax. (https://github.com/dafny-lang/dafny/pull/1832)
 - fix: No warning "File contains no code" if a file only contains a submodule (https://github.com/dafny-lang/dafny/pull/1840)
 - fix: export-reveals of function-by-method now allows the function body to be ghost (https://github.com/dafny-lang/dafny/pull/1855)
-- fix: Regain C# 7.1 compatibility of the compiled code. (https://github.com/dafny-lang/dafny/pull/1877)
+- fix: Regain C# 7.3 compatibility of the compiled code. (https://github.com/dafny-lang/dafny/pull/1877)
 
 
 # 3.4.2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 - feat: The keyword syntax for functions will change in Dafny version 4. The new command-line option `/functionSyntax` (see `/help`) allows early adoption of the new syntax. (https://github.com/dafny-lang/dafny/pull/1832)
 - fix: No warning "File contains no code" if a file only contains a submodule (https://github.com/dafny-lang/dafny/pull/1840)
 - fix: export-reveals of function-by-method now allows the function body to be ghost (https://github.com/dafny-lang/dafny/pull/1855)
-- fix: Dafnyruntime's c# language version explicitly set to 7.1 to stay backward compatible. (https://github.com/dafny-lang/dafny/pull/1877)
+- fix: Regain C# 7.1 compatibility of the compiled code. (https://github.com/dafny-lang/dafny/pull/1877)
 
 
 # 3.4.2

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -1199,7 +1199,7 @@ namespace Dafny {
 
       while (toVisit.Count != 0) {
         var seq = toVisit.Pop();
-        if (seq is ConcatSequence<T> { elmts: { IsDefault: true } } cs) {
+        if (seq is ConcatSequence<T> cs && cs.elmts.IsDefault) {
           (leftBuffer, rightBuffer) = (cs.left, cs.right);
           if (cs.left == null || cs.right == null) {
             // !cs.elmts.IsDefault, due to concurrent enumeration

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -9,7 +9,7 @@
       <PackageVersion>1.1.0</PackageVersion>
       <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
-      <LangVersion>7.1</LangVersion>
+      <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -9,6 +9,7 @@
       <PackageVersion>1.1.0</PackageVersion>
       <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
+      <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR enforces the runtime c# version to be 7.3 for now.

Fixes #1873

I added an explicit versioning for the c# language in the DafnyRuntime.csproj, which detected advanced features and led me to revert those to usual features. That way, we can stay backward compatible longer.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
