### PR TITLE
docs: Add matrix of supported features by target language

### DIFF
--- a/docs/DafnyRef/Attributes.md
+++ b/docs/DafnyRef/Attributes.md
@@ -385,7 +385,7 @@ recursion was explicitly requested.
 * If `{:tailrecursion true}` was specified but the code does not allow it,
 an error message is given.
 
-### 22.2.14. `{:test}`
+### 22.2.14. `{:test}` {#sec-test-attribute}
 This attribute indicates the target function or method is meant
 to be executed at runtime in order to test that the program is working as intended.
 

--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -390,7 +390,7 @@ These produce assertion errors:
 
 [^binding]: The binding power of shift and bit-wise operations is different than in C-like languages.
 
-## 7.4. Ordinal type
+## 7.4. Ordinal type {#sec-ordinals}
 ````grammar
 OrdinalType_ = "ORDINAL"
 ````
@@ -801,7 +801,7 @@ For any type `T`, a value of type `seq<T>` denotes a _sequence_ of `T`
 elements, that is, a mapping from a finite downward-closed set of natural
 numbers (called _indices_) to `T` values.
 
-### 10.3.1. Sequence Displays
+### 10.3.1. Sequence Displays {#sec-sequence-displays}
 A sequence can be formed using a _sequence display_ expression, which
 is a possibly empty, ordered list of expressions enclosed in square
 brackets.  To illustrate,
@@ -2572,7 +2572,7 @@ object whose allocated type is a trait.  But there can of course be
 objects of a class `C` that implement a trait `J`, and a reference to
 such a `C` object can be used as a value of type `J`.
 
-## 14.1. Type `object`
+## 14.1. Type `object` {#sec-object-type}
 ````grammar
 ObjectType_ = "object" | "object?"
 ````
