### PR TITLE
feat: Improve error message when compiler is used without initialization

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Dafny {
       Prune = true;
       NormalizeNames = true;
       EmitDebugInformation = false;
+      Compiler = new PlaceholderCompiler();
     }
 
     public override string VersionNumber {
@@ -582,7 +583,9 @@ namespace Microsoft.Dafny {
         XmlSink = new Bpl.XmlSink(this, BoogieXmlFilename);
       }
 
-      Compiler ??= new CsharpCompiler();
+      if (Compiler == null || Compiler is PlaceholderCompiler) {
+        Compiler = new CsharpCompiler();
+      }
 
       // expand macros in filenames, now that LogPrefix is fully determined
       ExpandFilename(DafnyPrelude, x => DafnyPrelude = x, LogPrefix, FileTimestamp);

--- a/Source/Dafny/Plugins/Compiler.cs
+++ b/Source/Dafny/Plugins/Compiler.cs
@@ -140,3 +140,42 @@ public abstract class Compiler {
   public abstract bool RunTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string pathsFilename,
     ReadOnlyCollection<string> otherFileNames, object compilationResult, TextWriter outputWriter);
 }
+
+/// <summary>
+/// A placeholder class used to initialize <c>Dafny.Options.O.Compiler</c>.
+/// </summary>
+class PlaceholderCompiler : Compiler {
+  public override IReadOnlySet<string> SupportedExtensions => new HashSet<string>();
+
+  public override string TargetLanguage => "unset";
+  public override string TargetExtension => "unset";
+
+  private Exception UnimplementedExeception() {
+    return new NotImplementedException("DafnyOptions.O.Compiler unset.\n" +
+                                       "Did you forget to call `DafnyOptions.O.ApplyDefaultOptions()`?.");
+  }
+
+  public override string PublicIdProtect(string name) {
+    throw UnimplementedExeception();
+  }
+
+  public override bool TextualTargetIsExecutable => false;
+  public override bool SupportsInMemoryCompilation => false;
+  public override void Compile(Program dafnyProgram, ConcreteSyntaxTree output) {
+    throw UnimplementedExeception();
+  }
+
+  public override void EmitCallToMain(Method mainMethod, string baseName, ConcreteSyntaxTree callToMainTree) {
+    throw UnimplementedExeception();
+  }
+
+  public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string pathsFilename,
+    ReadOnlyCollection<string> otherFileNames, bool runAfterCompile, TextWriter outputWriter, out object compilationResult) {
+    throw UnimplementedExeception();
+  }
+
+  public override bool RunTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string pathsFilename,
+    ReadOnlyCollection<string> otherFileNames, object compilationResult, TextWriter outputWriter) {
+    throw UnimplementedExeception();
+  }
+}


### PR DESCRIPTION
Closes GH-1932.

If I understand what's going on correctly, #1932 isn't a bug: the API isn't (wasn't?) being used correctly, and it's surfacing that incorrect usage.  The right fix is for the client code to call `ApplyDefaultOptions()`.

I've changed from `null` to a placeholder so that it prints a more helpful message.  WDYT @MikaelMayer ?