### PR TITLE
Fix deep test for Windows

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -141,7 +141,7 @@ jobs:
       run: |
         ls
         g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
-        ls ${{ github.workspace }}/dafny/Test/c++
+        ${{ github.workspace }}/dafny/Test/c++/while.exe
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -115,7 +115,6 @@ jobs:
         echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |
-        C:\msys64\mingw64\bin\g++ --version
         g++ --version
         which g++
         ls C:\msys64\usr\bin\

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls C:\msys64\mingw64\bin
+        ls C:\msys64\mingw64
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -112,6 +112,7 @@ jobs:
         mkdir ${{ github.workspace }}/bin
         New-Item -Path ${{ github.workspace }}/bin/g++.exe -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++.exe
         New-Item -Path ${{ github.workspace }}/lib -ItemType SymbolicLink -Value C:\msys64\mingw64\lib
+        New-Item -Path ${{ github.workspace }}/include -ItemType SymbolicLink -Value C:\msys64\mingw64\include
         echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,7 +102,7 @@ jobs:
         python3 --version
     - name: Set up shell
       run: |
-        echo $env:GITHUB_PATH | Out-File -FilePath $env:ORIG_PATH -Encoding utf8
+        echo $env:GITHUB_PATH | Out-File -FilePath orig -Encoding utf8
         echo C:\msys64\usr\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo C:\msys64\mingw64\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       shell: pwsh
@@ -113,7 +113,7 @@ jobs:
     - name: g++ update
       run: | 
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
-        echo $env:ORIG_PATH | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+        echo orig | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,8 +103,8 @@ jobs:
     - name: Run single test
       if: runner.os == 'Windows'
       run: |
-      ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:4 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
-      ${{ github.workspace }}/dafny/Test/c++/while
+        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:4 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+        ${{ github.workspace }}/dafny/Test/c++/while
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -100,27 +100,21 @@ jobs:
         which g++
         ls C:\msys64\usr\bin\
         python3 --version
-    - name: Set up shell
-      run: |
-        echo $env:GITHUB_PATH | Out-File -FilePath orig -Encoding utf8
-        echo C:\msys64\usr\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo C:\msys64\mingw64\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: pwsh
     - name: Pacman Version
       run: |
+        $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
         pacman.exe --version
         pacman.exe --noconfirm -Syu
     - name: g++ update
       run: | 
+        $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
-        echo orig | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-        echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo $env:GITHUB_PATH
     - name: Versions (again...)
       run: |
         g++ --version
         which g++
         ls C:\msys64\usr\bin\
+        echo $env:GITHUB_PATH
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -105,6 +105,8 @@ jobs:
         which g++
         ls C:\msys64\mingw64
         python3 --version
+    - name: Pacman Version
+      run: pacman.exe --version
     - name: Versions (again...)
       shell: msys2 {0}
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -89,6 +89,19 @@ jobs:
         java -version
         g++ --version
         python3 --version
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: mingw-w64-x86_64-gcc
+    - name: Versions (again)
+      run: |
+        dotnet --list-sdks
+        go version
+        node --version
+        java -version
+        g++ --version
+        python3 --version
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -109,7 +109,7 @@ jobs:
       shell: msys2 {0}
       run: |
         which g++
-        which mingw64/bin/g++
+        which /mingw64/bin/g++
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |
-        g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
+        g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
         ${{ github.workspace }}/dafny/Test/c++/while.exe
     - name: Run integration tests
       if: runner.os == 'Windows'

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -107,7 +107,8 @@ jobs:
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |
-        ${{ github.workspace }}/dafny/Test/c++/while
+        g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
+        ${{ github.workspace }}/dafny/Test/c++/while.exe
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -90,11 +90,6 @@ jobs:
         g++ --version
         which g++
         python3 --version
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        update: true
-        install: base-devel mingw-w64-x86_64-toolchain
     - name: Versions (again)
       run: |
         dotnet --list-sdks
@@ -135,20 +130,18 @@ jobs:
     - name: Build single test
       if: runner.os == 'Windows'
       run: |
