### PR TITLE
chore: Exclude `*.pdb` files from release package

### DIFF
--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -226,11 +226,7 @@ def path_leaf(path):
     return tail or ntpath.basename(head)
 
 def pathsInDirectory(directory):
-    l1 = list(map(lambda file: path.join(directory, file), os.listdir(directory)))
-    l2 = [path.join(directory, file) for file in os.listdir(directory)]
-    assert l1 == l2
     return [path.join(directory, file) for file in os.listdir(directory) if not file.endswith(".pdb")]
-    return l2
 
 def download(releases):
     flush("  - Downloading {} z3 archives".format(len(releases)))

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -183,9 +183,8 @@ class Release:
                 lowercaseDafny = path.join(self.buildDirectory, "dafny")
                 shutil.move(uppercaseDafny, lowercaseDafny)
                 os.chmod(lowercaseDafny, stat.S_IEXEC| os.lstat(lowercaseDafny).st_mode)
-            paths = pathsInDirectory(self.buildDirectory) + OTHERS
-            for fpath in paths:
-                if os.path.isdir(fpath):
+            for fpath in pathsInDirectory(self.buildDirectory) + OTHERS:
+                if os.path.isdir(fpath) or fpath.endswith(".pdb"):
                     continue
                 fname = ntpath.basename(fpath)
                 if path.exists(fpath):
@@ -226,7 +225,7 @@ def path_leaf(path):
     return tail or ntpath.basename(head)
 
 def pathsInDirectory(directory):
-    return [path.join(directory, file) for file in os.listdir(directory) if not file.endswith(".pdb")]
+    return [path.join(directory, file) for file in os.listdir(directory)]
 
 def download(releases):
     flush("  - Downloading {} z3 archives".format(len(releases)))

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -226,7 +226,11 @@ def path_leaf(path):
     return tail or ntpath.basename(head)
 
 def pathsInDirectory(directory):
-    return list(map(lambda file: path.join(directory, file), os.listdir(directory)))
+    l1 = list(map(lambda file: path.join(directory, file), os.listdir(directory)))
+    l2 = [path.join(directory, file) for file in os.listdir(directory)]
+    assert l1 == l2
+    return [path.join(directory, file) for file in os.listdir(directory) if not file.endswith(".pdb")]
+    return l2
 
 def download(releases):
     flush("  - Downloading {} z3 archives".format(len(releases)))

--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -1516,7 +1516,7 @@ If possible, Dafny compilers will represent values of the newtype using
 a native type for the sake of efficiency. This action can
 be inhibited or a specific native data type selected by
 using the `{:nativeType}` attribute, as explained in
