### PR TITLE
feat: Code in ProofObligationDescriptions

### DIFF
--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -6764,7 +6764,8 @@ namespace Microsoft.Dafny {
         var substMap = new Dictionary<IVariable, Expression>();
         substMap.Add(rdt.Var, expr);
         var typeMap = Resolver.TypeSubstitutionMap(rdt.TypeArgs, udt.TypeArgs);
-        var constraint = etran.TrExpr(Substitute(rdt.Constraint, null, substMap, typeMap));
+        var dafnyConstraint = Substitute(rdt.Constraint, null, substMap, typeMap);
+        var constraint = etran.TrExpr(dafnyConstraint);
         builder.Add(Assert(tok, constraint, new PODesc.ConversionSatisfiesConstraints(errorMsgPrefix, kind, rdt.Name)));
       }
     }


### PR DESCRIPTION
After #2021, this PR will make it possible for the IDE extension to suggest expliciting the failing assert, as a code action.

Remaining work:
- Fix compilation issues in the translator
- Fill in the TODOs (or not)
- Add the code suggestion feature
- Test the code suggestion feature for every supported failing assertion
- Add a note in RELEASE_NOTES.md
- 
@cpitclaudel and @atomb  you might be interested by this PR. Let me know if you would like to contribute for the TODOs.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
