### PR TITLE
fix: Substitute for receiver in automatically generated induction hypothesis

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - fix: DafnyOptions.Compiler was null, preventing instantiation of ModuleExportDecl (https://github.com/dafny-lang/dafny/pull/1933)
 - fix: /showSnippets crashes Dafny's legacy server (https://github.com/dafny-lang/dafny/pull/1970)
 - fix: Don't check for name collisions in modules that are not compiled (https://github.com/dafny-lang/dafny/pull/1998)
+- fix: Fix induction hypothesis generated for lemmas with a receiver parameter (https://github.com/dafny-lang/dafny/pull/2002)
 
 # 3.5.0
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -3031,7 +3031,7 @@ namespace Microsoft.Dafny {
 
               Expression recursiveCallReceiver;
               List<Expression> recursiveCallArgs;
-              Translator.RecursiveCallParameters(com.tok, prefixLemma, prefixLemma.TypeArgs, prefixLemma.Ins, substMap, out recursiveCallReceiver, out recursiveCallArgs);
+              Translator.RecursiveCallParameters(com.tok, prefixLemma, prefixLemma.TypeArgs, prefixLemma.Ins, null, substMap, out recursiveCallReceiver, out recursiveCallArgs);
               var methodSel = new MemberSelectExpr(com.tok, recursiveCallReceiver, prefixLemma.Name);
               methodSel.Member = prefixLemma;  // resolve here
               methodSel.TypeApplication_AtEnclosingClass = prefixLemma.EnclosingClass.TypeArgs.ConvertAll(tp => (Type)new UserDefinedType(tp.tok, tp));

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -3005,7 +3005,7 @@ namespace Microsoft.Dafny {
             if (k.Type.IsBigOrdinalType) {
               kk = new MemberSelectExpr(k.tok, new IdentifierExpr(k.tok, k.Name), "Offset");
               // As an "else" branch, we add recursive calls for the limit case.  When automatic induction is on,
-              // this get handled automatically, but we still want it in the case when automatic inductino has been
+              // this get handled automatically, but we still want it in the case when automatic induction has been
               // turned off.
               //     forall k', params | k' < _k && Precondition {
               //       pp(k', params);

--- a/Source/Dafny/Verifier/Translator.ClassMembers.cs
+++ b/Source/Dafny/Verifier/Translator.ClassMembers.cs
@@ -591,10 +591,8 @@ namespace Microsoft.Dafny {
             parBounds.Add(new ComprehensionExpr.SpecialAllocIndependenceAllocatedBoundedPool());  // record that we don't want alloc antecedents for these variables
           }
 
-          // Generate a CallStmt for the recursive call
-          Expression recursiveCallReceiver;
-          List<Expression> recursiveCallArgs;
-          RecursiveCallParameters(m.tok, m, m.TypeArgs, m.Ins, receiverSubst, substMap, out recursiveCallReceiver, out recursiveCallArgs);
+          // Generate a CallStmt to be used as the body of the 'forall' statement.
+          RecursiveCallParameters(m.tok, m, m.TypeArgs, m.Ins, receiverSubst, substMap, out var recursiveCallReceiver, out var recursiveCallArgs);
           var methodSel = new MemberSelectExpr(m.tok, recursiveCallReceiver, m.Name);
           methodSel.Member = m;  // resolve here
           methodSel.TypeApplication_AtEnclosingClass = m.EnclosingClass.TypeArgs.ConvertAll(tp => (Type)new UserDefinedType(tp.tok, tp));

--- a/Source/Dafny/Verifier/Translator.ClassMembers.cs
+++ b/Source/Dafny/Verifier/Translator.ClassMembers.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Dafny {
           // Generate a CallStmt for the recursive call
           Expression recursiveCallReceiver;
           List<Expression> recursiveCallArgs;
-          RecursiveCallParameters(m.tok, m, m.TypeArgs, m.Ins, substMap, out recursiveCallReceiver, out recursiveCallArgs);
+          RecursiveCallParameters(m.tok, m, m.TypeArgs, m.Ins, receiverSubst, substMap, out recursiveCallReceiver, out recursiveCallArgs);
           var methodSel = new MemberSelectExpr(m.tok, recursiveCallReceiver, m.Name);
           methodSel.Member = m;  // resolve here
           methodSel.TypeApplication_AtEnclosingClass = m.EnclosingClass.TypeArgs.ConvertAll(tp => (Type)new UserDefinedType(tp.tok, tp));

--- a/Source/Dafny/Verifier/Translator.ClassMembers.cs
+++ b/Source/Dafny/Verifier/Translator.ClassMembers.cs
@@ -547,12 +547,12 @@ namespace Microsoft.Dafny {
       if (!wellformednessProc) {
         var inductionVars = ApplyInduction(m.Ins, m.Attributes);
         if (inductionVars.Count != 0) {
-          // Let the parameters be this,x,y of the method M and suppose ApplyInduction returns y.
+          // Let the parameters be this,x,y of the method M and suppose ApplyInduction returns this,y.
           // Also, let Pre be the precondition and VF be the decreases clause.
           // Then, insert into the method body what amounts to:
           //     assume case-analysis-on-parameter[[ y' ]];
-          //     forall (y' | Pre(this, x, y') && VF(this, x, y') << VF(this, x, y)) {
-          //       this.M(x, y');
+          //     forall this',y' | Pre(this', x, y') && (VF(this', x, y') << VF(this', x, y)) {
+          //       this'.M(x, y');
           //     }
           // Generate bound variables for the forall statement, and a substitution for the Pre and VF
 

--- a/Source/Dafny/Verifier/Translator.TrStatement.cs
+++ b/Source/Dafny/Verifier/Translator.TrStatement.cs
@@ -1928,7 +1928,9 @@ namespace Microsoft.Dafny {
         }
       }
     }
-    void TrForallStmtCall(IToken tok, List<BoundVar> boundVars, List<ComprehensionExpr.BoundedPool> bounds, Expression range, ExpressionConverter additionalRange, List<Expression> forallExpressions, CallStmt s0,
+
+    void TrForallStmtCall(IToken tok, List<BoundVar> boundVars, List<ComprehensionExpr.BoundedPool> bounds,
+      Expression range, ExpressionConverter additionalRange, List<Expression> forallExpressions, CallStmt s0,
       BoogieStmtListBuilder definedness, BoogieStmtListBuilder exporter, List<Variable> locals, ExpressionTranslator etran) {
       Contract.Requires(tok != null);
       Contract.Requires(boundVars != null);
@@ -2020,8 +2022,6 @@ namespace Microsoft.Dafny {
         // call should be translated using "initEtran", whereas the method postcondition should be translated
         // using "callEtran".  To accomplish this, we translate the argument and then tuck the resulting
         // Boogie expressions into BoogieExprWrappers that are used in the DafnyExpr-to-DafnyExpr substitution.
-        // TODO
-        Bpl.Expr qq;
         var bvars = new List<Variable>();
         Dictionary<IVariable, Expression> substMap;
         Bpl.Trigger antitriggerBoundVarTypes;
@@ -2032,7 +2032,7 @@ namespace Microsoft.Dafny {
         Bpl.Expr post = Bpl.Expr.True;
         Bpl.Trigger tr;
         if (forallExpressions != null) {
-          // tranlate based on the forallExpressions since the triggers are computed based on it already.
+          // translate based on the forallExpressions since the triggers are computed based on it already.
           QuantifierExpr expr = (QuantifierExpr)forallExpressions[0];
           while (expr.SplitQuantifier != null) {
             expr = (QuantifierExpr)expr.SplitQuantifierExpression;
@@ -2066,7 +2066,7 @@ namespace Microsoft.Dafny {
         // TRIG (forall $ih#s0#0: Seq Box :: $Is($ih#s0#0, TSeq(TChar)) && $IsAlloc($ih#s0#0, TSeq(TChar), $initHeapForallStmt#0) && Seq#Length($ih#s0#0) != 0 && Seq#Rank($ih#s0#0) < Seq#Rank(s#0) ==> (forall i#2: int :: true ==> LitInt(0) <= i#2 && i#2 < Seq#Length($ih#s0#0) ==> char#ToInt(_module.CharChar.MinChar($LS($LZ), $Heap, this, $ih#s0#0)) <= char#ToInt($Unbox(Seq#Index($ih#s0#0, i#2)): char)))
         // TRIG (forall $ih#pat0#0: Seq Box, $ih#a0#0: Seq Box :: $Is($ih#pat0#0, TSeq(_module._default.Same0$T)) && $IsAlloc($ih#pat0#0, TSeq(_module._default.Same0$T), $initHeapForallStmt#0) && $Is($ih#a0#0, TSeq(_module._default.Same0$T)) && $IsAlloc($ih#a0#0, TSeq(_module._default.Same0$T), $initHeapForallStmt#0) && Seq#Length($ih#pat0#0) <= Seq#Length($ih#a0#0) && Seq#SameUntil($ih#pat0#0, $ih#a0#0, Seq#Length($ih#pat0#0)) && (Seq#Rank($ih#pat0#0) < Seq#Rank(pat#0) || (Seq#Rank($ih#pat0#0) == Seq#Rank(pat#0) && Seq#Rank($ih#a0#0) < Seq#Rank(a#0))) ==> _module.__default.IsRelaxedPrefixAux(_module._default.Same0$T, $LS($LZ), $Heap, $ih#pat0#0, $ih#a0#0, LitInt(1)))'
         // TRIG (forall $ih#m0#0: DatatypeType, $ih#n0#0: DatatypeType :: $Is($ih#m0#0, Tclass._module.Nat()) && $IsAlloc($ih#m0#0, Tclass._module.Nat(), $initHeapForallStmt#0) && $Is($ih#n0#0, Tclass._module.Nat()) && $IsAlloc($ih#n0#0, Tclass._module.Nat(), $initHeapForallStmt#0) && Lit(true) && (DtRank($ih#m0#0) < DtRank(m#0) || (DtRank($ih#m0#0) == DtRank(m#0) && DtRank($ih#n0#0) < DtRank(n#0))) ==> _module.__default.mult($LS($LZ), $Heap, $ih#m0#0, _module.__default.plus($LS($LZ), $Heap, $ih#n0#0, $ih#n0#0)) == _module.__default.mult($LS($LZ), $Heap, _module.__default.plus($LS($LZ), $Heap, $ih#m0#0, $ih#m0#0), $ih#n0#0))
-        qq = new Bpl.ForallExpr(tok, bvars, tr, Bpl.Expr.Imp(ante, post));  // TODO: Add a SMART_TRIGGER here.  If we can't find one, abort the attempt to do induction automatically
+        var qq = new Bpl.ForallExpr(tok, bvars, tr, Bpl.Expr.Imp(ante, post));  // TODO: Add a SMART_TRIGGER here.  If we can't find one, abort the attempt to do induction automatically
         exporter.Add(TrAssumeCmd(tok, qq));
       }
     }

--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -2611,7 +2611,7 @@ namespace Microsoft.Dafny {
         substMap.Add(pp.K, kprime);
         Expression recursiveCallReceiver;
         List<Expression> recursiveCallArgs;
-        RecursiveCallParameters(pp.tok, pp, pp.TypeArgs, pp.Formals, substMap, out recursiveCallReceiver, out recursiveCallArgs);
+        RecursiveCallParameters(pp.tok, pp, pp.TypeArgs, pp.Formals, null, substMap, out recursiveCallReceiver, out recursiveCallArgs);
         var ppCall = new FunctionCallExpr(pp.tok, pp.Name, recursiveCallReceiver, pp.tok, recursiveCallArgs);
         ppCall.Function = pp;
         ppCall.Type = Type.Bool;
@@ -2654,19 +2654,22 @@ namespace Microsoft.Dafny {
     }
 
     public static void RecursiveCallParameters(IToken tok, MemberDecl member, List<TypeParameter> typeParams, List<Formal> ins,
-      Dictionary<IVariable, Expression> substMap,
+      Expression receiverSubst, Dictionary<IVariable, Expression> substMap,
       out Expression receiver, out List<Expression> arguments) {
       Contract.Requires(tok != null);
       Contract.Requires(member != null);
       Contract.Requires(member.EnclosingClass is TopLevelDeclWithMembers);
       Contract.Requires(typeParams != null);
       Contract.Requires(ins != null);
+      // receiverSubst is allowed to be null
       Contract.Requires(substMap != null);
       Contract.Ensures(Contract.ValueAtReturn(out receiver) != null);
       Contract.Ensures(Contract.ValueAtReturn(out arguments) != null);
 
       if (member.IsStatic) {
-        receiver = new StaticReceiverExpr(tok, (TopLevelDeclWithMembers)member.EnclosingClass, true);  // this also resolves it
+        receiver = new StaticReceiverExpr(tok, (TopLevelDeclWithMembers)member.EnclosingClass, true); // this also resolves it
+      } else if (receiverSubst != null) {
+        receiver = receiverSubst;
       } else {
         receiver = new ImplicitThisExpr(tok);
         receiver.Type = Resolver.GetReceiverType(tok, member);  // resolve here

--- a/Test/dafny1/Induction.dfy
+++ b/Test/dafny1/Induction.dfy
@@ -233,7 +233,7 @@ class Node {
 
   lemma InstanceAboutUU()
     requires Valid()
-    ensures uu == 0 // regression: once up a time, this used to go through
+    ensures uu == 0 // regression: once upon a time, this used to go through
     decreases Repr
   {
     if left == null {

--- a/Test/dafny1/Induction.dfy
+++ b/Test/dafny1/Induction.dfy
@@ -203,3 +203,51 @@ function FooD(n: nat, d: D): int
   case Something(next) =>
     if n < 100 then n + 12 else FooD(n-13, next)
 }
+
+// ----------------------- Regression: remember to substitute "this" -----------------
+
+class Node {
+  ghost var Repr: set<object>
+  var left: Node?
+  var uu: nat
+
+  predicate Valid()
+    reads this, Repr
+    ensures Valid() ==> this in Repr
+  {
+    this in Repr &&
+    (left != null ==>
+      left in Repr && left.Repr <= Repr &&
+      this !in left.Repr &&
+      left.Valid()) &&
+    ((left == null && uu == 0) || (left != null && uu != 0))
+  }
+
+  constructor ()
+    ensures Valid() && fresh(Repr)
+  {
+    left := null;
+    uu := 0;
+    Repr := {this};
+  }
+
+  lemma InstanceAboutUU()
+    requires Valid()
+    ensures uu == 0 // regression: once up a time, this used to go through
+    decreases Repr
+  {
+    if left == null {
+    } else { // error: postcondition violation
+    }
+  }
+}
+
+lemma StaticAboutUU(th: Node)
+  requires th.Valid()
+  ensures th.uu == 0
+  decreases th.Repr
+{
+  if th.left == null {
+  } else { // error: postcondition violation
+  }
+}

--- a/Test/dafny1/Induction.dfy.expect
+++ b/Test/dafny1/Induction.dfy.expect
@@ -1,2 +1,6 @@
+Induction.dfy(240,11): Error: A postcondition might not hold on this return path.
+Induction.dfy(236,15): Related location: This is the postcondition that might not hold.
+Induction.dfy(251,9): Error: A postcondition might not hold on this return path.
+Induction.dfy(247,16): Related location: This is the postcondition that might not hold.
 
-Dafny program verifier finished with 29 verified, 0 errors
+Dafny program verifier finished with 32 verified, 2 errors

--- a/Test/dafny2/COST-verif-comp-2011-4-FloydCycleDetect.dfy
+++ b/Test/dafny2/COST-verif-comp-2011-4-FloydCycleDetect.dfy
@@ -267,7 +267,7 @@ class Node {
     }
   }
 
-  lemma Lemma_AboutCycles(a: int, b: int, k: int, S: set<Node?>)
+  lemma {:induction false} Lemma_AboutCycles(a: int, b: int, k: int, S: set<Node?>)
     requires IsClosed(S)
     requires 0 <= a <= k && 1 <= b && Nexxxt(a, S) != null && Nexxxt(a, S).Nexxxt(b, S) == Nexxxt(a, S)
     ensures Nexxxt(k + b, S) == Nexxxt(k, S)


### PR DESCRIPTION
A lemma like

``` dafny
class C {
  lemma MyLemma(x: X)
    requires Pre(x)
    ensures Post(x)
    decreases D(x)
  {
  }
}
```

should give rise to an induction hypothesis (which is provided by the verifier as an assumption on entry to the lemma's body) of the form

``` dafny
forall this': C, x': X | this'.Pre(x') && this'.D(x') < this.D(x) :: this'.Post(x')
```

Previously, this was generated incorrectly. In particular, the formula `this'.Post(x')` was previously generated as `this.P(x')`. This PR corrects the generated formula.

Fixes #2001

The example given in issue #2001 is included in `Test/dafny1/Induction.dfy`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
