### PR TITLE
fix: Strip "pos" field from diagnosticsFormat test

### DIFF
--- a/Source/XUnitExtensions/Lit/ILitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ILitCommand.cs
@@ -36,9 +36,9 @@ namespace XUnitExtensions.Lit {
       var hasGlobCharacters = false;
       for (int i = 0; i < line.Length; i++) {
         var c = line[i];
-        if (c == '\'') {
+        if (c == '\'' && !doubleQuoted) {
           singleQuoted = !singleQuoted;
-        } else if (c == '"') {
+        } else if (c == '"' && !singleQuoted) {
           doubleQuoted = !doubleQuoted;
         } else if (Char.IsWhiteSpace(c) && !(singleQuoted || doubleQuoted)) {
           if (argument.Length != 0) {

--- a/Source/XUnitExtensions/Lit/SedCommand.cs
+++ b/Source/XUnitExtensions/Lit/SedCommand.cs
@@ -22,7 +22,7 @@ namespace XUnitExtensions.Lit {
 
     public static ILitCommand Parse(string[] args) {
       if (args.Length != 2) {
-        throw new ArgumentException($"Wrong number of arguments for sed: {args}");
+        throw new ArgumentException($"Wrong number of arguments for sed: {args.Length}");
       }
       var regexpReplace = args[0];
 

--- a/Test/cli/diagnosticsFormats.dfy
+++ b/Test/cli/diagnosticsFormats.dfy
@@ -1,7 +1,10 @@
-// RUN: %dafny_0 /compile:0 /diagnosticsFormat:text "%s" > "%t"
-// RUN: %dafny_0 /compile:0 /diagnosticsFormat:json "%s" >> "%t"
-// RUN: %dafny_0 /compile:0 /diagnosticsFormat:json -printTooltips "%s" >> "%t"
-// RUN: %dafny_0 /compile:0 /diagnosticsFormat:json -showSnippets:1 "%s" >> "%t"
+// RUN: %dafny_0 /compile:0 /diagnosticsFormat:text "%s" > "%t".raw
+// RUN: %dafny_0 /compile:0 /diagnosticsFormat:json "%s" >> "%t".raw
+// RUN: %dafny_0 /compile:0 /diagnosticsFormat:json -printTooltips "%s" >> "%t".raw
+// RUN: %dafny_0 /compile:0 /diagnosticsFormat:json -showSnippets:1 "%s" >> "%t".raw
+// The "pos" field contains a different value on Windows and Linux (because of
+// line ending differences), so we strip it out:
+// RUN: %sed 's/"pos":[0-9]\+,//g' "%t".raw > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 newtype byte = i: int | 0 <= i < 256 // Info

--- a/Test/cli/diagnosticsFormats.dfy
+++ b/Test/cli/diagnosticsFormats.dfy
@@ -4,7 +4,7 @@
 // RUN: %dafny_0 /compile:0 /diagnosticsFormat:json -showSnippets:1 "%s" >> "%t".raw
 // The "pos" field contains a different value on Windows and Linux (because of
 // line ending differences), so we strip it out:
-// RUN: %sed 's/"pos":[0-9]\+,//g' "%t".raw > "%t"
+// RUN: %sed 's/"pos":[0-9]+,//g' "%t".raw > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 newtype byte = i: int | 0 <= i < 256 // Info

--- a/Test/cli/diagnosticsFormats.dfy.expect
+++ b/Test/cli/diagnosticsFormats.dfy.expect
@@ -1,22 +1,22 @@
-diagnosticsFormats.dfy(8,0): Warning: module-level const declarations are always non-instance, so the 'static' keyword is not allowed here
-diagnosticsFormats.dfy(9,17): Error: result of operation might violate newtype constraint for 'byte'
-diagnosticsFormats.dfy(12,16): Error: A precondition for this call might not hold.
-diagnosticsFormats.dfy(11,35): Related location: This is the precondition that might not hold.
+diagnosticsFormats.dfy(11,0): Warning: module-level const declarations are always non-instance, so the 'static' keyword is not allowed here
+diagnosticsFormats.dfy(12,17): Error: result of operation might violate newtype constraint for 'byte'
+diagnosticsFormats.dfy(15,16): Error: A precondition for this call might not hold.
+diagnosticsFormats.dfy(14,35): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 2 errors
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":367,"line":8,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":416,"line":9,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":508,"line":12,"character":16}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":466,"line":11,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":11,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":12,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":16}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
 
 Dafny program verifier finished with 1 verified, 2 errors
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":367,"line":8,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":330,"line":7,"character":8}}},"severity":4,"message":"newtype byte resolves as {:nativeType \u0022byte\u0022} (Detected Range: 0 .. 256)","source":"Resolver","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":416,"line":9,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":508,"line":12,"character":16}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":466,"line":11,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":11,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":10,"character":8}}},"severity":4,"message":"newtype byte resolves as {:nativeType \u0022byte\u0022} (Detected Range: 0 .. 256)","source":"Resolver","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":12,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":16}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
 
 Dafny program verifier finished with 1 verified, 2 errors
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":367,"line":8,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":416,"line":9,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":506,"line":12,"character":14},"end":{"pos":510,"line":12,"character":18}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"pos":466,"line":11,"character":35},"end":{"pos":466,"line":11,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":11,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":12,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":14},"end":{"line":15,"character":18}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35},"end":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
 
 Dafny program verifier finished with 1 verified, 2 errors

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -164,7 +164,7 @@ config.substitutions.append( ('%server', serverExecutable) )
 config.substitutions.append( ('%refmanexamples', os.path.join(repositoryRoot, 'docs', 'DafnyRef', 'examples')) )
 config.substitutions.append( ('%os', os.name) )
 config.substitutions.append( ('%ver', ver ) )
-config.substitutions.append( ('%sed', 'sed' ) )
+config.substitutions.append( ('%sed', 'sed -E' ) )
 if os.name == "nt":
     config.available_features = [ 'windows' ]
 elif "Darwin" in ver:


### PR DESCRIPTION
The Windows build checks out the repo with`\r\n` line endings, which changes the `"pos"` field by 1 unit per line.