### PR TITLE
chore: List of ghost expressions

### DIFF
--- a/docs/DafnyRef/Expressions.md
+++ b/docs/DafnyRef/Expressions.md
@@ -1,4 +1,4 @@
-# 20. Expressions
+# 20. Expressions {#sec-expressions}
 The grammar of Dafny expressions follows a hierarchy that
 reflects the precedence of Dafny operators. The following
 table shows the Dafny operators and their precedence
@@ -602,7 +602,7 @@ freshly allocated since control flow reached label `L`.
 The argument of `fresh` must be either an object reference
 or a set or sequence of object references.
 
-## 20.22. Allocated Expressions
+## 20.22. Allocated Expressions {#sec-allocated-expression}
 ````grammar
 AllocatedExpression_ =
   "allocated" "(" Expression(allowLemma: true, allowLambda: true) ")"
@@ -1090,7 +1090,7 @@ at the point in program execution that `test` is evaluated. This could be
 no instances, one per value of `x.i` in the stated range, multiple instances
 of `I` for each value of `x.i`, or any other combination.
 
-## 20.36. Statements in an Expression
+## 20.36. Statements in an Expression {#sec-statement-in-an-expression}
 ````grammar
 StmtInExpr = ( AssertStmt | AssumeStmt | ExpectStmt
              | RevealStmt | CalcStmt
@@ -1254,7 +1254,7 @@ prefix lemma (see [Section 18.3.5.3](#sec-prefix-lemmas)), the identifier
 must be the name of the greatest predicate or greatest lemma and it must be
 followed by a ``HashCall``.
 
-## 20.41. Hash Call
+## 20.41. Hash Call {#sec-hash-call}
 ````grammar
 HashCall = "#" [ GenericInstantiation ]
   "[" Expression(allowLemma: true, allowLambda: true) "]"
@@ -1582,3 +1582,13 @@ In Dafny, the following expressions are compile-time constants[^CTC], recursivel
 [^CTC]: This set of operations that are constant-folded may be enlarged in
 future versions of Dafny.
 
+## 20.47. List of specification expressions {#sec-list-of-specification-expressions}
+
+The following is a list of expressions that can only appear in specification contexts or in ghost blocks.
+
+* [Fresh expressions](#sec-fresh-expression)
+* [Allocated expressions](#sec-allocated-expression)
+* [Unchanged expressions](#sec-unchanged-expression)
+* [Old expressions](#sec-old-expression)
+* [Assert and calc expressions](#sec-statement-in-an-expression)
+* [Hash Calls](#sec-hash-call)

--- a/docs/DafnyRef/README.md
+++ b/docs/DafnyRef/README.md
@@ -42,8 +42,7 @@ directives, such as page breaks.
 
 You might want to apply this diff to the file `../GemFile`
 ```diff
--gem "kramdown", ">= 2.3.1"
-+gem "kramdown", ">= 2.3.0"
+gem "kramdown", ">= 2.3.1"
 +gem "webrick"
 ```
 

--- a/docs/DafnyRef/Specifications.md
+++ b/docs/DafnyRef/Specifications.md
@@ -69,6 +69,9 @@ The order of conjunctions
 can be important: earlier conjuncts can set conditions that
 establish that later conjuncts are well-defined.
 
+Within an ensures clause, you can of course make use of
+[specification expressions](#sec-list-of-specification-expressions) along with any [other expressions](#sec-expressions) you need.
+
 ### 5.1.3. Decreases Clause {#sec-decreases-clause}
 ````grammar
 DecreasesClause(allowWildcard, allowLambda) =


### PR DESCRIPTION
This PR adds a list of ghost expressions that are typically used in "ensures" clause.
I could also put it on "requires" but I have a little belief it's mostly useful on "ensures" clauses, so I put it there.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
