### PR TITLE
Fix: Verification gutter status with informations

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -122,4 +122,18 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
             [-][~][=][=][I][S][S][ ]:
                         [-][~][=][=]:");
   }
+
+  [TestMethod/*, Timeout(MaxTestExecutionTimeMs)*/]
+  public async Task EnsuresWorkWithInformationsAsWell() {
+    await VerifyTrace(@"
+ .  S [S][ ][I][S][S][ ]:method f(x: int) returns (y: int)
+ .  S [S][ ][I][S][S][ ]:ensures
+ .  S [=][=][-][~][=][=]:  x > 3 { y := x;
+ .  S [S][ ][I][S][S][ ]:  //Next1:\n
+ .  S [=][=][-][~][=][ ]:  while(y <= 1) invariant y >= 2 {
+ .  S [S][ ][-][~][=][=]:    y := y + 1;
+ .  S [S][ ][I][S][S][ ]:  }
+ .  S [S][ ][I][S][S][ ]:}
+            [I][S][S][ ]:");
+  }
 }

--- a/Source/DafnyLanguageServer/Workspace/DiagnosticPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/DiagnosticPublisher.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         // Therefore, we do not republish the errors when the document (re-)load was canceled.
         return;
       }
-      var errors = document.Diagnostics.Where(x => x.Severity == DiagnosticSeverity.Error).ToList();
+      var errors = document.ParseAndResolutionDiagnostics.Where(x => x.Severity == DiagnosticSeverity.Error).ToList();
       var linesCount = document.LinesCount;
       var verificationStatusGutter = VerificationStatusGutter.ComputeFrom(
         document.Uri,
@@ -57,8 +57,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         document.VerificationTree.Children.Select(child => child.GetCopyForNotification()).ToArray(),
         errors,
         linesCount,
-        verificationStarted,
-        document.ParseAndResolutionDiagnostics.Count
+        verificationStarted
       );
       languageServer.TextDocument.SendNotification(verificationStatusGutter);
     }


### PR DESCRIPTION
Before this PR, after inserting one line on this:
![image](https://user-images.githubusercontent.com/3601079/170567880-1a9a792d-22be-4a44-866d-befe990b762e.png)
it would result in the following wrong highlight
![image](https://user-images.githubusercontent.com/3601079/170567948-dfa7df95-8d78-4aae-8daa-23cf0a827cb8.png)
The reason for that is that it finds the "hint" that the while clause has an inferred decreases, and wrongly assumes it's a resolution error.

This PR fixes that and adds a test to ensure this won't happen ever again.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
