### PR TITLE
Disable NuGet uploading of releases for now

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -124,4 +124,7 @@ jobs:
 
     - name: Upload package to NuGet
       if: ${{ inputs.release_nuget }}
-      run: dotnet nuget push "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json
+      # Need --skip-duplicate for cases where we release a new Dafny
+      # version but the runtime hasn't changed and is still the old
+      # version.
+      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,7 +33,10 @@ jobs:
       sha: ${{ github.sha }}
       tag_name: ${{ github.ref }}
       draft: true
-      release_nuget: true
+      # Currently automated NuGet uploads have overly strict .NET
+      # version dependencies. Skipping until that's fixed. See here:
+      # https://github.com/dafny-lang/dafny/issues/2423
+      release_nuget: false
       # We can probably automate pulling this out of RELEASE_NOTES.md in the future
       release_notes: ""
     secrets:


### PR DESCRIPTION
Works around #2423 for now. We can manually upload NuGet packages until we've figured out why this is happening.

Also fixes one small, non-fatal issue that occurred during the 3.7.2 release.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
