### PR TITLE
fix(performance): Provide capacity for the immutable array builder in ConcatSequence.ComputeElements()

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -1187,7 +1187,7 @@ namespace Dafny {
 
     private ImmutableArray<T> ComputeElements() {
       // Traverse the tree formed by all descendants which are ConcatSequences
-      var ansBuilder = ImmutableArray.CreateBuilder<T>();
+      var ansBuilder = ImmutableArray.CreateBuilder<T>(count);
       var toVisit = new Stack<ISequence<T>>();
       var (leftBuffer, rightBuffer) = (left, right);
       if (left == null || right == null) {


### PR DESCRIPTION
This method calculates the result of a tree of lazily concatenated sequences. Not providing a capacity was functionally correct, but meant the `ImmutableArray<T>.Builder` had to reallocate its internal array and copy values repeatedly as more ranges were added. Since `ConcatSequence` already tracks the total length of the concatenation, we can provide it as the initial capacity for the builder and avoid all these reallocations and copies.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
