### PR TITLE
Remove unused references and don't link DafnyRuntime into DafnyDriver

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -38,9 +38,10 @@
     
   <ItemGroup>
     <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
-    <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj" />
+    <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\DafnyTestGeneration\DafnyTestGeneration.csproj" />
-    <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyLanguageServer.Test/Various/PluginsAdvancedTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/PluginsAdvancedTest.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
-using Microsoft.Extensions.DependencyModel;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various;

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -35,7 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" />
     <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
     <ProjectReference Include="..\Dafny\DafnyPipeline.csproj" />
   </ItemGroup>

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -4,7 +4,6 @@ using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Dafny.LanguageServer.Workspace.Notifications;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/Source/DafnyPipeline.Test/Issue1355.cs
+++ b/Source/DafnyPipeline.Test/Issue1355.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Diagnostics.Contracts;
 using System.IO;
 using Bpl = Microsoft.Boogie;
 using BplParser = Microsoft.Boogie.Parser;

--- a/Source/DafnyServer/CounterExampleGeneration/DafnyModel.cs
+++ b/Source/DafnyServer/CounterExampleGeneration/DafnyModel.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;

--- a/Source/DafnyTestGeneration.Test/DafnyTestGeneration.Test.csproj
+++ b/Source/DafnyTestGeneration.Test/DafnyTestGeneration.Test.csproj
@@ -14,7 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj" />
+        <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj">
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
         <ProjectReference Include="..\DafnyTestGeneration\DafnyTestGeneration.csproj" />
     </ItemGroup>
 

--- a/Source/IntegrationTests/IntegrationTests.csproj
+++ b/Source/IntegrationTests/IntegrationTests.csproj
@@ -22,7 +22,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\DafnyDriver\DafnyDriver.csproj" />
-        <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj" />
+        <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj">
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
         <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
         <ProjectReference Include="..\XUnitExtensions\XUnitExtensions.csproj" />
     </ItemGroup>


### PR DESCRIPTION
This is in preparation for linking the output of the Dafny-in-Dafny compiler into Dafny (as a compiler plugin).  We can't do that today because Dafny.exe (compiled from DafnyDriver) already links in a copy of the runtime, even though it doesn't use it.

