### PR TITLE
fix: Don't use CompileName outside of the compilers

### DIFF
--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -2788,14 +2788,8 @@ namespace Microsoft.Dafny {
     }
 
     string compileName;
-    public string CompileName {
-      get {
-        if (compileName == null) {
-          compileName = ResolvedClass.CompileName;
-        }
-        return compileName;
-      }
-    }
+    public string CompileName => compileName ??= ResolvedClass.CompileName;
+
     public string FullCompanionCompileName {
       get {
         Contract.Requires(ResolvedClass is TraitDecl || (ResolvedClass is NonNullTypeDecl nntd && nntd.Class is TraitDecl));
@@ -3362,7 +3356,6 @@ namespace Microsoft.Dafny {
     IToken IRegion.BodyStartTok { get { return BodyStartTok; } }
     IToken IRegion.BodyEndTok { get { return BodyEndTok; } }
     string INamedRegion.Name { get { return Name; } }
-    protected string compileName;
 
     private VisibilityScope opaqueScope = new VisibilityScope();
     private VisibilityScope revealScope = new VisibilityScope();
@@ -3409,19 +3402,20 @@ namespace Microsoft.Dafny {
       return IsRevealedInScope(scope) || opaqueScope.VisibleInScope(scope);
     }
 
+    protected string sanitizedName;
+    public virtual string SanitizedName => sanitizedName ??= NonglobalVariable.SanitizeName(Name);
+
+    protected string compileName;
     public virtual string CompileName {
       get {
         if (compileName == null) {
-          string qual;
-          IsExtern(out qual, out compileName);
-          if (compileName == null) {
-            // this is the usual name
-            compileName = NonglobalVariable.CompilerizeName(Name);
-          }
+          IsExtern(out _, out compileName);
+          compileName ??= SanitizedName;
         }
         return compileName;
       }
     }
+
     public bool IsExtern(out string/*?*/ qualification, out string/*?*/ name) {
       // ensures result==false ==> qualification == null && name == null
       Contract.Ensures(Contract.Result<bool>() || (Contract.ValueAtReturn(out qualification) == null && Contract.ValueAtReturn(out name) == null));
@@ -3487,19 +3481,21 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public override string CompileName {
+    public override string SanitizedName {
       get {
-        if (compileName == null) {
+        if (sanitizedName == null) {
           var name = Name;
           if (parent is MemberDecl && !name.StartsWith("_")) {
             // prepend "_" to type parameters of functions and methods, to ensure they don't clash with type parameters of the enclosing type
             name = "_" + name;
           }
-          compileName = NonglobalVariable.CompilerizeName(name);
+          sanitizedName = NonglobalVariable.SanitizeName(name);
         }
-        return compileName;
+        return sanitizedName;
       }
     }
+
+    public override string CompileName => SanitizedName; // Ignore :extern
 
     /// <summary>
     /// NonVariant_Strict     (default) - non-variant, no uses left of an arrow
@@ -3750,7 +3746,7 @@ namespace Microsoft.Dafny {
       Extends = extends;
       ProvideAll = provideAll;
       RevealAll = revealAll;
-      ThisScope = new VisibilityScope(this.FullCompileName);
+      ThisScope = new VisibilityScope(this.FullSanitizedName);
     }
 
     public ModuleExportDecl(IToken tok, string name, ModuleDefinition parent,
@@ -3762,7 +3758,7 @@ namespace Microsoft.Dafny {
       Extends = extends;
       ProvideAll = provideAll;
       RevealAll = revealAll;
-      ThisScope = new VisibilityScope(this.FullCompileName);
+      ThisScope = new VisibilityScope(this.FullSanitizedName);
     }
 
     public void SetupDefaultSignature() {
@@ -4000,21 +3996,36 @@ namespace Microsoft.Dafny {
     }
 
     VisibilityScope visibilityScope;
-
-    public VisibilityScope VisibilityScope {
-      get {
-        if (visibilityScope == null) {
-          visibilityScope = new VisibilityScope(this.CompileName);
-        }
-        return visibilityScope;
-      }
-    }
+    public VisibilityScope VisibilityScope =>
+      visibilityScope ??= new VisibilityScope(this.SanitizedName);
 
     public virtual bool IsDefaultModule {
       get {
         return false;
       }
     }
+
+    private string sanitizedName = null;
+
+    public string SanitizedName {
+      get {
+        if (sanitizedName == null) {
+          if (IsBuiltinName) {
+            sanitizedName = Name;
+          } else if (EnclosingModule != null && EnclosingModule.Name != "_module") {
+            // Include all names in the module tree path, to disambiguate when compiling
+            // a flat list of modules.
+            // Use an "underscore-escaped" character as a module name separator, since
+            // underscores are already used as escape characters in SanitizeName()
+            sanitizedName = EnclosingModule.SanitizedName + "_m" + NonglobalVariable.SanitizeName(Name);
+          } else {
+            sanitizedName = NonglobalVariable.SanitizeName(Name);
+          }
+        }
+        return sanitizedName;
+      }
+    }
+
     string compileName;
     public string CompileName {
       get {
@@ -4022,27 +4033,13 @@ namespace Microsoft.Dafny {
           var externArgs = DafnyOptions.O.DisallowExterns ? null : Attributes.FindExpressions(this.Attributes, "extern");
           if (externArgs != null && 1 <= externArgs.Count && externArgs[0] is StringLiteralExpr) {
             compileName = (string)((StringLiteralExpr)externArgs[0]).Value;
-          } else if (IsBuiltinName || externArgs != null) {
+          } else if (externArgs != null) {
             compileName = Name;
           } else {
-            if (EnclosingModule != null && EnclosingModule.Name != "_module") {
-              // Include all names in the module tree path, to disambiguate when compiling
-              // a flat list of modules.
-              // Use an "underscore-escaped" character as a module name separator, since
-              // underscores are already used as escape characters in CompilerizeName()
-              compileName = EnclosingModule.CompileName + "_m" + NonglobalVariable.CompilerizeName(Name);
-            } else {
-              compileName = NonglobalVariable.CompilerizeName(Name);
-            }
+            compileName = SanitizedName;
           }
         }
         return compileName;
-      }
-    }
-
-    public string RefinementCompileName {
-      get {
-        return this.CompileName;
       }
     }
 
@@ -4291,13 +4288,7 @@ namespace Microsoft.Dafny {
     }
     public string FullSanitizedName {
       get {
-        return EnclosingModuleDefinition.CompileName + "." + CompileName;
-      }
-    }
-
-    public string FullSanitizedRefinementName {
-      get {
-        return EnclosingModuleDefinition.RefinementCompileName + "." + CompileName;
+        return EnclosingModuleDefinition.SanitizedName + "." + SanitizedName;
       }
     }
 
@@ -4755,7 +4746,7 @@ namespace Microsoft.Dafny {
         if (argumentGhostness[i]) {
           // This name is irrelevant, since it won't be used in compilation. Give it a strange name
           // that would alert us of any bug that nevertheless tries to access this name.
-          compileName = "this * is * never * used * " + i.ToString();
+          compileName = "this * ghost * arg * should * never * be * compiled * " + i.ToString();
         } else {
           compileName = nonGhostArgs.ToString();
           nonGhostArgs++;
@@ -4769,11 +4760,10 @@ namespace Microsoft.Dafny {
       return new List<DatatypeCtor>() { ctor };
     }
 
-    public override string CompileName {
-      get {
-        return "Tuple" + BuiltIns.ArgumentGhostnessToString(ArgumentGhostness);
-      }
-    }
+    public override string SanitizedName =>
+      sanitizedName ??= $"Tuple{BuiltIns.ArgumentGhostnessToString(ArgumentGhostness)}";
+    public override string CompileName =>
+      compileName ??= SanitizedName;
   }
 
   public class CoDatatypeDecl : DatatypeDecl {
@@ -5207,6 +5197,13 @@ namespace Microsoft.Dafny {
         return EnclosingClass.FullName + "." + Name;
       }
     }
+
+    public override string SanitizedName =>
+      (Name == EnclosingClass.Name ? "_" : "") + base.SanitizedName;
+
+    public override string CompileName =>
+      (Name == EnclosingClass.Name ? "_" : "") + base.CompileName;
+
     public virtual string FullSanitizedName {
       get {
         Contract.Requires(EnclosingClass != null);
@@ -5217,52 +5214,12 @@ namespace Microsoft.Dafny {
         } else if (Name == "reads") {
           return Translator.Reads(((ArrowTypeDecl)EnclosingClass).Arity);
         } else {
-          return EnclosingClass.FullSanitizedName + "." + CompileName;
+          return EnclosingClass.FullSanitizedName + "." + SanitizedName;
         }
       }
     }
-    public virtual string FullSanitizedRefinementName {
-      get {
-        Contract.Requires(EnclosingClass != null);
-        Contract.Ensures(Contract.Result<string>() != null);
 
-        if (Name == "requires") {
-          return Translator.Requires(((ArrowTypeDecl)EnclosingClass).Arity);
-        } else if (Name == "reads") {
-          return Translator.Reads(((ArrowTypeDecl)EnclosingClass).Arity);
-        } else {
-          return EnclosingClass.FullSanitizedRefinementName + "." + CompileName;
-        }
-      }
-    }
-    public virtual string FullNameInContext(ModuleDefinition context) {
-      Contract.Requires(EnclosingClass != null);
-      Contract.Ensures(Contract.Result<string>() != null);
-
-      return EnclosingClass.FullNameInContext(context) + "." + Name;
-    }
-    public override string CompileName {
-      get {
-        var nm = base.CompileName;
-        if (this.Name == EnclosingClass.Name) {
-          nm = "_" + nm;
-        }
-        return nm;
-      }
-    }
-    public virtual string FullCompileName {
-      get {
-        Contract.Requires(EnclosingClass != null);
-        Contract.Ensures(Contract.Result<string>() != null);
-
-        return EnclosingClass.FullCompileName + "." + Declaration.IdProtect(CompileName);
-      }
-    }
-    public virtual IEnumerable<Expression> SubExpressions {
-      get {
-        yield break;
-      }
-    }
+    public virtual IEnumerable<Expression> SubExpressions => Enumerable.Empty<Expression>();
   }
 
   public class Field : MemberDecl {
@@ -5353,37 +5310,17 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public override string FullSanitizedName {
+    public override string FullSanitizedName { // Override beacuse EnclosingClass may be null
       get {
         Contract.Ensures(Contract.Result<string>() != null);
-        return EnclosingClass != null ? EnclosingClass.FullSanitizedName + "." + CompileName : CompileName;
+        return EnclosingClass != null ? EnclosingClass.FullSanitizedName + "." + SanitizedName : SanitizedName;
       }
-    }
-
-    public override string FullSanitizedRefinementName {
-      get {
-        Contract.Ensures(Contract.Result<string>() != null);
-        return EnclosingClass != null ? EnclosingClass.FullSanitizedRefinementName + "." + CompileName : CompileName;
-      }
-    }
-
-    public override string FullNameInContext(ModuleDefinition context) {
-      Contract.Ensures(Contract.Result<string>() != null);
-      return EnclosingClass != null ? EnclosingClass.FullNameInContext(context) + "." + Name : Name;
     }
 
     public override string CompileName {
       get {
         Contract.Ensures(Contract.Result<string>() != null);
         return EnclosingClass != null ? base.CompileName : Name;
-      }
-    }
-
-    public override string FullCompileName {
-      get {
-        Contract.Ensures(Contract.Result<string>() != null);
-        var cn = Declaration.IdProtect(CompileName);
-        return EnclosingClass != null ? EnclosingClass.FullCompileName + "." + cn : cn;
       }
     }
   }
@@ -5448,7 +5385,7 @@ namespace Microsoft.Dafny {
     public override string WhatKind { get { return "const field"; } }
     public readonly Expression Rhs;
     public ConstantField(IToken tok, string name, Expression/*?*/ rhs, bool hasStaticKeyword, bool isGhost, Type type, Attributes attributes)
-      : base(tok, name, SpecialField.ID.UseIdParam, NonglobalVariable.CompilerizeName(name), hasStaticKeyword, isGhost, false, false, type, attributes) {
+      : base(tok, name, SpecialField.ID.UseIdParam, NonglobalVariable.SanitizeName(name), hasStaticKeyword, isGhost, false, false, type, attributes) {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
       Contract.Requires(type != null);
@@ -5848,6 +5785,9 @@ namespace Microsoft.Dafny {
     }
     static FreshIdGenerator CompileNameIdGenerator = new FreshIdGenerator();
     string AssignUniqueName(FreshIdGenerator generator);
+    string SanitizedName {
+      get;
+    }
     string CompileName {
       get;
     }
@@ -5890,6 +5830,12 @@ namespace Microsoft.Dafny {
     }
     public bool HasBeenAssignedUniqueName {
       get {
+        throw new NotImplementedException();  // this getter implementation is here only so that the Ensures contract can be given here
+      }
+    }
+    public string SanitizedName {
+      get {
+        Contract.Ensures(Contract.Result<string>() != null);
         throw new NotImplementedException();  // this getter implementation is here only so that the Ensures contract can be given here
       }
     }
@@ -5953,29 +5899,17 @@ namespace Microsoft.Dafny {
         return name;
       }
     }
-    public string DisplayName {
-      get { return LocalVariable.DisplayNameHelper(this); }
-    }
+    public string DisplayName =>
+      LocalVariable.DisplayNameHelper(this);
+
     private string uniqueName;
-    public string UniqueName {
-      get {
-        return uniqueName;
-      }
-    }
-    public bool HasBeenAssignedUniqueName {
-      get {
-        return uniqueName != null;
-      }
-    }
+    public string UniqueName => uniqueName;
+    public bool HasBeenAssignedUniqueName => uniqueName != null;
     public string AssignUniqueName(FreshIdGenerator generator) {
-      if (uniqueName == null) {
-        uniqueName = generator.FreshId(Name + "#");
-        compileName = string.Format("_{0}_{1}", IVariable.CompileNameIdGenerator.FreshNumericId(), CompilerizeName(name));
-      }
-      return UniqueName;
+      return uniqueName ??= generator.FreshId(Name + "#");
     }
     static char[] specialChars = new char[] { '\'', '_', '?', '\\', '#' };
-    public static string CompilerizeName(string nm) {
+    public static string SanitizeName(string nm) {
       if ('0' <= nm[0] && nm[0] <= '9') {
         // the identifier is one that consists of just digits
         return "_" + nm;
@@ -6010,15 +5944,15 @@ namespace Microsoft.Dafny {
         }
       }
     }
+
+    private string sanitizedName;
+    public virtual string SanitizedName =>
+      sanitizedName ??= $"_{IVariable.CompileNameIdGenerator.FreshNumericId()}_{SanitizeName(Name)}";
+
     protected string compileName;
-    public virtual string CompileName {
-      get {
-        if (compileName == null) {
-          compileName = string.Format("_{0}_{1}", IVariable.CompileNameIdGenerator.FreshNumericId(), CompilerizeName(name));
-        }
-        return compileName;
-      }
-    }
+    public virtual string CompileName =>
+      compileName ??= SanitizedName;
+
     Type type;
     public Type SyntacticType { get { return type; } }  // returns the non-normalized type
     public Type Type {
@@ -6094,14 +6028,12 @@ namespace Microsoft.Dafny {
         return !Name.StartsWith("#");
       }
     }
-    public override string CompileName {
-      get {
-        if (compileName == null) {
-          compileName = CompilerizeName(NameForCompilation);
-        }
-        return compileName;
-      }
-    }
+
+    private string sanitizedName;
+    public override string SanitizedName =>
+      sanitizedName ??= SanitizeName(Name); // No unique-ification
+    public override string CompileName =>
+      compileName ??= SanitizeName(NameForCompilation);
   }
 
   /// <summary>
@@ -6680,7 +6612,7 @@ namespace Microsoft.Dafny {
     public BlockStmt Body {
       get {
         // Lemma from included files do not need to be resolved and translated
-        // so we return emptyBody. This is to speed up resolvor and translator.
+        // so we return emptyBody. This is to speed up resolver and translator.
         if (methodBody != null && IsLemmaLike && this.tok is IncludeToken && !DafnyOptions.O.VerifyAllModules) {
           return Method.emptyBody;
         } else {
@@ -7814,32 +7746,20 @@ namespace Microsoft.Dafny {
       get { return DisplayNameHelper(this); }
     }
     private string uniqueName;
-    public string UniqueName {
-      get {
-        return uniqueName;
-      }
-    }
-    public bool HasBeenAssignedUniqueName {
-      get {
-        return uniqueName != null;
-      }
-    }
+    public string UniqueName => uniqueName;
+    public bool HasBeenAssignedUniqueName => uniqueName != null;
     public string AssignUniqueName(FreshIdGenerator generator) {
-      if (uniqueName == null) {
-        uniqueName = generator.FreshId(Name + "#");
-        compileName = string.Format("_{0}_{1}", IVariable.CompileNameIdGenerator.FreshNumericId(), NonglobalVariable.CompilerizeName(name));
-      }
-      return UniqueName;
+      return uniqueName ??= generator.FreshId(Name + "#");
     }
+
+    private string sanitizedName;
+    public string SanitizedName =>
+      sanitizedName ??= $"_{IVariable.CompileNameIdGenerator.FreshNumericId()}_{NonglobalVariable.SanitizeName(Name)}";
+
     string compileName;
-    public string CompileName {
-      get {
-        if (compileName == null) {
-          compileName = string.Format("_{0}_{1}", IVariable.CompileNameIdGenerator.FreshNumericId(), NonglobalVariable.CompilerizeName(name));
-        }
-        return compileName;
-      }
-    }
+    public string CompileName =>
+      compileName ??= SanitizedName;
+
     public readonly Type OptionalType;  // this is the type mentioned in the declaration, if any
     Type IVariable.OptionalType { get { return this.OptionalType; } }
     internal Type type;  // this is the declared or inferred type of the variable; it is non-null after resolution (even if resolution fails)

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -5908,7 +5908,14 @@ namespace Microsoft.Dafny {
     public string AssignUniqueName(FreshIdGenerator generator) {
       return uniqueName ??= generator.FreshId(Name + "#");
     }
-    static char[] specialChars = new char[] { '\'', '_', '?', '\\', '#' };
+
+    static char[] specialChars = { '\'', '_', '?', '\\', '#' };
+    /// <summary>
+    /// Mangle name <c>nm</c> by replacing and escaping characters most likely to cause issues when compiling and
+    /// when translating to Boogie.  This transformation is injective.
+    /// </summary>
+    /// <returns>A string uniquely determined from <c>nm</c>, containing none of the characters in
+    /// <c>specialChars</c>.</returns>
     public static string SanitizeName(string nm) {
       if ('0' <= nm[0] && nm[0] <= '9') {
         // the identifier is one that consists of just digits

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Dafny {
           ModuleSignature p;
           if (ResolveExport(abs, abs.EnclosingModuleDefinition, abs.QId, abs.Exports, out p, reporter)) {
             abs.OriginalSignature = p;
-            abs.Signature = MakeAbstractSignature(p, abs.FullCompileName, abs.Height, prog.ModuleSigs, compilationModuleClones);
+            abs.Signature = MakeAbstractSignature(p, abs.FullSanitizedName, abs.Height, prog.ModuleSigs, compilationModuleClones);
           } else {
             abs.Signature = new ModuleSignature(); // there was an error, give it a valid but empty signature
           }

--- a/Source/Dafny/Util.cs
+++ b/Source/Dafny/Util.cs
@@ -316,9 +316,9 @@ namespace Microsoft.Dafny {
 
       foreach (var vertex in functionCallGraph.GetVertices()) {
         var func = vertex.N;
-        Console.Write("{0},{1}=", func.CompileName, func.EnclosingClass.EnclosingModuleDefinition.CompileName);
+        Console.Write("{0},{1}=", func.SanitizedName, func.EnclosingClass.EnclosingModuleDefinition.SanitizedName);
         foreach (var callee in vertex.Successors) {
-          Console.Write("{0} ", callee.N.CompileName);
+          Console.Write("{0} ", callee.N.SanitizedName);
         }
         Console.Write("\n");
       }

--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -843,9 +843,9 @@ namespace Microsoft.Dafny {
         if (translator.sink == null || translator.sink == null) {
           // something went wrong during construction, which reads the prelude; an error has
           // already been printed, so just return an empty program here (which is non-null)
-          yield return new Tuple<string, Bpl.Program>(outerModule.CompileName, new Bpl.Program());
+          yield return new Tuple<string, Bpl.Program>(outerModule.SanitizedName, new Bpl.Program());
         }
-        yield return new Tuple<string, Bpl.Program>(outerModule.CompileName, translator.DoTranslation(p, outerModule));
+        yield return new Tuple<string, Bpl.Program>(outerModule.SanitizedName, translator.DoTranslation(p, outerModule));
       }
     }
 

--- a/Source/DafnyServer/SymbolTable.cs
+++ b/Source/DafnyServer/SymbolTable.cs
@@ -101,8 +101,8 @@ namespace DafnyServer {
         };
         if (fs.Type is UserDefinedType) {
           var userType = fs.Type as UserDefinedType;
-          fieldSymbol.ReferencedClass = userType.ResolvedClass.CompileName;
-          fieldSymbol.ReferencedModule = userType.ResolvedClass.EnclosingModuleDefinition.CompileName;
+          fieldSymbol.ReferencedClass = userType.ResolvedClass.SanitizedName;
+          fieldSymbol.ReferencedModule = userType.ResolvedClass.EnclosingModuleDefinition.SanitizedName;
         }
         information.Add(fieldSymbol);
       }
@@ -153,8 +153,8 @@ namespace DafnyServer {
                 var name = declarationLocal.Name;
                 information.Add(new SymbolInformation {
                   Name = name,
-                  ParentClass = userType.ResolvedClass.CompileName,
-                  Module = userType.ResolvedClass.EnclosingModuleDefinition.CompileName,
+                  ParentClass = userType.ResolvedClass.SanitizedName,
+                  Module = userType.ResolvedClass.EnclosingModuleDefinition.SanitizedName,
                   SymbolType = SymbolInformation.Type.Definition,
                   StartToken = method.BodyStartTok,
                   EndToken = method.BodyEndTok
@@ -214,9 +214,9 @@ namespace DafnyServer {
         var userType = (UserDefinedType)callStmt.Receiver.Type;
         var reveiverName = receiver == null ? "" : receiver.Name;
         information.Add(new SymbolInformation {
-          Name = callStmt.Method.CompileName,
-          ParentClass = userType.ResolvedClass.CompileName,
-          Module = userType.ResolvedClass.EnclosingModuleDefinition.CompileName,
+          Name = callStmt.Method.SanitizedName,
+          ParentClass = userType.ResolvedClass.SanitizedName,
+          Module = userType.ResolvedClass.EnclosingModuleDefinition.SanitizedName,
           Call = reveiverName + "." + callStmt.MethodSelect.Member,
           SymbolType = SymbolInformation.Type.Call,
           StartToken = callStmt.MethodSelect.tok
@@ -241,8 +241,8 @@ namespace DafnyServer {
         var designator = segment == null ? "" : segment.Name;
         information.Add(new SymbolInformation {
           Name = exprDotName.SuffixName,
-          ParentClass = type.ResolvedClass.CompileName,
-          Module = type.ResolvedClass.EnclosingModuleDefinition.CompileName,
+          ParentClass = type.ResolvedClass.SanitizedName,
+          Module = type.ResolvedClass.EnclosingModuleDefinition.SanitizedName,
           Call = designator + "." + exprDotName.SuffixName,
           SymbolType = SymbolInformation.Type.Call,
           StartToken = exprDotName.tok
@@ -319,8 +319,8 @@ namespace DafnyServer {
           foreach (var exprDotName in allExprDotNames) {
             if (exprDotName.Lhs.Type is UserDefinedType) {
               var type = (UserDefinedType)exprDotName.Lhs.Type;
-              if (fieldName == exprDotName.SuffixName && className == type.ResolvedClass.CompileName &&
-                  moduleName == type.ResolvedClass.EnclosingModuleDefinition.CompileName) {
+              if (fieldName == exprDotName.SuffixName && className == type.ResolvedClass.SanitizedName &&
+                  moduleName == type.ResolvedClass.EnclosingModuleDefinition.SanitizedName) {
                 information.Add(new ReferenceInformation {
                   MethodName = exprDotName.SuffixName,
                   StartToken = exprDotName.tok,
@@ -335,8 +335,8 @@ namespace DafnyServer {
             if (nameSegment.ResolvedExpression is MemberSelectExpr) {
               var memberAcc = (MemberSelectExpr)nameSegment.ResolvedExpression;
               if (fieldName == memberAcc.MemberName &&
-                  className == memberAcc.Member.EnclosingClass.CompileName &&
-                  moduleName == memberAcc.Member.EnclosingClass.EnclosingModuleDefinition.CompileName) {
+                  className == memberAcc.Member.EnclosingClass.SanitizedName &&
+                  moduleName == memberAcc.Member.EnclosingClass.EnclosingModuleDefinition.SanitizedName) {
                 information.Add(new ReferenceInformation {
                   MethodName = memberAcc.MemberName,
                   StartToken = memberAcc.tok,

--- a/Test/git-issues/git-issue-1984.dfy
+++ b/Test/git-issues/git-issue-1984.dfy
@@ -1,0 +1,5 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method {:extern "test"} testInt(i: int)
+method {:extern "test"} testBool(b: bool) // Previously the verifier reported a name collision

--- a/Test/git-issues/git-issue-1984.dfy.expect
+++ b/Test/git-issues/git-issue-1984.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
* Source/Dafny/AST/DafnyAst.cs:

  (Declaration.SanitizedName, TypeParameter.SanitizedName,
   TupleTypeDecl.SanitizedName, NonglobalVariable.SanitizedName,
   LocalVariable.SanitizedName, Formal.SanitizedName):
  New property

  (ModuleDefinition.SanitizedName):
  New property (created by splitting off the non-extern parts of CompileName)

  (Declaration.CompileName, ModuleDefinition.CompileName):
  Use SanitizedName

  (TypeParameter.CompileName, TupleTypeDecl.CompileName,
   NonglobalVariable.CompileName, LocalVariable.CompileName):
  Alias to SanitizedName

  (ModuleExportDecl, ModuleDefinition.VisibilityScope):
  Use SanitizedName when creating the VisibilityScope

  (ModuleDefinition.FullSanitizedName, DataTypeDecl.FullSanitizedName):
  Use SanitizedName, not CompileName

  (NonglobalVariable.CompilerizeName):
  Rename to SanitizeName

  (NonglobalVariable.AssignUniqueName, LocalVariable.AssignUniqueName):
  Only assign uniqueName (compileName initialization was duplicated with the
  CompileName getter)

  (FunctionCallFinder.PrintFunctionCallGraph):
  Use SanitizedName, not CompileName

  (ModuleDefinition.RefinementCompileName,
   ModuleDefinition.FullSanitizedRefinementName, MemberDecl.FullNameInContext,
   MemberDecl.FullSanitizedRefinementName, SpecialField.FullCompileName,
   SpecialField.FullNameInContext, SpecialField.FullSanitizedRefinementName):
  Remove unused properties

* Source/Dafny/Verifier/Translator.cs (Translator.Translate):
* Source/DafnyServer/SymbolTable.cs (*):

  Use SanitizedName, not CompileName

* Source/Dafny/Resolver.cs (ResolveProgram):
  Use FullSanitizedName instead of FullCompileName when creating a signature for
  an abstract module (originally changed from .Name to .FullCompileName in
  66b9c19c9692ccece00fb6202bb0d2440999d93b)

Fixes #1984.