@@ -2877,7 +2877,7 @@ conversion:
 multiset(a[..]) == multiset(old(a[..]))
 ```
 
-## 15.2. Multi-dimensional arrays
+## 15.2. Multi-dimensional arrays {#sec-multi-dimensional-arrays}
 
 An array of 2 or more dimensions is mostly like a one-dimensional
 array, except that `new` takes more length arguments (one for each

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -947,6 +947,76 @@ implementation.
 - The current backend also assumes the use of C++17 in order to cleanly and
   performantly implement datatypes.
 
+### 24.9.8. Supported features by target language
+
+Some Dafny features are not supported by every target language.
+The table below shows which features are supported by each backend.
+An empty cell indicated that a feature is not supported,
+while an X indicates that it is.
+
+Note that this information is currently based on code inspection
+and is not yet guaranteed to be updated as features and backends are modified,
+but such a mechanism is in the works.
+
+| Feature | C# | JavaScript | Go | Java | Python | C++ |
+|-|-|-|-|-|-|-|
+| [Unbounded integers](#sec-numeric-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [Real numbers](#sec-numeric-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [Ordinals](#sec-ordinals) |  X  |  X  |  X  |  X  |  X  |  |
+| [Function values](#sec-arrow-subset-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [Iterators](#sec-iterator-types) |  X  |  X  |  X  |  |  |  |
+| [Collections with trait element types](#sec-collection-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [User-defined types with traits as type parameters](#sec-trait-types) |  X  |  X  |  X  |  |  X  |  X  |
+| [External module names with only underscores](#sec-extern-decls) |  X  |  X  |  |  X  |  X  |  X  |
+| [Co-inductive datatypes](#sec-co-inductive-datatypes) |  X  |  X  |  X  |  X  |  |  |
+| [Multisets](#sec-multisets) |  X  |  X  |  X  |  X  |  |  |
+| [Runtime type descriptors](#) |  X  |  X  |  X  |  X  |  |  |
+| [Multi-dimensional arrays](#sec-multi-dimensional-arrays) |  X  |  X  |  X  |  X  |  X  |  |
+| [Map comprehensions](#sec-map-comprehension-expression) |  X  |  X  |  X  |  X  |  X  |  |
+| [Traits](#sec-trait-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [Let-such-that expressions](#sec-let-expression) |  X  |  X  |  X  |  X  |  X  |  |
+| [Non-native numeric newtypes](#sec-newtypes) |  X  |  X  |  X  |  X  |  X  |  |
+| [Method synthesis](#sec-synthesize-attr) |  X  |  |  |  |  |  |
+| [External classes](#sec-extern-decls) |  X  |  X  |  X  |  X  |  X  |  |
+| [Instantiating the `object` type](#sec-object-type) |  X  |  X  |  X  |  X  |  X  |  |
+| [`forall` statements that cannot be sequentialized](#sec-forall-statement)[^feature-note-1] |  X  |  X  |  X  |  X  |  |  |
+| [Taking an array's length](#sec-array-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [`m.Items` when `m` is a map](#sec-maps) |  X  |  X  |  X  |  X  |  X  |  |
+| [The /runAllTests option](#sec-test-attribute) |  X  |  X  |  X  |  X  |  X  |  |
+| [Integer range constraints in quantifiers (e.g. `a <= x <= b`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  |  X  |
+| [Exact value constraints in quantifiers (`x == C`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  |  |
+| [Sequence displays of characters](#sec-sequence-displays)[^feature-note-2] |  X  |  X  |  X  |  X  |  X  |  |
+| [Type test expressions (`x is T`)](#sec-as-expression) |  X  |  X  |  X  |  X  |  X  |  |
+| [Type test expressions on subset types](#sec-as-expression) |  |  |  |  |  |  |
+| [Quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  X  |  |
+| [Bitvector RotateLeft/RotateRight functions](#sec-bit-vector-types) |  X  |  X  |  X  |  X  |  X  |  |
+| [`for` loops](#sec-for-loops) |  X  |  X  |  X  |  X  |  |  X  |
+| [`continue` statements](#sec-break-continue) |  X  |  X  |  X  |  X  |  |  X  |
+| [Assign-such-that statements with potentially infinite bounds](#sec-update-and-call-statement)[^feature-note-3] |  X  |  X  |  X  |  X  |  |  X  |
+| [Sequence update expressions](#sec-other-sequence-expressions) |  X  |  X  |  X  |  X  |  |  X  |
+| [Sequence constructions with non-lambda initializers](#sec-sequence-displays)[^feature-note-4] |  X  |  X  |  X  |  X  |  |  X  |
+| [Externally-implemented constructors](#sec-extern-decls) |  X  |  |  |  X  |  X  |  X  |
+| [Static constants](#sec-constant-field-declarations) |  X  |  X  |  X  |  X  |  |  X  |
+| [Auto-initialization of tuple variables](#sec-tuple-types) |  X  |  X  |  X  |  X  |  |  X  |
+| [Subtype constraints in quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  |  X  |
+
+[^feature-note-1]: 'Sequentializing' a `forall` statement refers to compiling it directly to a series of nested loops
+    with the statement's body directly inside. The alternative, default compilation strategy
+    is to calculate the quantified variable bindings separately as a collection of tuples,
+    and then execute the statement's body for each tuple.
+    Not all `forall` statements can be sequentialized; See [the implementation](https://github.com/dafny-lang/dafny/blob/master/Source/Dafny/Compilers/SinglePassCompiler.cs#L3493-L3528)
+    for details.
+
+[^feature-note-2]: This refers to an expression such as `['H', 'e', 'l', 'l', 'o']`, as opposed to a string literal such as "Hello".
+
+[^feature-note-3]: This refers to assign-such-that statements with multiple variables,
+    and where at least one variable has potentially infinite bounds.
+    For example, the implementation of the statement `var x: nat, y: nat :| y != 0 && x / y == 10;`
+    needs to avoid the naive approach of iterating all possible values of `x` and `y` in a nested loop.
+
+[^feature-note-4]: Sequence construction expressions often use a direct lambda expression, as in `seq(10, x => x * x)`,
+    but they can also be used with arbitrary function values, as in `seq(10, squareFn)`.
+
 ## 24.10. Dafny Command Line Options {#sec-command-line-options}
 
 There are many command-line options to the `dafny` tool.

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -979,42 +979,42 @@ but such a mechanism is in the works.
 | [Method synthesis](#sec-synthesize-attr) |  X  |  |  |  |  |  |
 | [External classes](#sec-extern-decls) |  X  |  X  |  X  |  X  |  X  |  |
 | [Instantiating the `object` type](#sec-object-type) |  X  |  X  |  X  |  X  |  X  |  |
-| [`forall` statements that cannot be sequentialized](#sec-forall-statement)[^feature-note-1] |  X  |  X  |  X  |  X  |  |  |
+| [`forall` statements that cannot be sequentialized](#sec-forall-statement)[^compiler-feature-forall-note] |  X  |  X  |  X  |  X  |  |  |
 | [Taking an array's length](#sec-array-types) |  X  |  X  |  X  |  X  |  X  |  |
 | [`m.Items` when `m` is a map](#sec-maps) |  X  |  X  |  X  |  X  |  X  |  |
 | [The /runAllTests option](#sec-test-attribute) |  X  |  X  |  X  |  X  |  X  |  |
 | [Integer range constraints in quantifiers (e.g. `a <= x <= b`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  |  X  |
 | [Exact value constraints in quantifiers (`x == C`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  |  |
-| [Sequence displays of characters](#sec-sequence-displays)[^feature-note-2] |  X  |  X  |  X  |  X  |  X  |  |
+| [Sequence displays of characters](#sec-sequence-displays)[^compiler-sequence-display-of-characters-note] |  X  |  X  |  X  |  X  |  X  |  |
 | [Type test expressions (`x is T`)](#sec-as-expression) |  X  |  X  |  X  |  X  |  X  |  |
 | [Type test expressions on subset types](#sec-as-expression) |  |  |  |  |  |  |
 | [Quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  X  |  |
 | [Bitvector RotateLeft/RotateRight functions](#sec-bit-vector-types) |  X  |  X  |  X  |  X  |  X  |  |
 | [`for` loops](#sec-for-loops) |  X  |  X  |  X  |  X  |  |  X  |
 | [`continue` statements](#sec-break-continue) |  X  |  X  |  X  |  X  |  |  X  |
-| [Assign-such-that statements with potentially infinite bounds](#sec-update-and-call-statement)[^feature-note-3] |  X  |  X  |  X  |  X  |  |  X  |
+| [Assign-such-that statements with potentially infinite bounds](#sec-update-and-call-statement)[^compiler-infinite-assign-such-that-note] |  X  |  X  |  X  |  X  |  |  X  |
 | [Sequence update expressions](#sec-other-sequence-expressions) |  X  |  X  |  X  |  X  |  |  X  |
-| [Sequence constructions with non-lambda initializers](#sec-sequence-displays)[^feature-note-4] |  X  |  X  |  X  |  X  |  |  X  |
+| [Sequence constructions with non-lambda initializers](#sec-sequence-displays)[^compiler-sequence-display-nolambda-note] |  X  |  X  |  X  |  X  |  |  X  |
 | [Externally-implemented constructors](#sec-extern-decls) |  X  |  |  |  X  |  X  |  X  |
 | [Static constants](#sec-constant-field-declarations) |  X  |  X  |  X  |  X  |  |  X  |
 | [Auto-initialization of tuple variables](#sec-tuple-types) |  X  |  X  |  X  |  X  |  |  X  |
 | [Subtype constraints in quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  |  X  |
 
-[^feature-note-1]: 'Sequentializing' a `forall` statement refers to compiling it directly to a series of nested loops
+[^compiler-feature-forall-note]: 'Sequentializing' a `forall` statement refers to compiling it directly to a series of nested loops
     with the statement's body directly inside. The alternative, default compilation strategy
     is to calculate the quantified variable bindings separately as a collection of tuples,
     and then execute the statement's body for each tuple.
     Not all `forall` statements can be sequentialized; See [the implementation](https://github.com/dafny-lang/dafny/blob/master/Source/Dafny/Compilers/SinglePassCompiler.cs#L3493-L3528)
     for details.
 
-[^feature-note-2]: This refers to an expression such as `['H', 'e', 'l', 'l', 'o']`, as opposed to a string literal such as "Hello".
+[^compiler-sequence-display-of-characters-note]: This refers to an expression such as `['H', 'e', 'l', 'l', 'o']`, as opposed to a string literal such as "Hello".
 
-[^feature-note-3]: This refers to assign-such-that statements with multiple variables,
+[^compiler-infinite-assign-such-that-note]: This refers to assign-such-that statements with multiple variables,
     and where at least one variable has potentially infinite bounds.
     For example, the implementation of the statement `var x: nat, y: nat :| y != 0 && x / y == 10;`
     needs to avoid the naive approach of iterating all possible values of `x` and `y` in a nested loop.
 
-[^feature-note-4]: Sequence construction expressions often use a direct lambda expression, as in `seq(10, x => x * x)`,
+[^compiler-sequence-display-nolambda-note]: Sequence construction expressions often use a direct lambda expression, as in `seq(10, x => x * x)`,
     but they can also be used with arbitrary function values, as in `seq(10, squareFn)`.
 
 ## 24.10. Dafny Command Line Options {#sec-command-line-options}

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1011,7 +1011,7 @@ but such a mechanism is in the works.
 
 [^compiler-infinite-assign-such-that-note]: This refers to assign-such-that statements with multiple variables,
     and where at least one variable has potentially infinite bounds.
-    For example, the implementation of the statement `var x: nat, y: nat :| y != 0 && x / y == 10;`
+    For example, the implementation of the statement `var x: nat, y: nat :| 0 < x && 0 < y && x*x == y*y*y + 1;`
     needs to avoid the naive approach of iterating all possible values of `x` and `y` in a nested loop.
 
 [^compiler-sequence-display-nolambda-note]: Sequence construction expressions often use a direct lambda expression, as in `seq(10, x => x * x)`,


### PR DESCRIPTION
Adds a section to the User's Guide under Compilation, documenting known cases of specific backends not supporting given Dafny features. See dry run on my fork here to verify that the links and footnotes work correctly: https://robin-aws.github.io/dafny/DafnyRef/DafnyRef#2498-supported-features-by-target-language

Partially addresses #1770 - I generated the data for this table by implementing the mechanism described there (or at least a simpler version of it) on [this branch](https://github.com/robin-aws/dafny/tree/compiler-feature-support-matrix), but that implementation is not yet ready, especially since it involves changing the way many if not all integration tests are run. In the meantime, having this information documented is very useful!

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
