### PR TITLE
Allow `{:options "/noNLarith"}`

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -1299,6 +1299,7 @@ class ErrorReportingCommandLineParseState : Bpl.CommandLineParseState {
 class DafnyAttributeOptions : DafnyOptions {
   public static readonly HashSet<string> KnownOptions = new() {
     "functionSyntax",
+    "noNLarith",
     "quantifierSyntax"
   };
 

--- a/Test/dafny0/ParserOptions.dfy
+++ b/Test/dafny0/ParserOptions.dfy
@@ -29,6 +29,20 @@ module BackToDefault {
   function GhostFunction() : int { 1 }
 }
 
+module {:options "/noNLarith"} Math__div_def_i {
+  function my_div_pos(x:int, d:int) : int
+    requires d >  0;
+    decreases if x < 0 then (d - x) else x;
+  {
+    if x < 0 then
+      -1 + my_div_pos(x+d, d)
+    else if x < d then
+      0
+    else
+      1 + my_div_pos(x-d, d)
+  }
+}
+
 // Sanity check
 method Main() {
   print FunctionMethodSyntax.CompiledFunction()

--- a/Test/dafny0/ParserOptions.dfy.expect
+++ b/Test/dafny0/ParserOptions.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
This will make it possible to verify the [standard library](https://github.com/dafny-lang/libraries/) without a special command line.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
