### PR TITLE
Chore: More assertions explained

### DIFF
--- a/docs/DafnyRef/Expressions.md
+++ b/docs/DafnyRef/Expressions.md
@@ -1344,7 +1344,7 @@ selected by the ``DotSuffix`` is generic), or
   or colemma. The result is the result of calling the prefix copredicate
   or colemma.
 
-### 20.42.2. Datatype Update Suffix
+### 20.42.2. Datatype Update Suffix {#sec-datatype-update-suffix}
 
 ````grammar
 DatatypeUpdateSuffix_ =

--- a/docs/DafnyRef/Specifications.md
+++ b/docs/DafnyRef/Specifications.md
@@ -350,7 +350,7 @@ elements---one could imagine
 Also, ``FrameField`` is not taken into consideration for
 lambda expressions.
 
-### 5.1.5. Reads Clause
+### 5.1.5. Reads Clause {#sec-reads-clause}
 ````grammar
 ReadsClause(allowLemma, allowLambda, allowWild) =
   "reads"
@@ -392,7 +392,7 @@ read.
 
 TO BE WRITTEN: multiset of objects allowed in reads clauses
 
-### 5.1.6. Modifies Clause
+### 5.1.6. Modifies Clause {#sec-modifies-clause}
 
 ````grammar
 ModifiesClause(allowLambda) =
@@ -441,7 +441,7 @@ interprets JML's `assigns/modifies` in sense (b).
 ACSL and ACSL++ use the `assigns` keyword, but with _modify_ (b) semantics.
 Ada/SPARK's dataflow contracts encode _write_ (a) semantics.
 
-### 5.1.7. Invariant Clause
+### 5.1.7. Invariant Clause {#sec-invariant-clause}
 ````grammar
 InvariantClause_ =
   "invariant" { Attribute }

--- a/docs/DafnyRef/Statements.md
+++ b/docs/DafnyRef/Statements.md
@@ -862,7 +862,7 @@ method M1() returns (ghost y: int)
 }
 ```
 
-## 19.11. If Statement
+## 19.11. If Statement {#sec-if-statement}
 ````grammar
 IfStmt = "if"
   ( AlternativeBlock(allowBindingGuards: true)
@@ -1188,7 +1188,7 @@ loop condition). Just as Dafny will not discover properties of a method
 on its own, it will not know that any but the most basic properties of a loop
 are preserved unless it is told via an invariant.
 
-### 19.14.2. Loop termination
+### 19.14.2. Loop termination {#sec-loop-termination}
 
 Dafny proves that code terminates, i.e. does not loop forever, by using
 `decreases` annotations. For many things, Dafny is able to guess the right

--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -319,7 +319,7 @@ function `as real` from `int` to `real`, as described in
 
 TODO: Need syntax for real literals with exponents
 
-## 7.3. Bit-vector Types
+## 7.3. Bit-vector Types {#sec-bit-vector-types}
 ````grammar
 BitVectorType_ = bvToken
 ````
@@ -2299,7 +2299,7 @@ See [Section 23.5.3](#sec-friendliness) for descriptions
 of inductive predicates and lemmas.
 
 <!--PDF NEWPAGE-->
-# 14. Trait Types
+# 14. Trait Types {#sec-trait-types}
 ````grammar
 TraitDecl =
   "trait" { Attribute } ClassName [ GenericParameters ]
@@ -3103,7 +3103,7 @@ var pair: (int, ghost int) := (1, ghost 2);
 ```
 
 <!--PDF NEWPAGE-->
