### PR TITLE
indent param test code

### DIFF
--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -486,11 +486,72 @@ namespace Microsoft.Dafny.Compilers {
       }
       return wGet;
     }
+
+    private string WriteDafnyStructure(Method m, ConcreteSyntaxTree wr) {
+      string res = "dafny.DafnySequence<? extends dafny.Tuple" + m.Ins.Count.ToString() + "<";
+      foreach (var o in m.Ins) {
+        res += this.BoxedTypeName(o.Type, wr, o.tok);
+        if (!o.Equals(m.Ins.Last())) {
+          res += ", ";
+        }
+      }
+      res += ">>";
+      return res;
+    }
+
+    private void WriteGlueCode(ConcreteSyntaxTree wr, string methodName, string dafnyStructure, int tupleLength) {
+      var converterWr = wr.Fork();
+      converterWr = converterWr.NewBlock("public static java.util.Collection<Object[]> " + methodName + "Converter(" + dafnyStructure + " dafnyStructure)");
+      converterWr.WriteLine("java.util.List<Object[]> newList = new java.util.ArrayList<>();");
+      var forLoopWr = converterWr.Fork();
+      forLoopWr = forLoopWr.NewBlock("for (var tuple : dafnyStructure)");
+      forLoopWr.Write("newList.add(new Object[] {");
+      for (int i = 0; i < tupleLength; i++) {
+        string tupleValue = "tuple.dtor__" + i.ToString() + "()";
+        forLoopWr.Write(tupleValue);
+        if (i < tupleLength - 1) {
+          forLoopWr.Write(", ");
+        }
+      }
+      forLoopWr.WriteLine("});");
+      converterWr.WriteLine("return newList;");
+
+      var sourceWr = wr.Fork();
+      sourceWr = wr.NewBlock("public static java.util.Collection<Object[]> _" + methodName + "()");
+      sourceWr.WriteLine(dafnyStructure + " retValue =  " + methodName + "();");
+      sourceWr.WriteLine("return " + methodName + "Converter(retValue);");
+
+      wr.WriteLine("@org.junit.jupiter.params.ParameterizedTest");
+      wr.WriteLine("@org.junit.jupiter.params.provider.MethodSource(\"_" + methodName + "\")");
+    }
+
+    private void AddTestCheckerIfNeeded(Declaration decl, ConcreteSyntaxTree wr) {
+      if (!Attributes.Contains(decl.Attributes, "test")) {
+        return;
+      }
+      var args = Attributes.FindExpressions(decl.Attributes, "test");
+      if (args.Count == 2 && args[0] is LiteralExpr && args[1] is LiteralExpr) {
+        LiteralExpr sourceType = (LiteralExpr)args[0];
+        if (sourceType.Value.ToString().Equals("MethodSource")) {
+          Method m = (Method)decl;
+          LiteralExpr methodNameExpr = (LiteralExpr)args[1];
+          string dafnyStructure = WriteDafnyStructure(m, wr);
+          string compiledSourceName = NonglobalVariable.CompilerizeName(methodNameExpr.Value.ToString());
+          WriteGlueCode(wr, compiledSourceName, dafnyStructure, m.Ins.Count);
+          return;
+        }
+      } else {
+        wr.WriteLine("@org.junit.jupiter.api.Test");
+        return;
+      }
+    }
+
     protected ConcreteSyntaxTree CreateMethod(Method m, List<TypeArgumentInstantiation> typeArgs, bool createBody, ConcreteSyntaxTree wr, bool forBodyInheritance, bool lookasideBody) {
       if (m.IsExtern(out _, out _) && (m.IsStatic || m is Constructor)) {
         // No need for an abstract version of a static method or a constructor
         return null;
       }
+      AddTestCheckerIfNeeded(m, wr);
       string targetReturnTypeReplacement = null;
       int nonGhostOuts = 0;
       int nonGhostIndex = 0;
@@ -551,6 +612,7 @@ namespace Microsoft.Dafny.Compilers {
         // No need for abstract version of static method
         return null;
       }
+      AddTestCheckerIfNeeded(member, wr);
       var customReceiver = createBody && !forBodyInheritance && NeedsCustomReceiver(member);
       var receiverType = UserDefinedType.FromTopLevelDecl(member.tok, member.EnclosingClass);
       wr.Write("public {0}{1}", !createBody && !(member.EnclosingClass is TraitDecl) ? "abstract " : "", isStatic || customReceiver ? "static " : "");

--- a/docs/DafnyRef/Attributes.md
+++ b/docs/DafnyRef/Attributes.md
@@ -343,11 +343,26 @@ recursion was explicitly requested.
 * If `{:tailrecursion true}` was specified but the code does not allow it,
 an error message is given.
 
+### 22.1.13. `{:test}`
+The C# and Java compilers can inject test annotations for XUnit and JUnit, respectively.  You must provide the :test attribute for all unit tests you want annotated.
 
-### 22.2.13. `{:timeLimit N}`
+    method {:test} test_example()
+
+Dafny also provides support for unit tests with parameters provided by a method source.  To invoke this behavior, your tests should be of this form.
+
+    method {:test "MethodSource", "MethodSourceName"} test_example([parameters])
+
+Your method source's signature should be of this form
+
+    static method MethodSourceName() returns (inputs : seq<([parameter-types])>)
+
+where the method is static and the return type is a sequence of tuples.  The types inside each tuple must match the types of your test method's parameters.  The Java compiler will convert the above code into JUnit; the C# compiler will convert it into XUnit.
+
+
+### 22.2.14. `{:timeLimit N}`
 Set the time limit for verifying a given function or method.
 
-### 22.2.14. `{:timeLimitMultiplier X}`
+### 22.2.15. `{:timeLimitMultiplier X}`
 This attribute may be placed on a method or function declaration
 and has an integer argument. If `{:timeLimitMultiplier X}` was
 specified a `{:timelimit Y}` attributed is passed on to Boogie
@@ -355,14 +370,14 @@ where `Y` is `X` times either the default verification time limit
 for a function or method, or times the value specified by the
 Boogie `timelimit` command-line option.
 
-### 22.2.15. `{:verify false}` {#sec-verify}
+### 22.2.16. `{:verify false}` {#sec-verify}
      
 Skip verification of a function or a method altogether.
 Will not even try to verify well-formedness of postconditions and preconditions.
 We discourage to use this attribute. Prefer [`{:axiom}`](#sec-axiom),
 which performs these minimal checks while not checking that the body satisfies postconditions.
 
-### 22.2.16. `{:vcs_max_cost N}` {#sec-vcs_max_cost}
+### 22.2.17. `{:vcs_max_cost N}` {#sec-vcs_max_cost}
 Per-method version of the command-line option `/vcsMaxCost`.
 
 The [assertion batch](#sec-assertion-batches) of a method
@@ -371,7 +386,7 @@ number, defaults to 2000.0. In
 [keep-going mode](#sec-vcs_max_keep_going_splits), only applies to the first round.
 If [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) is set, then this parameter is useless.
 
-### 22.2.17. `{:vcs_max_keep_going_splits N}` {#sec-vcs_max_keep_going_splits}
+### 22.2.18. `{:vcs_max_keep_going_splits N}` {#sec-vcs_max_keep_going_splits}
 
 Per-method version of the command-line option `/vcsMaxKeepGoingSplits`.
 If set to more than 1, activates the _keep going mode_ where, after the first round of splitting,
@@ -382,7 +397,7 @@ case error is reported for that assertion).
 Defaults to 1.
 If [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) is set, then this parameter is useless.
 
-### 22.2.18. `{:vcs_max_splits N}` {#sec-vcs_max_splits}
+### 22.2.19. `{:vcs_max_splits N}` {#sec-vcs_max_splits}
 
 Per-method version of the command-line option `/vcsMaxSplits`.
 Maximal number of [assertion batches](#sec-assertion-batches) generated for this method.
@@ -390,7 +405,7 @@ In [keep-going mode](#sec-vcs_max_keep_going_splits), only applies to the first 
 Defaults to 1.
 If [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) is set, then this parameter is useless.
 
-### 22.2.19. `{:vcs_split_on_every_assert}` {#sec-vcs_split_on_every_assert}
+### 22.2.20. `{:vcs_split_on_every_assert}` {#sec-vcs_split_on_every_assert}
 Per-method version of the command-line option `/vcsSplitOnEveryAssert`.
 
 In the first and only verification round, this option will split the original [assertion batch](#sec-assertion-batches)
@@ -398,7 +413,7 @@ into one assertion batch per assertion.
 This is mostly helpful for debugging which assertion is taking the most time to prove, e.g. to profile them.
 
 
-### 22.2.20. synthesize {#sec-synthesize-attr}
+### 22.2.21. synthesize {#sec-synthesize-attr}
 
 The `{:synthesize}` attribute must be used on methods that have no body and
 return one or more fresh objects. During compilation, 


### PR DESCRIPTION
This branch edits the C# and Java compilers to emit parameterized testing code when the attribute `{:test "MethodSource"...}` is specified on a unit test.  The name of the method source should be provided as a string following the `"MethodSource"` parameter.

Here's an example:
```
        static method Mult_Source() returns (testInputs : seq<(int, int, int)>)
        {
            return [
                (2, 3, 6),
                (40, -2, -80),
                (-7, -7, 49)
            ];
        }

        method {:test "MethodSource", "Mult_Source"} test_mult_shouldMultTwoArguments(a : int, b : int, expected : int) 
        requires expected == a * b 
        {
            var product := Calculator.mult(a, b);
            Assertions.assertEquals(expected, product);
        }
```

In order for the cross-compiled test code to execute properly, there are a few things the programmer must know beforehand:
- The specified name should be a string and should match the name of the actual method source
- The return type should be a sequence of tuples
- The types inside each tuple must match the types of the parameters that the unit test is expecting

I've edited the Attributes.md documentation to make the programmer aware of these necessities.  If you'd like me to put them in a more visible place, I would be happy to do so.

This solution is not framework-agnostic; the Java compiler creates JUnit-specific annotations while the C# compiler does the same with XUnit such as `[Theory]`.  I don't perceive this to be a problem, given that the C# compiler already uses `[Fact]` when `{:test}` is present.

On the subject of `[Fact]`, this branch also edits the Java compiler to behave similarly to the C# compiler when encountering `{:test}` (this time without a "MethodSource" parameter).  Similar to `[Fact]`, the Java Compiler emits an `@org.junit.jupiter.api.Test` annotation.

I can see how the string `"MethodSouce"` may cause some confusion, since the idea of a Method Source really only exists inside JUnit.  XUnit's equivalent is called `MemberData`.  I would be happy to change this keyword as needed.