### PR TITLE
fix: Add reads checks for 'unchanged' arguments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Upcoming
 
+- fix: Check that arguments of 'unchanged' satisfy enclosing reads clause.
+
 # 3.7.1
 
 - fix: The Dafny runtime library for C# is now compatible with .NET Standard 2.1, as it was before 3.7.0. Its version has been updated to 1.2.0 to reflect this. (https://github.com/dafny-lang/dafny/pull/2277)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Upcoming
 
-- fix: Check that arguments of 'unchanged' satisfy enclosing reads clause.
+- fix: Check that arguments of 'unchanged' satisfy enclosing reads clause. (https://github.com/dafny-lang/dafny/pull/2302)
 
 # 3.7.1
 

--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -6011,6 +6011,13 @@ namespace Microsoft.Dafny {
               description != "object");
             builder.Add(Assert(GetToken(fe.E), BplImp(BplAnd(ante, nonNull), wh), desc));
           }
+          // check that the 'unchanged' argument reads only what the context is allowed to read
+          if (options.DoReadsChecks) {
+            CheckFrameSubset(fe.E.tok,
+              new List<FrameExpression>() { fe },
+              null, new Dictionary<IVariable, Expression>(), etran, options.AssertSink(this, builder),
+              new PODesc.FrameSubset($"read state of 'unchanged' {description}", false), options.AssertKv);
+          }
         }
       } else if (expr is UnaryExpr) {
         UnaryExpr e = (UnaryExpr)expr;

--- a/Test/dafny0/LabelsOldAt.dfy
+++ b/Test/dafny0/LabelsOldAt.dfy
@@ -236,7 +236,9 @@ class C {
     && old(c'.x) == 3 // error: c' is not allocated in old state
   }
 
-  twostate function FUnchanged(x: int, c: C, new c': C, s: set<C>, new s': set<C>): bool {
+  twostate function FUnchanged(x: int, c: C, new c': C, s: set<C>, new s': set<C>): bool
+    reads this, c, c', s, s'
+  {
     && unchanged(this)
     && unchanged(c)
     && (x == 7 ==> unchanged(c')) // error: c' is not allocated in old state
@@ -251,28 +253,40 @@ class C {
   }
 }
 
-twostate predicate M0(u: C, s: set<C>, t: seq<C>) {
+twostate predicate M0(u: C, s: set<C>, t: seq<C>)
+  reads u, s, t
+{
   && unchanged(u)
   && unchanged(s)
   && unchanged(t)
 }
-twostate predicate M1(u: C?, s: set<C?>, t: seq<C?>) {
+twostate predicate M1(u: C?, s: set<C?>, t: seq<C?>)
+  reads u, s, t
+{
   && unchanged(u) // error: may be null
   && unchanged(s) // error: may be null
   && unchanged(t) // error: may be null
 }
 
-twostate predicate N0(new u: C, new s: set<C>, new t: seq<C>) {
+twostate predicate N0(new u: C, new s: set<C>, new t: seq<C>)
+  reads u, s, t
+{
   && unchanged(u) // error: may not be allocated in old
   && unchanged(s) // error: may not be allocated in old
   && unchanged(t) // error: may not be allocated in old
 }
-twostate predicate N1(new u: C?, new s: set<C?>, new t: seq<C?>) {
+twostate predicate N1(new u: C?, new s: set<C?>, new t: seq<C?>)
+  reads u
+{
   && unchanged(u) // error (x2): may be null, may not be allocated in old
 }
-twostate predicate N2(new u: C?, new s: set<C?>, new t: seq<C?>) {
+twostate predicate N2(new u: C?, new s: set<C?>, new t: seq<C?>)
+  reads s
+{
   && unchanged(s) // error (x2): may be null, may not be allocated in old
 }
-twostate predicate N3(new u: C?, new s: set<C?>, new t: seq<C?>) {
+twostate predicate N3(new u: C?, new s: set<C?>, new t: seq<C?>)
+  reads t
+{
   && unchanged(t) // error (x2): may be null, may not be allocated in old
 }

--- a/Test/dafny0/LabelsOldAt.dfy.expect
+++ b/Test/dafny0/LabelsOldAt.dfy.expect
@@ -15,19 +15,19 @@ LabelsOldAt.dfy(195,25): Error: object might not be allocated in the old-state o
 LabelsOldAt.dfy(197,31): Error: object might not be allocated in the old-state of the 'unchanged' predicate
 LabelsOldAt.dfy(207,31): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
 LabelsOldAt.dfy(236,14): Error: receiver might not be allocated in the state in which its fields are accessed
-LabelsOldAt.dfy(242,29): Error: object might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(244,29): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(260,15): Error: object might be null
-LabelsOldAt.dfy(261,15): Error: some set element might be null
-LabelsOldAt.dfy(262,15): Error: some sequence element might be null
-LabelsOldAt.dfy(266,15): Error: object might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(267,15): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(268,15): Error: some sequence element might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(271,15): Error: object might be null
-LabelsOldAt.dfy(271,15): Error: object might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(274,15): Error: some set element might be null
-LabelsOldAt.dfy(274,15): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
-LabelsOldAt.dfy(277,15): Error: some sequence element might be null
-LabelsOldAt.dfy(277,15): Error: some sequence element might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(244,29): Error: object might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(246,29): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(266,15): Error: object might be null
+LabelsOldAt.dfy(267,15): Error: some set element might be null
+LabelsOldAt.dfy(268,15): Error: some sequence element might be null
+LabelsOldAt.dfy(274,15): Error: object might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(275,15): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(276,15): Error: some sequence element might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(281,15): Error: object might be null
+LabelsOldAt.dfy(281,15): Error: object might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(286,15): Error: some set element might be null
+LabelsOldAt.dfy(286,15): Error: some set element might not be allocated in the old-state of the 'unchanged' predicate
+LabelsOldAt.dfy(291,15): Error: some sequence element might be null
+LabelsOldAt.dfy(291,15): Error: some sequence element might not be allocated in the old-state of the 'unchanged' predicate
 
 Dafny program verifier finished with 3 verified, 31 errors

--- a/Test/git-issues/git-issue-2301.dfy
+++ b/Test/git-issues/git-issue-2301.dfy
@@ -1,0 +1,57 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class Twostate {
+  var z: int
+
+  twostate predicate NoChange_ReadsThis()
+    reads this
+  {
+    unchanged(this)
+  }
+
+  twostate predicate NoChange_ReadsNothing()
+  {
+    unchanged(this) // error: insufficient reads clause
+  }
+
+  method Test0()
+    modifies this
+  {
+    assert NoChange_ReadsThis();
+    z := z + 1;
+    assert NoChange_ReadsThis(); // error: does not hold
+  }
+
+  method Test1()
+    modifies this
+  {
+    assert NoChange_ReadsNothing();
+    z := z + 1;
+    // If NoChange_ReadsNothing has an empty reads clause, then the following assertion
+    // from the previous assertion.
+    assert NoChange_ReadsNothing();
+  }
+
+  twostate predicate BadVariations(c: Twostate, d: Twostate, e: Twostate, f: Twostate)
+  {
+    && unchanged(
+        this, // error: insufficient reads clause
+        c // error: insufficient reads clause
+      )
+    && unchanged({c, d}) // error: insufficient reads clause
+    && unchanged(
+        multiset{e, e, c, e}, // error: insufficient reads clause
+        [c, d, e],
+        [c, f, e, d] // error: insufficient reads clause
+      )
+  }
+
+  twostate predicate GoodVariations(c: Twostate, d: Twostate, e: Twostate, f: Twostate)
+    reads [this], c, {d, e}, multiset{f}
+  {
+    && unchanged(this, c)
+    && unchanged({c, d})
+    && unchanged(multiset{e, e, c, e}, [c, d, e], [c, f, e, d])
+  }
+}

--- a/Test/git-issues/git-issue-2301.dfy.expect
+++ b/Test/git-issues/git-issue-2301.dfy.expect
@@ -1,0 +1,10 @@
+git-issue-2301.dfy(15,14): Error: insufficient reads clause to read state of 'unchanged' object
+git-issue-2301.dfy(23,11): Error: assertion might not hold
+git-issue-2301.dfy(10,4): Related location
+git-issue-2301.dfy(39,8): Error: insufficient reads clause to read state of 'unchanged' object
+git-issue-2301.dfy(40,8): Error: insufficient reads clause to read state of 'unchanged' object
+git-issue-2301.dfy(42,17): Error: insufficient reads clause to read state of 'unchanged' set element
+git-issue-2301.dfy(44,8): Error: insufficient reads clause to read state of 'unchanged' multiset element
+git-issue-2301.dfy(46,8): Error: insufficient reads clause to read state of 'unchanged' sequence element
+
+Dafny program verifier finished with 3 verified, 7 errors


### PR DESCRIPTION
This PR adds checks that the state of arguments given to `unchanged` are allowed to be read.

Fixes #2301

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
