### PR TITLE
compiler: Use name DafnyRuntime, not Dafny

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - fix: Populate TestResult.ResourceCount in `/verificationLogger:csv` output correctly when verification condition splitting occurs (e.g. when using `/vcsSplitOnEveryAssert`).
 - fix: DafnyOptions.Compiler was null, preventing instantiation of ModuleExportDecl (https://github.com/dafny-lang/dafny/pull/1933)
 - fix: /showSnippets crashes Dafny's legacy server (https://github.com/dafny-lang/dafny/pull/1970)
+- break: Change the namespace of the C# Dafny runtime from `Dafny` to `DafnyRuntime` (https://github.com/dafny-lang/dafny/pull/1999)
 
 # 3.5.0
 

--- a/Source/Dafny/Compilers/Compiler-Csharp.cs
+++ b/Source/Dafny/Compilers/Compiler-Csharp.cs
@@ -40,17 +40,17 @@ namespace Microsoft.Dafny.Compilers {
     public override bool SupportsInMemoryCompilation => true;
     public override bool TextualTargetIsExecutable => false;
 
-    const string DafnyISet = "Dafny.ISet";
-    const string DafnyIMultiset = "Dafny.IMultiSet";
-    const string DafnyISeq = "Dafny.ISequence";
-    const string DafnyIMap = "Dafny.IMap";
+    const string DafnyISet = "DafnyRuntime.ISet";
+    const string DafnyIMultiset = "DafnyRuntime.IMultiSet";
+    const string DafnyISeq = "DafnyRuntime.ISequence";
+    const string DafnyIMap = "DafnyRuntime.IMap";
 
-    const string DafnySetClass = "Dafny.Set";
-    const string DafnyMultiSetClass = "Dafny.MultiSet";
-    const string DafnySeqClass = "Dafny.Sequence";
-    const string DafnyMapClass = "Dafny.Map";
+    const string DafnySetClass = "DafnyRuntime.Set";
+    const string DafnyMultiSetClass = "DafnyRuntime.MultiSet";
+    const string DafnySeqClass = "DafnyRuntime.Sequence";
+    const string DafnyMapClass = "DafnyRuntime.Map";
 
-    const string DafnyHelpersClass = "Dafny.Helpers";
+    const string DafnyHelpersClass = "DafnyRuntime.Helpers";
 
     static string FormatTypeDescriptorVariable(string typeVarName) => $"_td_{typeVarName}";
     static string FormatTypeDescriptorVariable(TypeParameter tp) => FormatTypeDescriptorVariable(tp.CompileName);
@@ -121,7 +121,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitBuiltInDecls(BuiltIns builtIns, ConcreteSyntaxTree wr) {
-      var dafnyNamespace = CreateModule("Dafny", false, false, null, wr);
+      var dafnyNamespace = CreateModule("DafnyRuntime", false, false, null, wr);
       EmitInitNewArrays(builtIns, dafnyNamespace);
       if (Synthesize) {
         CsharpSynthesizer.EmitMultiMatcher(dafnyNamespace);
@@ -224,7 +224,7 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override string GetHelperModuleName() => DafnyHelpersClass;
 
-    const string DafnyTypeDescriptor = "Dafny.TypeDescriptor";
+    const string DafnyTypeDescriptor = "DafnyRuntime.TypeDescriptor";
 
     internal string TypeParameters(List<TypeParameter>/*?*/ targs, bool addVariance = false, bool uniqueNames = false) {
       Contract.Requires(targs == null || cce.NonNullElements(targs));
@@ -1357,7 +1357,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (xType is IntType || xType is BigOrdinalType) {
         return "BigInteger";
       } else if (xType is RealType) {
-        return "Dafny.BigRational";
+        return "DafnyRuntime.BigRational";
       } else if (xType is BitvectorType) {
         var t = (BitvectorType)xType;
         return t.NativeType != null ? GetNativeTypeName(t.NativeType) : "BigInteger";
@@ -1409,7 +1409,7 @@ namespace Microsoft.Dafny.Compilers {
     public string TypeHelperName(Type type, ConcreteSyntaxTree wr, Bpl.IToken tok, Type/*?*/ otherType = null) {
       var xType = type.NormalizeExpand();
       if (xType is SeqType seqType) {
-        return "Dafny.Sequence" + "<" + CommonTypeName(seqType.Arg, otherType?.AsSeqType?.Arg, wr, tok) + ">";
+        return "DafnyRuntime.Sequence" + "<" + CommonTypeName(seqType.Arg, otherType?.AsSeqType?.Arg, wr, tok) + ">";
       } else if (xType is SetType setType) {
         return $"{DafnySetClass}<{CommonTypeName(setType.Arg, otherType?.AsSetType?.Arg, wr, tok)}>";
       } else if (xType is MultiSetType msType) {
@@ -1453,7 +1453,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (xType is IntType || xType is BigOrdinalType) {
         return "BigInteger.Zero";
       } else if (xType is RealType) {
-        return "Dafny.BigRational.ZERO";
+        return "DafnyRuntime.BigRational.ZERO";
       } else if (xType is BitvectorType) {
         var t = (BitvectorType)xType;
         return t.NativeType != null ? "0" : "BigInteger.Zero";
@@ -1568,19 +1568,19 @@ namespace Microsoft.Dafny.Compilers {
     protected override string TypeDescriptor(Type type, ConcreteSyntaxTree wr, Bpl.IToken tok) {
       type = type.NormalizeExpandKeepConstraints();
       if (type is BoolType) {
-        return "Dafny.Helpers.BOOL";
+        return "DafnyRuntime.Helpers.BOOL";
       } else if (type is CharType) {
-        return "Dafny.Helpers.CHAR";
+        return "DafnyRuntime.Helpers.CHAR";
       } else if (type is IntType || type is BigOrdinalType) {
-        return "Dafny.Helpers.INT";
+        return "DafnyRuntime.Helpers.INT";
       } else if (type is RealType) {
-        return "Dafny.Helpers.REAL";
+        return "DafnyRuntime.Helpers.REAL";
       } else if (type is BitvectorType) {
         var t = (BitvectorType)type;
         if (t.NativeType != null) {
           return GetNativeTypeDescriptor(AsNativeType(type));
         } else {
-          return "Dafny.Helpers.INT";
+          return "DafnyRuntime.Helpers.INT";
         }
       } else if (type is SetType setType) {
         return $"{DafnySetClass}<{TypeName(setType.Arg, wr, tok)}>.{TypeDescriptorMethodName}()";
@@ -1591,12 +1591,12 @@ namespace Microsoft.Dafny.Compilers {
       } else if (type is MapType mapType) {
         return $"{DafnyMapClass}<{TypeName(mapType.Domain, wr, tok)}, {TypeName(mapType.Range, wr, tok)}>.{TypeDescriptorMethodName}()";
       } else if (type.IsRefType) {
-        return $"Dafny.Helpers.NULL<{TypeName(type, wr, tok)}>()";
+        return $"DafnyRuntime.Helpers.NULL<{TypeName(type, wr, tok)}>()";
       } else if (type.IsArrayType) {
         ArrayClassDecl at = type.AsArrayType;
         var elType = UserDefinedType.ArrayElementType(type);
         var elTypeName = TypeName(elType, wr, tok);
-        return $"Dafny.Helpers.ARRAY{(at.Dims == 1 ? "" : $"{at.Dims}")}<{elTypeName}>()";
+        return $"DafnyRuntime.Helpers.ARRAY{(at.Dims == 1 ? "" : $"{at.Dims}")}<{elTypeName}>()";
       } else if (type.IsTypeParameter) {
         var tp = type.AsTypeParameter;
         Contract.Assert(tp != null);
@@ -1605,13 +1605,13 @@ namespace Microsoft.Dafny.Compilers {
         }
         return FormatTypeDescriptorVariable(type.AsTypeParameter.CompileName);
       } else if (type.IsBuiltinArrowType) {
-        return $"Dafny.Helpers.NULL<{TypeName(type, wr, tok)}>()";
+        return $"DafnyRuntime.Helpers.NULL<{TypeName(type, wr, tok)}>()";
       } else if (type is UserDefinedType udt) {
         var cl = udt.ResolvedClass;
         Contract.Assert(cl != null);
         bool isHandle = true;
         if (Attributes.ContainsBool(cl.Attributes, "handle", ref isHandle) && isHandle) {
-          return "Dafny.Helpers.INT64";
+          return "DafnyRuntime.Helpers.INT64";
         }
 
         List<Type> relevantTypeArgs;
@@ -1638,21 +1638,21 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assert(nt != null);
       switch (nt.Sel) {
         case NativeType.Selection.SByte:
-          return $"Dafny.Helpers.INT8";
+          return $"DafnyRuntime.Helpers.INT8";
         case NativeType.Selection.Byte:
-          return $"Dafny.Helpers.UINT8";
+          return $"DafnyRuntime.Helpers.UINT8";
         case NativeType.Selection.Short:
-          return $"Dafny.Helpers.INT16";
+          return $"DafnyRuntime.Helpers.INT16";
         case NativeType.Selection.UShort:
-          return $"Dafny.Helpers.UINT16";
+          return $"DafnyRuntime.Helpers.UINT16";
         case NativeType.Selection.Int:
-          return $"Dafny.Helpers.INT32";
+          return $"DafnyRuntime.Helpers.INT32";
         case NativeType.Selection.UInt:
-          return $"Dafny.Helpers.UINT32";
+          return $"DafnyRuntime.Helpers.UINT32";
         case NativeType.Selection.Long:
-          return $"Dafny.Helpers.INT64";
+          return $"DafnyRuntime.Helpers.INT64";
         case NativeType.Selection.ULong:
-          return $"Dafny.Helpers.UINT64";
+          return $"DafnyRuntime.Helpers.UINT64";
         default:
           Contract.Assert(false);
           throw new cce.UnreachableException();
@@ -1814,7 +1814,7 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override void EmitHalt(Bpl.IToken tok, Expression/*?*/ messageExpr, ConcreteSyntaxTree wr) {
       var wStmts = wr.Fork();
-      wr.Write("throw new Dafny.HaltException(");
+      wr.Write("throw new DafnyRuntime.HaltException(");
       if (tok != null) {
         wr.Write(SymbolDisplay.FormatLiteral(ErrorReporter.TokenToString(tok) + ": ", true) + " + ");
       }
@@ -1952,7 +1952,7 @@ namespace Microsoft.Dafny.Compilers {
         }
         wr.Write("]{0}", brackets);
       } else {
-        wr.Write("Dafny.ArrayHelpers.InitNewArray{0}<{1}>", dimCount, TypeName(elmtType, wr, tok));
+        wr.Write("DafnyRuntime.ArrayHelpers.InitNewArray{0}<{1}>", dimCount, TypeName(elmtType, wr, tok));
         var inParens = wr.ForkInParens();
         inParens.Write(DefaultValue(elmtType, inParens, tok, true));
         for (var d = 0; d < dimCount; d++) {
@@ -2022,13 +2022,13 @@ namespace Microsoft.Dafny.Compilers {
         EmitIntegerLiteral(bigInteger, wr);
       } else if (e.Value is BigDec n) {
         if (0 <= n.Exponent) {
-          wr.Write("new Dafny.BigRational(BigInteger.Parse(\"{0}", n.Mantissa);
+          wr.Write("new DafnyRuntime.BigRational(BigInteger.Parse(\"{0}", n.Mantissa);
           for (int i = 0; i < n.Exponent; i++) {
             wr.Write("0");
           }
           wr.Write("\"), BigInteger.One)");
         } else {
-          wr.Write("new Dafny.BigRational(");
+          wr.Write("new DafnyRuntime.BigRational(");
           EmitIntegerLiteral(n.Mantissa, wr);
           wr.Write(", BigInteger.Parse(\"1");
           for (int i = n.Exponent; i < 0; i++) {
@@ -2348,19 +2348,19 @@ namespace Microsoft.Dafny.Compilers {
           compiledName = "ToBigInteger()";
           break;
         case SpecialField.ID.IsLimit:
-          preString = "Dafny.BigOrdinal.IsLimit(";
+          preString = "DafnyRuntime.BigOrdinal.IsLimit(";
           postString = ")";
           break;
         case SpecialField.ID.IsSucc:
-          preString = "Dafny.BigOrdinal.IsSucc(";
+          preString = "DafnyRuntime.BigOrdinal.IsSucc(";
           postString = ")";
           break;
         case SpecialField.ID.Offset:
-          preString = "Dafny.BigOrdinal.Offset(";
+          preString = "DafnyRuntime.BigOrdinal.Offset(";
           postString = ")";
           break;
         case SpecialField.ID.IsNat:
-          preString = "Dafny.BigOrdinal.IsNat(";
+          preString = "DafnyRuntime.BigOrdinal.IsNat(";
           postString = ")";
           break;
         case SpecialField.ID.Keys:
@@ -2570,7 +2570,7 @@ namespace Microsoft.Dafny.Compilers {
     // case that f is a lambda expression.  In that case, rather than
     // something like
     //
-    //   var s = Dafny.Sequence.Create(N, i => ...);
+    //   var s = DafnyRuntime.Sequence.Create(N, i => ...);
     //
     // (which will call the lambda N times), we'd rather write
     //
@@ -2579,18 +2579,18 @@ namespace Microsoft.Dafny.Compilers {
     //   for (int i = 0; i < dim; i++) {
     //     arr[i] = ...;
     //   }
-    //   var s = Dafny.Sequence<T>.FromArray(a);
+    //   var s = DafnyRuntime.Sequence<T>.FromArray(a);
     //
     // and thus avoid method calls.  Unfortunately, since we can't add
     // statements easily, we have to settle for the slightly clunkier
     //
-    //   var s = ((System.Func<Dafny.Sequence<T>>) (() => {
+    //   var s = ((System.Func<DafnyRuntime.Sequence<T>>) (() => {
     //     var dim = N;
     //     var arr = new T[dim];
     //     for (int i = 0; i < dim; i++) {
     //       arr[i] = ...;
     //     }
-    //     return Dafny.Sequence<T>.FromArray(a);
+    //     return DafnyRuntime.Sequence<T>.FromArray(a);
     //   }))();
     private void EmitSeqConstructionExprFromLambda(Expression lengthExpr, BoundVar boundVar, Expression body, bool inLetExprBody, ConcreteSyntaxTree wr) {
       wr.Format($"((System.Func<{TypeName(new SeqType(body.Type), wr, body.tok)}>) (() =>{ExprBlock(out ConcreteSyntaxTree wrLamBody)}))()");
@@ -2666,7 +2666,7 @@ namespace Microsoft.Dafny.Compilers {
 
     string DowncastConverter(Type from, Type to, ConcreteSyntaxTree errorWr, Bpl.IToken tok) {
       if (IsTargetSupertype(from, to, true)) {
-        return $"Dafny.Helpers.Id<{TypeName(to, errorWr, tok)}>";
+        return $"DafnyRuntime.Helpers.Id<{TypeName(to, errorWr, tok)}>";
       }
       if (from.AsCollectionType != null) {
         var sTo = TypeName(to, errorWr, tok);
@@ -2676,7 +2676,7 @@ namespace Microsoft.Dafny.Compilers {
         return wr.ToString();
       }
       // use a type
-      return $"Dafny.Helpers.CastConverter<{TypeName(from, errorWr, tok)}, {TypeName(to, errorWr, tok)}>";
+      return $"DafnyRuntime.Helpers.CastConverter<{TypeName(from, errorWr, tok)}, {TypeName(to, errorWr, tok)}>";
     }
 
     protected override bool TargetLambdaCanUseEnclosingLocals => false;
@@ -2911,7 +2911,7 @@ namespace Microsoft.Dafny.Compilers {
         if (e.ToType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // (int or bv or char) -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
-          wr.Write("new Dafny.BigRational(");
+          wr.Write("new DafnyRuntime.BigRational(");
           if (AsNativeType(e.E.Type) != null) {
             wr.Write("new BigInteger");
           }
@@ -2994,7 +2994,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write("(char)");
           TrParenExpr(e.E, wr, inLetExprBody, wStmts);
         } else if (e.ToType.IsNumericBased(Type.NumericPersuasion.Real)) {
-          wr.Write("new Dafny.BigRational(");
+          wr.Write("new DafnyRuntime.BigRational(");
           if (AsNativeType(e.E.Type) != null) {
             wr.Write("new BigInteger");
             TrParenExpr(e.E, wr, inLetExprBody, wStmts);
@@ -3049,7 +3049,7 @@ namespace Microsoft.Dafny.Compilers {
         bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var arguments = elements.Select(p => {
         var result = new ConcreteSyntaxTree();
-        result.Format($"new Dafny.Pair{BracketList((LineSegment)TypeName(p.A.Type, result, p.A.tok), (LineSegment)TypeName(p.B.Type, result, p.B.tok))}");
+        result.Format($"new DafnyRuntime.Pair{BracketList((LineSegment)TypeName(p.A.Type, result, p.A.tok), (LineSegment)TypeName(p.B.Type, result, p.B.tok))}");
         result.Append(ParensList(Expr(p.A, inLetExprBody, wStmts), Expr(p.B, inLetExprBody, wStmts)));
         return result;
       }).ToArray<ICanRender>();
@@ -3066,7 +3066,7 @@ namespace Microsoft.Dafny.Compilers {
       var mt = e.Type.AsMapType;
       var domtypeName = TypeName(mt.Domain, wrVarInit, e.tok);
       var rantypeName = TypeName(mt.Range, wrVarInit, e.tok);
-      wrVarInit.Write($"new System.Collections.Generic.List<Dafny.Pair<{domtypeName},{rantypeName}>>()");
+      wrVarInit.Write($"new System.Collections.Generic.List<DafnyRuntime.Pair<{domtypeName},{rantypeName}>>()");
     }
 
     protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, bool inLetExprBody, ConcreteSyntaxTree wr) {
@@ -3083,7 +3083,7 @@ namespace Microsoft.Dafny.Compilers {
       var rantypeName = TypeName(mt.Range, wr, tok);
       var termLeftWriter = new ConcreteSyntaxTree();
       var wStmts = wr.Fork();
-      wr.FormatLine($"{collName}.Add(new Dafny.Pair<{domtypeName},{rantypeName}>{ParensList(termLeftWriter, Expr(term, inLetExprBody, wStmts))});");
+      wr.FormatLine($"{collName}.Add(new DafnyRuntime.Pair<{domtypeName},{rantypeName}>{ParensList(termLeftWriter, Expr(term, inLetExprBody, wStmts))});");
       return termLeftWriter;
     }
 

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -18,7 +18,7 @@ namespace DafnyAssembly {
   }
 }
 
-namespace Dafny {
+namespace DafnyRuntime {
   using System.Collections.Generic;
   using System.Collections.Immutable;
   using System.Linq;
@@ -43,7 +43,7 @@ namespace Dafny {
 
     public static readonly ISet<T> Empty = new Set<T>(ImmutableHashSet<T>.Empty, false);
 
-    private static readonly TypeDescriptor<ISet<T>> _TYPE = new Dafny.TypeDescriptor<ISet<T>>(Empty);
+    private static readonly TypeDescriptor<ISet<T>> _TYPE = new DafnyRuntime.TypeDescriptor<ISet<T>>(Empty);
     public static TypeDescriptor<ISet<T>> _TypeDescriptor() {
       return _TYPE;
     }
@@ -211,11 +211,11 @@ namespace Dafny {
     public override int GetHashCode() {
       var hashCode = 1;
       if (containsNull) {
-        hashCode = hashCode * (Dafny.Helpers.GetHashCode(default(T)) + 3);
+        hashCode = hashCode * (DafnyRuntime.Helpers.GetHashCode(default(T)) + 3);
       }
 
       foreach (var t in this.setImpl) {
-        hashCode = hashCode * (Dafny.Helpers.GetHashCode(t) + 3);
+        hashCode = hashCode * (DafnyRuntime.Helpers.GetHashCode(t) + 3);
       }
 
       return hashCode;
@@ -225,12 +225,12 @@ namespace Dafny {
       var s = "{";
       var sep = "";
       if (containsNull) {
-        s += sep + Dafny.Helpers.ToString(default(T));
+        s += sep + DafnyRuntime.Helpers.ToString(default(T));
         sep = ", ";
       }
 
       foreach (var t in this.setImpl) {
-        s += sep + Dafny.Helpers.ToString(t);
+        s += sep + DafnyRuntime.Helpers.ToString(t);
         sep = ", ";
       }
 
@@ -306,7 +306,7 @@ namespace Dafny {
     }
     public static readonly MultiSet<T> Empty = new MultiSet<T>(ImmutableDictionary<T, BigInteger>.Empty.ToBuilder(), BigInteger.Zero);
 
-    private static readonly TypeDescriptor<IMultiSet<T>> _TYPE = new Dafny.TypeDescriptor<IMultiSet<T>>(Empty);
+    private static readonly TypeDescriptor<IMultiSet<T>> _TYPE = new DafnyRuntime.TypeDescriptor<IMultiSet<T>>(Empty);
     public static TypeDescriptor<IMultiSet<T>> _TypeDescriptor() {
       return _TYPE;
     }
@@ -426,12 +426,12 @@ namespace Dafny {
     public override int GetHashCode() {
       var hashCode = 1;
       if (occurrencesOfNull > 0) {
-        var key = Dafny.Helpers.GetHashCode(default(T));
+        var key = DafnyRuntime.Helpers.GetHashCode(default(T));
         key = (key << 3) | (key >> 29) ^ occurrencesOfNull.GetHashCode();
         hashCode = hashCode * (key + 3);
       }
       foreach (var kv in dict) {
-        var key = Dafny.Helpers.GetHashCode(kv.Key);
+        var key = DafnyRuntime.Helpers.GetHashCode(kv.Key);
         key = (key << 3) | (key >> 29) ^ kv.Value.GetHashCode();
         hashCode = hashCode * (key + 3);
       }
@@ -441,11 +441,11 @@ namespace Dafny {
       var s = "multiset{";
       var sep = "";
       for (var i = BigInteger.Zero; i < occurrencesOfNull; i++) {
-        s += sep + Dafny.Helpers.ToString(default(T));
+        s += sep + DafnyRuntime.Helpers.ToString(default(T));
         sep = ", ";
       }
       foreach (var kv in dict) {
-        var t = Dafny.Helpers.ToString(kv.Key);
+        var t = DafnyRuntime.Helpers.ToString(kv.Key);
         for (var i = BigInteger.Zero; i < kv.Value; i++) {
           s += sep + t;
           sep = ", ";
@@ -644,7 +644,7 @@ namespace Dafny {
       this.nullValue = nullValue;
     }
 
-    private static readonly TypeDescriptor<IMap<U, V>> _TYPE = new Dafny.TypeDescriptor<IMap<U, V>>(Empty);
+    private static readonly TypeDescriptor<IMap<U, V>> _TYPE = new DafnyRuntime.TypeDescriptor<IMap<U, V>>(Empty);
     public static TypeDescriptor<IMap<U, V>> _TypeDescriptor() {
       return _TYPE;
     }
@@ -754,13 +754,13 @@ namespace Dafny {
     public override int GetHashCode() {
       var hashCode = 1;
       if (hasNullKey) {
-        var key = Dafny.Helpers.GetHashCode(default(U));
-        key = (key << 3) | (key >> 29) ^ Dafny.Helpers.GetHashCode(nullValue);
+        var key = DafnyRuntime.Helpers.GetHashCode(default(U));
+        key = (key << 3) | (key >> 29) ^ DafnyRuntime.Helpers.GetHashCode(nullValue);
         hashCode = hashCode * (key + 3);
       }
       foreach (var kv in dict) {
-        var key = Dafny.Helpers.GetHashCode(kv.Key);
-        key = (key << 3) | (key >> 29) ^ Dafny.Helpers.GetHashCode(kv.Value);
+        var key = DafnyRuntime.Helpers.GetHashCode(kv.Key);
+        key = (key << 3) | (key >> 29) ^ DafnyRuntime.Helpers.GetHashCode(kv.Value);
         hashCode = hashCode * (key + 3);
       }
       return hashCode;
@@ -769,11 +769,11 @@ namespace Dafny {
       var s = "map[";
       var sep = "";
       if (hasNullKey) {
-        s += sep + Dafny.Helpers.ToString(default(U)) + " := " + Dafny.Helpers.ToString(nullValue);
+        s += sep + DafnyRuntime.Helpers.ToString(default(U)) + " := " + DafnyRuntime.Helpers.ToString(nullValue);
         sep = ", ";
       }
       foreach (var kv in dict) {
-        s += sep + Dafny.Helpers.ToString(kv.Key) + " := " + Dafny.Helpers.ToString(kv.Value);
+        s += sep + DafnyRuntime.Helpers.ToString(kv.Key) + " := " + DafnyRuntime.Helpers.ToString(kv.Value);
         sep = ", ";
       }
       return s + "]";
@@ -813,18 +813,18 @@ namespace Dafny {
     public ISet<U> Keys {
       get {
         if (hasNullKey) {
-          return Dafny.Set<U>.FromCollectionPlusOne(dict.Keys, default(U));
+          return DafnyRuntime.Set<U>.FromCollectionPlusOne(dict.Keys, default(U));
         } else {
-          return Dafny.Set<U>.FromCollection(dict.Keys);
+          return DafnyRuntime.Set<U>.FromCollection(dict.Keys);
         }
       }
     }
     public ISet<V> Values {
       get {
         if (hasNullKey) {
-          return Dafny.Set<V>.FromCollectionPlusOne(dict.Values, nullValue);
+          return DafnyRuntime.Set<V>.FromCollectionPlusOne(dict.Values, nullValue);
         } else {
-          return Dafny.Set<V>.FromCollection(dict.Values);
+          return DafnyRuntime.Set<V>.FromCollection(dict.Values);
         }
       }
     }
@@ -845,7 +845,7 @@ namespace Dafny {
       foreach (var item in m.ItemEnumerable) {
         result.Add(_System.Tuple2<U, V>.create(item.Car, item.Cdr));
       }
-      return Dafny.Set<_System._ITuple2<U, V>>.FromCollection(result);
+      return DafnyRuntime.Set<_System._ITuple2<U, V>>.FromCollection(result);
     }
   }
 
@@ -882,7 +882,7 @@ namespace Dafny {
   public abstract class Sequence<T> : ISequence<T> {
     public static readonly ISequence<T> Empty = new ArraySequence<T>(new T[0]);
 
-    private static readonly TypeDescriptor<ISequence<T>> _TYPE = new Dafny.TypeDescriptor<ISequence<T>>(Empty);
+    private static readonly TypeDescriptor<ISequence<T>> _TYPE = new DafnyRuntime.TypeDescriptor<ISequence<T>>(Empty);
     public static TypeDescriptor<ISequence<T>> _TypeDescriptor() {
       return _TYPE;
     }
@@ -1024,7 +1024,7 @@ namespace Dafny {
 
       var hashCode = 0;
       for (var i = 0; i < elmts.Length; i++) {
-        hashCode = (hashCode << 3) | (hashCode >> 29) ^ Dafny.Helpers.GetHashCode(elmts[i]);
+        hashCode = (hashCode << 3) | (hashCode >> 29) ^ DafnyRuntime.Helpers.GetHashCode(elmts[i]);
       }
       return hashCode;
     }
@@ -1042,7 +1042,7 @@ namespace Dafny {
         var s = "[";
         var sep = "";
         foreach (var t in elmts) {
-          s += sep + Dafny.Helpers.ToString(t);
+          s += sep + DafnyRuntime.Helpers.ToString(t);
           sep = ", ";
         }
         return s + "]";
@@ -1693,24 +1693,24 @@ namespace @_System {
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 0;
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._0));
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._1));
+      hash = ((hash << 5) + hash) + ((ulong)DafnyRuntime.Helpers.GetHashCode(this._0));
+      hash = ((hash << 5) + hash) + ((ulong)DafnyRuntime.Helpers.GetHashCode(this._1));
       return (int)hash;
     }
     public override string ToString() {
       string s = "";
       s += "(";
-      s += Dafny.Helpers.ToString(this._0);
+      s += DafnyRuntime.Helpers.ToString(this._0);
       s += ", ";
-      s += Dafny.Helpers.ToString(this._1);
+      s += DafnyRuntime.Helpers.ToString(this._1);
       s += ")";
       return s;
     }
     public static _ITuple2<T0, T1> Default(T0 _default_T0, T1 _default_T1) {
       return create(_default_T0, _default_T1);
     }
-    public static Dafny.TypeDescriptor<_System._ITuple2<T0, T1>> _TypeDescriptor(Dafny.TypeDescriptor<T0> _td_T0, Dafny.TypeDescriptor<T1> _td_T1) {
-      return new Dafny.TypeDescriptor<_System._ITuple2<T0, T1>>(_System.Tuple2<T0, T1>.Default(_td_T0.Default(), _td_T1.Default()));
+    public static DafnyRuntime.TypeDescriptor<_System._ITuple2<T0, T1>> _TypeDescriptor(DafnyRuntime.TypeDescriptor<T0> _td_T0, DafnyRuntime.TypeDescriptor<T1> _td_T1) {
+      return new DafnyRuntime.TypeDescriptor<_System._ITuple2<T0, T1>>(_System.Tuple2<T0, T1>.Default(_td_T0.Default(), _td_T1.Default()));
     }
     public static _ITuple2<T0, T1> create(T0 _0, T1 _1) {
       return new Tuple2<T0, T1>(_0, _1);


### PR DESCRIPTION
This makes it easier to link the output of the compiler into Dafny (otherwise
the runtime pollutes the main Dafny namespace).
