### PR TITLE
chore: Enable `run-deep-tests`

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Check whitespace and style
       working-directory: dafny
       run: dotnet tool run dotnet-format -w -s error --check Source/Dafny.sln --exclude Dafny/Scanner.cs --exclude Dafny/Parser.cs
-  
+
   check-deep-tests:
     uses: ./.github/workflows/check-deep-tests-reusable.yml
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -52,10 +52,10 @@ jobs:
   
   check-deep-tests:
     uses: ./.github/workflows/check-deep-tests-reusable.yml
-    if: "!(contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))"
  
   integration-tests:
     needs: check-deep-tests
+    if: always() && (needs.check-deep-tests.result == 'success' || contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
       # By default run only on one platform, but run on all platforms if the PR has the "run-deep-tests"

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   dotnet-version: 6.0.x # SDK Version for building Dafny
-  
+
 jobs:
   singletons:
     runs-on: ubuntu-18.04

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -52,7 +52,7 @@ jobs:
   
   check-deep-tests:
     uses: ./.github/workflows/check-deep-tests-reusable.yml
- 
+
   integration-tests:
     needs: check-deep-tests
     if: always() && (needs.check-deep-tests.result == 'success' || contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))


### PR DESCRIPTION
The problem is, that not running `check-deep-tests`, as we do in case of  `run-deep-tests`, keeps us from running the `integration-tests` at all.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
