### PR TITLE
chore: Run single-platform integration tests even if nightly build failed

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -53,13 +53,12 @@ jobs:
       run: dotnet pack --no-build dafny/Source/Dafny.sln
 
   check-deep-tests:
+    if: ! contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))
     uses: ./.github/workflows/check-deep-tests-reusable.yml
     with:
       branch: master
 
   integration-tests:
-    needs: check-deep-tests
-    if: always() && (needs.check-deep-tests.result == 'success' || contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
       # By default run only on one platform, but run on all platforms if the PR has the "run-deep-tests"


### PR DESCRIPTION
There's no good reason to not run the integration tests in this situation: the results can still help tell you if your PR is in good shape while the nightly build gets fixed.

Our previous attempt to fix this didn't work because if `check-deep-tests` failed, the `integration-tests` job was skipped no matter what it's `if` clause evaluated to. Instead this change removes the `need` dependency entirely. All jobs still have to pass to unblock the PR anyway.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