-        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+        D:a/dafny/dafny\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp D:a/dafny/dafny/dafny/Test/c++/while.dfy
     - name: Run single exe
       if: runner.os == 'Windows'
-      shell: msys2 {0}
       run: |
         ls
-        g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
-        ${{ github.workspace }}/dafny/Test/c++/while.exe
+        g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I D:a/dafny/dafny/dafny/Binaries -o D:a/dafny/dafny/dafny/Test/c++/while.exe D:a/dafny/dafny/dafny/Test/c++/while.cpp
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:
         XUNIT_SHARD: ${{ matrix.shard }}
         XUNIT_SHARD_COUNT: 1
-        DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafny
+        DAFNY_RELEASE: D:a/dafny/dafny\unzippedRelease\dafny
       run: |
         dotnet test -v:n --logger trx dafny/Source/IntegrationTests/IntegrationTests.csproj --filter DisplayName~c++
     - name: Run integration tests

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls C:\msys644\mingw64\bin
+        ls C:\msys64\mingw64\bin
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,7 +102,7 @@ jobs:
         unzip dafny/Package/CI.zip -d unzippedRelease
     - name: Run single test
       if: runner.os == 'Windows'
-      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp TestFiles/LitTests/LitTest/c++/while.dfy
+      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}dafny/Test/c++/while.dfy
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -109,14 +109,7 @@ jobs:
       shell: msys2 {0}
       run: |
         which g++
-        dotnet --list-sdks
-        go version
-        node --version
-        java -version
-        g++ --version
-        which g++
-        which C:\msys64\mingw64\bin\g++.exe
-        python3 --version
+        which mingw64/bin/g++
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -115,6 +115,7 @@ jobs:
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         echo orig | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo $env:GITHUB_PATH
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls C:\msys64\mingw64\bin
+        C:\msys64\mingw64\bin\g++ --version
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -143,7 +143,7 @@ jobs:
       env:
         XUNIT_SHARD: ${{ matrix.shard }}
         XUNIT_SHARD_COUNT: 1
-        DAFNY_RELEASE: D:a/dafny/dafny\unzippedRelease\dafny
+        DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafny
       run: |
         dotnet test -v:n --logger trx dafny/Source/IntegrationTests/IntegrationTests.csproj --filter DisplayName~c++
     - name: Run integration tests

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -100,10 +100,13 @@ jobs:
     - if: runner.os != 'Windows'
       run: |
         unzip dafny/Package/CI.zip -d unzippedRelease
-    - name: Run single test
+    - name: Build single test
       if: runner.os == 'Windows'
       run: |
         ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+    - name: Run single exe
+      if: runner.os == 'Windows'
+      run: |
         ${{ github.workspace }}/dafny/Test/c++/while
     - name: Run integration tests
       if: runner.os == 'Windows'

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |
-        g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wunused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
+        g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
         ${{ github.workspace }}/dafny/Test/c++/while.exe
     - name: Run integration tests
       if: runner.os == 'Windows'

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,7 +102,7 @@ jobs:
         unzip dafny/Package/CI.zip -d unzippedRelease
     - name: Run single test
       if: runner.os == 'Windows'
-      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}dafny/Test/c++/while.dfy
+      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -129,12 +129,13 @@ jobs:
     - name: Build single test
       if: runner.os == 'Windows'
       run: |
-        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |
         ls
         g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
+        ls ${{ github.workspace }}/dafny/Test/c++
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -113,6 +113,7 @@ jobs:
       run: | 
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         $env:GITHUB_PATH = $origPath
+        echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -106,7 +106,7 @@ jobs:
         ls C:\msys64\usr\bin\
         python3 --version
     - name: Set up shell
-      run: echo C:\msys64\usr\bin\ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append 
+      run: $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
       shell: pwsh
     - name: Pacman Version
       run: pacman.exe --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls msys64
+        ls C:\msys64
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -132,12 +132,12 @@ jobs:
     - name: Build single test
       if: runner.os == 'Windows'
       run: |
