### PR TITLE
docs: Minor wording change

### DIFF
--- a/docs/OnlineTutorial/guide.md
+++ b/docs/OnlineTutorial/guide.md
@@ -1823,10 +1823,10 @@ to their `reads` cousins,
 except they say what can be changed, rather than what the value of the function
 depends on. In combination with reads, modification
 restrictions allow Dafny to prove properties of code that would otherwise be
-very difficult or impossible. `reads` and `modifies` are one of the tools that
-allow Dafny to work on one method at a time, because they restrict what would
-otherwise be arbitrary modifications of memory to something that Dafny can
-reason about.
+very difficult or impossible. `reads` and `modifies` are among the tools that
+make it possible for Dafny to work on one method at a time, because they
+restrict what would otherwise be arbitrary modifications of memory to something
+that Dafny can reason about.
 
 
 Note that framing only applies to the *heap*, or memory accessed through

--- a/docs/OnlineTutorial/guide.md
+++ b/docs/OnlineTutorial/guide.md
@@ -1824,9 +1824,9 @@ except they say what can be changed, rather than what the value of the function
 depends on. In combination with reads, modification
 restrictions allow Dafny to prove properties of code that would otherwise be
 very difficult or impossible. `reads` and `modifies` are among the tools that
-make it possible for Dafny to work on one method at a time, because they
-restrict what would otherwise be arbitrary modifications of memory to something
-that Dafny can reason about.
+enable Dafny to work on one method at a time, because they restrict what would
+otherwise be arbitrary modifications of memory to something that Dafny can
+reason about.
 
 
 Note that framing only applies to the *heap*, or memory accessed through


### PR DESCRIPTION
Changed "one of" to "among" because two things are discussed. Also tried to reword it so that it is clearer

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
