### PR TITLE
fix: Correctly infer type of numeric arguments when the type is a subset type of a newtype

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - fix: Fix bug in translation of two-state predicates with heap labels. (https://github.com/dafny-lang/dafny/pull/2300)
 - fix: Check that arguments of 'unchanged' satisfy enclosing reads clause. (https://github.com/dafny-lang/dafny/pull/2302)
+- fix: Correctly infer type of numeric arguments, where the type is a subset type of a newtype. (issue https://github.com/dafny-lang/dafny/issues/2307)
 
 # 3.7.1
 

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -1861,7 +1861,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(builtIns != null);
       var j = JoinX(a, b, builtIns);
       if (DafnyOptions.O.TypeInferenceDebug) {
-        Console.WriteLine("DEBUG: Meet( {0}, {1} ) = {2}", a, b, j);
+        Console.WriteLine("DEBUG: Join( {0}, {1} ) = {2}", a, b, j);
       }
       return j;
     }

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -2090,6 +2090,18 @@ namespace Microsoft.Dafny {
       Contract.Requires(b != null);
       Contract.Requires(builtIns != null);
 
+      a = a.NormalizeExpandKeepConstraints();
+      b = b.NormalizeExpandKeepConstraints();
+      if (a is IntVarietiesSupertype) {
+        return b is IntVarietiesSupertype || b.IsNumericBased(NumericPersuasion.Int) || b.IsBigOrdinalType || b.IsBitVectorType ? b : null;
+      } else if (b is IntVarietiesSupertype) {
+        return a.IsNumericBased(NumericPersuasion.Int) || a.IsBigOrdinalType || a.IsBitVectorType ? a : null;
+      } else if (a is RealVarietiesSupertype) {
+        return b is RealVarietiesSupertype || b.IsNumericBased(NumericPersuasion.Real) ? b : null;
+      } else if (b is RealVarietiesSupertype) {
+        return a.IsNumericBased(NumericPersuasion.Real) ? a : null;
+      }
+
       var towerA = GetTowerOfSubsetTypes(a);
       var towerB = GetTowerOfSubsetTypes(b);
       if (towerB.Count < towerA.Count) {
@@ -2129,16 +2141,8 @@ namespace Microsoft.Dafny {
       }
       Contract.Assert(towerA.Count == 1 && towerB.Count == 1);
 
-      if (a is IntVarietiesSupertype) {
-        return b is IntVarietiesSupertype || b.IsNumericBased(NumericPersuasion.Int) || b.IsBigOrdinalType || b.IsBitVectorType ? b : null;
-      } else if (b is IntVarietiesSupertype) {
-        return a.IsNumericBased(NumericPersuasion.Int) || a.IsBigOrdinalType || a.IsBitVectorType ? a : null;
-      } else if (a.IsBoolType || a.IsCharType || a.IsBigOrdinalType || a.IsTypeParameter || a.IsInternalTypeSynonym || a is TypeProxy) {
+      if (a.IsBoolType || a.IsCharType || a.IsBigOrdinalType || a.IsTypeParameter || a.IsInternalTypeSynonym || a is TypeProxy) {
         return a.Equals(b) ? a : null;
-      } else if (a is RealVarietiesSupertype) {
-        return b is RealVarietiesSupertype || b.IsNumericBased(NumericPersuasion.Real) ? b : null;
-      } else if (b is RealVarietiesSupertype) {
-        return a.IsNumericBased(NumericPersuasion.Real) ? a : null;
       } else if (a.IsNumericBased()) {
         return a.Equals(b) ? a : null;
       } else if (a.IsBitVectorType) {

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -1798,8 +1798,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(type != null);
       type = type.NormalizeExpandKeepConstraints();
       List<Type> tower;
-      var udt = type as UserDefinedType;
-      if (udt != null && udt.ResolvedClass is SubsetTypeDecl) {
+      if (type is UserDefinedType udt && udt.ResolvedClass is SubsetTypeDecl) {
         var sst = (SubsetTypeDecl)udt.ResolvedClass;
         var parent = sst.RhsWithArgument(udt.TypeArgs);
         tower = GetTowerOfSubsetTypes(parent);
@@ -2061,14 +2060,12 @@ namespace Microsoft.Dafny {
 
       var joinNeedsNonNullConstraint = false;
       Type j;
-      if (a is UserDefinedType && ((UserDefinedType)a).ResolvedClass is NonNullTypeDecl) {
+      if ((a as UserDefinedType)?.ResolvedClass is NonNullTypeDecl aClass) {
         joinNeedsNonNullConstraint = true;
-        var nnt = (NonNullTypeDecl)((UserDefinedType)a).ResolvedClass;
-        j = MeetX(nnt.RhsWithArgument(a.TypeArgs), b, builtIns);
-      } else if (b is UserDefinedType && ((UserDefinedType)b).ResolvedClass is NonNullTypeDecl) {
+        j = MeetX(aClass.RhsWithArgument(a.TypeArgs), b, builtIns);
+      } else if ((b as UserDefinedType)?.ResolvedClass is NonNullTypeDecl bClass) {
         joinNeedsNonNullConstraint = true;
-        var nnt = (NonNullTypeDecl)((UserDefinedType)b).ResolvedClass;
-        j = MeetX(a, nnt.RhsWithArgument(b.TypeArgs), builtIns);
+        j = MeetX(a, bClass.RhsWithArgument(b.TypeArgs), builtIns);
       } else {
         j = MeetX(a, b, builtIns);
       }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -6838,7 +6838,11 @@ namespace Microsoft.Dafny {
           }
         } else if (CheckTypeIsDetermined(expr.tok, expr.Type, "expression")) {
           if (expr is UnaryOpExpr uop) {
-            uop.ResolveOp(); // Force resolution eagerly at this point to catch potential bugs
+            // The CheckTypeInference_Visitor has already visited uop.E, but uop.E's may be undetermined. If that happened,
+            // then an error has already been reported.
+            if (CheckTypeIsDetermined(uop.E.tok, uop.E.Type, "expression")) {
+              uop.ResolveOp(); // Force resolution eagerly at this point to catch potential bugs
+            }
           } else if (expr is BinaryExpr) {
             var e = (BinaryExpr)expr;
             e.ResolvedOp = ResolveOp(e.Op, e.E0.Type, e.E1.Type);

--- a/Test/git-issues/git-issue-2307.dfy
+++ b/Test/git-issues/git-issue-2307.dfy
@@ -1,0 +1,42 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  newtype int0 = x: int | true
+  type int1 = x: int0 | true
+
+  const x: int0 := 0;
+  const y: int1 := 0 as int1;
+  // It was once the case that Dafny inferred the type of 0 in the next line as 'int', which is bad.
+  const z: int1 := 0;
+}
+
+module B {
+  newtype int0 = int
+  type int1 = x: int0 | true
+
+  const x: int0 := 0;
+  const y: int1 := 0 as int1;
+  // It was once the case that Dafny inferred the type of 0 in the next line as 'int', which is bad.
+  const z: int1 := 0;
+}
+
+module C {
+  newtype real0 = x: real | true
+  type real1 = x: real0 | true
+
+  const x: real0 := 0.0;
+  const y: real1 := 0.0 as real1;
+  // It was once the case that Dafny inferred the type of 0.0 in the next line as 'real', which is bad.
+  const z: real1 := 0.0;
+}
+
+module D {
+  newtype real0 = real
+  type real1 = x: real0 | true
+
+  const x: real0 := 0.0;
+  const y: real1 := 0.0 as real1;
+  // It was once the case that Dafny inferred the type of 0.0 in the next line as 'real', which is bad.
+  const z: real1 := 0.0;
+}

--- a/Test/git-issues/git-issue-2307.dfy.expect
+++ b/Test/git-issues/git-issue-2307.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 16 verified, 0 errors


### PR DESCRIPTION
Fixes #2307 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