-        D:a/dafny/dafny\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp D:a/dafny/dafny/dafny/Test/c++/while.dfy
+        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |
         ls
-        g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I D:a/dafny/dafny/dafny/Binaries -o D:a/dafny/dafny/dafny/Test/c++/while.exe D:a/dafny/dafny/dafny/Test/c++/while.cpp
+        g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,14 +102,17 @@ jobs:
         python3 --version
     - name: Set up shell
       run: |
-        echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append  
+        $origPath = $env:GITHUB_PATH
+        $env:GITHUB_PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
       shell: pwsh
     - name: Pacman Version
       run: |
         C:\msys64\usr\bin\pacman.exe --version
         C:\msys64\usr\bin\pacman.exe --noconfirm -Syu
     - name: g++ update
-      run: C:\msys64\usr\bin\pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
+      run: | 
+        C:\msys64\usr\bin\pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
+        $env:GITHUB_PATH = $origPath
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -88,6 +88,7 @@ jobs:
         node --version
         java -version
         g++ --version
+        which g++
         python3 --version
     - uses: msys2/setup-msys2@v2
       with:
@@ -101,6 +102,7 @@ jobs:
         node --version
         java -version
         g++ --version
+        which g++
         python3 --version
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -112,7 +112,6 @@ jobs:
         New-Item -Path ${{ github.workspace }}/bin/g++.exe -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++.exe
         New-Item -Path ${{ github.workspace }}/lib -ItemType SymbolicLink -Value C:\msys64\mingw64\lib
         New-Item -Path ${{ github.workspace }}/include -ItemType SymbolicLink -Value C:\msys64\mingw64\include
-        echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,15 +102,14 @@ jobs:
         python3 --version
     - name: Set up shell
       run: |
-        echo C:\msys64\usr\bin\ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo C:\msys64\mingw64\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append  
+        echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append  
       shell: pwsh
     - name: Pacman Version
       run: |
-        pacman.exe --version
-        pacman.exe --noconfirm -Syu
+        C:\msys64\usr\bin\pacman.exe --version
+        C:\msys64\usr\bin\pacman.exe --noconfirm -Syu
     - name: g++ update
-      run: pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
+      run: C:\msys64\usr\bin\pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -105,6 +105,17 @@ jobs:
         which g++
         which C:\msys64\mingw64\bin\g++.exe
         python3 --version
+    - name: Versions (again...)
+      shell: msys2 {0}
+      run: |
+        dotnet --list-sdks
+        go version
+        node --version
+        java -version
+        g++ --version
+        which g++
+        which C:\msys64\mingw64\bin\g++.exe
+        python3 --version
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -109,6 +109,7 @@ jobs:
       run: | 
         $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
+        echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,10 +103,10 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls C:\msys64\mingw64
+        ls C:\msys64\usr\bin\
         python3 --version
     - name: Set up shell
-      run: echo ::add-path::C:\msys64\usr\bin\
+      run: echo C:\msys64\usr\bin\ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append 
       shell: pwsh
     - name: Pacman Version
       run: pacman.exe --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -114,6 +114,7 @@ jobs:
         echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |
+        C:\msys64\mingw64\bin\g++ --version
         g++ --version
         which g++
         ls C:\msys64\usr\bin\

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,6 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
+        ls msys64
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,9 +103,8 @@ jobs:
     - name: Set up shell
       run: |
         echo $env:GITHUB_PATH | Out-File -FilePath $env:ORIG_PATH -Encoding utf8
-        $origPath = $env:GITHUB_PATH
-        $env:GITHUB_PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
-        echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:ORIG_PATH" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+        echo C:\msys64\usr\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo C:\msys64\mingw64\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       shell: pwsh
     - name: Pacman Version
       run: |
@@ -114,7 +113,7 @@ jobs:
     - name: g++ update
       run: | 
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
-        $env:GITHUB_PATH = $origPath
+        echo $env:ORIG_PATH | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Build single test
       if: runner.os == 'Windows'
       run: |