-# 18. Algebraic Datatypes
+# 18. Algebraic Datatypes {#sec-algebraic-datatype}
 
 ````grammar
 DatatypeDecl =

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -324,21 +324,21 @@ For every method (or function, constructor, etc.), Dafny extracts _assertions_. 
 **Integer assertions:**
 
 * Every [division](#sec-numeric-types) yields an _assertion_ that the divisor is never zero.
-* Every [bounded number operation](#sec-numeric-types) yields an _assertion_ that the result will have the same bounds (no overflow, no underflows).
-* Every [conversion](#sec-as-expression) yields an _assertion_ that conversion is compatible
+* Every [bounded number operation](#sec-numeric-types) yields an _assertion_ that the result will be within the same bounds (no overflow, no underflows).
+* Every [conversion](#sec-as-expression) yields an _assertion_ that conversion is compatible.
 * Every [bitvector shift](#sec-bit-vector-types) yields an _assertion_ that the shift amount is never negative, and that the shift amount is within the width of the value.
 
 **Object assertions:**
 
-* Every [object property access](#sec-class-types) yields an _assertion_ that the object is not null
-* Every assignment `o.f := E;` yield an _assertion_ that `o` is among the set of objects of the enclosing [`modifies`](#sec-loop-framing) clause in loops, or the enclosing [`modifies`](#sec-modifies-clause) clause on methods.
-* Every read `o.f` yield an _assertion_ that `o` is among the set of objects of the enclosing [`reads`](#sec-reads-clause) clause on functions and predicates, or the enclosing [`modifies`](#sec-modifies-clause) clause on methods
-* Every [array access](#sec-array-types) `a[x]` yield the assertion that `0 <= x < a.Length`
+* Every [object property access](#sec-class-types) yields an _assertion_ that the object is not null.
+* Every assignment `o.f := E;` yield an _assertion_ that `o` is among the set of objects of the `modifies` clause of the enclosing [loop](#sec-loop-framing) or [method](#sec-modifies-clause).
+* Every read `o.f` yield an _assertion_ that `o` is among the set of objects of the [`reads`](#sec-reads-clause) clause of the enclosing function or predicate; or the enclosing [`modifies`](#sec-modifies-clause) clause of the enclosing method.
+* Every [array access](#sec-array-types) `a[x]` yield the assertion that `0 <= x < a.Length`.
 * Every [sequence access](#sec-sequences) `a[x]` yield an _assertion_, that `0 <= x < |a|`, because sequences are never null.
 * Every [datatype update expression](#sec-datatype-update-suffix) and [datatype destruction](#sec-algebraic-datatype) yields an _assertion_ that the object has the given property.
-* Every method overriding a [`trait`](#sec-trait-types) yield an _assertion_ that it provides a postcondition equal to or more detailed than in its parent trait, and an _assertion_ that it provides a precondition equal to or more permissive than in its parent trait.
+* Every method overriding a [`trait`](#sec-trait-types) yield an _assertion_ that any postcondition it provides is equal to or more detailed than in its parent trait, and an _assertion_ that any precondition it provides is equal to or more permissive than in its parent trait.
 
-**Implicit assertions:**
+**Other implicit assertions:**
 
 * Every value whose type is assigned to a [subset type](#sec-subset-types) yields an _assertion_ that it satisfies the subset type constraint.
 * Every non-empty [subset type](#sec-subset-types) yields an _assertion_ that its witness satisfies the constraint.

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -301,7 +301,7 @@ This list is not exhaustive but can definitely be useful to provide the next ste
  <br><br><br><br><br>`assert forall x :: P(x) ==> Q(x);` | [`forall x | P(x)`](#sec-forall-statement)<br>&nbsp;&nbsp;`  ensures Q(x)`<br>`{`<br>&nbsp;&nbsp;`  assert Q(x);`<br>`};`<br>` assert forall x :: P(x) ==> Q(x);`
  <br>`assert exists x :: P(x);`<br> | `assert P(x0);`<br>`assert exists x :: P(x);`<br>for a given expression `x0`.
  <br>`ensures exists i :: P(i);`<br> | `returns (j: int)`<br>`ensures P(j) ensures exists i :: P(i)`<br>in a lemma, so that the `j` can be computed explicitly.
- <br><br>`assert A == B;`<br>`callLemma(x);`<br>`assert B == C;`<br> | [`calc == {`](#sec-calc-statement)<br>&nbsp;&nbsp;`  A;`<br>&nbsp;&nbsp;`  B;`<br>&nbsp;&nbsp;`  { callLemma(x); }`<br>&nbsp;&nbsp;`  C;`<br>`};`<br>`assert A == B;`<br>where the [calc statement](#sec-calc-statement) can be used to make intermediate computation steps explicit. Works with `<`, `>`, `<=`, `>=`, `==>`, `<==` and `<==>` for example.
+ <br><br>`assert A == B;`<br>`callLemma(x);`<br>`assert B == C;`<br> | [`calc == {`](#sec-calc-statement)<br>&nbsp;&nbsp;`  A;`<br>&nbsp;&nbsp;`  B;`<br>&nbsp;&nbsp;`  { callLemma(x); }`<br>&nbsp;&nbsp;`  C;`<br>`};`<br>`assert A == B;`<br>where the [`calc`](#sec-calc-statement) statement can be used to make intermediate computation steps explicit. Works with `<`, `>`, `<=`, `>=`, `==>`, `<==` and `<==>` for example.
  <br><br><br>`assert A ==> B;` | `if A {`<br>&nbsp;&nbsp;`  assert B;`<br>`};`<br>`assert A ==> B;`
  <br><br>`assert A && B;` | `assert A;`<br>`assert B;`<br>`assert A && B;`
  <br>`assert P(x);`<br>where `P` is an [`{:opaque}`](#sec-opaque) predicate | [`reveal P();`](#sec-reveal-statement)<br>`assert P(x);`<br><br>
@@ -319,17 +319,45 @@ This list is not exhaustive but can definitely be useful to provide the next ste
 To understand how to control verification,
 it is first useful to understand how Dafny verifies functions and methods.
 
-For every method (or function, constructor, etc.), Dafny extracts _assertions_, for example:
+For every method (or function, constructor, etc.), Dafny extracts _assertions_. Here is a non-exhaustive list of such extracted assertions:
 
-* any explicit [`assert` statement](#sec-assert-statement) is _an assertion_[^precision-requires-clause].
-* A consecutive pair of lines in a [`calc` statement](#sec-calc-statement) forms _an assertion_ that the expressions are related according to the common operator.
-* Every call to a function or method with a [`requires` clause](#sec-requires-clause) yields _one assertion per requires clause_[^precision-requires-clause]
-  (special cases such as sequence indexing come with a special require clause that the index is within bounds).
-* Assignments `o.f := E;` yield an _assertion_ that `o.f` is allowed by the enclosing [`modifies` clause](#sec-loop-framing).
-* [Assign-such-that operators](#sec-update-and-call-statement) `x :| P(x)` yield an _assertion_ that `exists x :: P(x)`.
-* Every [`ensures` clause](#sec-ensures-clause) yields an _assertion_ at the end of the method and on every return.
-* Every [`decreases` clause](#sec-decreases-clause) yields an _assertion_ at either a call site or at the end of a while loop.
+**Integer assertions:**
+
+* Every [division](#sec-numeric-types) yields an _assertion_ that the divisor is never zero.
+* Every [bounded number operation](#sec-numeric-types) yields an _assertion_ that the result will have the same bounds (no overflow, no underflows).
+* Every [conversion](#sec-as-expression) yields an _assertion_ that conversion is compatible
+* Every [bitvector shift](#sec-bit-vector-types) yields an _assertion_ that the shift amount is never negative, and that the shift amount is within the width of the value.
+
+**Object assertions:**
+
+* Every [object property access](#sec-class-types) yields an _assertion_ that the object is not null
+* Every assignment `o.f := E;` yield an _assertion_ that `o` is among the set of objects of the enclosing [`modifies`](#sec-loop-framing) clause in loops, or the enclosing [`modifies`](#sec-modifies-clause) clause on methods.
+* Every read `o.f` yield an _assertion_ that `o` is among the set of objects of the enclosing [`reads`](#sec-reads-clause) clause on functions and predicates, or the enclosing [`modifies`](#sec-modifies-clause) clause on methods
+* Every [array access](#sec-array-types) `a[x]` yield the assertion that `0 <= x < a.Length`
+* Every [sequence access](#sec-sequences) `a[x]` yield an _assertion_, that `0 <= x < |a|`, because sequences are never null.
+* Every [datatype update expression](#sec-datatype-update-suffix) and [datatype destruction](#sec-algebraic-datatype) yields an _assertion_ that the object has the given property.
+* Every method overriding a [`trait`](#sec-trait-types) yield an _assertion_ that it provides a postcondition equal to or more detailed than in its parent trait, and an _assertion_ that it provides a precondition equal to or more permissive than in its parent trait.
+
+**Implicit assertions:**
+
+* Every value whose type is assigned to a [subset type](#sec-subset-types) yields an _assertion_ that it satisfies the subset type constraint.
 * Every non-empty [subset type](#sec-subset-types) yields an _assertion_ that its witness satisfies the constraint.
+* [Assign-such-that operators](#sec-update-and-call-statement) `x :| P(x)` yield an _assertion_ that `exists x :: P(x)`.
+* Every recursive function yield an _assertion_ that [it terminates](#sec-loop-termination).
+* Every [match expression](#sec-match-expression) or [alternative if statement](#sec-if-statement) yield an _assertion_ that all cases are covered.
+
+**Explicit assertions:**
+
+* Any explicit [`assert`](#sec-assert-statement) statement is _an assertion_[^precision-requires-clause].
+* A consecutive pair of lines in a [`calc`](#sec-calc-statement) statement forms _an assertion_ that the expressions are related according to the common operator.
+* Every call to a function or method with a [`requires`](#sec-requires-clause) clause yields _one assertion per requires clause_[^precision-requires-clause]
+  (special cases such as sequence indexing come with a special require clause that the index is within bounds).
+* Every [`ensures`](#sec-ensures-clause) clause yields an _assertion_ at the end of the method and on every return, and on [`forall`](#sec-forall-statement) statements.
+* Every [`invariant`](#sec-invariant-clause) clause yields an _assertion_ that it holds before the loop and an _assertion_ that it holds at the end of the loop.
+* Every [`decreases`](#sec-decreases-clause) clause yields an _assertion_ at either a call site or at the end of a while loop.
+* Every [`yield ensures`](#sec-iterator-specification) clause on [iterator](#sec-iterator-types) yield _assertions_ that the clause hold at every yielding point.
+* Every [`yield requires`](#sec-iterator-specification) clause on [iterator](#sec-iterator-types) yield _assertions_ that the clause hold at every point when the iterator is called.
+
 
 [^precision-requires-clause]: Dafny actually breaks things down further. For example, a precondition `requires A && B` or an assert statement `assert A && B;` turns into two assertions, more or less like `requires A requires B` and `assert A; assert B;`.
 

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -332,7 +332,7 @@ For every method (or function, constructor, etc.), Dafny extracts _assertions_. 
 
 * Every [object property access](#sec-class-types) yields an _assertion_ that the object is not null.
 * Every assignment `o.f := E;` yield an _assertion_ that `o` is among the set of objects of the `modifies` clause of the enclosing [loop](#sec-loop-framing) or [method](#sec-modifies-clause).
-* Every read `o.f` yield an _assertion_ that `o` is among the set of objects of the [`reads`](#sec-reads-clause) clause of the enclosing function or predicate; or the enclosing [`modifies`](#sec-modifies-clause) clause of the enclosing method.
+* Every read `o.f` yield an _assertion_ that `o` is among the set of objects of the [`reads`](#sec-reads-clause) clause of the enclosing function or predicate; or the [`modifies`](#sec-modifies-clause) clause of the enclosing method.
 * Every [array access](#sec-array-types) `a[x]` yield the assertion that `0 <= x < a.Length`.
 * Every [sequence access](#sec-sequences) `a[x]` yield an _assertion_, that `0 <= x < |a|`, because sequences are never null.
 * Every [datatype update expression](#sec-datatype-update-suffix) and [datatype destruction](#sec-algebraic-datatype) yields an _assertion_ that the object has the given property.


### PR DESCRIPTION
After reviewing carefully #1915 , I figured out we ought to add more descriptions of common assertions that Dafny verifies, especially those that most programmers are used to (i.e. division by zero, object not null) in first position.
This will increase the understanding about what Dafny will check, and can also serve as an entry point to visit relevant sections in the manual.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
