### PR TITLE
ci: Build and release process cleanups after 3.7.3

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -124,7 +124,6 @@ jobs:
 
     - name: Make NuGet package available as an artifact
       uses: actions/upload-artifact@v2
-      if: always()
       with:
         name: nuget-packages-${{ matrix.os }}
         path: dafny/Binaries/*.nupkg

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -122,6 +122,13 @@ jobs:
       # NuGet will consider any package with a version-suffix as a prerelease
       run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
 
+    - name: Make NuGet package available as an artifact
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: nuget-packages-${{ matrix.os }}
+        path: dafny/Binaries/*.nupkg
+
     - name: Upload package to NuGet
       if: ${{ inputs.release_nuget }}
       # Need --skip-duplicate for cases where we release a new Dafny

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -24,8 +24,8 @@ jobs:
             z3: z3-4.8.5-x64-win
             chmod: false
             coverage: false
-          - os: macos-10.15
-            suffix: osx-10.14.1
+          - os: macos-11
+            suffix: osx-11
             z3: z3-4.8.5-x64-osx-10.14.2
             chmod: true
             coverage: false

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -24,8 +24,8 @@ jobs:
             z3: z3-4.8.5-x64-win
             chmod: false
             coverage: false
-          - os: macos-11
-            suffix: osx-11
+          - os: macos-latest
+            suffix: osx
             z3: z3-4.8.5-x64-osx-10.14.2
             chmod: true
             coverage: false

--- a/Source/Dafny/DafnyPipeline.csproj
+++ b/Source/Dafny/DafnyPipeline.csproj
@@ -19,6 +19,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <VersionPrefix>3.7.3.40719</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -13,6 +13,7 @@
 
       <PackAsTool>true</PackAsTool>
       <ToolCommandName>dafny</ToolCommandName>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -10,6 +10,7 @@
       <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
       <LangVersion>7.3</LangVersion>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -153,14 +153,6 @@ with git commands and concepts is helpful.
 
 5. Before releasing a new version of the VSCode plugin, make sure to add to the release notes in `CHANGELOG.md`
 
-6. Select a new version number `$VER` for the plugin (e.g. "2.4.0") and change the value of the constant `version` in the file `package.json`
-   to `$VER` and commit the changes.
+6. Follow the release process detailed in the plugin's repository:
 
-7. Then tag and push the changes:
-
-       git tag v<$VER>
-       git push origin v<$VER>
-
-8. Create a pull request and, once merged, a GitHub action will automatically run in reaction to the tag being pushed to master, which will create a new release in the VSCode marketplace.
-
-9. Announce the release to the world.
+   <https://github.com/dafny-lang/ide-vscode/blob/master/CONTRIBUTING.md>

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -55,7 +55,7 @@
 
 6. Once the action completes, you should find the draft release at
    https://github.com/dafny-lang/dafny/releases. Edit the release body
-   to add in the release notes from `RELEASE_NOTES.md`. 
+   to add in the release notes from `RELEASE_NOTES.md`.
    Also check the box to create a new discussion based on
    the release, if this is not a pre-release.
 
@@ -64,22 +64,31 @@
    on multiple platforms. Again you can watch for this workflow at
    https://github.com/dafny-lang/dafny/actions.
 
-8. Manually trigger the "Test NuGet Tool Installation" workflow on the
+8. Manually upload packages to NuGet, from the fresh checkout of the
+   repository used for tagging.
+
+   ```
+   dotnet build Source/Dafny.sln
+   dotnet pack --no-build dafny/Source/Dafny.sln
+   dotnet nuget push --skip-duplicate "Binaries/Dafny*.nupkg" -k $A_VALID_API_KEY -s https://api.nuget.org/v3/index.json
+   ```
+
+9. Manually trigger the "Test NuGet Tool Installation" workflow on the
    `master` branch (following the same process as for step 3).
 
-9. If preparing a pre-release, stop here, as
-   the following steps declare the release as the latest version, which
-   is not the intention.
+10. If preparing a pre-release, stop here, as
+    the following steps declare the release as the latest version, which
+    is not the intention.
 
-10. If something goes wrong, delete the tag and release in GitHub, fix the
-   problem and try again.
+11. If something goes wrong, delete the tag and release in GitHub, fix the
+    problem and try again.
 
-11. Update the Homebrew formula for Dafny (see below).
-   Note that it is fine to leave this for the next day,
-   and other members of the community may update the formula
-   in the meantime anyway.
+12. Update the Homebrew formula for Dafny (see below).
+    Note that it is fine to leave this for the next day,
+    and other members of the community may update the formula
+    in the meantime anyway.
 
-12. Announce the new release to the world.
+13. Announce the new release to the world.
 
 ## Updating Dafny on Homebrew
 
@@ -98,63 +107,35 @@ with git commands and concepts is helpful.
    Running `which brew` will tell you if it is. See
    <https://docs.brew.sh/Installation> if not.
 
-1. Update brew: `brew update`
+1. Create a GitHub personal access token (if you don't have one handy),
+   and put it in an environment variable:
 
-2. Find the formula: `cd $(brew --repo)/Library/Taps/homebrew/homebrew-core/Formula`
+   ```
+   export HOMEBREW_GITHUB_API_TOKEN=your_token_here
+   ```
 
-3. Prepare the repository:
-
-        git checkout master
-        git pull origin
-        git checkout -b <some new branch name>
-
-   The branch name is needed in various places below
-
-4. Edit the formula (e.g., `vi dafny.rb`). For a normal release change,
-   all that is needed is to change the name of the archive file for the
-   release and its SHA.
-
-   a) Change the line near the top of the file that looks like
-
-          url "https://github.com/dafny-lang/dafny/archive/v2.3.0.tar.gz"
-
-      to hold the actual release number (this is the url for the source
-      asset; you can see the actual name on the Releases page for the
-      latest build).
-   b) Save the file
-   c) Run `brew reinstall dafny`.
-   d) The command will complain that the SHA does not match. Copy the
-      correct SHA, reopen the file and paste the new SHA into the `sha`
-      line after the `url` line.
-   e) Bump up the revision number (by one) on the succeeding line.
-   f) Save the file
-   g) Check that you have not introduced any syntax errors by running
-      `brew reinstall dafny` again. If you totally mess up the file,
-      you can do `git checkout dafny.rb`.
-
-5. Create a pull request following the instructions here:
+2. Create a pull request following the instructions here:
 
     <https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request>
 
-6. Expect comments from the reviewers. If changes are needed, do 4-6
+   These instructions currently involve the following command:
+
+   ```
+  brew bump-formula-pr \
+    --url <source .tar.gz for the release> \
+    --sha256 <sha256 of the source .tar.gz for the release>
+   ```
+
+3. Expect comments from the reviewers. If changes are needed, do 4-6
    again. Eventually the reviewers will accept and merge the PR.
 
-7. Then bring your Homebrew installation back to normal:
-
-        git checkout master
-        git pull origin master
-
-8. Test the installation by running
+4. Test the installation by running
 
         brew reinstall dafny
 
    and then execute `dafny` on a sample file to see if it has the
    correct version number. Even better is to try this step on a
    different machine than the one on which the `dafny.rb` file was edited
-
-9. If everything works you can, at your leisure do
-
-        git branch -d <the branch name>
 
 ## Updating and releasing a new version of VSCode plugin
 
@@ -178,7 +159,7 @@ with git commands and concepts is helpful.
 7. Then tag and push the changes:
 
        git tag v<$VER>
-       git push v<$VER>
+       git push origin v<$VER>
 
 8. Create a pull request and, once merged, a GitHub action will automatically run in reaction to the tag being pushed to master, which will create a new release in the VSCode marketplace.
 

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -133,9 +133,9 @@ with git commands and concepts is helpful.
 
         brew reinstall dafny
 
-   and then execute `dafny` on a sample file to see if it has the
-   correct version number. Even better is to try this step on a
-   different machine than the one on which the `dafny.rb` file was edited
+   and then execute `dafny /version` see if it has the correct version
+   number. Even better is to try this step on a different machine than
+   the one on which the `dafny.rb` file was edited
 
 ## Updating and releasing a new version of VSCode plugin
 


### PR DESCRIPTION
* Update release process documentation
* Include license expressions in packages for NuGet, to avoid warnings
* Always upload `.nupkg` files as artifacts, for debugging

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