-        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -106,10 +106,16 @@ jobs:
         ls C:\msys64\usr\bin\
         python3 --version
     - name: Set up shell
-      run: $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
+      run: |
+        echo C:\msys64\usr\bin\ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo C:\msys64\mingw64\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append  
       shell: pwsh
     - name: Pacman Version
-      run: pacman.exe --version
+      run: |
+        pacman.exe --version
+        pacman.exe -Syu
+    - name: g++ update
+      run: pacman.exe -S --needed base-devel mingw-w64-x86_64-toolchain
     - name: Versions (again...)
       shell: msys2 {0}
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        which C:\msys64\mingw64\bin\g++.exe
+        ls /c/Program Files/PowerShell/7:/d/a/_temp/setup-msys2
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |
-        g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
+        g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -Wunused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
         ${{ github.workspace }}/dafny/Test/c++/while.exe
     - name: Run integration tests
       if: runner.os == 'Windows'

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -94,7 +94,7 @@ jobs:
       with:
         msystem: MINGW64
         update: true
-        install: mingw-w64-x86_64-gcc
+        install: base-devel mingw-w64-x86_64-toolchain
     - name: Versions (again)
       run: |
         dotnet --list-sdks

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls C:\
+        ls C:\msys644\mingw64\bin
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Run single test
       if: runner.os == 'Windows'
       run: |
-        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:4 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
         ${{ github.workspace }}/dafny/Test/c++/while
     - name: Run integration tests
       if: runner.os == 'Windows'

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -107,11 +107,11 @@ jobs:
       shell: pwsh
     - name: Pacman Version
       run: |
-        C:\msys64\usr\bin\pacman.exe --version
-        C:\msys64\usr\bin\pacman.exe --noconfirm -Syu
+        pacman.exe --version
+        pacman.exe --noconfirm -Syu
     - name: g++ update
       run: | 
-        C:\msys64\usr\bin\pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
+        pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         $env:GITHUB_PATH = $origPath
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -105,6 +105,9 @@ jobs:
         which g++
         ls C:\msys64\mingw64
         python3 --version
+    - name: Set up shell
+      run: echo ::add-path::C:\msys64\usr\bin\
+      shell: pwsh
     - name: Pacman Version
       run: pacman.exe --version
     - name: Versions (again...)

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,6 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
+        which C:\msys64\mingw64\bin\g++.exe
         python3 --version
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -117,11 +117,10 @@ jobs:
     - name: g++ update
       run: pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
     - name: Versions (again...)
-      shell: msys2 {0}
       run: |
         g++ --version
         which g++
-        which /mingw64/bin/g++
+        ls C:\msys64\usr\bin\
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Create release
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -108,7 +108,6 @@ jobs:
     - name: g++ update
       run: | 
         $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
-        pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         mkdir ${{ github.workspace }}/bin
         New-Item -Path ${{ github.workspace }}/bin/g++.exe -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++.exe
         New-Item -Path ${{ github.workspace }}/lib -ItemType SymbolicLink -Value C:\msys64\mingw64\lib

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -109,7 +109,9 @@ jobs:
       run: | 
         $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
-        echo C:\msys64\mingw64\bin\g++ | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        mkdir ${{ github.workspace }}/bin
+        mklink ${{ github.workspace }}/bin/g++ C:\msys64\mingw64\bin\g++
+        echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |
         g++ --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,7 +102,9 @@ jobs:
         unzip dafny/Package/CI.zip -d unzippedRelease
     - name: Run single test
       if: runner.os == 'Windows'
-      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:4 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+      run: |
+      ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:4 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+      ${{ github.workspace }}/dafny/Test/c++/while
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -108,6 +108,7 @@ jobs:
     - name: Versions (again...)
       shell: msys2 {0}
       run: |
+        g++ --version
         which g++
         which /mingw64/bin/g++
     - run: rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -110,7 +110,7 @@ jobs:
         $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         mkdir ${{ github.workspace }}/bin
