### PR TITLE
Bounded pool for not in

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 - fix: Miscompilation due to incorrect parenthesization in C# output for casts. (#1908)
 - fix: Populate TestResult.ResourceCount in `/verificationLogger:csv` output correctly when verification condition splitting occurs (e.g. when using `/vcsSplitOnEveryAssert`).
+- fix: Fix malformed Java code generated for comprehensions that use maps
+- feat: Recognize `!in` operator when looking for compilable comprehensions
 
 # 3.5.0
 

--- a/Source/Dafny/Compilers/SinglePassCompiler.cs
+++ b/Source/Dafny/Compilers/SinglePassCompiler.cs
@@ -3313,7 +3313,8 @@ namespace Microsoft.Dafny.Compilers {
       } else if (bound is ComprehensionExpr.MapBoundedPool) {
         var b = (ComprehensionExpr.MapBoundedPool)bound;
         TrParenExpr(su.Substitute(b.Map), collectionWriter, inLetExprBody);
-        collectionWriter.Write(".Keys{0}.Elements{0}", propertySuffix);
+        GetSpecialFieldInfo(SpecialField.ID.Keys, null, null, out var keyName, out _, out _);
+        collectionWriter.Write($".{keyName}.Elements{propertySuffix}");
       } else if (bound is ComprehensionExpr.SeqBoundedPool) {
         var b = (ComprehensionExpr.SeqBoundedPool)bound;
         TrParenExpr(su.Substitute(b.Seq), collectionWriter, inLetExprBody);

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -17736,6 +17736,26 @@ namespace Microsoft.Dafny {
             newROp = polarity ? BinaryExpr.ResolvedOpcode.NeqCommon : BinaryExpr.ResolvedOpcode.EqCommon;
             swapOperands = false;
             break;
+          case BinaryExpr.ResolvedOpcode.NotInSet:  // A !in B         yield polarity ? (A !in B) : (A in B);
+            newOp = polarity ? BinaryExpr.Opcode.NotIn : BinaryExpr.Opcode.In;
+            newROp = polarity ? BinaryExpr.ResolvedOpcode.NotInSet : BinaryExpr.ResolvedOpcode.InSet;
+            swapOperands = false;
+            break;
+          case BinaryExpr.ResolvedOpcode.NotInSeq:  // A !in B         yield polarity ? (A !in B) : (A in B);
+            newOp = polarity ? BinaryExpr.Opcode.NotIn : BinaryExpr.Opcode.In;
+            newROp = polarity ? BinaryExpr.ResolvedOpcode.NotInSeq : BinaryExpr.ResolvedOpcode.InSeq;
+            swapOperands = false;
+            break;
+          case BinaryExpr.ResolvedOpcode.NotInMultiSet:  // A !in B         yield polarity ? (A !in B) : (A in B);
+            newOp = polarity ? BinaryExpr.Opcode.NotIn : BinaryExpr.Opcode.In;
+            newROp = polarity ? BinaryExpr.ResolvedOpcode.NotInMultiSet : BinaryExpr.ResolvedOpcode.InMultiSet;
+            swapOperands = false;
+            break;
+          case BinaryExpr.ResolvedOpcode.NotInMap:  // A !in B         yield polarity ? (A !in B) : (A in B);
+            newOp = polarity ? BinaryExpr.Opcode.NotIn : BinaryExpr.Opcode.In;
+            newROp = polarity ? BinaryExpr.ResolvedOpcode.NotInMap : BinaryExpr.ResolvedOpcode.InMap;
+            swapOperands = false;
+            break;
           default:
             goto JUST_RETURN_IT;
         }

--- a/Test/comp/Comprehensions.dfy
+++ b/Test/comp/Comprehensions.dfy
@@ -1,7 +1,8 @@
-// RUN: %dafny /compile:3 /spillTargetCode:2 /compileTarget:cs "%s" > "%t"
-// RUN: %dafny /compile:3 /spillTargetCode:2 /compileTarget:js "%s" >> "%t"
-// RUN: %dafny /compile:3 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"
-// RUN: %dafny /compile:3 /spillTargetCode:2 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:java "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 method Main() {
@@ -9,6 +10,7 @@ method Main() {
   LetSuchThat();
   Quantifier();
   MapComprehension();
+  TestCollectionEmptiness();
   OutParamsUnderLambdas();  // white-box testing
   AltControlFlow();
   Sequences();
@@ -64,6 +66,39 @@ method MapComprehension() {
   m := map x | 12 <= x < 15 :: FourMore(x) := x;
   print m, "\n";
 }
+
+method TestCollectionEmptiness() {
+  var a, b, c, d;
+  a, b, c, d := {2, 4}, multiset{4, 4, 1}, [0, 9, 0], map[13 := 26];
+  PrintCollectionEmptiness(a, b, c, d);
+  a, b, c, d := {}, multiset{}, [], map[];
+  PrintCollectionEmptiness(a, b, c, d);
+}
+
+method PrintCollectionEmptiness<X(==)>(a: set<X>, b: multiset<X>, c: seq<X>, d: map<X, int>) {
+  var r0, r1;
+  // set
+  r0 := forall x :: !(x in a);
+  r1 := forall x :: x !in a;
+  expect r0 == r1;
+  print r0, " ";
+  // multiset
+  r0 := forall x :: !(x in b);
+  r1 := forall x :: x !in b;
+  expect r0 == r1;
+  print r0, " ";
+  // seq
+  r0 := forall x :: !(x in c);
+  r1 := forall x :: x !in c;
+  expect r0 == r1;
+  print r0, " ";
+  // map
+  r0 := forall x :: !(x in d);
+  r1 := forall x :: x !in d;
+  expect r0 == r1;
+  print r0, "\n";
+}
+
 
 method OutParamsUnderLambdas() {
   var x, b := XP();

--- a/Test/comp/Comprehensions.dfy.expect
+++ b/Test/comp/Comprehensions.dfy.expect
@@ -1,11 +1,15 @@
 
-Dafny program verifier finished with 26 verified, 0 errors
+Dafny program verifier finished with 27 verified, 0 errors
+
+Dafny program verifier did not attempt verification
 x=13 y=14
 x=13 y=14 b=yes
 true false
 true false
 map[12 := 6, 13 := 6, 14 := 7]
 map[16 := 12, 17 := 13, 18 := 14]
+false false false false
+true true true true
 XP returned: 0 false
 after: 0 before: 0
 after: 2 before: 2
@@ -57,13 +61,15 @@ false true
 true true
 3
 
-Dafny program verifier finished with 26 verified, 0 errors
+Dafny program verifier did not attempt verification
 x=13 y=14
 x=13 y=14 b=yes
 true false
 true false
 map[12 := 6, 13 := 6, 14 := 7]
 map[16 := 12, 17 := 13, 18 := 14]
+false false false false
+true true true true
 XP returned: 0 false
 after: 0 before: 0
 after: 2 before: 2
@@ -115,13 +121,15 @@ false true
 true true
 3
 
-Dafny program verifier finished with 26 verified, 0 errors
+Dafny program verifier did not attempt verification
 x=13 y=14
 x=13 y=14 b=yes
 true false
 true false
 map[12 := 6, 13 := 6, 14 := 7]
 map[16 := 12, 17 := 13, 18 := 14]
+false false false false
+true true true true
 XP returned: 0 false
 after: 0 before: 0
 after: 2 before: 2
@@ -173,13 +181,15 @@ false true
 true true
 3
 
-Dafny program verifier finished with 26 verified, 0 errors
+Dafny program verifier did not attempt verification
 x=13 y=14
 x=13 y=14 b=yes
 true false
 true false
 map[12 := 6, 13 := 6, 14 := 7]
 map[16 := 12, 17 := 13, 18 := 14]
+false false false false
+true true true true
 XP returned: 0 false
 after: 0 before: 0
 after: 2 before: 2


### PR DESCRIPTION
Recognize `!in` operator when looking for compilable comprehensions. For example, each of the quantifications

``` dafny
!exists x :: x in S
forall x :: !(x in S)
forall x :: x in S ==> false
```

compiled, but the equivalent

``` dafny
forall x :: x !in S
```

did not. Now, all of them compile.

Also, fix malformed Java code generated for comprehensions that use maps.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
