### PR TITLE
feat: Better LSP related location error messages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+- feat: Snippet in the error messages of the language server. (https://github.com/dafny-lang/dafny/pull/2434)
+
 # 3.7.2
 
 - fix: Hovering over variables and methods inside cases of nested match statements work again. (https://github.com/dafny-lang/dafny/pull/2334)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Upcoming
 
-- feat: Snippet in the error messages of the language server. (https://github.com/dafny-lang/dafny/pull/2434)
+- feat: *Less code navigation when verifying code*: In the IDE, failing postconditions and preconditions error messages now immediately display the sub-conditions that Dafny could not prove. Both on hover and in the Problems window. (https://github.com/dafny-lang/dafny/pull/2434)
 
 # 3.7.2
 

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
@@ -58,7 +58,7 @@ method Abs(x: int) returns (y: int)
 ", "testFile.dfy", CompilationStatus.VerificationFailed);
       // When hovering the postcondition, it should display the position of the failing path
       await AssertHoverMatches(documentItem, (2, 15),
-        @"[Error:](???) A postcondition might not hold on this return path.  
+        @"[Error:](???) This postcondition might not hold on a return path.  
 This is assertion #1 of 2 in method Abs  
 Resource usage: ??? RU  
 Related location: testFile.dfy(6, 5)"

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -200,7 +200,7 @@ method Multiply(x: int, y: int) returns (product: int)
       Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[1].Severity);
       Assert.AreEqual(1, diagnostics[0].RelatedInformation.Count());
       var relatedInformation = diagnostics[0].RelatedInformation.First();
-      Assert.AreEqual("This is the postcondition that might not hold.", relatedInformation.Message);
+      Assert.AreEqual("This postcondition might not hold: product >= 0", relatedInformation.Message);
       Assert.AreEqual(new Range(new Position(2, 30), new Position(2, 42)), relatedInformation.Location.Range);
       await AssertNoDiagnosticsAreComing(CancellationToken);
     }
@@ -531,9 +531,9 @@ class Test {
       Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[0].Severity);
       var relatedInformation = diagnostics[0].RelatedInformation.ToArray();
       Assert.AreEqual(2, relatedInformation.Length);
-      Assert.AreEqual("This is the postcondition that might not hold.", relatedInformation[0].Message);
+      Assert.AreEqual("This postcondition might not hold: Valid()", relatedInformation[0].Message);
       Assert.AreEqual(new Range((14, 16), (14, 23)), relatedInformation[0].Location.Range);
-      Assert.AreEqual("Related location", relatedInformation[1].Message);
+      Assert.AreEqual("Could not prove: b < c", relatedInformation[1].Message);
       Assert.AreEqual(new Range((9, 11), (9, 16)), relatedInformation[1].Location.Range);
       await AssertNoDiagnosticsAreComing(CancellationToken);
     }

--- a/Source/DafnyLanguageServer.Test/Unit/ParserExceptionTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/ParserExceptionTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
       var errorReporter = new ParserExceptionSimulatingErrorReporter();
       parser.Parse(documentItem, errorReporter, default);
       Assert.AreEqual($"encountered an exception while parsing file:///{TestFilePath}", lastDebugLogger.LastDebugMessage);
-      Assert.AreEqual($"/{TestFilePath}(1,0): Error: [internal error] Parser exception: Simulated parser internal error", errorReporter.LastMessage);
+      Assert.AreEqual($"file:///{TestFilePath}(1,0): Error: [internal error] Parser exception: Simulated parser internal error", errorReporter.LastMessage);
     }
 
     /// <summary>

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -180,6 +180,11 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       var batchRef = AddAssertionBatchDocumentation("batch");
       var assertionCount = assertionBatch.Children.Count;
 
+
+      var currentlyHoveringPostcondition =
+        !(assertionNode.GetCounterExample() is ReturnCounterexample returnCounterexample2 &&
+          returnCounterexample2.FailingReturn.tok.GetLspRange().Contains(position));
+
       var obsolescence = assertionNode.StatusCurrent switch {
         CurrentStatus.Current => "",
         CurrentStatus.Obsolete => "(obsolete) ",
@@ -187,14 +192,22 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       };
 
       string GetDescription(Boogie.ProofObligationDescription? description) {
-        return assertionNode?.StatusVerification switch {
-          GutterVerificationStatus.Verified => $"{obsolescence}<span style='color:green'>**Success:**</span> " +
-                                                       (description?.SuccessDescription ?? "_no message_"),
-          GutterVerificationStatus.Error =>
-            $"{obsolescence}[Error:](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-verification-debugging) " +
-            (description?.FailureDescription ?? "_no message_"),
-          GutterVerificationStatus.Inconclusive => $"{obsolescence}**Ignored or could not reach conclusion**",
-          _ => $"{obsolescence}**Waiting to be verified...**",
+        switch (assertionNode?.StatusVerification) {
+          case GutterVerificationStatus.Verified:
+            return $"{obsolescence}<span style='color:green'>**Success:**</span> " +
+                   (description?.SuccessDescription ?? "_no message_");
+          case GutterVerificationStatus.Error:
+            var failureDescription = description?.FailureDescription ?? "_no message_";
+            if (currentlyHoveringPostcondition &&
+                  (failureDescription == new PostconditionDescription().FailureDescription ||
+                   failureDescription == new EnsuresDescription().FailureDescription)) {
+              failureDescription = "This postcondition might not hold on a return path.";
+            }
+            return $"{obsolescence}[Error:](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-verification-debugging) " +
+                   failureDescription;
+          case GutterVerificationStatus.Inconclusive:
+            return $"{obsolescence}**Ignored or could not reach conclusion**";
+          default: return $"{obsolescence}**Waiting to be verified...**";
         };
       }
 
@@ -229,8 +242,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       }
 
       // Not the main error displayed in diagnostics
-      if (!(assertionNode.GetCounterExample() is ReturnCounterexample returnCounterexample2 &&
-            returnCounterexample2.FailingReturn.tok.GetLspRange().Contains(position))) {
+      if (currentlyHoveringPostcondition) {
         information += "  \n" + (assertionNode.SecondaryPosition != null
           ? $"Related location: {Path.GetFileName(assertionNode.Filename)}({assertionNode.SecondaryPosition.Line + 1}, {assertionNode.SecondaryPosition.Character + 1})"
           : "");

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
           }
           // Ok no assertion here. Maybe a method?
           if (node.Position.Line == position.Line &&
-              node.Filename == document.Uri.GetFileSystemPath()) {
+              node.Filename == document.Uri.ToString()) {
             areMethodStatistics = true;
             return GetTopLevelInformation(node, orderedAssertionBatches);
           }

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
           document.Text,
           document.GetFilePath(),
           // We use the full path as filename so we can better re-construct the DocumentUri for the definition lookup.
-          document.GetFilePath(),
+          document.Uri.ToString(),
           program.DefaultModule,
           program.BuiltIns,
           errorReporter
@@ -83,7 +83,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       } catch (Exception e) {
         logger.LogDebug(e, "encountered an exception while parsing {DocumentUri}", document.Uri);
         var internalErrorDummyToken = new Token {
-          filename = document.GetFilePath(),
+          filename = document.Uri.ToString(),
           line = 1,
           col = 1,
           pos = 0,
@@ -101,8 +101,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       // Ensure that the statically kept scopes are empty when parsing a new document.
       Type.ResetScopes();
       return new Dafny.Program(
-        // The file system path is used as the program's name to identify the entry document. See PathExtensions
-        document.GetFilePath(),
+        document.Uri.ToString(),
         new LiteralModuleDecl(new DefaultModuleDecl(), null),
         // BuiltIns cannot be initialized without Type.ResetScopes() before.
         new BuiltIns(),

--- a/Source/DafnyLanguageServer/Util/PathExtensions.cs
+++ b/Source/DafnyLanguageServer/Util/PathExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Dafny.LanguageServer.Util {
     /// <param name="documentUri">The URI to check.</param>
     /// <returns><c>true</c> if the given URI is the entrypoint document of the given program.</returns>
     public static bool IsEntryDocument(this Dafny.Program program, DocumentUri documentUri) {
-      return GetFilePath(documentUri) == program.FullName;
+      return documentUri.ToString() == program.FullName;
     }
 
     /// <summary>
@@ -62,7 +62,10 @@ namespace Microsoft.Dafny.LanguageServer.Util {
     /// <param name="token">The token to get the boogie token from.</param>
     /// <returns>The uri of the document where the token is located.</returns>
     public static DocumentUri GetDocumentUri(this Boogie.IToken token) {
-      return DocumentUri.FromFileSystemPath(token.filename);
+      if (token is IncludeToken includeToken) {
+        return DocumentUri.FromFileSystemPath(includeToken.Include.CanonicalPath);
+      }
+      return DocumentUri.Parse(token.filename);
     }
 
     /// <summary>

--- a/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
 
       // Render verification tree content into lines.
       foreach (var verificationTree in verificationTrees) {
-        if (verificationTree.Filename == uri.GetFileSystemPath() ||
+        if (verificationTree.Filename == uri.ToString() ||
             "untitled:" + verificationTree.Filename == uri) {
           verificationTree.RenderInto(result);
         }

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     public DafnyDocument CreateUnloaded(DocumentTextBuffer textDocument, CancellationToken cancellationToken) {
-      var errorReporter = new DiagnosticErrorReporter(textDocument.Uri);
+      var errorReporter = new DiagnosticErrorReporter(textDocument.Text, textDocument.Uri);
       return CreateDocumentWithEmptySymbolTable(
         loggerFactory.CreateLogger<SymbolTable>(),
         textDocument,
@@ -153,7 +153,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     private DafnyDocument LoadInternal(DocumentTextBuffer textDocument, CancellationToken cancellationToken) {
-      var errorReporter = new DiagnosticErrorReporter(textDocument.Uri);
+      var errorReporter = new DiagnosticErrorReporter(textDocument.Text, textDocument.Uri);
       statusPublisher.SendStatusNotification(textDocument, CompilationStatus.ResolutionStarted);
       var program = parser.Parse(textDocument, errorReporter, cancellationToken);
       IncludePluginLoadErrors(errorReporter, program);
@@ -316,7 +316,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     private List<Diagnostic> GetDiagnosticsFromResult(DafnyDocument document, VerificationResult result) {
-      var errorReporter = new DiagnosticErrorReporter(document.Uri);
+      var errorReporter = new DiagnosticErrorReporter(document.TextDocumentItem.Text, document.Uri);
       foreach (var counterExample in result.Errors) {
         errorReporter.ReportBoogieError(counterExample.CreateErrorInformation(result.Outcome, Options.ForceBplErrors));
       }

--- a/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
+++ b/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
@@ -68,7 +68,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
       }
     }
 
-    var documentFilePath = document.GetFilePath();
+    var documentFilePath = document.Uri.ToString();
     foreach (var module in document.Program.Modules()) {
       foreach (var topLevelDecl in module.TopLevelDecls) {
         if (topLevelDecl is DatatypeDecl datatypeDecl) {


### PR DESCRIPTION
Improvement: instead of "Related location", explicit what these related locations are about:
![image](https://user-images.githubusercontent.com/3601079/179565732-c269c3de-b8bb-43b9-826f-8debf0122de6.png)


Fixes https://github.com/dafny-lang/ide-vscode/issues/211
On hovering a postcondition, the main message is now "This postcondition might not hold on a return path". https://github.com/dafny-lang/dafny/pull/2433 takes cares of changing "related location" to "return path".

Fixes https://github.com/dafny-lang/ide-vscode/issues/197 by changing all Uri to string conversion to the standard `Uri.toString() / DocumentUri.Parse()` so that there is no loss of conversion, and we don't assume a valid file name. Except for includes.

Fixes  https://github.com/dafny-lang/ide-vscode/issues/193 by providing which postconditions are failing explicitely





<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
