### PR TITLE
Fix computation of equality support for datatypes (fixes #1427)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 - fix: Allow datatype update expressions for constructors with nameonly parameters (https://github.com/dafny-lang/dafny/pull/1949)
 - fix: Fix malformed Java code generated for comprehensions that use maps (https://github.com/dafny-lang/dafny/pull/1939)
 - fix: Comprehensions with nested subset types fully supported, subtype is correctly checked (https://github.com/dafny-lang/dafny/pull/1997)
+- fix: Fix computation of equality support for datatypes (https://github.com/dafny-lang/dafny/pull/2066)
 - fix: Fix induction hypothesis generated for lemmas with a receiver parameter (https://github.com/dafny-lang/dafny/pull/2002)
 - fix: Make verifier understand `(!new)` (https://github.com/dafny-lang/dafny/pull/1935)
 - fix: Fix initialization of non-auto-init in-parameters in C#/JavaScript/Go compilers (https://github.com/dafny-lang/dafny/pull/1935)

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -3036,6 +3036,7 @@ namespace Microsoft.Dafny {
           if (dt.EqualitySupport == IndDatatypeDecl.ES.Never) {
             return false;
           }
+          // FIXME datatype doesn't have type args but is marked as consult type args
           Contract.Assert(dt.TypeArgs.Count == TypeArgs.Count);
           var i = 0;
           foreach (var tp in dt.TypeArgs) {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -9841,18 +9841,18 @@ namespace Microsoft.Dafny {
       Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(cce.NonNullElements(dependencies));
 
       var scc = dependencies.GetSCC(startingPoint);
-      // First, the simple case:  If any parameter of any inductive datatype in the SCC is of a codatatype type, then
-      // the whole SCC is incapable of providing the equality operation.  Also, if any parameter of any inductive datatype
-      // is a ghost, then the whole SCC is incapable of providing the equality operation.
+      // First, the simple case:  If any parameter of any inductive datatype in the SCC is of non-equatable type, then
+      // the whole SCC is incapable of providing the equality operation.
       foreach (var dt in scc) {
         Contract.Assume(dt.EqualitySupport == IndDatatypeDecl.ES.NotYetComputed);
         foreach (var ctor in dt.Ctors) {
           foreach (var arg in ctor.Formals) {
-            var anotherIndDt = arg.Type.AsIndDatatype;
+            var type = arg.Type.NormalizeExpand();
             if (arg.IsGhost ||
-                (anotherIndDt != null && anotherIndDt.EqualitySupport == IndDatatypeDecl.ES.Never) ||
-                arg.Type.IsCoDatatype ||
-                arg.Type.IsArrowType) {
+                (type.AsIndDatatype is { EqualitySupport: IndDatatypeDecl.ES.Never }) ||
+                (type.AsIndDatatype is { EqualitySupport: IndDatatypeDecl.ES.ConsultTypeArguments }
+                 && type.TypeArgs.Any(ta => ta.NecessaryForEqualitySupportOfSurroundingInductiveDatatype)))
+                (!type.IsIndDatatype && !type.IsTypeParameter && !type.SupportsEquality)) {
               // arg.Type is known never to support equality
               // So, go around the entire SCC and record what we learnt
               foreach (var ddtt in scc) {

--- a/Test/git-issues/git-issue-1427.dfy
+++ b/Test/git-issues/git-issue-1427.dfy
@@ -1,0 +1,17 @@
+type Opaque
+type OpaqueT(==) = Opaque // Error: Opaque doesn't support ==
+
+datatype Datatype = DT(t: Opaque)
+type DatatypeT(==) = Datatype // Error: Opaque doesn't support ==
+
+type Synonym = Opaque
+type SynonymT(==) = Synonym // Error: Opaque doesn't support ==
+
+type Subset = t: Opaque | true witness *
+type SubsetT(==) = Subset // Error: Opaque doesn't support ==
+
+datatype Ghost = G(ghost i: int)
+type GhostT(==) = Ghost // Error: `i` is ghost
+
+datatype ThroughArg = C(s: Ghost)
+type ThroughArgT(==) = ThroughArg // Error: Ghost doesn't support ==

--- a/Test/git-issues/git-issue-1427.dfy.expect
+++ b/Test/git-issues/git-issue-1427.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-1427.dfy(8,2): Error: == can only be applied to expressions of types that support equality (got Datatype)
+git-issue-1427.dfy(12,2): Error: == can only be applied to expressions of types that support equality (got T) (perhaps try declaring opaque type 'T' on line 1 as 'T(==)', which says it can only be instantiated with a type that supports equality)
+git-issue-1427.dfy(16,2): Error: == can only be applied to expressions of types that support equality (got T) (perhaps try declaring opaque type 'T' on line 1 as 'T(==)', which says it can only be instantiated with a type that supports equality)
+3 resolution/type errors detected in git-issue-1427.dfy

--- a/Test/git-issues/git-issue-1429.dfy
+++ b/Test/git-issues/git-issue-1429.dfy
@@ -1,0 +1,10 @@
+type Opaque
+
+datatype Box<A> = Box(A)
+type BoxT(==)<A> = Box<A> // Error: A might not support equality
+type BoxInt(==) = Box<int> // OK
+type BoxBox(==)<A> = Box<Box<A>> // Error: A might not support equality
+type BoxedOpaque(==) = Box<Opaque> // Error: Opaque doesn't support eq
+
+datatype DBoxedOpaque = DBoxedOpaque(s: Box<Opaque>)
+type DBoxedOpaqueT(==) = DBoxedOpaque // Error: s has ghost fields through Box<>

--- a/Test/git-issues/git-issue-2070.dfy
+++ b/Test/git-issues/git-issue-2070.dfy
@@ -1,0 +1,8 @@
+datatype D<A> = D(a: A)
+type DT(==)<A> = D<A> // Error: A might not support ==
+
+datatype D1<A> = D1(d: D<A>)
+type D1T(==)<A> = D1<A> // Error: A might not support ==
+
+datatype D2<A> = D1(d: D<D<A>>)
+type D2T(==)<A> = D2<A> // Error: A might not support ==


### PR DESCRIPTION
Fix computation of equality support for datatypes (fixes #1427)

* Source/Dafny/Resolver.cs (DetermineEqualitySupport):

  Change early-exit criterion: use general `Type.SupportsEquality` instead of
  special-casing codatatypes and arrow types.  Separately check for datatypes to
  avoid infinite recursion.
