### PR TITLE
fix(compiler): Add parentheses around C# casts to fix #1714

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 - fix: Regain C# 7.3 compatibility of the compiled code. (https://github.com/dafny-lang/dafny/pull/1877)
 - fix: The error "assertion violation" is replaced by the better wording "assertion might not hold". This indicates better that the verifier is unable to prove the assertion. (https://github.com/dafny-lang/dafny/pull/1862)
 
+
 # 3.4.2
 
 - fix: No output when compiling to JavaScript on Windows (https://github.com/dafny-lang/dafny/pull/1824)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Upcoming
 
+- fix: Miscompilation due to incorrect parenthesization in C# output for casts. (#1908)
+
 # 3.5.0
 
 - feat: `continue` statements. Like Dafny's `break` statements, these come in two forms: one that uses a label to name the continue target and one that specifies the continue target by nesting level. See section [19.2](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-break-continue) of the Reference Manual. (https://github.com/dafny-lang/dafny/pull/1839)
@@ -10,7 +12,6 @@
 - fix: export-reveals of function-by-method now allows the function body to be ghost (https://github.com/dafny-lang/dafny/pull/1855)
 - fix: Regain C# 7.3 compatibility of the compiled code. (https://github.com/dafny-lang/dafny/pull/1877)
 - fix: The error "assertion violation" is replaced by the better wording "assertion might not hold". This indicates better that the verifier is unable to prove the assertion. (https://github.com/dafny-lang/dafny/pull/1862)
-
 
 # 3.4.2
 

--- a/Source/Dafny/Compilers/Compiler-Csharp.cs
+++ b/Source/Dafny/Compilers/Compiler-Csharp.cs
@@ -1479,7 +1479,7 @@ namespace Microsoft.Dafny.Compilers {
         if (Attributes.ContainsBool(cl.Attributes, "handle", ref isHandle) && isHandle) {
           return "0";
         } else {
-          return $"({TypeName(xType, wr, udt.tok)})null";
+          return $"(({TypeName(xType, wr, udt.tok)})null)";
         }
       } else if (cl is DatatypeDecl dt) {
         var s = FullTypeName(udt, ignoreInterface: true);
@@ -2583,7 +2583,7 @@ namespace Microsoft.Dafny.Compilers {
 
       var w = new ConcreteSyntaxTree();
       if (to.IsRefType) {
-        wr.Format($"({TypeName(to, wr, tok)})({w})");
+        wr.Format($"(({TypeName(to, wr, tok)})({w}))");
       } else {
         Contract.Assert(Type.SameHead(from, to));
 

--- a/Test/git-issues/git-issue-1714.dfy
+++ b/Test/git-issues/git-issue-1714.dfy
@@ -1,0 +1,16 @@
+// RUN: %dafny /compile:4 /compileTarget:cs "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+trait Base {}
+class Derived extends Base { var n: int; constructor() { n := 0; } }
+
+method f(b: Base) {
+  if (b is Derived) {
+    print "(b as Derived).n == ", (b as Derived).n, "\n";
+  }
+}
+
+method Main() {
+  var d := new Derived();
+  f(d);
+}

--- a/Test/git-issues/git-issue-1714.dfy.expect
+++ b/Test/git-issues/git-issue-1714.dfy.expect
@@ -1,0 +1,5 @@
+
+Dafny program verifier finished with 2 verified, 0 errors
+Running...
+
+(b as Derived).n == 0

--- a/Test/git-issues/git-issue-1714.dfy.expect
+++ b/Test/git-issues/git-issue-1714.dfy.expect
@@ -1,5 +1,3 @@
 
 Dafny program verifier finished with 2 verified, 0 errors
-Running...
-
 (b as Derived).n == 0


### PR DESCRIPTION
Fixes #1714
