### PR TITLE
chore: Description of the rlimit attribute + reordering opaque/print

### DIFF
--- a/docs/DafnyRef/Attributes.md
+++ b/docs/DafnyRef/Attributes.md
@@ -277,7 +277,16 @@ lemma Fill_J(s: seq<int>)
 }
 ```
 
-### 22.2.8. `{:print}` {#sec-print}
+### 22.2.8. `{:opaque}` {#sec-opaque}
+Ordinarily, the body of a function is transparent to its users, but
+sometimes it is useful to hide it. If a function `foo` or `bar` is given the
+`{:opaque}` attribute, then Dafny hides the body of the function,
+so that it can only be seen within its recursive clique (if any),
+or if the programmer specifically asks to see it via the statement `reveal foo(), bar();`.
+
+More information about the Boogie implementation of `{:opaque}` [here](https://github.com/dafny-lang/dafny/blob/master/docs/Compilation/Boogie.md).
+
+### 22.2.9. `{:print}` {#sec-print}
 This attributes declares that a method may have print effects,
 that is, it may use 'print' statements and may call other methods
 that have print effects. The attribute can be applied to compiled
@@ -286,15 +295,6 @@ applied to functions or ghost methods. An overriding method is
 allowed to use a {:print} attribute only if the overridden method
 does.
 Print effects are enforced only with `/trackPrintEffects:1`.
-
-### 22.2.9. `{:opaque}` {#sec-opaque}
-Ordinarily, the body of a function is transparent to its users, but
-sometimes it is useful to hide it. If a function `foo` or `bar` is given the
-`{:opaque}` attribute, then Dafny hides the body of the function,
-so that it can only be seen within its recursive clique (if any),
-or if the programmer specifically asks to see it via the statement `reveal foo(), bar();`.
-
-More information about the Boogie implementation of `{:opaque}` [here](https://github.com/dafny-lang/dafny/blob/master/docs/Compilation/Boogie.md).
 
 <!--
 Describe this where refinement is described, as appropriate.
@@ -316,19 +316,60 @@ the functionality is already adequately described where
 refinement is described.
 -->
 
-### 22.2.10. `{:priority N}`
-Assign a positive priority 'N' to an implementation to control the order
-in which implementations are verified (default: N = 1).
+### 22.2.10. `{:priority}`
+`{:priority N}` assigns a positive priority 'N' to a method or function to control the order
+in which methods or functions are verified (default: N = 1).
 
+### 22.2.11: `{:rlimit}` {#sec-rlimit}
 
-### 22.2.11. `{:selective_checking}`
+`{:rlimit N}` limits the verifier resource usage to verify the method or function at `N * 1000`.
+This is the per-method equivalent of the command-line flag `/rlimit:N`.
+If using [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) as well, the limit will be set for each assertion.
+
+To give orders of magnitude about resource usage, here is a list of examples indicating how many resources are used to verify each method:
+
+* 8K resource usage
+  ```dafny
+  method f() {
+    assert true;
+  }
+  ```
+* 10K resource usage using assertions that do not add assumptions:
+   ```dafny
+  method f() {
+    assert a: (a ==> b) <==> (!b ==> !a);
+    assert b: (a ==> b) <==> (!b ==> !a);
+    assert c: (a ==> b) <==> (!b ==> !a);
+    assert d: (a ==> b) <==> (!b ==> !a);
+  }
+  ```
+
+* 40K total resource usage using [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert)
+  ```dafny
+  method {:vcs_split_on_every_assert} f(a: bool, b: bool) {
+    assert a: (a ==> b) <==> (!b ==> !a);
+    assert b: (a ==> b) <==> (!b ==> !a);
+    assert c: (a ==> b) <==> (!b ==> !a);
+    assert d: (a ==> b) <==> (!b ==> !a);
+  }
+  ```
+*  37K total resource usage and fails out of resource.
+   ```dafny
+   method {:rlimit 30} f(a: int, b: int, c: int) {
+     assert ((1 + a*a)*c) / (1 + a*a) == c;
+   }
+   ```
+
+Note that, when using the default solver Z3, a 7K to 8K resource usage seem to always added to the set `{:rlimit}`, so if you put `{:rlimit 20}` in the last example, the total resource usage would be `27K`.
+
+### 22.2.12. `{:selective_checking}`
 Turn all assertions into assumptions except for the ones reachable from after the
 assertions marked with the attribute `{:start_checking_here}`.
 Thus, `assume {:start_checking_here} something;` becomes an inverse
 of `assume false;`: the first one disables all verification before
 it, and the second one disables all verification after.
 
-### 22.2.12. `{:tailrecursion}`
+### 22.2.13. `{:tailrecursion}`
 This attribute is used on method declarations. It has a boolean argument.
 
 If specified with a `false` value, it means the user specifically
@@ -344,7 +385,7 @@ recursion was explicitly requested.
 * If `{:tailrecursion true}` was specified but the code does not allow it,
 an error message is given.
 
-### 22.2.13. `{:test}`
+### 22.2.14. `{:test}`
 This attribute indicates the target function or method is meant
 to be executed at runtime in order to test that the program is working as intended.
 
@@ -375,10 +416,10 @@ There are also two different approaches to executing all tests in a program:
    This runner is currently very basic, but avoids introducing any additional target
    language dependencies in the compiled code.
 
-### 22.2.14. `{:timeLimit N}`
+### 22.2.15. `{:timeLimit N}`
 Set the time limit for verifying a given function or method.
 
-### 22.2.15. `{:timeLimitMultiplier X}`
+### 22.2.16. `{:timeLimitMultiplier X}`
 This attribute may be placed on a method or function declaration
 and has an integer argument. If `{:timeLimitMultiplier X}` was
 specified a `{:timelimit Y}` attributed is passed on to Boogie
@@ -386,14 +427,14 @@ where `Y` is `X` times either the default verification time limit
 for a function or method, or times the value specified by the
 Boogie `timelimit` command-line option.
 
-### 22.2.16. `{:verify false}` {#sec-verify}
+### 22.2.17. `{:verify false}` {#sec-verify}
      
 Skip verification of a function or a method altogether.
 Will not even try to verify well-formedness of postconditions and preconditions.
 We discourage to use this attribute. Prefer [`{:axiom}`](#sec-axiom),
 which performs these minimal checks while not checking that the body satisfies postconditions.
 
-### 22.2.17. `{:vcs_max_cost N}` {#sec-vcs_max_cost}
+### 22.2.18. `{:vcs_max_cost N}` {#sec-vcs_max_cost}
 Per-method version of the command-line option `/vcsMaxCost`.
 
 The [assertion batch](#sec-assertion-batches) of a method
@@ -402,7 +443,7 @@ number, defaults to 2000.0. In
 [keep-going mode](#sec-vcs_max_keep_going_splits), only applies to the first round.
 If [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) is set, then this parameter is useless.
 
-### 22.2.18. `{:vcs_max_keep_going_splits N}` {#sec-vcs_max_keep_going_splits}
+### 22.2.19. `{:vcs_max_keep_going_splits N}` {#sec-vcs_max_keep_going_splits}
 
 Per-method version of the command-line option `/vcsMaxKeepGoingSplits`.
 If set to more than 1, activates the _keep going mode_ where, after the first round of splitting,
@@ -413,7 +454,7 @@ case error is reported for that assertion).
 Defaults to 1.
 If [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) is set, then this parameter is useless.
 
-### 22.2.19. `{:vcs_max_splits N}` {#sec-vcs_max_splits}
+### 22.2.20. `{:vcs_max_splits N}` {#sec-vcs_max_splits}
 
 Per-method version of the command-line option `/vcsMaxSplits`.
 Maximal number of [assertion batches](#sec-assertion-batches) generated for this method.
@@ -421,14 +462,14 @@ In [keep-going mode](#sec-vcs_max_keep_going_splits), only applies to the first 
 Defaults to 1.
 If [`{:vcs_split_on_every_assert}`](#sec-vcs_split_on_every_assert) is set, then this parameter is useless.
 
-### 22.2.20. `{:vcs_split_on_every_assert}` {#sec-vcs_split_on_every_assert}
+### 22.2.21. `{:vcs_split_on_every_assert}` {#sec-vcs_split_on_every_assert}
 Per-method version of the command-line option `/vcsSplitOnEveryAssert`.
 
 In the first and only verification round, this option will split the original [assertion batch](#sec-assertion-batches)
 into one assertion batch per assertion.
 This is mostly helpful for debugging which assertion is taking the most time to prove, e.g. to profile them.
 
-### 22.2.21. `{:synthesize}` {#sec-synthesize-attr}
+### 22.2.22. `{:synthesize}` {#sec-synthesize-attr}
 
 The `{:synthesize}` attribute must be used on methods that have no body and
 return one or more fresh objects. During compilation, 
@@ -462,7 +503,7 @@ BOUNDVARS = ID : ID
           | BOUNDVARS, BOUNDVARS
 ```
 
