### PR TITLE
fix: calc of multiset crashes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@
 - fix: Prevent refinements from changing datatype and newtype definitions (https://github.com/dafny-lang/dafny/pull/2038)
 - feat: The new `older` modifier on arguments to predicates indicates that a predicate ensures the allocatedness of some of its arguments. This allows more functions to show that their quantifiers do not depend on the allocation state. For more information, see the reference manual section on `older`. (https://github.com/dafny-lang/dafny/pull/1936)
 - fix: Fix `(!new)` checks (https://github.com/dafny-lang/dafny/issues/1419)
-- fix: multiset keyword no more crashes the parser (https://github.com/dafny-lang/dafny/pull/2079)
+- fix: multiset keyword no longer crashes the parser (https://github.com/dafny-lang/dafny/pull/2079)
 
 # 3.5.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@
 - fix: Prevent refinements from changing datatype and newtype definitions (https://github.com/dafny-lang/dafny/pull/2038)
 - feat: The new `older` modifier on arguments to predicates indicates that a predicate ensures the allocatedness of some of its arguments. This allows more functions to show that their quantifiers do not depend on the allocation state. For more information, see the reference manual section on `older`. (https://github.com/dafny-lang/dafny/pull/1936)
 - fix: Fix `(!new)` checks (https://github.com/dafny-lang/dafny/issues/1419)
+- fix: multiset keyword no more crashes the parser (https://github.com/dafny-lang/dafny/pull/2079)
 
 # 3.5.0
 

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -386,7 +386,8 @@ bool IsSetDisplay() {
   if (la.kind == _lbrace) return true;
   int k = scanner.Peek().kind;
   if (la.kind == _iset && k == _lbrace) return true;
-  if (la.kind == _multiset && (k == _lbrace || k == _openparen)) return true;
+  // Until there is a multiset comprehension, there is no point in checking the next item.
+  if (la.kind == _multiset/* && (k == _lbrace || k == _openparen)*/) return true;
   return false;
 }
 

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -376,12 +376,12 @@ bool IsNonFinalColon() {
   return la.kind == _colon && scanner.Peek().kind != _rbracket;
 }
 
-bool IsMapDisplay() {
+bool ExprIsMapDisplay() {
   scanner.ResetPeek();
   return (la.kind == _map || la.kind == _imap) && scanner.Peek().kind == _lbracket;
 }
 
-bool IsSetDisplay() {
+bool ExprIsSetDisplay() {
   scanner.ResetPeek();
   if (la.kind == _lbrace) return true;
   int k = scanner.Peek().kind;
@@ -3906,10 +3906,10 @@ UnaryExpression<out Expression e, bool allowLemma, bool allowLambda, bool allowB
 /*------------------------------------------------------------------------*/
 PrimaryExpression<out Expression e, bool allowLemma, bool allowLambda, bool allowBitwiseOps>
 = (. Contract.Ensures(Contract.ValueAtReturn(out e) != null); e = dummyExpr; .)
-  ( IF(IsMapDisplay())  /* this alternative must be checked before going into EndlessExpression, where there is another "map" */
+  ( IF(ExprIsMapDisplay())  /* this alternative must be checked before going into EndlessExpression, where there is another "map" */
     MapDisplayExpr<out e>
     { IF(IsSuffix()) Suffix<ref e> }
-  | IF(IsSetDisplay())  /* this alternative must be checked before going into EndlessExpression, where there is another "iset" */
+  | IF(ExprIsSetDisplay())  /* this alternative must be checked before going into EndlessExpression, where there is another "iset" */
     SetDisplayExpr<out e>
     { IF(IsSuffix()) Suffix<ref e> }
   | IF(IsLambda(allowLambda))

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -386,8 +386,7 @@ bool IsSetDisplay() {
   if (la.kind == _lbrace) return true;
   int k = scanner.Peek().kind;
   if (la.kind == _iset && k == _lbrace) return true;
-  // Until there is a multiset comprehension, there is no point in checking the next item.
-  if (la.kind == _multiset/* && (k == _lbrace || k == _openparen)*/) return true;
+  if (la.kind == _multiset) return true;
   return false;
 }
 

--- a/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
@@ -285,5 +285,22 @@ method Abs(x: int) returns (y: int)
       Assert.AreEqual(documentItem2.Version, compilation2.Version);
       Assert.AreEqual(CompilationStatus.CompilationSucceeded, compilation2.Status);
     }
+
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
+    public async Task MultisetShouldNotCrashParser() {
+      var source = @"
+    lemma Something(i: int)
+    {
+      calc {
+        multiset
+      }
+    }";
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var compilation = await notificationReceiver.AwaitNextNotificationAsync(CancellationToken);
+      Assert.AreEqual(documentItem.Uri, compilation.Uri);
+      Assert.AreEqual(documentItem.Version, compilation.Version);
+      Assert.AreEqual(CompilationStatus.ParsingFailed, compilation.Status);
+    }
   }
 }

--- a/Test/git-issues/git-issue-1682.dfy.expect
+++ b/Test/git-issues/git-issue-1682.dfy.expect
@@ -1,2 +1,2 @@
-git-issue-1682.dfy(6,9): Error: invalid PrimaryExpression
+git-issue-1682.dfy(7,0): Error: invalid SetDisplayExpr
 1 parse errors detected in git-issue-1682.dfy


### PR DESCRIPTION
Fixes #2078 

`calc{multiset}`  triggers a while loop that will try to get all inner statements, but the while loop is guarded by something that checks if the next element is the start of an expression, which it is (`multiset` can be the start of an expression). However, since it is not a valid expression, it will emit an error, store a dummy expression, and continue without changing the scanner's position.

The problem does not arise with `iset` because that keyword can be used both for set display and set comprehension, so the scanner can continue in any case.

Since there is no multiset comprehension for now, I removed the lookahead code so that now multiset always expects a `(` or a `{` after it, and the scanner can move on in any case.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
