### PR TITLE
fix: Don't deadlock when reading `javac`'s output (fixes #2156)

### DIFF
--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -2220,8 +2220,8 @@ namespace Microsoft.Dafny.Compilers {
         WorkingDirectory = Path.GetFullPath(Path.GetDirectoryName(targetFilename))
       };
       psi.EnvironmentVariables["CLASSPATH"] = classpath;
-      var proc = Process.Start(psi);
-      var printer = (sender, e) => { outputWriter.Write(e.Data + Environment.NewLine); };
+      var proc = Process.Start(psi)!;
+      DataReceivedEventHandler printer = (sender, e) => { outputWriter.Write(e.Data + Environment.NewLine); };
       proc.ErrorDataReceived += printer;
       proc.OutputDataReceived += printer;
       proc.BeginErrorReadLine();

--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -2221,13 +2221,13 @@ namespace Microsoft.Dafny.Compilers {
       };
       psi.EnvironmentVariables["CLASSPATH"] = classpath;
       var proc = Process.Start(psi);
-      while (!proc.StandardOutput.EndOfStream) {
-        outputWriter.WriteLine(proc.StandardOutput.ReadLine());
-      }
-      while (!proc.StandardError.EndOfStream) {
-        outputWriter.WriteLine(proc.StandardError.ReadLine());
-      }
+      var printer = (sender, e) => { outputWriter.Write(e.Data + Environment.NewLine); };
+      proc.ErrorDataReceived += printer;
+      proc.OutputDataReceived += printer;
+      proc.BeginErrorReadLine();
+      proc.BeginOutputReadLine();
       proc.WaitForExit();
+
       if (proc.ExitCode != 0) {
         outputWriter.WriteLine($"Error while compiling Java files. Process exited with exit code {proc.ExitCode}");
         return false;

--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -2221,7 +2221,11 @@ namespace Microsoft.Dafny.Compilers {
       };
       psi.EnvironmentVariables["CLASSPATH"] = classpath;
       var proc = Process.Start(psi)!;
-      DataReceivedEventHandler printer = (sender, e) => { outputWriter.Write(e.Data + Environment.NewLine); };
+      DataReceivedEventHandler printer = (sender, e) => {
+        if (e.Data is not null) {
+          outputWriter.WriteLine(e.Data);
+        }
+      };
       proc.ErrorDataReceived += printer;
       proc.OutputDataReceived += printer;
       proc.BeginErrorReadLine();


### PR DESCRIPTION
fixes #2156