### PR TITLE
refactor: Expose `Cloner` API

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -10,9 +10,7 @@ using Microsoft.Boogie;
 using IToken = Microsoft.Boogie.IToken;
 
 namespace Microsoft.Dafny {
-  class Cloner {
-
-
+  public class Cloner {
     public virtual ModuleDefinition CloneModuleDefinition(ModuleDefinition m, string name) {
       ModuleDefinition nw;
       if (m is DefaultModuleDecl) {


### PR DESCRIPTION
This is to be able to clone Dafny modules from third-party projects (my REPL, in this case).  This is a cherry-picked PR from the Dafny-in-Dafny branch.