### PR TITLE
feat: Allow leading `|` in disjunctive patterns

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -3328,7 +3328,7 @@ SingleExtendedPattern<.out ExtendedPattern pat.>
 ExtendedPattern<.out ExtendedPattern pat.>
 = (. List<ExtendedPattern> branches = null;
      ExtendedPattern branch = null; .)
-  SingleExtendedPattern<out branch>
+  [ "|" ] SingleExtendedPattern<out branch>
   { "|"                                    (. branches ??= new() { branch }; .)
     SingleExtendedPattern<out branch>      (. branches.Add(branch); .)
   }

--- a/Test/patterns/OrPatterns.dfy
+++ b/Test/patterns/OrPatterns.dfy
@@ -27,8 +27,8 @@ module Constants {
 
   method M(i: int) {
     match i
-      case ONE | TWO => return; // `ONE` and `TWO` are not variables here
-      case _ => // Not redundant
+      case | ONE | TWO => return; // `ONE` and `TWO` are not variables here
+      case | _ => // Not redundant
   }
 }
 

--- a/docs/DafnyRef/Expressions.md
+++ b/docs/DafnyRef/Expressions.md
@@ -957,7 +957,7 @@ SingleExtendedPattern =
   )
 
 ExtendedPattern =
-  ( SingleExtendedPattern { "|" SingleExtendedPattern } )
+  ( [ "|" ] SingleExtendedPattern { "|" SingleExtendedPattern } )
 
 PossiblyNegatedLiteralExpression =
   ( "-" ( Nat | Dec )


### PR DESCRIPTION
Requested by @seebees.