### PR TITLE
doc: RM - aligning RM with LambdaSpec grammar

### DIFF
--- a/docs/DafnyRef/Introduction.md
+++ b/docs/DafnyRef/Introduction.md
@@ -29,8 +29,8 @@ changing the program’s type declarations, specifications, and statements.
 and `dafny` to refer to the software tool that verifies and compiles programs
 in the Dafny language.)
 
-The easiest way to try out `dafny` is to [download](https://github.com/dafny-lang/dafny/releases) it
-to run it on your machine as you follow along with the [Dafny tutorial](../OnlineTutorial/guide).
+The easiest way to try out the Dafny language is to [download the supporting tools and documentation](https://github.com/dafny-lang/dafny/releases) and
+run `dafny` on your machine as you follow along with the [Dafny tutorial](../OnlineTutorial/guide).
 The `dafny` tool can be run from the command line (on Linux, MacOS, Windows or other platforms) or from an IDE
 such as emacs or an editor such as VSCode, which can provide syntax highlighting without
 the built-in verification.

--- a/docs/DafnyRef/Specifications.md
+++ b/docs/DafnyRef/Specifications.md
@@ -545,7 +545,6 @@ LambdaSpec =
   | "requires" Expression(allowLemma: false, allowLambda: false)
   }
 ````
-// TODO - the above grammar is not quite right for Requires
 
 A lambda specification provides a specification for a lambda function expression;
 it consists of zero or more `reads` or `requires` clauses.

--- a/docs/DafnyRef/Specifications.md
+++ b/docs/DafnyRef/Specifications.md
@@ -542,16 +542,18 @@ allowed to modify any memory.
 LambdaSpec =
   { ReadsClause(allowLemma: true, allowLambda: false,
                                   allowWild: true)
-  | RequiresClause(allowLabel: false)
+  | "requires" Expression(allowLemma: false, allowLambda: false)
   }
 ````
 // TODO - the above grammar is not quite right for Requires
 
-A lambda specification is zero or more `reads` or `requires` clauses.
+A lambda specification provides a specification for a lambda function expression;
+it consists of zero or more `reads` or `requires` clauses.
+Any `requires` clauses may not have labels or attributes.
 Lambda specifications do not have `ensures` clauses because the body
 is never opaque.
 Lambda specifications do not have `decreases`
-clauses because they do not have names and thus cannot be recursive. A
+clauses because lambda expressions do not have names and thus cannot be recursive. A
 lambda specification does not have `modifies` clauses because lambdas
 are not allowed to modify any memory.
 


### PR DESCRIPTION
Fixes a mismatch between the RM and the grammar for LambdaSpec; removes a TODO

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
