### PR TITLE
Remove mention of deprecated flags in /extractCounterexample help text

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -1093,7 +1093,7 @@ Exit code: 0 -- success; 1 -- invalid command-line; 2 -- parse or type errors;
 /extractCounterexample
     If verification fails, report a detailed counterexample for the first
     failing assertion. Requires specifying the /mv option as well as
-    /proverOpt:0:model_compress=false and /proverOpt:0:model.completion=true.
+    /proverOpt:O:model_compress=false and /proverOpt:O:model.completion=true.
 /countVerificationErrors:<n>
     [ deprecated ]
     0 - Set exit code to 0 regardless of the presence of any other errors.


### PR DESCRIPTION
Per https://github.com/dafny-lang/dafny/issues/2026 :

Previously, the help string for /extractCounterexample would make
mention of certain proverOpt flags that have seemingly since been
removed.  This patch removes mention of them from the help string
(and makes explicit that /mv takes a file path argument).

Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
