### PR TITLE
fix: reads function of seq/multiset

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -5465,7 +5465,7 @@ namespace Microsoft.Dafny {
                   return false;  // there is not enough information
                 }
               }
-              if (t.IsRefType) {
+              if (t.IsRefType && (arrTy == null || collType != null)) {
                 resolver.ConstrainSubtypeRelation_Equal(u, t, errorMsg);
                 convertedIntoOtherTypeConstraints = true;
                 return true;

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -875,7 +875,10 @@ namespace Microsoft.Dafny {
               new ApplyExpr(e.tok, e, bexprs) {
                 Type = new SetType(true, builtIns.ObjectQ())
               }) {
-              ResolvedOp = BinaryExpr.ResolvedOpcode.InSet,
+              ResolvedOp =
+                arrTy.Result.AsMultiSetType != null ? BinaryExpr.ResolvedOpcode.InMultiSet :
+                arrTy.Result.AsSeqType != null ? BinaryExpr.ResolvedOpcode.InSeq :
+                BinaryExpr.ResolvedOpcode.InSet,
               Type = Type.Bool
             }, obj, null) {
             Type = new SetType(true, builtIns.ObjectQ())

--- a/Test/dafny0/ResolutionErrors.dfy
+++ b/Test/dafny0/ResolutionErrors.dfy
@@ -3624,7 +3624,7 @@ module FrameTypes {
     g: int -> object, h: int -> set<object>, i: int -> iset<object>, j: int -> seq<object>, k: set<object> -> int,
     l: bool -> multiset<object>, m: bool -> map<object, object>)
     reads f // error: wrong argument type for reads
-    reads g
+    reads g // error: a function must be to a collection of references
     reads h
     reads i
     reads j

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -581,6 +581,7 @@ ResolutionErrors.dfy(3615,10): Error: a reads-clause expression must denote an o
 ResolutionErrors.dfy(3616,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got iset<bv8>)
 ResolutionErrors.dfy(3617,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got seq<int>)
 ResolutionErrors.dfy(3626,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got int -> int)
+ResolutionErrors.dfy(3627,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got int -> object)
 ResolutionErrors.dfy(3631,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got set<object> -> int)
 ResolutionErrors.dfy(3633,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got bool -> map<object, object>)
 ResolutionErrors.dfy(3652,12): Error: a 'break break break continue' statement is allowed only in contexts with 4 enclosing loops, but the current context only has 3
@@ -602,4 +603,4 @@ ResolutionErrors.dfy(3760,8): Error: ghost-context break statement is not allowe
 ResolutionErrors.dfy(3768,8): Error: ghost-context continue statement is not allowed to continue out of non-ghost loop
 ResolutionErrors.dfy(3783,10): Error: ghost-context continue statement is not allowed to continue out of non-ghost loop
 ResolutionErrors.dfy(3806,10): Error: ghost-context continue statement is not allowed to continue out of non-ghost loop
-599 resolution/type errors detected in ResolutionErrors.dfy
+600 resolution/type errors detected in ResolutionErrors.dfy

--- a/Test/hofs/ReadsReads.dfy
+++ b/Test/hofs/ReadsReads.dfy
@@ -140,3 +140,129 @@ module ReadsOnFunctions {
     assert g.reads(10) == f.reads(10);
   }
 }
+
+module FuncCollectionRegressions {
+  class C {
+    var x: int
+    var y: int
+  }
+
+  function F(st: set<C>, ss: iset<C>, sq: seq<C>, ms: multiset<C>): int
+    reads st
+    reads ss
+    reads sq
+    reads ms
+
+  method CallF0(c: C, st: set<C>, ss: iset<C>, sq: seq<C>, ms: multiset<C>)
+    requires c !in st && c !in ss && c !in sq && c !in ms
+    modifies c
+  {
+    var a := F(st, ss, sq, ms);
+    c.x := c.y + 3;
+    var b := F(st, ss, sq, ms);
+    assert a == b;
+  }
+
+  method CallF1(c: C, st: set<C>, ss: iset<C>, sq: seq<C>, ms: multiset<C>)
+    requires c !in ss && c !in sq && c !in ms
+    modifies c
+  {
+    var a := F(st, ss, sq, ms);
+    c.x := c.y + 3;
+    var b := F(st, ss, sq, ms);
+    assert a == b; // error: F may have changed
+  }
+
+  method CallF2(c: C, st: set<C>, ss: iset<C>, sq: seq<C>, ms: multiset<C>)
+    requires c !in st && c !in sq && c !in ms
+    modifies c
+  {
+    var a := F(st, ss, sq, ms);
+    c.x := c.y + 3;
+    var b := F(st, ss, sq, ms);
+    assert a == b; // error: F may have changed
+  }
+
+  method CallF3(c: C, st: set<C>, ss: iset<C>, sq: seq<C>, ms: multiset<C>)
+    requires c !in st && c !in ss && c !in ms
+    modifies c
+  {
+    var a := F(st, ss, sq, ms);
+    c.x := c.y + 3;
+    var b := F(st, ss, sq, ms);
+    assert a == b; // error: F may have changed
+  }
+
+  method CallF4(c: C, st: set<C>, ss: iset<C>, sq: seq<C>, ms: multiset<C>)
+    requires c !in st && c !in ss && c !in sq
+    modifies c
+  {
+    var a := F(st, ss, sq, ms);
+    c.x := c.y + 3;
+    var b := F(st, ss, sq, ms);
+    assert a == b; // error: F may have changed
+  }
+
+  function A0(): set<C>
+  function A1(): iset<C>
+  function A2(): seq<C>
+  function A3(): multiset<C>
+
+  function G(): int
+    reads A0
+    reads A1
+    // regression: the following line once caused malformed Boogie
+    reads A2
+    // regression: the following line once caused malformed Boogie
+    reads A3
+
+  method P0(c: C)
+    requires c !in A0() && c !in A1() && c !in A2() && c !in A3()
+    modifies c
+  {
+    var a := G();
+    c.x := c.y + 3;
+    var b := G();
+    assert a == b;
+  }
+
+  method P1(c: C)
+    requires c !in A1() && c !in A2() && c !in A3()
+    modifies c
+  {
+    var a := G();
+    c.x := c.y + 3;
+    var b := G();
+    assert a == b; // error: G may have changed
+  }
+
+  method P2(c: C)
+    requires c !in A0() && c !in A2() && c !in A3()
+    modifies c
+  {
+    var a := G();
+    c.x := c.y + 3;
+    var b := G();
+    assert a == b; // error: G may have changed
+  }
+
+  method P3(c: C)
+    requires c !in A0() && c !in A1() && c !in A3()
+    modifies c
+  {
+    var a := G();
+    c.x := c.y + 3;
+    var b := G();
+    assert a == b; // error: G may have changed
+  }
+
+  method P4(c: C)
+    requires c !in A0() && c !in A1() && c !in A2()
+    modifies c
+  {
+    var a := G();
+    c.x := c.y + 3;
+    var b := G();
+    assert a == b; // error: G may have changed
+  }
+}

--- a/Test/hofs/ReadsReads.dfy.expect
+++ b/Test/hofs/ReadsReads.dfy.expect
@@ -6,5 +6,13 @@ ReadsReads.dfy(87,49): Error: assertion might not hold
 ReadsReads.dfy(89,28): Error: assertion might not hold
 ReadsReads.dfy(99,36): Error: assertion might not hold
 ReadsReads.dfy(101,28): Error: assertion might not hold
+ReadsReads.dfy(173,13): Error: assertion might not hold
+ReadsReads.dfy(183,13): Error: assertion might not hold
+ReadsReads.dfy(193,13): Error: assertion might not hold
+ReadsReads.dfy(203,13): Error: assertion might not hold
+ReadsReads.dfy(236,13): Error: assertion might not hold
+ReadsReads.dfy(246,13): Error: assertion might not hold
+ReadsReads.dfy(256,13): Error: assertion might not hold
+ReadsReads.dfy(266,13): Error: assertion might not hold
 
-Dafny program verifier finished with 13 verified, 8 errors
+Dafny program verifier finished with 16 verified, 16 errors

--- a/Test/hofs/Types.dfy
+++ b/Test/hofs/Types.dfy
@@ -18,3 +18,9 @@ method FnEqGhost<A>() {
   ghost var b7 := g == zz; // should fail
 }
 
+function ToObject(): object
+
+function F(): int
+  // Regression: the following used resolve, but would then cause malformed Boogie.
+  // There's no strong use case for this, so it's better to just forbid it.
+  reads ToObject // error: arrow to collection of references is allowed, but no other arrows

--- a/Test/hofs/Types.dfy.expect
+++ b/Test/hofs/Types.dfy.expect
@@ -1,4 +1,5 @@
 Types.dfy(9,20): Error: arguments must have comparable types (got A -> A -> A and (A -> A) -> A)
 Types.dfy(14,20): Error: arguments must have comparable types (got (A -> A) -> A and A -> A -> A)
 Types.dfy(18,20): Error: arguments must have comparable types (got A -> A -> A and (A -> A) -> A)
-3 resolution/type errors detected in Types.dfy
+Types.dfy(26,8): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got () -> object)
+4 resolution/type errors detected in Types.dfy


### PR DESCRIPTION
This PR fixes two issues with advanced `reads` clauses.

One issue was with `reads F`, where `F` is an expression of type `... ~> seq<object>` or `... ~> multiset<object>`. Previously, these generated malformed Boogie. This is now fixed.

The other issue was with `reads F` where `F` is an expression of type `... ~> object`. Previously, the resolver allowed this, but the translator generated malformed Boogie. There's no strong use case for allowing such a type, so this PR fixes the issue by making the resolver forbid this case.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
