### PR TITLE
fix: Incorrect error message for modifies clause (closes #2384)

### DIFF
--- a/Source/Dafny/Verifier/ProofObligationDescription.cs
+++ b/Source/Dafny/Verifier/ProofObligationDescription.cs
@@ -378,20 +378,22 @@ public class YieldEnsures : ProofObligationDescription {
 public class TraitFrame : ProofObligationDescription {
   public override string SuccessDescription =>
     isModify
-      ? "expression abides by trait context's modifies clause"
-      : "expression abides by trait context's reads clause";
+      ? $"{whatKind} abides by trait context's modifies clause"
+      : $"{whatKind} abides by trait context's reads clause";
 
   public override string FailureDescription =>
     isModify
-      ? "expression might read an object not in the parent trait context's reads clause"
-      : "expression might modify an object not in the parent trait context's modifies clause";
+      ? $"{whatKind} might modify an object not in the parent trait context's modifies clause"
+      : $"{whatKind} might read an object not in the parent trait context's reads clause";
 
   public override string ShortDescription =>
     isModify ? "trait modifies" : "trait reads";
 
+  private readonly string whatKind;
   private bool isModify;
 
-  public TraitFrame(bool isModify) {
+  public TraitFrame(string whatKind, bool isModify) {
+    this.whatKind = whatKind;
     this.isModify = isModify;
   }
 }

--- a/Source/Dafny/Verifier/Translator.ClassMembers.cs
+++ b/Source/Dafny/Verifier/Translator.ClassMembers.cs
@@ -1323,7 +1323,7 @@ namespace Microsoft.Dafny {
       Boogie.Expr consequent2 = InRWClause(tok, o, f, traitFrameExps, etran, null, null);
       Boogie.Expr q = new Boogie.ForallExpr(tok, new List<TypeVariable> { alpha }, new List<Variable> { oVar, fVar },
         Boogie.Expr.Imp(Boogie.Expr.And(ante, oInCallee), consequent2));
-      builder.Add(Assert(tok, q, new PODesc.TraitFrame(true), kv));
+      builder.Add(Assert(tok, q, new PODesc.TraitFrame(m.WhatKind, true), kv));
     }
 
     /// <summary>

--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -3611,7 +3611,7 @@ namespace Microsoft.Dafny {
       Bpl.Expr consequent2 = InRWClause(tok, o, f, traitFrameExps, etran, null, null);
       Bpl.Expr q = new Bpl.ForallExpr(tok, new List<TypeVariable> { alpha }, new List<Variable> { oVar, fVar },
                                       Bpl.Expr.Imp(Bpl.Expr.And(ante, oInCallee), consequent2));
-      builder.Add(Assert(tok, q, new PODesc.TraitFrame(false), kv));
+      builder.Add(Assert(tok, q, new PODesc.TraitFrame(func.WhatKind, false), kv));
     }
 
     private void AddFunctionOverrideReqsChk(Function f, BoogieStmtListBuilder builder, ExpressionTranslator etran, Dictionary<IVariable, Expression> substMap) {

--- a/Test/git-issues/git-issue-2384.dfy
+++ b/Test/git-issues/git-issue-2384.dfy
@@ -1,0 +1,19 @@
+// RUN: %dafny_0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+trait T {
+  method M()
+  predicate P()
+  function F(): int
+}
+
+class C extends T {
+  method M() // method might modify an object not in the parent trait context's modifies clause
+    modifies this
+
+  predicate P() // predicate might read an object not in the parent trait context's reads clause
+    reads this
+
+  function F(): int // function might read an object not in the parent trait context's reads clause
+    reads this
+}

--- a/Test/git-issues/git-issue-2384.dfy.expect
+++ b/Test/git-issues/git-issue-2384.dfy.expect
@@ -1,0 +1,5 @@
+git-issue-2384.dfy(11,9): Error: method might modify an object not in the parent trait context's modifies clause
+git-issue-2384.dfy(14,12): Error: predicate might read an object not in the parent trait context's reads clause
+git-issue-2384.dfy(17,11): Error: function might read an object not in the parent trait context's reads clause
+
+Dafny program verifier finished with 0 verified, 3 errors


### PR DESCRIPTION
The bug was introduced by a typo in 53765c537.  This PR further improves the
message by not mentioning "expressions".
