### PR TITLE
Fix MergeOrdered and empty observable

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -959,5 +959,21 @@ method Foo() {
       var verificationDiagnostics2 = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
       Assert.AreEqual(1, verificationDiagnostics2.Length);
     }
+
+    [TestMethod]
+    public async Task DiagnosticsAfterSavingWithVerifyOnChange() {
+      var source = @"
+method Foo() { 
+  assert true; 
+}".TrimStart();
+      var documentItem = CreateTestDocument(source);
+      client.OpenDocument(documentItem);
+      await client.SaveDocumentAndWaitAsync(documentItem, CancellationToken);
+      var diagnostics1 = await GetLastDiagnostics(documentItem, CancellationToken);
+      Assert.AreEqual(0, diagnostics1.Length);
+      ApplyChange(ref documentItem, new Range(0,0,0,0), "SyntaxError");
+      var diagnostics2 = await GetLastDiagnostics(documentItem, CancellationToken);
+      Assert.IsTrue(diagnostics2.Any());
+    }
   }
 }

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -971,7 +971,7 @@ method Foo() {
       await client.SaveDocumentAndWaitAsync(documentItem, CancellationToken);
       var diagnostics1 = await GetLastDiagnostics(documentItem, CancellationToken);
       Assert.AreEqual(0, diagnostics1.Length);
-      ApplyChange(ref documentItem, new Range(0,0,0,0), "SyntaxError");
+      ApplyChange(ref documentItem, new Range(0, 0, 0, 0), "SyntaxError");
       var diagnostics2 = await GetLastDiagnostics(documentItem, CancellationToken);
       Assert.IsTrue(diagnostics2.Any());
     }

--- a/Source/DafnyPipeline.Test/MergeOrderedTest.cs
+++ b/Source/DafnyPipeline.Test/MergeOrderedTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Microsoft.Dafny;
 using Xunit;
@@ -60,6 +61,24 @@ public class MergeOrderedTest {
     outer.OnCompleted();
     first.OnNext(1);
     first.OnCompleted();
+
+    Assert.Equal(new List<int>() { 1, -1 }, list);
+  }
+
+  [Fact]
+  public void EmptyObservable() {
+    var list = new List<int>();
+
+    var first = new ReplaySubject<int>();
+    first.OnNext(1);
+    first.OnCompleted();
+
+    var merged = new MergeOrdered<int>();
+    merged.Subscribe(value => list.Add(value), _ => { }, () => list.Add(-1));
+
+    merged.OnNext(Observable.Empty<int>());
+    merged.OnNext(first);
+    merged.OnCompleted();
 
     Assert.Equal(new List<int>() { 1, -1 }, list);
   }

--- a/Source/DafnyPipeline.Test/MergeOrderedTest.cs
+++ b/Source/DafnyPipeline.Test/MergeOrderedTest.cs
@@ -82,4 +82,23 @@ public class MergeOrderedTest {
 
     Assert.Equal(new List<int>() { 1, -1 }, list);
   }
+
+  [Fact]
+  public void ComplicatedCase() {
+    var list = new List<int>();
+
+    var first = new ReplaySubject<int>();
+
+    var merged = new MergeOrdered<int>();
+    merged.Subscribe(value => list.Add(value), _ => { }, () => list.Add(-1));
+
+    merged.OnNext(first);
+    merged.OnNext(Observable.Empty<int>());
+    merged.OnNext(Observable.Empty<int>());
+    merged.OnCompleted();
+    first.OnNext(1);
+    first.OnCompleted();
+
+    Assert.Equal(new List<int>() { 1, -1 }, list);
+  }
 }


### PR DESCRIPTION
Fixes a bug that would ignore subsequent inner observables after MergeOrdered received an empty inner observable, which in Dafny would cause notifications to stop occurring after saving a file that did not have verify on save turned on.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
