### PR TITLE
Move boogie reference

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,7 +28,7 @@ jobs:
       id: boogieVersion
       uses: QwerMike/xpath-action@v1
       with:
-        filename: 'dafny/Source/Directory.Build.props'
+        filename: 'dafny/Source/Dafny/DafnyPipeline.csproj'
         expression: "//PackageReference[@Include='Boogie.ExecutionEngine']/@Version"
 
     - uses: actions-ecosystem/action-regex-match@v2

--- a/Source/Dafny/DafnyPipeline.csproj
+++ b/Source/Dafny/DafnyPipeline.csproj
@@ -25,6 +25,7 @@
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="2.13.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -5,9 +5,4 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
-  <!-- Boogie dependency -->
-  <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="2.13.4" />
-  </ItemGroup>
-
 </Project>

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -1,5 +1,5 @@
 diff --git a/Source/Dafny.sln b/Source/Dafny.sln
-index 36bb4d93..7194b644 100644
+index 36bb4d93b..0dea612cf 100644
 --- a/Source/Dafny.sln
 +++ b/Source/Dafny.sln
 @@ -30,6 +30,34 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DafnyTestGeneration", "Dafn
@@ -130,16 +130,16 @@ index 36bb4d93..7194b644 100644
 +		{1EE372AA-4FF9-47FB-9C04-18CBF219F6E8} = {60332269-9C5D-465E-8582-01F9B738BD90}
 +	EndGlobalSection
  EndGlobal
-diff --git a/Source/Directory.Build.props b/Source/Directory.Build.props
-index 30e67936..64a5a976 100644
---- a/Source/Directory.Build.props
-+++ b/Source/Directory.Build.props
-@@ -7,7 +7,7 @@
- 
-   <!-- Boogie dependency -->
-   <ItemGroup>
--    <PackageReference Include="Boogie.ExecutionEngine" Version="2.13.4" />
-+    <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
+diff --git a/Source/Dafny/DafnyPipeline.csproj b/Source/Dafny/DafnyPipeline.csproj
+index 6ea0de067..ca1e0e527 100644
+--- a/Source/Dafny/DafnyPipeline.csproj
++++ b/Source/Dafny/DafnyPipeline.csproj
+@@ -25,7 +25,7 @@
+       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+       <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.13.4" />
++      <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
    </ItemGroup>
  
- </Project>
+   <ItemGroup>


### PR DESCRIPTION
Move the Boogie reference from `Directory.Build.props` to `DafnyPipeline.csproj`. 

This reference was picked up by the C# code generated by `tutorial/Simple_compiler/Compiler.dfy`, which would cause build failures after applying `customBoogie.patch` (example failure: https://github.com/dafny-lang/dafny/runs/5990731332?check_suite_focus=true).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
