### PR TITLE
Hotfix: Copy the DafnyLanguageServer.dll

### DIFF
--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -6,6 +6,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Dafny.LanguageServer</RootNamespace>
+    <OutputPath>..\..\Binaries\</OutputPath>
     <IsPackable>false</IsPackable>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>


### PR DESCRIPTION
With [this merge](https://github.com/dafny-lang/dafny/commit/51b6885390ed292b479d430a0d1d363e12dbcc0c), `DafnyLanguageServer.dll` was no longer copied to the `Binaries` folder, which resulted in no updates taken into account when testing a custom version of Dafny in VSCode.

This PR fixes this.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
