### PR TITLE
Expose BigRational.{num,den} in the C# runtime

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -1499,7 +1499,7 @@ namespace Dafny {
     // We need to deal with the special case "num == 0 && den == 0", because
     // that's what C#'s default struct constructor will produce for BigRational. :(
     // To deal with it, we ignore "den" when "num" is 0.
-    internal readonly BigInteger num, den;  // invariant 1 <= den || (num == 0 && den == 0)
+    public readonly BigInteger num, den;  // invariant 1 <= den || (num == 0 && den == 0)
 
     public override string ToString() {
       int log10;


### PR DESCRIPTION
This patch is needed in Dafny-in-Dafny to print bignums; we could decide to leave it there, too.