### PR TITLE
Change default for errorTrace option so it's off

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Dafny {
 
     public DafnyOptions()
       : base("Dafny", "Dafny program verifier", new DafnyConsolePrinter()) {
+      ErrorTrace = 0;
       Prune = true;
       NormalizeNames = true;
       EmitDebugInformation = false;

--- a/Source/DafnyTestGeneration/ProgramModification.cs
+++ b/Source/DafnyTestGeneration/ProgramModification.cs
@@ -52,6 +52,7 @@ namespace DafnyTestGeneration {
       options.Parse(new[] { "/proc:" + procedure });
       options.NormalizeNames = false;
       options.EmitDebugInformation = true;
+      options.ErrorTrace = 1;
       options.EnhancedErrorMessages = 1;
       options.ModelViewFile = "-";
       options.ProverOptions = new List<string>() {

--- a/Test/allocated1/Allocated1.dfy
+++ b/Test/allocated1/Allocated1.dfy
@@ -1,3 +1,3 @@
-// RUN: %dafny /verifyAllModules /allocated:1 /errorLimit:99 /errorTrace:0 /compile:0 /dprint:"%t.dprint" /autoTriggers:0 "%s" > "%t"
+// RUN: %dafny /verifyAllModules /allocated:1 /errorLimit:99 /compile:0 /dprint:"%t.dprint" /autoTriggers:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 include "AllocatedCommon.dfyi"

--- a/Test/allocated1/Allocated2.dfy
+++ b/Test/allocated1/Allocated2.dfy
@@ -1,3 +1,3 @@
-// RUN: %dafny /verifyAllModules /allocated:2 /errorLimit:99 /errorTrace:0 /compile:0 /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %dafny /verifyAllModules /allocated:2 /errorLimit:99 /compile:0 /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 include "AllocatedCommon.dfyi"

--- a/Test/dafny0/ShowSnippets.dfy
+++ b/Test/dafny0/ShowSnippets.dfy
@@ -3,7 +3,7 @@
 // https://github.com/dafny-lang/dafny/issues/1518.
 // To work around this, we don't pass /useBaseNameForFileName and instead manually
 // truncate the source paths to their base names using sed.
-// RUN: %baredafny /countVerificationErrors:0 /errorTrace:0 /compile:0 /showSnippets:1 "%s" > "%t".raw
+// RUN: %baredafny /countVerificationErrors:0 /compile:0 /showSnippets:1 "%s" > "%t".raw
 // RUN: %sed 's/^.*[\/\\]//' "%t".raw > "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/Test/dafny0/snapshots/Snapshots6.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots6.run.dfy.expect
@@ -5,7 +5,5 @@ Dafny program verifier finished with 1 verified, 0 errors
 Processing command (at Snapshots6.v1.dfy(20,14)) assert false;
   >>> DoNothingToAssert
 Snapshots6.v1.dfy(20,13): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/dafny0/snapshots/Snapshots7.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots7.run.dfy.expect
@@ -10,7 +10,5 @@ Processing command (at <unknown location>) a##cached##0 := a##cached##0 && ##ext
 Processing command (at Snapshots7.v1.dfy(19,14)) assert false;
   >>> MarkAsPartiallyVerified
 Snapshots7.v1.dfy(19,13): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/dafny0/snapshots/Snapshots8.run.dfy
+++ b/Test/dafny0/snapshots/Snapshots8.run.dfy
@@ -1,2 +1,2 @@
-// RUN: %dafny /compile:0 /verifySnapshots:3 /traceCaching:1 /errorTrace:0 %S/Inputs/Snapshots8.dfy > "%t"
+// RUN: %dafny /compile:0 /verifySnapshots:3 /traceCaching:1 %S/Inputs/Snapshots8.dfy > "%t"
 // RUN: %diff "%s.expect" "%t"

--- a/Test/dafny4/git-issue143.transcript.expect
+++ b/Test/dafny4/git-issue143.transcript.expect
@@ -3,8 +3,6 @@
 Verifying Impl$$B.__default.Bar ...
   [1 proof obligation]  error
 Cache.dfy(9,21): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 

--- a/Test/server/counterexample.transcript.expect
+++ b/Test/server/counterexample.transcript.expect
@@ -4,8 +4,6 @@ Verifying Impl$$_module.__default.Abs ...
   [1 proof obligation]  error
 c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return path.
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
-Execution trace:
-    (0,0): anon0
 COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"},{"CanonicalName":"-1","Name":"y","RealName":null,"Value":"-1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]

--- a/Test/server/counterexample_commandline.dfy
+++ b/Test/server/counterexample_commandline.dfy
@@ -1,4 +1,4 @@
-// RUN: %dafny /compile:0 /proverOpt:O:model_compress=false /proverOpt:O:model.completion=true /warnShadowing /extractCounterexample /errorTrace:0 /mv:%t.model "%s" > "%t"
+// RUN: %dafny /compile:0 /proverOpt:O:model_compress=false /proverOpt:O:model.completion=true /warnShadowing /extractCounterexample /mv:%t.model "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The following method performs string equality comparison whereas its 

--- a/Test/server/git-issue223.transcript.expect
+++ b/Test/server/git-issue223.transcript.expect
@@ -4,8 +4,6 @@ Verifying Impl$$_module.__default.Abs ...
   [1 proof obligation]  error
 c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return path.
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
-Execution trace:
-    (0,0): anon0
 COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"},{"CanonicalName":"-1","Name":"y","RealName":null,"Value":"-1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
@@ -14,8 +12,6 @@ Verifying Impl$$_module.__default.Abs ...
   [0 proof obligations]  error
 c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return path.
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
-Execution trace:
-    (0,0): anon0
 COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"},{"CanonicalName":"-1","Name":"y","RealName":null,"Value":"-1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]

--- a/Test/server/minimal.transcript.expect
+++ b/Test/server/minimal.transcript.expect
@@ -3,7 +3,5 @@
 Verifying Impl$$_module.__default.A ...
   [1 proof obligation]  error
 transcript(3,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]

--- a/Test/server/simple-session.transcript.expect
+++ b/Test/server/simple-session.transcript.expect
@@ -3,6 +3,7 @@
 Verifying Impl$$_module.__default.A ...
   [1 proof obligation]  error
 transcript(3,9): Error: assertion might not hold
+Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 
 Verifying Impl$$_module.__default.A ...

--- a/Test/server/simple-session.transcript.expect
+++ b/Test/server/simple-session.transcript.expect
@@ -3,32 +3,23 @@
 Verifying Impl$$_module.__default.A ...
   [1 proof obligation]  error
 transcript(3,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
+[SUCCESS] [[DAFNY-SERVER: EOM]]
+
+Verifying Impl$$_module.__default.A ...
+  [0 proof obligations]  error
+transcript(3,9): Error: assertion might not hold
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 
 Verifying Impl$$_module.__default.A ...
   [0 proof obligations]  error
 transcript(3,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 
 Verifying Impl$$_module.__default.A ...
   [0 proof obligations]  error
 transcript(3,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
-Verification completed successfully!
-[SUCCESS] [[DAFNY-SERVER: EOM]]
-
-Verifying Impl$$_module.__default.A ...
-  [0 proof obligations]  error
-transcript(3,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 Verification completed successfully!
@@ -130,10 +121,6 @@ transcript(10,9): Info: Selected triggers: {x' * x'}
 Verifying Impl$$_module.__default.M_k ...
   [1 proof obligation]  error
 transcript(10,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
-    (0,0): anon3_Then
-    (0,0): anon2
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
@@ -276,10 +263,6 @@ Retrieving cached verification result for implementation Impl$$_module.__default
 Verifying Impl$$_module.__default.M2 ...
   [2 proof obligations]  error
 transcript(38,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
-    (0,0): anon3_Then
-    (0,0): anon2
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here
@@ -307,10 +290,6 @@ Retrieving cached verification result for implementation Impl$$_module.__default
 Verifying Impl$$_module.__default.M2 ...
   [2 proof obligations]  error
 transcript(38,9): Error: assertion might not hold
-Execution trace:
-    (0,0): anon0
-    (0,0): anon3_Then
-    (0,0): anon2
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 transcript(5,0): Warning: module-level methods are always non-instance, so the 'static' keyword is not allowed here


### PR DESCRIPTION
Error traces can be a nuisance to customers so it's better to turn them off by default.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
