### PR TITLE
fix: Protect newtypes and datatypes from refinement

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@
 - fix: Fix initialization of non-auto-init in-parameters in C#/JavaScript/Go compilers (https://github.com/dafny-lang/dafny/pull/1935)
 - fix: Resolution of static functions-by-method (https://github.com/dafny-lang/dafny/pull/2023)
 - fix: Export sets did not work with inner modules (https://github.com/dafny-lang/dafny/pull/2025)
-
+- fix: Prevent refinements from changing datatype and newtype definitions (https://github.com/dafny-lang/dafny/pull/2038)
 
 # 3.5.0
 

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -4622,7 +4622,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(cce.NonNullElements(typeArgs));
       Contract.Requires(cce.NonNullElements(ctors));
       Contract.Requires(cce.NonNullElements(members));
-      Contract.Requires(1 <= ctors.Count);
+      Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
       Ctors = ctors;
       this.NewSelfSynonym();
     }
@@ -4684,7 +4684,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(cce.NonNullElements(typeArgs));
       Contract.Requires(cce.NonNullElements(ctors));
       Contract.Requires(cce.NonNullElements(members));
-      Contract.Requires(1 <= ctors.Count);
+      Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
     }
   }
 
@@ -4779,7 +4779,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(cce.NonNullElements(typeArgs));
       Contract.Requires(cce.NonNullElements(ctors));
       Contract.Requires(cce.NonNullElements(members));
