### PR TITLE
fix: Errors in translation no longer result in a server crash

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 # Upcoming
 
+- fix: The IDE will no longer permanently crash in the case of translation errors (in the verification pipeline) (https://github.com/dafny-lang/dafny/pull/2249)
 - feat: The IDE will show verification errors for a method immediately after that method has been verified, instead of after all methods are verified.
 - feat: The Dafny CLI, Dafny as a library, and the C# runtime are now available on NuGet.  You can install the CLI with `dotnet tool install --global Dafny`. The library is available as `DafnyPipeline` and the runtime is available as `DafnyRuntime`.
 - feat: New syntax for quantified variables, allowing per-variable domains (`x <- C`) and ranges (`x | P(x), y | Q(x, y)`). See [the quantifier domain section](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-quantifier-domains) of the Reference Manual.

--- a/Source/DafnyLanguageServer.Test/Unit/DocumentDatabaseTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/DocumentDatabaseTest.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.Dafny.LanguageServer.Language;
+using Microsoft.Dafny.LanguageServer.Language.Symbols;
+using Microsoft.Dafny.LanguageServer.Workspace;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntervalTree;
+using JetBrains.Annotations;
+using Microsoft.Boogie;
+using Microsoft.Dafny.LanguageServer.Workspace.ChangeProcessors;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
+  [TestClass]
+  public class DocumentDatabaseTest {
+    private Mock<ITextDocumentLoader> textDocumentLoader;
+    private DocumentDatabase documentDatabase;
+    private Mock<MockedLogger> documentDatabaseLogger;
+    private MockedOptions options;
+    private Mock<TextChangeProcessor> textChangeProcessor;
+    private Mock<IRelocator> relocator;
+
+    public abstract class MockedLogger : ILogger<DocumentDatabase> {
+      public abstract void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter);
+      public abstract bool IsEnabled(LogLevel logLevel);
+      public abstract IDisposable BeginScope<TState>(TState state);
+    }
+
+    public class MockedOptions : IOptions<DocumentOptions> {
+      public DocumentOptions Value => new DocumentOptions() {
+        ProverOptions = ""
+      };
+    }
+
+    [TestInitialize]
+    public void SetUp() {
+      DafnyOptions.Install(new DafnyOptions());
+      textChangeProcessor = new Mock<TextChangeProcessor>();
+      relocator = new Mock<IRelocator>();
+      documentDatabaseLogger = new Mock<MockedLogger>();
+      textDocumentLoader = new Mock<ITextDocumentLoader>();
+      options = new MockedOptions();
+      documentDatabase = new DocumentDatabase(documentDatabaseLogger.Object,
+        options,
+        textDocumentLoader.Object,
+        textChangeProcessor.Object,
+        relocator.Object);
+    }
+
+    private static DocumentTextBuffer CreateTestDocument() {
+      return new DocumentTextBuffer(0) {
+        LanguageId = "dafny",
+        Version = 1,
+        Text = "",
+        Uri = "untitled:Untitled-1"
+      };
+    }
+
+    class MockedReporter : BatchErrorReporter {
+      public List<string> Errors => AllMessages.GetValueOrDefault(ErrorLevel.Error, new List<ErrorMessage>())
+        .Select(errorMessage => errorMessage.message).ToList();
+    }
+
+    [TestMethod]
+    public async Task LoadReturnsCanceledTaskIfOperationIsCanceled() {
+      var source = new CancellationTokenSource();
+      var reporter = new MockedReporter();
+      var moduleDefinition = new Mock<DefaultModuleDecl>();
+      var moduleDecl = new Mock<LiteralModuleDecl>(moduleDefinition.Object, null);
+      var program = new Mock<Microsoft.Dafny.Program>(
+        "dummy", moduleDecl.Object, new Mock<BuiltIns>().Object, reporter);
+      var intervalTree = new Mock<IIntervalTree<Position, ILocalizableSymbol>>();
+      intervalTree.Setup(t => t.Query(new Position(0, 0))).Returns<ILocalizableSymbol>(null);
+      var symbolTable = new Mock<SymbolTable>(
+        null, null, null, null, intervalTree.Object, null
+        );
+      var dafnyDocument = new DafnyDocument(CreateTestDocument(),
+        new List<Diagnostic>(),
+        true,
+        null,
+        new List<Counterexample>(),
+        new List<Diagnostic>(),
+        program.Object,
+        symbolTable.Object,
+        null
+      );
+      Task<DafnyDocument> documentTask = Task.FromResult(
+        dafnyDocument);
+      textDocumentLoader.Setup(t => t.PrepareVerificationTasksAsync(dafnyDocument, source.Token))
+        .ThrowsAsync(new ArgumentException());
+      var token = Token.NoToken;
+      var result = await documentDatabase.LoadVerificationTasksAsync(documentTask, source.Token);
+      Assert.AreEqual(1, reporter.Count(ErrorLevel.Error));
+      Assert.AreEqual(0, reporter.CountExceptVerifierAndCompiler(ErrorLevel.Error));
+      Assert.IsTrue(reporter.Errors[0].Contains("Dafny encountered an error during 'translation'"));
+      Assert.IsFalse(result.CanDoVerification);
+    }
+  }
+}

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       );
     }
 
-    public async Task<DafnyDocument> PrepareVerificationTasksAsync(DafnyDocument loaded, CancellationToken cancellationToken) {
+    public virtual async Task<DafnyDocument> PrepareVerificationTasksAsync(DafnyDocument loaded, CancellationToken cancellationToken) {
       if (loaded.ParseAndResolutionDiagnostics.Any(d =>
             d.Severity == DiagnosticSeverity.Error &&
             d.Source != MessageSource.Compiler.ToString() &&


### PR DESCRIPTION
This fix prevent any errors in the verifier/translator to permanently crash the language server.

I added a unit test, `DocumentDatabaseTest`, to only test that, if the `TextDocumentLoader.PrepareVerificationTasksAsync` throws an exception, then an error is reported and the resolved document is returned.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