-        mklink ${{ github.workspace }}/bin/g++ C:\msys64\mingw64\bin\g++
+        New-Item -Path ${{ github.workspace }}/bin/g++ -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++
         echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -113,9 +113,9 @@ jobs:
     - name: Pacman Version
       run: |
         pacman.exe --version
-        pacman.exe -Syu
+        pacman.exe --noconfirm -Syu
     - name: g++ update
-      run: pacman.exe -S --needed base-devel mingw-w64-x86_64-toolchain
+      run: pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
     - name: Versions (again...)
       shell: msys2 {0}
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,8 +102,10 @@ jobs:
         python3 --version
     - name: Set up shell
       run: |
+        echo $env:GITHUB_PATH | Out-File -FilePath $env:ORIG_PATH -Encoding utf8
         $origPath = $env:GITHUB_PATH
         $env:GITHUB_PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
+        echo "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:ORIG_PATH" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
       shell: pwsh
     - name: Pacman Version
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -110,7 +110,7 @@ jobs:
         $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         mkdir ${{ github.workspace }}/bin
-        New-Item -Path ${{ github.workspace }}/bin/g++ -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++
+        New-Item -Path ${{ github.workspace }}/bin/g++.exe -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++.exe
         echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -102,7 +102,7 @@ jobs:
         unzip dafny/Package/CI.zip -d unzippedRelease
     - name: Run single test
       if: runner.os == 'Windows'
-      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:3 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+      run: ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:4 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Build single test
       if: runner.os == 'Windows'
       run: |
-        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
+        ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:0 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run single exe
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        C:\msys64\mingw64\bin\g++ --version
+        ls C:\msys64\mingw64\bin
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -128,6 +128,7 @@ jobs:
         ${{ github.workspace }}\unzippedRelease\dafny\dafny /vcsCores:2 /useBaseNameForFileName /compileVerbose:1 /errorTrace:2 /timeLimit:300 /compile:1 /spillTargetCode:2 /compileTarget:cpp ${{ github.workspace }}/dafny/Test/c++/while.dfy
     - name: Run single exe
       if: runner.os == 'Windows'
+      shell: msys2 {0}
       run: |
         g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
         ${{ github.workspace }}/dafny/Test/c++/while.exe

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,11 +103,11 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls /c/Program Files/PowerShell/7:/d/a/_temp/setup-msys2
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}
       run: |
+        which g++
         dotnet --list-sdks
         go version
         node --version

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -103,7 +103,7 @@ jobs:
         java -version
         g++ --version
         which g++
-        ls C:\msys64
+        ls C:\
         python3 --version
     - name: Versions (again...)
       shell: msys2 {0}

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -111,6 +111,7 @@ jobs:
         pacman.exe --noconfirm -S --needed base-devel mingw-w64-x86_64-toolchain
         mkdir ${{ github.workspace }}/bin
         New-Item -Path ${{ github.workspace }}/bin/g++.exe -ItemType SymbolicLink -Value C:\msys64\mingw64\bin\g++.exe
+        New-Item -Path ${{ github.workspace }}/lib -ItemType SymbolicLink -Value C:\msys64\mingw64\lib
         echo ${{ github.workspace }}\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Versions (again...)
       run: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -132,6 +132,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: msys2 {0}
       run: |
+        ls
         g++ -g -v -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-label -std=c++17 -I ${{ github.workspace }}/dafny/Binaries -o ${{ github.workspace }}/dafny/Test/c++/while.exe ${{ github.workspace }}/dafny/Test/c++/while.cpp
         ${{ github.workspace }}/dafny/Test/c++/while.exe
     - name: Run integration tests


### PR DESCRIPTION
Fixes #https://github.com/dafny-lang/dafny/issues/2294

TODO: currently only fixes the Makefile issue, but there are other issues causing various integration tests for C++ to fail (example https://github.com/dafny-lang/dafny/runs/7041083236?check_suite_focus=true). I don't see any PRs that were merged yesterday which could cause these issues, so I assume something changed on Github Actions, but I have no idea what changed. All issues seems filepath related.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
