### PR TITLE
Sort output of `/verificationLogger:text`

### DIFF
--- a/Source/DafnyDriver/TextLogger.cs
+++ b/Source/DafnyDriver/TextLogger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Boogie;
 
 namespace Microsoft.Dafny;
@@ -13,13 +14,14 @@ public class TextLogger {
   }
 
   public void LogResults(List<(Implementation, VerificationResult)> verificationResults) {
-    foreach (var (implementation, result) in verificationResults) {
+    var orderedResults = verificationResults.OrderBy(vr => vr.Item1.Name);
+    foreach (var (implementation, result) in orderedResults) {
       tw.WriteLine("");
       tw.WriteLine($"Results for {implementation.Name}");
       tw.WriteLine($"  Overall outcome: {result.Outcome}");
       tw.WriteLine($"  Overall time: {result.End - result.Start}");
       tw.WriteLine($"  Overall resource count: {result.ResourceCount}");
-      foreach (var vcResult in result.VCResults) {
+      foreach (var vcResult in result.VCResults.OrderBy(r => r.vcNum)) {
         tw.WriteLine("");
         tw.WriteLine($"  Assertion batch {vcResult.vcNum}:");
         tw.WriteLine($"    Outcome: {vcResult.outcome}");


### PR DESCRIPTION
The order of elements in the lists that `/verificationLogger:text` iterates over can vary when using multiple cores. This PR sorts those lists before printing their contents to ensure deterministic output.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