-      Contract.Requires(1 <= ctors.Count);
+      Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
     }
 
     public override DatatypeCtor GetGroundingCtor() {
@@ -5513,18 +5513,18 @@ namespace Microsoft.Dafny {
   public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, RedirectingTypeDecl {
     public override string WhatKind { get { return "newtype"; } }
     public override bool CanBeRevealed() { return true; }
-    public readonly Type BaseType;
-    public readonly BoundVar Var;  // can be null (if non-null, then object.ReferenceEquals(Var.Type, BaseType))
-    public readonly Expression Constraint;  // is null iff Var is
-    public readonly SubsetTypeDecl.WKind WitnessKind = SubsetTypeDecl.WKind.CompiledZero;
-    public readonly Expression/*?*/ Witness;  // non-null iff WitnessKind is Compiled or Ghost
-    public NativeType NativeType; // non-null for fixed-size representations (otherwise, use BigIntegers for integers)
+    public Type BaseType { get; set; } // null when refining
+    public BoundVar Var { get; set; }  // can be null (if non-null, then object.ReferenceEquals(Var.Type, BaseType))
+    public Expression Constraint { get; set; }  // is null iff Var is
+    public SubsetTypeDecl.WKind WitnessKind { get; set; } = SubsetTypeDecl.WKind.CompiledZero;
+    public Expression/*?*/ Witness { get; set; } // non-null iff WitnessKind is Compiled or Ghost
+    [FilledInDuringResolution] public NativeType NativeType; // non-null for fixed-size representations (otherwise, use BigIntegers for integers)
     public NewtypeDecl(IToken tok, string name, ModuleDefinition module, Type baseType, List<MemberDecl> members, Attributes attributes, bool isRefining)
       : base(tok, name, module, new List<TypeParameter>(), members, attributes, isRefining) {
       Contract.Requires(tok != null);
       Contract.Requires(name != null);
       Contract.Requires(module != null);
-      Contract.Requires(baseType != null);
+      Contract.Requires(isRefining ^ (baseType != null));
       Contract.Requires(members != null);
       BaseType = baseType;
     }

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1236,11 +1236,12 @@ DatatypeDecl<DeclModifierData dmod, ModuleDefinition/*!*/ module, out DatatypeDe
   { Attribute<ref attrs> }
   DatatypeName<out id>
   [ GenericParameters<typeArgs, true> ]
+  (
   "="                                      (. bodyStart = t; .)
-  [ ellipsis                               (. isRefining = true; .)
-  ]
   [ "|" ] DatatypeMemberDecl<ctors>
   { "|" DatatypeMemberDecl<ctors> }
+  | ellipsis                               (. isRefining = true; bodyStart = t; .)
+  )
   [ TypeMembers<module, members> ]
   (. if (co) {
        dt = new CoDatatypeDecl(id, id.val, module, typeArgs, ctors, members, attrs, isRefining);
@@ -1339,16 +1340,14 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
      Type baseType = null;
      Expression constraint;
      Expression witness = null;
-     bool isRefining = false;
      CheckDeclModifiers(ref dmod, "newtype", AllowedDeclModifiers.None);
      var members = new List<MemberDecl>();
   .)
   "newtype"
   { Attribute<ref attrs> }
   NewtypeName<out id>
+  (
   "="
-  [ ellipsis                         (. isRefining = true; .)
-  ]
   ( IF(IsIdentColonOrBar())
     LocalVarName<out bvId>
     [ ":" Type<out baseType> ]       (. if (baseType == null) { baseType = new InferredTypeProxy(); } .)
@@ -1365,11 +1364,16 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
       )
     ]
     [ TypeMembers<module, members> ]
-    (. td = new NewtypeDecl(id, id.val, module, new BoundVar(bvId, bvId.val, baseType), constraint, witnessKind, witness, members, attrs, isRefining);
+    (. td = new NewtypeDecl(id, id.val, module, new BoundVar(bvId, bvId.val, baseType), constraint, witnessKind, witness, members, attrs, isRefining: false);
     .)
   | Type<out baseType>
     [ TypeMembers<module, members> ]
-    (. td = new NewtypeDecl(id, id.val, module, baseType, members, attrs, isRefining); .)
+    (. td = new NewtypeDecl(id, id.val, module, baseType, members, attrs, isRefining: false); .)
+  )
+  | ellipsis
+    [ TypeMembers<module, members> ]
+    (. baseType = null; // Base type is not known yet
+       td = new NewtypeDecl(id, id.val, module, baseType, members, attrs, isRefining: true); .)
   )
   .
 

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1238,6 +1238,9 @@ DatatypeDecl<DeclModifierData dmod, ModuleDefinition/*!*/ module, out DatatypeDe
   [ GenericParameters<typeArgs, true> ]
   (
   "="                                      (. bodyStart = t; .)
+  [ ellipsis                               (. SemErr(t, // Help users adjust to the new syntax
+      $"Refinement cannot change the constructors of a `datatype`.  To refine `{id.val}`, either omit this `...` or omit the `=` sign and the datatype constructors."); .)
+  ]
   [ "|" ] DatatypeMemberDecl<ctors>
   { "|" DatatypeMemberDecl<ctors> }
   | ellipsis                               (. isRefining = true; bodyStart = t; .)
@@ -1348,6 +1351,9 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
   NewtypeName<out id>
   (
   "="
+  [ ellipsis                               (. SemErr(t, // Help users adjust to the new syntax
+      $"Refinement cannot change the base type of a `newtype`.  To refine `{id.val}`, either omit this `...` or omit the `=` sign and the parent type's body."); .)
+  ]
   ( IF(IsIdentColonOrBar())
     LocalVarName<out bvId>
     [ ":" Type<out baseType> ]       (. if (baseType == null) { baseType = new InferredTypeProxy(); } .)

--- a/Source/Dafny/DafnyMain.cs
+++ b/Source/Dafny/DafnyMain.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Dafny {
 
     // Returns a canonical string for the given file path, namely one which is the same
     // for all paths to a given file and different otherwise. The best we can do is to
-    // make the path absolute -- detecting case and canoncializing symbolic and hard
+    // make the path absolute -- detecting case and canonicalizing symbolic and hard
     // links are difficult across file systems (which may mount parts of other filesystems,
     // with different characteristics) and is not supported by .Net libraries
     public static string Canonicalize(String filePath) {

--- a/Source/Dafny/RefinementTransformer.cs
+++ b/Source/Dafny/RefinementTransformer.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Dafny {
 
         Contract.Assert(RefinedSig.ModuleDef != null);
         Contract.Assert(m.RefinementQId.Def == RefinedSig.ModuleDef);
-        // check that the openess in the imports between refinement and its base matches
+        // check that the openness in the imports between refinement and its base matches
         List<TopLevelDecl> declarations = m.TopLevelDecls;
         List<TopLevelDecl> baseDeclarations = m.RefinementQId.Def.TopLevelDecls;
         foreach (var im in declarations) {
@@ -196,7 +196,8 @@ namespace Microsoft.Dafny {
         PreResolveWorker(m);
       } else {
         // do this also for non-refining modules
-        CheckSuperflousRefiningMarks(m.TopLevelDecls, new List<string>());
+        CheckSuperfluousRefiningMarks(m.TopLevelDecls, new List<string>());
+        AddDefaultBaseTypeToUnresolvedNewtypes(m.TopLevelDecls);
       }
     }
 
@@ -242,7 +243,8 @@ namespace Microsoft.Dafny {
           }
         }
       }
-      CheckSuperflousRefiningMarks(m.TopLevelDecls, processedDecl);
+      CheckSuperfluousRefiningMarks(m.TopLevelDecls, processedDecl);
+      AddDefaultBaseTypeToUnresolvedNewtypes(m.TopLevelDecls);
 
       // Merge the imports of prev
       var prevTopLevelDecls = RefinedSig.TopLevels.Values;
@@ -259,12 +261,25 @@ namespace Microsoft.Dafny {
       Contract.Assert(moduleUnderConstruction == m);  // this should be as it was set earlier in this method
     }
 
-    private void CheckSuperflousRefiningMarks(List<TopLevelDecl> topLevelDecls, List<string> excludeList) {
+    private void CheckSuperfluousRefiningMarks(List<TopLevelDecl> topLevelDecls, List<string> excludeList) {
       Contract.Requires(topLevelDecls != null);
       Contract.Requires(excludeList != null);
       foreach (var d in topLevelDecls) {
         if (d.IsRefining && !excludeList.Contains(d.Name)) {
           Reporter.Error(MessageSource.RefinementTransformer, d.tok, $"declaration '{d.Name}' indicates refining (notation `...`), but does not refine anything");
+        }
+      }
+    }
+
+    /// <summary>
+    /// Give unresolved newtypes a reasonable default type (<c>int</c>), to avoid having to support `null` in the
+    /// rest of the resolution pipeline.
+    /// </summary>
+    private void AddDefaultBaseTypeToUnresolvedNewtypes(List<TopLevelDecl> topLevelDecls) {
+      foreach (var d in topLevelDecls) {
+        if (d is NewtypeDecl { IsRefining: true, BaseType: null } decl) {
+          Reporter.Info(MessageSource.RefinementTransformer, decl.tok, $"defaulting to 'int' for unspecified base type of '{decl.Name}'");
+          decl.BaseType = new IntType(); // Set `BaseType` to some reasonable default to allow resolution to proceed
         }
       }
     }
@@ -364,18 +379,30 @@ namespace Microsoft.Dafny {
         Reporter.Error(MessageSource.RefinementTransformer, nw,
           "an opaque type declaration ({0}) in a refining module cannot replace a more specific type declaration in the refinement base", nw.Name);
       } else if ((d is IndDatatypeDecl && nw is IndDatatypeDecl) || (d is CoDatatypeDecl && nw is CoDatatypeDecl)) {
+        var (dd, nwd) = ((DatatypeDecl)d, (DatatypeDecl)nw);
+        Contract.Assert(!nwd.Ctors.Any());
+        nwd.Ctors.AddRange(dd.Ctors.Select(refinementCloner.CloneCtor));
         m.TopLevelDecls[index] = MergeClass((DatatypeDecl)nw, (DatatypeDecl)d);
       } else if (nw is DatatypeDecl) {
         Reporter.Error(MessageSource.RefinementTransformer, nw, commonMsg, nw.WhatKind, nw.Name);
       } else if (d is NewtypeDecl && nw is NewtypeDecl) {
+        var (dn, nwn) = ((NewtypeDecl)d, (NewtypeDecl)nw);
+        Contract.Assert(nwn.BaseType == null && nwn.Var == null &&
+                        nwn.Constraint == null && nwn.Witness == null);
+        nwn.Var = dn.Var == null ? null : refinementCloner.CloneBoundVar(dn.Var);
+        nwn.BaseType = nwn.Var?.Type ?? refinementCloner.CloneType(dn.BaseType); // Preserve newtype invariant that Var.Type is BaseType
+        nwn.Constraint = dn.Constraint == null ? null : refinementCloner.CloneExpr(dn.Constraint);
+        nwn.WitnessKind = dn.WitnessKind;
+        nwn.Witness = dn.Witness == null ? null : refinementCloner.CloneExpr(dn.Witness);
         m.TopLevelDecls[index] = MergeClass((NewtypeDecl)nw, (NewtypeDecl)d);
       } else if (nw is NewtypeDecl) {
+        // `.Basetype` will be set in AddDefaultBaseTypeToUnresolvedNewtypes
         Reporter.Error(MessageSource.RefinementTransformer, nw, commonMsg, nw.WhatKind, nw.Name);
       } else if (nw is IteratorDecl) {
         if (d is IteratorDecl) {
           m.TopLevelDecls[index] = MergeIterator((IteratorDecl)nw, (IteratorDecl)d);
         } else {
-          Reporter.Error(MessageSource.RefinementTransformer, nw, "an iterator declaration ({0}) is a refining module cannot replace a different kind of declaration in the refinement base", nw.Name);
+          Reporter.Error(MessageSource.RefinementTransformer, nw, "an iterator declaration ({0}) in a refining module cannot replace a different kind of declaration in the refinement base", nw.Name);
         }
       } else if (nw is TraitDecl) {
         if (d is TraitDecl) {

--- a/Test/dafny0/Modules0.dfy
+++ b/Test/dafny0/Modules0.dfy
@@ -346,7 +346,7 @@ module AA refines Library {
 }
 
 module B refines AA {
-  datatype T = ... MakeT(int)  // illegal
+  datatype T ...  // illegal
 }
 
 // ---------------------- some modules from above without errors

--- a/Test/git-issues/git-issue-1180a.dfy
+++ b/Test/git-issues/git-issue-1180a.dfy
@@ -1,4 +1,4 @@
-// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /compile:0 /printTooltips "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // resolution errors
@@ -6,9 +6,9 @@
 module BadRefiningIndications {
   type Opaque ... // error: uses ... but there's nothing to refine
   type Opaque' ... { } // error: uses ... but there's nothing to refine
-  datatype Datatype = ... Make(x: int) // error: uses ... but there's nothing to refine
-  codatatype Codatatype = ... Make(x: int) // error: uses ... but there's nothing to refine
-  newtype Newtype = ... int // error: uses ... but there's nothing to refine
+  datatype Datatype ... // error: uses ... but there's nothing to refine
+  codatatype Codatatype ... // error: uses ... but there's nothing to refine
+  newtype Newtype ... // error: uses ... but there's nothing to refine
   class Class ... { } // error: uses ... but there's nothing to refine
   trait Trait ... { } // error: uses ... but there's nothing to refine
 }
@@ -18,9 +18,9 @@ module EmptyRefinementParent { }
 module MoreBadRefiningIndications refines EmptyRefinementParent {
   type Opaque ... // error: uses ... but there's nothing to refine
   type Opaque' ... { } // error: uses ... but there's nothing to refine
-  datatype Datatype = ... Make(x: int) // error: uses ... but there's nothing to refine
-  codatatype Codatatype = ... Make(x: int) // error: uses ... but there's nothing to refine
-  newtype Newtype = ... int // error: uses ... but there's nothing to refine
+  datatype Datatype ... // error: uses ... but there's nothing to refine
+  codatatype Codatatype ... // error: uses ... but there's nothing to refine
+  newtype Newtype ... // error: uses ... but there's nothing to refine
   class Class ... { } // error: uses ... but there's nothing to refine
   trait Trait ... { } // error: uses ... but there's nothing to refine
 }
@@ -95,14 +95,14 @@ module StartingFromDatatype {
     type Ty ... { } // error: cannot refine a datatype with an opaque type
   }
   module Datatype refines A {
-    datatype Ty = ... Make(w: int) {
+    datatype Ty ... {
     }
   }
   module Codatatype refines A {
-    codatatype Ty = ... Make(w: int) // error: cannot refine a datatype with a codatatype
+    codatatype Ty ... // error: cannot refine a datatype with a codatatype
   }
   module Newtype refines A {
-    newtype Ty = ... int { } // error: cannot refine a datatype with a newtype
+    newtype Ty ... { } // error: cannot refine a datatype with a newtype
   }
   module Class refines A {
     class Ty ... { } // error: cannot refine a datatype with a class
@@ -127,14 +127,14 @@ module StartingFromCodatatype {
     type Ty ... // error: cannot refine a codatatype with an opaque type
   }
   module Datatype refines A {
-    datatype Ty = ... Make(w: int) // error: cannot refine a codatatype with a datatype
+    datatype Ty ... // error: cannot refine a codatatype with a datatype
   }
   module Codatatype refines A {
-    codatatype Ty = ... Make(w: int) {
+    codatatype Ty ... {
     }
   }
   module Newtype refines A {
-    newtype Ty = ... int { } // error: cannot refine a codatatype with a newtype
+    newtype Ty ... { } // error: cannot refine a codatatype with a newtype
   }
   module Class refines A {
     class Ty ... { } // error: cannot refine a codatatype with a class
@@ -159,10 +159,10 @@ module StartingFromNewtype {
     type Ty ... // error: cannot refine a newtype with an opaque type
   }
   module Datatype refines A {
-    datatype Ty = ... Make(w: int) // error: cannot refine a newtype with a datatype
+    datatype Ty ... // error: cannot refine a newtype with a datatype
   }
   module Codatatype refines A {
-    codatatype Ty = ... Make(w: int) { // error: cannot refine a newtype with a codatatype
+    codatatype Ty ... { // error: cannot refine a newtype with a codatatype
     }
   }
   module Class refines A {
@@ -188,14 +188,14 @@ module StartingFromClass {
     type Ty ... // error: cannot refine a class with an opaque type
   }
   module Datatype refines A {
-    datatype Ty = ... Make(w: int) // error: cannot refine a class with a datatype
+    datatype Ty ... // error: cannot refine a class with a datatype
   }
   module Codatatype refines A {
-    codatatype Ty = ... Make(w: int) { // error: cannot refine a class with a codatatype
+    codatatype Ty ... { // error: cannot refine a class with a codatatype
     }
   }
   module Newtype refines A {
-    newtype Ty = ... int { } // error: cannot refine a class with a newtype
+    newtype Ty ... { } // error: cannot refine a class with a newtype
   }
   module Trait refines A {
     trait Ty ... { } // error: cannot refine a class with a trait
@@ -217,14 +217,14 @@ module StartingFromTrait {
     type Ty ... // error: cannot refine a trait with an opaque type
   }
   module Datatype refines A {
-    datatype Ty = ... Make(w: int) // error: cannot refine a trait with a datatype
+    datatype Ty ... // error: cannot refine a trait with a datatype
   }
   module Codatatype refines A {
-    codatatype Ty = ... Make(w: int) { // error: cannot refine a trait with a codatatype
+    codatatype Ty ... { // error: cannot refine a trait with a codatatype
     }
   }
   module Newtype refines A {
-    newtype Ty = ... int { } // error: cannot refine a trait with a newtype
+    newtype Ty ... { } // error: cannot refine a trait with a newtype
   }
   module Class refines A {
     class Ty ... { } // error: cannot refine a trait with a class

--- a/Test/git-issues/git-issue-1180a.dfy.expect
+++ b/Test/git-issues/git-issue-1180a.dfy.expect
@@ -5,6 +5,7 @@ git-issue-1180a.dfy(10,13): Error: declaration 'Codatatype' indicates refining (
 git-issue-1180a.dfy(11,10): Error: declaration 'Newtype' indicates refining (notation `...`), but does not refine anything
 git-issue-1180a.dfy(12,8): Error: declaration 'Class' indicates refining (notation `...`), but does not refine anything
 git-issue-1180a.dfy(13,8): Error: declaration 'Trait' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(11,10): Info: defaulting to 'int' for unspecified base type of 'Newtype'
 git-issue-1180a.dfy(19,7): Error: declaration 'Opaque' indicates refining (notation `...`), but does not refine anything
 git-issue-1180a.dfy(20,7): Error: declaration 'Opaque'' indicates refining (notation `...`), but does not refine anything
 git-issue-1180a.dfy(21,11): Error: declaration 'Datatype' indicates refining (notation `...`), but does not refine anything
@@ -12,6 +13,7 @@ git-issue-1180a.dfy(22,13): Error: declaration 'Codatatype' indicates refining (
 git-issue-1180a.dfy(23,10): Error: declaration 'Newtype' indicates refining (notation `...`), but does not refine anything
 git-issue-1180a.dfy(24,8): Error: declaration 'Class' indicates refining (notation `...`), but does not refine anything
 git-issue-1180a.dfy(25,8): Error: declaration 'Trait' indicates refining (notation `...`), but does not refine anything
+git-issue-1180a.dfy(23,10): Info: defaulting to 'int' for unspecified base type of 'Newtype'
 git-issue-1180a.dfy(37,9): Error: opaque type 'Ty' is declared with a different number of type parameters (2 instead of 1) than the corresponding opaque type in the module it refines
 git-issue-1180a.dfy(38,22): Error: function 'F' is declared with a different number of type parameters (1 instead of 0) than the corresponding function in the module it refines
 git-issue-1180a.dfy(38,22): Error: the result type of function 'F' (Z) differs from the result type of the corresponding function in the module it refines (nat)
@@ -53,12 +55,14 @@ git-issue-1180a.dfy(92,9): Error: an opaque type declaration (Ty) in a refining 
 git-issue-1180a.dfy(95,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
 git-issue-1180a.dfy(102,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
 git-issue-1180a.dfy(105,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(105,12): Info: defaulting to 'int' for unspecified base type of 'Ty'
 git-issue-1180a.dfy(108,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
 git-issue-1180a.dfy(111,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
 git-issue-1180a.dfy(114,9): Error: a type synonym (Ty) is not allowed to replace a datatype from the refined module (A), even if it denotes the same type
 git-issue-1180a.dfy(127,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
 git-issue-1180a.dfy(130,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
 git-issue-1180a.dfy(137,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(137,12): Info: defaulting to 'int' for unspecified base type of 'Ty'
 git-issue-1180a.dfy(140,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
 git-issue-1180a.dfy(143,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
 git-issue-1180a.dfy(146,9): Error: a type synonym (Ty) is not allowed to replace a codatatype from the refined module (A), even if it denotes the same type
@@ -72,12 +76,14 @@ git-issue-1180a.dfy(188,9): Error: an opaque type declaration (Ty) in a refining
 git-issue-1180a.dfy(191,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
 git-issue-1180a.dfy(194,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
 git-issue-1180a.dfy(198,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(198,12): Info: defaulting to 'int' for unspecified base type of 'Ty'
 git-issue-1180a.dfy(201,10): Error: a trait declaration (Ty) in a refinement module can only refine a trait declaration or replace an opaque type declaration
 git-issue-1180a.dfy(204,9): Error: a type synonym (Ty) is not allowed to replace a class from the refined module (A), even if it denotes the same type
 git-issue-1180a.dfy(217,9): Error: an opaque type declaration (Ty) in a refining module cannot replace a more specific type declaration in the refinement base
 git-issue-1180a.dfy(220,13): Error: a datatype declaration (Ty) in a refinement module can only refine a datatype declaration or replace an opaque type declaration
 git-issue-1180a.dfy(223,15): Error: a codatatype declaration (Ty) in a refinement module can only refine a codatatype declaration or replace an opaque type declaration
 git-issue-1180a.dfy(227,12): Error: a newtype declaration (Ty) in a refinement module can only refine a newtype declaration or replace an opaque type declaration
+git-issue-1180a.dfy(227,12): Info: defaulting to 'int' for unspecified base type of 'Ty'
 git-issue-1180a.dfy(230,10): Error: a class declaration (Ty) in a refinement module can only refine a class declaration or replace an opaque type declaration
 git-issue-1180a.dfy(233,9): Error: a type synonym (Ty) is not allowed to replace a trait from the refined module (A), even if it denotes the same type
 82 resolution/type errors detected in git-issue-1180a.dfy

--- a/Test/git-issues/git-issue-1180b.dfy
+++ b/Test/git-issues/git-issue-1180b.dfy
@@ -79,7 +79,7 @@ module StartingFromDatatype {
     }
   }
   module Datatype refines A {
-    datatype Ty = ... Make(w: int) {
+    datatype Ty ... {
       function method F(x: nat): nat { x } // error: postcondition violation
       method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
     }
@@ -99,7 +99,7 @@ module StartingFromNewtype {
     }
   }
   module Newtype refines A {
-    newtype Ty = ... int {
+    newtype Ty ... {
       function method F(x: nat): nat { x } // error: postcondition violation
       method M(x: nat) returns (r: nat) { r := c; } // error: postcondition violation
     }

--- a/Test/git-issues/git-issue-1963a.dfy
+++ b/Test/git-issues/git-issue-1963a.dfy
@@ -9,7 +9,7 @@ module A {
 }
 
 module B refines A {
-  newtype NT = ... x: int | x < 0 witness -1
+  newtype NT = ... x: int | x < 0 witness -1 // Error: Change (or repeat) a newtype body
 }
 
 method M() ensures false {

--- a/Test/git-issues/git-issue-1963a.dfy
+++ b/Test/git-issues/git-issue-1963a.dfy
@@ -1,0 +1,17 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+/// This file checks that refinement is forbidden for newtypes
+
+module A {
+  newtype NT = x: int | x >= 0 witness 0
+  lemma P(x: NT) ensures x >= 0 {}
+}
+
+module B refines A {
+  newtype NT = ... x: int | x < 0 witness -1
+}
+
+method M() ensures false {
+  assert -1 >= 0 by { B.P(-1); }
+}

--- a/Test/git-issues/git-issue-1963a.dfy.expect
+++ b/Test/git-issues/git-issue-1963a.dfy.expect
@@ -1,2 +1,2 @@
-git-issue-1963a.dfy(12,15): Error: invalid NewtypeDecl
+git-issue-1963a.dfy(12,15): Error: Refinement cannot change the base type of a `newtype`.  To refine `NT`, either omit this `...` or omit the `=` sign and the parent type's body.
 1 parse errors detected in git-issue-1963a.dfy

--- a/Test/git-issues/git-issue-1963a.dfy.expect
+++ b/Test/git-issues/git-issue-1963a.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-1963a.dfy(12,15): Error: invalid NewtypeDecl
+1 parse errors detected in git-issue-1963a.dfy

--- a/Test/git-issues/git-issue-1963b.dfy
+++ b/Test/git-issues/git-issue-1963b.dfy
@@ -9,7 +9,7 @@ module A {
 }
 
 module B refines A {
-  datatype D = ... D | D'
+  datatype D = ... D | D' // Error: Cannot change (or repeat) constructors
 }
 
 method M() ensures false {

--- a/Test/git-issues/git-issue-1963b.dfy
+++ b/Test/git-issues/git-issue-1963b.dfy
@@ -1,0 +1,17 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+/// This file checks that refinement is forbidden for datatypes
+
+module A {
+  datatype D = D
+  lemma P(d: D) ensures d == D {}
+}
+
+module B refines A {
+  datatype D = ... D | D'
+}
+
+method M() ensures false {
+  assert B.D == B.D' by { B.P(B.D'); }
+}

--- a/Test/git-issues/git-issue-1963b.dfy.expect
+++ b/Test/git-issues/git-issue-1963b.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-1963b.dfy(12,15): Error: invalid NoUSIdentOrDigits
+1 parse errors detected in git-issue-1963b.dfy

--- a/Test/git-issues/git-issue-1963b.dfy.expect
+++ b/Test/git-issues/git-issue-1963b.dfy.expect
@@ -1,2 +1,2 @@
-git-issue-1963b.dfy(12,15): Error: invalid NoUSIdentOrDigits
+git-issue-1963b.dfy(12,15): Error: Refinement cannot change the constructors of a `datatype`.  To refine `D`, either omit this `...` or omit the `=` sign and the datatype constructors.
 1 parse errors detected in git-issue-1963b.dfy

--- a/Test/git-issues/git-issue-1963c.dfy
+++ b/Test/git-issues/git-issue-1963c.dfy
@@ -4,7 +4,7 @@
 /// This file checks that refinement works for members of newtypes and
 /// datatypes.
 
-module A {
+abstract module A {
   datatype D = D {
     function method f(): int
     function method g(): int { 1 }

--- a/Test/git-issues/git-issue-1963c.dfy
+++ b/Test/git-issues/git-issue-1963c.dfy
@@ -1,0 +1,55 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+/// This file checks that refinement works for members of newtypes and
+/// datatypes.
+
+module A {
+  datatype D = D {
+    function method f(): int
+    function method g(): int { 1 }
+  }
+
+  newtype NT0 = int {
+    function method f(): int
+    function method g(): int { 1 }
+  }
+
+  newtype NT = x: int | x >= 0 witness 0 {
+    function method f(): int
+    function method g(): int { 1 }
+  }
+}
+
+module B refines A {
+  datatype D ... {
+    function method f() : int { 1 }
+    function method g ...
+  }
+
+  newtype NT0 ... {
+    function method f() : int { 1 }
+    function method g ...
+  }
+
+  newtype NT ... {
+    function method f() : int { 1 }
+    function method g ...
+  }
+}
+
+module Parent {
+  type t
+  newtype pos = n: nat | n > 0 witness 1
+  datatype Bool = True | False
+}
+
+module Child refines Parent {
+  type t
+  newtype pos ... {
+    method Print() { print this; }
+  }
+  datatype Bool ... {
+    function method AsDafnyBool() : bool { this.True? }
+  }
+}

--- a/Test/git-issues/git-issue-1963c.dfy.expect
+++ b/Test/git-issues/git-issue-1963c.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/git-issues/git-issue-852.dfy
+++ b/Test/git-issues/git-issue-852.dfy
@@ -14,19 +14,19 @@ module Q0 refines M0 {
 }
 
 module Q1 refines M0 {
-  newtype T = ... n:nat | true {
+  newtype T ... {
     predicate p() {true}  // error: p() already has a body in M0
   }
 }
 
 module Q2 refines M0 {
-  newtype T = ... n:nat | true {
+  newtype T ... {
     predicate p... {true}  // error: p() already has a body in M0
   }
 }
 
 module Q3 refines M0 {
-  newtype T = ... n:nat | true {
+  newtype T ... {
     predicate p...  // allowed (but what's the point?)
   }
 }


### PR DESCRIPTION
Closes GH-1363, GH-1963.

Here's my understanding of the current refinement situation (trying to prevent similar bugs.  I have put 🆗 for places that I'm decently confident make sense, ❓ when I don't know, 🐛 for known issues, and an additional ✔️ when we checked further with @RustanLeino.

- `ModuleExport`: ellipsis comes before exports 🆗
- `ClassDecl`, `TraitDecl`: ellipsis replaces `extends` 🆗 
- `DatatypeDecl`: ellipsis comes before "|" (`DatatypeMemberDecl`) 🐛
  **FIXED, now comes instead of `|` and constructors**
- `ConstantFieldDecl`: ellipsis comes before `:=`  ❓  ✔️ 
- `NewtypeDecl`: ellipsis comes after `=`, before type and subset constraint 🐛
  **FIXED, now comes instead of `=`, type, and constraints**
- `SynonymTypeDecl`: ellipsis replaces `=` and definition 🆗 
- `MethodDecl`, `FunctionDecl`, `IteratorDecl`: ellipsis replaces signature 🆗 
- `SkeletonStmt`: ellipsis comes before `;` 🆗 
- `IfStmt`: ellipsis replaces guard 🆗
- `WhileStmt`: ellipsis replaces guard or body 🆗 
- `AssertStmt`, `AssumeStmt`: ellipsis replaces body (follows attributes) 🆗 (❓ for attributes) ✔️
- `ModifyStmt`: ellipsis replaces frame expressions ❓ 🐛 (follow up in https://github.com/dafny-lang/dafny/issues/2056)

Question: `ConstantFieldDecl` allows `const x ... := 1` to refine `const x: nat`.  But `const x := 1` is also a valid refinement of `const x: nat`, so the refinement is unnecessary.  In contrast, `ghost const x ...` is not allowed (must have type or definition), so to ghostify one must write `ghost const x: nat`.  Should we change anything here? → Moved to https://github.com/dafny-lang/dafny/issues/2057

