### PR TITLE
chore: Fixed a concurrency issue

### DIFF
--- a/Source/Dafny/DafnyConsolePrinter.cs
+++ b/Source/Dafny/DafnyConsolePrinter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,12 +8,11 @@ using Microsoft.Boogie;
 namespace Microsoft.Dafny;
 
 public class DafnyConsolePrinter : ConsolePrinter {
-  private readonly Dictionary<string, List<string>> fsCache = new();
+  private readonly ConcurrentDictionary<string, List<string>> fsCache = new();
   public List<(Implementation, VerificationResult)> VerificationResults { get; } = new();
 
   private string GetFileLine(string filename, int lineIndex) {
-    List<string> lines;
-    if (!fsCache.ContainsKey(filename)) {
+    List<string> lines = fsCache.GetOrAdd(filename, key => {
       try {
         // Note: This is not guaranteed to be the same file that Dafny parsed. To ensure that, Dafny should keep
         // an in-memory version of each file it parses.
@@ -20,10 +20,8 @@ public class DafnyConsolePrinter : ConsolePrinter {
       } catch (Exception) {
         lines = new List<string>();
       }
-      fsCache.Add(filename, lines);
-    } else {
-      lines = fsCache[filename];
-    }
+      return lines;
+    });
     if (0 <= lineIndex && lineIndex < lines.Count) {
       return lines[lineIndex];
     }


### PR DESCRIPTION
I recently got a CI issue in this PR:
https://github.com/dafny-lang/dafny/runs/6355961286?check_suite_focus=true

The error was the following
>Unhandled exception. System.AggregateException: One or more errors occurred. (An item with the same key has already been added. Key: /home/runner/work/dafny/dafny/dafny/Source/IntegrationTests/bin/Debug/net6.0/TestFiles/LitTests/LitTest/dafny0/ShowSnippets.dfy)
 ---> System.ArgumentException: An item with the same key has already been added. Key: /home/runner/work/dafny/dafny/dafny/Source/IntegrationTests/bin/Debug/net6.0/TestFiles/LitTests/LitTest/dafny0/ShowSnippets.dfy
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Microsoft.Dafny.DafnyConsolePrinter.GetFileLine(String filename, Int32 lineIndex)

I saw that there could be a race condition in the way we test if a key exist, then we compute a value, and then we add it, if done from two different threads.

This PR fixes it. I don't know how to create a test in the general case.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