-### 22.2.22. `{:options OPT0, OPT1, ... }` {#sec-attr-options}
+### 22.2.23. `{:options OPT0, OPT1, ... }` {#sec-attr-options}
 
 This attribute applies only to modules. It attribute configures Dafny as if
 `OPT0`, `OPT1`, … had been passed on the command line.  Outside of the module,

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -739,7 +739,7 @@ There are many great options that control various aspects of verifying dafny pro
 - Control of output: [`/dprint`](#sec-controlling-output), [`/rprint`](#sec-controlling-output), `/stats`, [`/compileVerbose`](#sec-controlling-compilation)
 - Whether to print warnings: `/proverWarnings`
 - Control of time: `/timeLimit`
-- Control of resources: `/rLimit` and `{:rlimit}`
+- Control of resources: `/rLimit` and [`{:rlimit}`](#sec-rlimit)
 - Control of the prover used: `/prover`
 - Control of how many times to _unroll_ functions: [`{:fuel}`](#sec-fuel)
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.4.7)
+    activesupport (6.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -14,7 +14,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.4)
+    commonmarker (0.23.5)
     concurrent-ruby (1.1.10)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
@@ -25,30 +25,11 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.8.1)
-    faraday (1.10.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.3.0)
+      faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    ffi (1.15.5)
+    faraday-net_http (2.0.3)
+    ffi (1.15.5-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (225)
@@ -102,7 +83,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (>= 3.0, < 5.0)
       typhoeus (~> 1.3)
-    html-pipeline (2.14.0)
+    html-pipeline (2.14.1)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
@@ -226,22 +207,19 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.8.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.15.0)
-    multipart-post (2.1.1)
-    nokogiri (1.13.6)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.6-x64-mingw-ucrt)
       racc (~> 1.4)
-    octokit (4.22.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
+    octokit (4.23.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     racc (1.6.0)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
@@ -256,9 +234,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sawyer (0.8.2)
+    sawyer (0.9.1)
       addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
+      faraday (>= 0.17.3, < 3)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     terminal-table (1.8.0)
@@ -270,12 +248,13 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.1)
+    unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     zeitwerk (2.5.4)
 
 PLATFORMS
-  ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   github-pages (~> 225)
@@ -285,6 +264,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick
 
 BUNDLED WITH
-   1.17.3
+   2.3.8


### PR DESCRIPTION
I explain how the `{:rlimit}` attribute works, and switch two sections so that they are in alphabetical order.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
