### PR TITLE
Fix: No more crashing on hovering bodies of nested match statements 

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -10,9 +10,7 @@ using Microsoft.Boogie;
 using IToken = Microsoft.Boogie.IToken;
 
 namespace Microsoft.Dafny {
-  class Cloner {
-
-
+  public class Cloner {
     public virtual ModuleDefinition CloneModuleDefinition(ModuleDefinition m, string name) {
       ModuleDefinition nw;
       if (m is DefaultModuleDecl) {

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -11960,7 +11960,7 @@ namespace Microsoft.Dafny {
       }
 
       public RBranchStmt(int branchid, NestedMatchCaseStmt x, Attributes attrs = null) : base(x.Tok, branchid, new List<ExtendedPattern>()) {
-        this.Body = x.Body;
+        this.Body = new List<Statement>(x.Body); // Resolving the body will insert new elements. 
         this.Attributes = attrs;
         this.Patterns.Add(x.Pat);
       }

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -11960,7 +11960,7 @@ namespace Microsoft.Dafny {
       }
 
       public RBranchStmt(int branchid, NestedMatchCaseStmt x, Attributes attrs = null) : base(x.Tok, branchid, new List<ExtendedPattern>()) {
-        this.Body = x.Body.ConvertAll((new Cloner()).CloneStmt);
+        this.Body = x.Body;
         this.Attributes = attrs;
         this.Patterns.Add(x.Pat);
       }

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
@@ -427,5 +427,16 @@ function ToRelativeIndependent(): (p: Position)
 }
 ");
     }
+
+    [TestMethod]
+    public async Task HoveringVariablesInsideNestedMatchStmtWorks() {
+      await AssertHover(@"
+lemma dummy(e: int) {
+  match e {
+    case _ => var xx := 1;
+                   ^[```dafny\nghost xx: int\n```]
+  }
+}");
+    }
   }
 }


### PR DESCRIPTION
Fixes #2333

This is a very substantial problem.
The body of a NestedMatchStmt was cloned when resolved, resulting in variables not being resolved in the original tree, which caused the LSP to crash when asking about their hovering information.

I added a test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
