### PR TITLE
chore: Disable nuget publishing from nightly build

### DIFF
--- a/.github/workflows/deep-tests.yml
+++ b/.github/workflows/deep-tests.yml
@@ -46,7 +46,7 @@ jobs:
       name: ${{ needs.determine-vars.outputs.name }}
       sha: ${{ github.sha }}
       tag_name: nightly
-      # TODO: The Nuget publishing workflow doesn't handle preleases correctly yet
+      # TODO: The Nuget publishing workflow doesn't handle preleases correctly yet.
       release_nuget: false
       draft: false
       release_notes: "This is an automatically published nightly release. This release is not as stable as versioned releases and does not contain release notes."

--- a/.github/workflows/deep-tests.yml
+++ b/.github/workflows/deep-tests.yml
@@ -46,7 +46,8 @@ jobs:
       name: ${{ needs.determine-vars.outputs.name }}
       sha: ${{ github.sha }}
       tag_name: nightly
-      release_nuget: true
+      # TODO: The Nuget publishing workflow doesn't handle preleases correctly yet
+      release_nuget: false
       draft: false
       release_notes: "This is an automatically published nightly release. This release is not as stable as versioned releases and does not contain release notes."
       prerelease: true


### PR DESCRIPTION
The `publish-release-reusable.yml` workflow isn't careful enough about only building prerelease `*.nupkg` files, and is currently trying to re-publish actuall release packages and failing.

The API key secret issue should still be fixed so I'm only disabling it from the nightly build this time.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