-[Section 22.1.12](#sec-nativetype).
+[Section 22.1.2](#sec-nativetype).
 
 Furthermore, for the compiler to be able to make an appropriate choice of
 representation, the constants in the defining expression as shown above must be
@@ -2279,7 +2279,7 @@ transparent all the way.
 
 But the transparency of a function is affected by
 whether the function was given the `{:opaque}` attribute (as explained
-in [Section 22.1.13](#sec-opaque)).
+in [Section 22.2.9](#sec-opaque)).
 
 The following table summarizes where the function is transparent.
 The module referenced in the table is the module in which the


### PR DESCRIPTION
To avoid leaking the compile-time locations of the source files in stack traces, we stop distributing the program database (PDB).

Before:
```
Unhandled exception. System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Dafny.SkeletonStatement.get_SubStatements()+MoveNext() in /Users/fmadge/Documents/dafny/Source/Dafny/AST/DafnyAst.cs:line 8850
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Dafny.ProgramTraverser.Traverse(Statement stmt, String field, Object parent) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 747
   at Microsoft.Dafny.ProgramTraverser.<>c__DisplayClass17_0.<Traverse>b__2(Statement subStmt) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 749
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Dafny.ProgramTraverser.Traverse(Statement stmt, String field, Object parent) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 747
   at Microsoft.Dafny.ProgramTraverser.Traverse(MemberDecl memberDeclaration, String field, Object parent) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 729
   at Microsoft.Dafny.ProgramTraverser.<>c__DisplayClass15_0.<Traverse>b__0(MemberDecl memberDecl) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 603
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Dafny.ProgramTraverser.Traverse(TopLevelDecl topd) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 603
   at Microsoft.Dafny.ProgramTraverser.Traverse(List`1 topLevelDecls) in /Users/fmadge/Documents/dafny/Source/Dafny/Util.cs:line 544
   at Microsoft.Dafny.Resolver.ResolveTopLevelDecls_Core(List`1 declarations, Graph`1 datatypeDependencies, Graph`1 codatatypeDependencies, Boolean isAnExport) in /Users/fmadge/Documents/dafny/Source/Dafny/Resolver.cs:line 3535
   at Microsoft.Dafny.Resolver.ResolveModuleDefinition(ModuleDefinition m, ModuleSignature sig, Boolean isAnExport) in /Users/fmadge/Documents/dafny/Source/Dafny/Resolver.cs:line 1024
   at Microsoft.Dafny.Resolver.ResolveProgram(Program prog) in /Users/fmadge/Documents/dafny/Source/Dafny/Resolver.cs:line 499
   at Microsoft.Dafny.Main.Resolve(Program program, ErrorReporter reporter) in /Users/fmadge/Documents/dafny/Source/Dafny/DafnyMain.cs:line 162
   at Microsoft.Dafny.DafnyDriver.ProcessFiles(IList`1 dafnyFiles, ReadOnlyCollection`1 otherFileNames, ErrorReporter reporter, Boolean lookForSnapshots, String programId) in /Users/fmadge/Documents/dafny/Source/DafnyDriver/DafnyDriver.cs:line 249
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at Microsoft.Dafny.DafnyDriver.ThreadMain(String[] args) in /Users/fmadge/Documents/dafny/Source/DafnyDriver/DafnyDriver.cs:line 67
   at Microsoft.Dafny.DafnyDriver.<>c__DisplayClass6_0.<Main>b__0() in /Users/fmadge/Documents/dafny/Source/DafnyDriver/DafnyDriver.cs:line 47
   at System.Threading.Thread.StartCallback()
```
After:
```
Unhandled exception. System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Dafny.SkeletonStatement.get_SubStatements()+MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Dafny.ProgramTraverser.Traverse(Statement stmt, String field, Object parent)
   at Microsoft.Dafny.ProgramTraverser.<>c__DisplayClass17_0.<Traverse>b__2(Statement subStmt)
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Dafny.ProgramTraverser.Traverse(Statement stmt, String field, Object parent)
   at Microsoft.Dafny.ProgramTraverser.Traverse(MemberDecl memberDeclaration, String field, Object parent)
   at Microsoft.Dafny.ProgramTraverser.<>c__DisplayClass15_0.<Traverse>b__0(MemberDecl memberDecl)
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Dafny.ProgramTraverser.Traverse(TopLevelDecl topd)
   at Microsoft.Dafny.ProgramTraverser.Traverse(List`1 topLevelDecls)
   at Microsoft.Dafny.Resolver.ResolveTopLevelDecls_Core(List`1 declarations, Graph`1 datatypeDependencies, Graph`1 codatatypeDependencies, Boolean isAnExport)
   at Microsoft.Dafny.Resolver.ResolveModuleDefinition(ModuleDefinition m, ModuleSignature sig, Boolean isAnExport)
   at Microsoft.Dafny.Resolver.ResolveProgram(Program prog)
   at Microsoft.Dafny.Main.Resolve(Program program, ErrorReporter reporter)
   at Microsoft.Dafny.DafnyDriver.ProcessFiles(IList`1 dafnyFiles, ReadOnlyCollection`1 otherFileNames, ErrorReporter reporter, Boolean lookForSnapshots, String programId)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at Microsoft.Dafny.DafnyDriver.ThreadMain(String[] args)
   at Microsoft.Dafny.DafnyDriver.<>c__DisplayClass6_0.<Main>b__0()
   at System.Threading.Thread.StartCallback()
```
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
