### PR TITLE
Use a concurrent bag for verification results

### DIFF
--- a/Source/Dafny/DafnyConsolePrinter.cs
+++ b/Source/Dafny/DafnyConsolePrinter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Dafny;
 
 public class DafnyConsolePrinter : ConsolePrinter {
   private readonly ConcurrentDictionary<string, List<string>> fsCache = new();
-  public List<(Implementation, VerificationResult)> VerificationResults { get; } = new();
+  public ConcurrentBag<(Implementation, VerificationResult)> VerificationResults { get; } = new();
 
   private string GetFileLine(string filename, int lineIndex) {
     List<string> lines = fsCache.GetOrAdd(filename, key => {

--- a/Source/DafnyDriver/BoogieXmlConvertor.cs
+++ b/Source/DafnyDriver/BoogieXmlConvertor.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Dafny {
           // and then it would make sense to rename this class.
           var textLogger = new TextLogger();
           textLogger.Initialize(parameters);
-          textLogger.LogResults((DafnyOptions.O.Printer as DafnyConsolePrinter).VerificationResults);
+          textLogger.LogResults((DafnyOptions.O.Printer as DafnyConsolePrinter).VerificationResults.ToList());
         } else {
           throw new ArgumentException("Unsupported verification logger config: {loggerConfig}");
         }


### PR DESCRIPTION
The previous implementation was not thread safe, and could occasionally lead to failures during addition. We don’t have a reliable way to reproduce one of these failures, however, so this commit doesn’t add any new tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
