### PR TITLE
Fix: CI instability on hover tests

### DIFF
--- a/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
@@ -266,7 +266,7 @@ class Sub extends Base {}".TrimStart();
       var source = @"
 datatype SomeType = SomeType {
   method AssertEqual(x: int, y: int) {
-    assert x == y;
+    var j:=x == y;
   }
 }".TrimStart();
       var documentItem = CreateTestDocument(source);
@@ -334,7 +334,7 @@ method f(i: int) {
     public async Task HoveringForallBoundVarReturnsBoundVarInferredType() {
       var source = @"
 method f(i: int) {
-  assert forall j :: j + i == i + j;
+  var x:=forall j :: j + i == i + j;
 }".TrimStart();
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
@@ -354,7 +354,7 @@ method f(i: int) {
     public async Task HoveringExistsBoundVarReturnsBoundVarInferredType() {
       var source = @"
 method f(i: int) {
-  assert exists j :: j + i == i;
+  var x:=exists j :: j + i == i;
 }".TrimStart();
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);


### PR DESCRIPTION
Will prevent build failures such as this one:
https://github.com/dafny-lang/dafny/runs/6887347120?check_suite_focus=true

The reason was, we did hover test on the variable `x` of `assert P(x)`. The problem is, with the newest changes, hovering `x` will also hover the assertion, so the hovering message can be more complicated.

This PR removes the ambiguity by replacing assertions with variable assignments.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
