### PR TITLE
Use the same C++ warning flags on all platforms

### DIFF
--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2424,10 +2424,22 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assert(assemblyLocation != null);
       var codebase = System.IO.Path.GetDirectoryName(assemblyLocation);
       Contract.Assert(codebase != null);
-      var warnings = "-Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy -Wno-unused-label -Wno-unused-but-set-variable -Wno-unknown-warning-option";
-      var args = warnings + $" -g -std=c++17 -I {codebase} -o {ComputeExeName(targetFilename)} {targetFilename}";
+      var args = new List<string> {
+                       "-Wall",
+                       "-Wextra",
+                       "-Wpedantic",
+                       "-Wno-unused-variable",
+                       "-Wno-deprecated-copy",
+                       "-Wno-unused-label",
+                       "-Wno-unused-but-set-variable",
+                       "-Wno-unknown-warning-option",
+                        "-g",
+                        "-std=c++17",
+                        "-I", $"{codebase}",
+                        "-o", $"{ComputeExeName(targetFilename)}",
+                        $"{targetFilename}" };
       compilationResult = null;
-      var psi = new ProcessStartInfo("g++", args) {
+      var psi = new ProcessStartInfo("g++", string.Join(" ", args)) {
         CreateNoWindow = true,
         UseShellExecute = false,
         RedirectStandardOutput = true,

--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2435,9 +2435,9 @@ namespace Microsoft.Dafny.Compilers {
                        "-Wno-unknown-warning-option",
                         "-g",
                         "-std=c++17",
-                        "-I", $"{codebase}",
+                        "-I", codebase,
                         "-o", $"{ComputeExeName(targetFilename)}",
-                        $"{targetFilename}" };
+                        targetFilename };
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", string.Join(" ", args)) {
         CreateNoWindow = true,

--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2436,7 +2436,7 @@ namespace Microsoft.Dafny.Compilers {
                         "-g",
                         "-std=c++17",
                         "-I", codebase,
-                        "-o", $"{ComputeExeName(targetFilename)}",
+                        "-o", ComputeExeName(targetFilename),
                         targetFilename };
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", string.Join(" ", args)) {

--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2424,26 +2424,27 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assert(assemblyLocation != null);
       var codebase = System.IO.Path.GetDirectoryName(assemblyLocation);
       Contract.Assert(codebase != null);
-      var args = new List<string> {
-                       "-Wall",
-                       "-Wextra",
-                       "-Wpedantic",
-                       "-Wno-unused-variable",
-                       "-Wno-deprecated-copy",
-                       "-Wno-unused-label",
-                       "-Wno-unused-but-set-variable",
-                       "-Wno-unknown-warning-option",
-                        "-g",
-                        "-std=c++17",
-                        "-I", codebase,
-                        "-o", ComputeExeName(targetFilename),
-                        targetFilename };
       compilationResult = null;
-      var psi = new ProcessStartInfo("g++", string.Join(" ", args)) {
+      var psi = new ProcessStartInfo("g++") {
         CreateNoWindow = true,
         UseShellExecute = false,
         RedirectStandardOutput = true,
-        RedirectStandardError = true
+        RedirectStandardError = true,
+        ArgumentList = {
+          "-Wall",
+          "-Wextra",
+          "-Wpedantic",
+          "-Wno-unused-variable",
+          "-Wno-deprecated-copy",
+          "-Wno-unused-label",
+          "-Wno-unused-but-set-variable",
+          "-Wno-unknown-warning-option",
+          "-g",
+          "-std=c++17",
+          "-I", codebase,
+          "-o", ComputeExeName(targetFilename),
+          targetFilename
+        }
       };
       var proc = Process.Start(psi);
       while (!proc.StandardOutput.EndOfStream) {

--- a/Source/Dafny/Compilers/Compiler-cpp.cs
+++ b/Source/Dafny/Compilers/Compiler-cpp.cs
@@ -2424,12 +2424,7 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assert(assemblyLocation != null);
       var codebase = System.IO.Path.GetDirectoryName(assemblyLocation);
       Contract.Assert(codebase != null);
-      var warnings = "-Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy -Wno-unused-label";
-      if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-        warnings += " -Wno-unused-but-set-variable";
-      } else {
-        warnings += " -Wno-unknown-warning-option";
-      }
+      var warnings = "-Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-deprecated-copy -Wno-unused-label -Wno-unused-but-set-variable -Wno-unknown-warning-option";
       var args = warnings + $" -g -std=c++17 -I {codebase} -o {ComputeExeName(targetFilename)} {targetFilename}";
       compilationResult = null;
       var psi = new ProcessStartInfo("g++", args) {


### PR DESCRIPTION
Fixes #2041.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
