### PR TITLE
Add `/attrHelp` entry for `{:autoReq}`

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -812,7 +812,16 @@ namespace Microsoft.Dafny {
       TODO
 
     {:autoReq}
-      TODO
+      When applied to a function definition, Dafny automatically
+      strengthens that function's `requires` clause sufficiently so that
+      it may call each of the functions that it calls.
+
+      When applied to a module, this attribute is inherited by every
+      function in the module.
+
+      The `/autoReqPrint:<file>` option will print out the inferred,
+      stronger requires clauses to the given file. The `/noAutoReq`
+      option instructs Dafny to ignore any `{:autoReq}` attributes.
 
     {:timeLimitMultiplier}
       TODO


### PR DESCRIPTION
Adds documentation for the `{:autoReq}` attribute to the output of `/attrHelp` .

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
