### PR TITLE
fix: Untitled documents get their verification diagnostics

### DIFF
--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
@@ -132,7 +132,7 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
       return new TextDocumentItem {
         LanguageId = LanguageId,
         Text = source,
-        Uri = DocumentUri.FromFileSystemPath(filePath),
+        Uri = filePath.StartsWith("untitled:") ? DocumentUri.Parse(filePath) : DocumentUri.FromFileSystemPath(filePath),
         Version = version
       };
     }

--- a/Source/DafnyLanguageServer.Test/Various/DiagnosticMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/DiagnosticMigrationTest.cs
@@ -17,7 +17,7 @@ public class DiagnosticMigrationTest : ClientBasedLanguageServerTest {
 
   [TestMethod]
   public async Task ResolutionDiagnosticsContainPreviousVerificationResultsWhenCodeIsInsertedAfter() {
-    var documentItem = CreateTestDocument(FastToFailVerification);
+    var documentItem = CreateTestDocument(FastToFailVerification, "untitled:Untitled-1");
     client.OpenDocument(documentItem);
     var verificationDiagnostics = await GetLastVerificationDiagnostics(documentItem, CancellationToken);
     Assert.AreEqual(1, verificationDiagnostics.Length);

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -35,9 +35,13 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     public IReadOnlyList<Diagnostic> GetDiagnostics(DocumentUri documentUri) {
       rwLock.EnterReadLock();
       try {
+        var alternativeUntitled = documentUri.GetFileSystemPath();
         // Concurrency: Return a copy of the list not to expose a reference to an object that requires synchronization.
         // LATER: Make the Diagnostic type immutable, since we're not protecting it from concurrent accesses
-        return new List<Diagnostic>(diagnostics.GetValueOrDefault(documentUri) ?? Enumerable.Empty<Diagnostic>());
+        return new List<Diagnostic>(
+          diagnostics.GetValueOrDefault(documentUri) ??
+          diagnostics.GetValueOrDefault(alternativeUntitled) ??
+          Enumerable.Empty<Diagnostic>());
       }
       finally {
         rwLock.ExitReadLock();

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     public IReadOnlyList<Diagnostic> GetDiagnostics(DocumentUri documentUri) {
       rwLock.EnterReadLock();
       try {
+        // For untitled documents, the URI needs to have a "untitled" scheme
+        // to match what the client requires in the `diagnostics` dictionary.
+        // We achieve this by expanding it into a file system path and parsing it again.
         var alternativeUntitled = documentUri.GetFileSystemPath();
         // Concurrency: Return a copy of the list not to expose a reference to an object that requires synchronization.
         // LATER: Make the Diagnostic type immutable, since we're not protecting it from concurrent accesses


### PR DESCRIPTION
Fixes #2147  which was an untested regression issue (it was working previously)
Added a test that recognized URI scheme used by VSCode.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
