### PR TITLE
fix: Populate TestResult.ResourceCount for assertion batches

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Upcoming
 
 - fix: Miscompilation due to incorrect parenthesization in C# output for casts. (#1908)
+- fix: Populate TestResult.ResourceCount in `/verificationLogger:csv` output correctly when verification condition splitting occurs (e.g. when using `/vcsSplitOnEveryAssert`).
 
 # 3.5.0
 

--- a/Source/DafnyDriver/BoogieXmlConvertor.cs
+++ b/Source/DafnyDriver/BoogieXmlConvertor.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Dafny {
                                             .OfType<XElement>()
                                             .Single(n => n.Name.LocalName == "conclusion");
       var duration = float.Parse(conclusionNode.Attribute("duration")!.Value);
+      var resourceCount = conclusionNode.Attribute("resourceCount")?.Value;
       var outcome = conclusionNode.Attribute("outcome")!.Value;
 
       var testCase = TestCaseForEntry(currentFileFragment, name);
@@ -150,6 +151,10 @@ namespace Microsoft.Dafny {
         StartTime = DateTimeOffset.Parse(startTime),
         Duration = TimeSpan.FromMilliseconds((long)(duration * 1000))
       };
+
+      if (resourceCount != null) {
+        testResult.SetPropertyValue(ResourceCountProperty, int.Parse(resourceCount));
+      }
 
       if (outcome == "valid") {
         testResult.Outcome = TestOutcome.Passed;

--- a/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
+++ b/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
@@ -18,7 +18,7 @@ namespace XUnitExtensions.Lit {
   }
 
   public readonly record struct OutputCheckCommand(OutputCheckOptions options) : ILitCommand {
-    
+
     private abstract record CheckDirective(string File, int LineNumber) {
 
     private static readonly Dictionary<string, Func<string, int, string, CheckDirective>> DirectiveParsers = new();
@@ -100,7 +100,7 @@ namespace XUnitExtensions.Lit {
       return $"CheckLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
     }
   }
-  
+
   private record CheckNextLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
     public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
       return new CheckNextLiteral(file, lineNumber, arguments);
@@ -127,7 +127,7 @@ namespace XUnitExtensions.Lit {
       Wrapped = wrapped;
       Check = check;
     }
-    
+
     public bool MoveNext() {
       var result = Wrapped.MoveNext();
       if (result) {
@@ -146,7 +146,7 @@ namespace XUnitExtensions.Lit {
 
     public void Dispose() => Wrapped.Dispose();
   }
-  
+
   private record CheckNotRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
     public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
       return new CheckNotRegexp(file, lineNumber, new Regex(arguments));
@@ -176,7 +176,7 @@ namespace XUnitExtensions.Lit {
       return $"CheckNotLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
     }
   }
-  
+
   public static ILitCommand Parse(IEnumerable<string> args, LitTestConfiguration config) {
     ILitCommand? result = null;
     Parser.Default.ParseArguments<OutputCheckOptions>(args).WithParsed(o => {

--- a/Test/logger/CSVLogger.dfy
+++ b/Test/logger/CSVLogger.dfy
@@ -2,7 +2,12 @@
 // RUN: %OutputCheck --file-to-check "%t.csv" "%s"
 
 // CHECK: TestResult\.DisplayName,TestResult\.Outcome,TestResult\.Duration,TestResult\.ResourceCount
+// The CHECK-NOT directives are a regression test: previously the BoogieXmlConvertor
+// wasn't populating the resource count test result property, and the CSV logger was
+// defaulting to 0 for that column.
+// CHECK-NOT: Impl\$\$_module.__default\.ExampleWithSplits\$\$.*,Passed,.*,0
 // CHECK-NEXT: Impl\$\$_module.__default\.ExampleWithSplits\$\$1,Passed,.*,.*
+// CHECK-NOT: Impl\$\$_module.__default\.ExampleWithSplits\$\$.*,Passed,.*,0
 
 method ExampleWithSplits() returns (y: int)
   ensures y >= 0


### PR DESCRIPTION
Also add support for CHECK-NOT[-L] OutputCheck directives, and use them to add a regression test.

Also address the fact that CHECK-NEXT[-L] directives were never implemented, so their use was silently doing nothing. :(

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
