### PR TITLE
Optimize shift/rotate for more efficient solving

### DIFF
--- a/Source/Dafny/Resolver/BoundsDiscovery.cs
+++ b/Source/Dafny/Resolver/BoundsDiscovery.cs
@@ -4,9 +4,12 @@
 // SPDX-License-Identifier: MIT
 //
 //-----------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics.Contracts;
+using System.Numerics;
 using Microsoft.Boogie;
 
 namespace Microsoft.Dafny {

--- a/Source/Dafny/Resolver/BoundsDiscovery.cs
+++ b/Source/Dafny/Resolver/BoundsDiscovery.cs
@@ -5,11 +5,9 @@
 //
 //-----------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics.Contracts;
-using System.Numerics;
 using Microsoft.Boogie;
 
 namespace Microsoft.Dafny {

--- a/Source/Dafny/Resolver/BoundsDiscovery.cs
+++ b/Source/Dafny/Resolver/BoundsDiscovery.cs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 //
 //-----------------------------------------------------------------------------
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics.Contracts;

--- a/Source/Dafny/Verifier/Translator.ExpressionTranslator.cs
+++ b/Source/Dafny/Verifier/Translator.ExpressionTranslator.cs
@@ -991,11 +991,11 @@ namespace Microsoft.Dafny {
 
             case BinaryExpr.ResolvedOpcode.LeftShift: {
                 Contract.Assert(0 <= bvWidth);
-                return TrToFunctionCall(GetToken(expr), "LeftShift_bv" + bvWidth, translator.BplBvType(bvWidth), e0, translator.ConvertExpression(GetToken(expr), e1, e.E1.Type, e.Type), liftLit);
+                return TrShiftRotateExpr("LeftShift", e, e0, e1, e.E1.Type, bvWidth, liftLit);
               }
             case BinaryExpr.ResolvedOpcode.RightShift: {
                 Contract.Assert(0 <= bvWidth);
-                return TrToFunctionCall(GetToken(expr), "RightShift_bv" + bvWidth, translator.BplBvType(bvWidth), e0, translator.ConvertExpression(GetToken(expr), e1, e.E1.Type, e.Type), liftLit);
+                return TrShiftRotateExpr("RightShift", e, e0, e1, e.E1.Type, bvWidth, liftLit);
               }
             case BinaryExpr.ResolvedOpcode.BitwiseAnd: {
                 Contract.Assert(0 <= bvWidth);
@@ -1422,17 +1422,27 @@ namespace Microsoft.Dafny {
         }
       }
 
+      // If the LHS has type Bitvector(w), cast the RHS to the number of bits
+      // required to represent w - 1 and then to Bitvector(w), to result in
+      // an easier SMT problem. This is always valid because the value of the
+      // RHS must be less than w.
+      private Expr TrShiftRotateExpr(string fnName, Expression expr, Expr lhs, Expr rhs, Type rhsType, int w, bool liftLit) {
+        var intermediateBvWidth = (int)(new BigInteger(w - 1)).GetBitLength();
+        translator.AddBitwidth(intermediateBvWidth);
+        var tok = GetToken(expr);
+        var rhsConvertedType = new BitvectorType(intermediateBvWidth);
+        var rhsConverted = translator.ConvertExpression(tok, rhs, rhsType, rhsConvertedType);
+        var rhsFinal = translator.ConvertExpression(tok, rhsConverted, rhsConvertedType, expr.Type);
+        return TrToFunctionCall(tok, fnName + "_bv" + w, translator.BplBvType(w), lhs, rhsFinal, liftLit);
+      }
+
       public Expr TrExprSpecialFunctionCall(FunctionCallExpr expr) {
         Contract.Requires(expr.Function is SpecialFunction);
         string name = expr.Function.Name;
-        if (name == "RotateLeft") {
+        if (name is "RotateLeft" or "RotateRight") {
           var w = expr.Type.AsBitVectorType.Width;
           Expression arg = expr.Args[0];
-          return TrToFunctionCall(GetToken(expr), "LeftRotate_bv" + w, translator.BplBvType(w), TrExpr(expr.Receiver), translator.ConvertExpression(GetToken(expr), TrExpr(arg), arg.Type, expr.Type), false);
-        } else if (name == "RotateRight") {
-          var w = expr.Type.AsBitVectorType.Width;
-          Expression arg = expr.Args[0];
-          return TrToFunctionCall(GetToken(expr), "RightRotate_bv" + w, translator.BplBvType(w), TrExpr(expr.Receiver), translator.ConvertExpression(GetToken(expr), TrExpr(arg), arg.Type, expr.Type), false);
+          return TrShiftRotateExpr(name, expr, TrExpr(expr.Receiver), TrExpr(arg), arg.Type, w, false);
         } else {
           bool argsAreLit_dummy;
           var args = FunctionInvocationArguments(expr, null, true, out argsAreLit_dummy);

--- a/Source/Dafny/Verifier/Translator.ExpressionTranslator.cs
+++ b/Source/Dafny/Verifier/Translator.ExpressionTranslator.cs
@@ -1423,11 +1423,11 @@ namespace Microsoft.Dafny {
       }
 
       // If the LHS has type Bitvector(w), cast the RHS to the number of bits
-      // required to represent w - 1 and then to Bitvector(w), to result in
+      // required to represent w and then to Bitvector(w), to result in
       // an easier SMT problem. This is always valid because the value of the
-      // RHS must be less than w.
+      // RHS must be no more than w (as Dafny checks elsewhere).
       private Expr TrShiftRotateExpr(string fnName, Expression expr, Expr lhs, Expr rhs, Type rhsType, int w, bool liftLit) {
-        var intermediateBvWidth = (int)(new BigInteger(w - 1)).GetBitLength();
+        var intermediateBvWidth = (int)(new BigInteger(w)).GetBitLength();
         translator.AddBitwidth(intermediateBvWidth);
         var tok = GetToken(expr);
         var rhsConvertedType = new BitvectorType(intermediateBvWidth);

--- a/Source/Dafny/Verifier/Translator.cs
+++ b/Source/Dafny/Verifier/Translator.cs
@@ -702,7 +702,7 @@ namespace Microsoft.Dafny {
     }
 
     private void AddBitwidth(int w) {
-      if (generatedBitwidths.Contains(w)) {
+      if (!generatedBitwidths.Add(w)) {
         return;
       }
 
@@ -732,7 +732,6 @@ namespace Microsoft.Dafny {
       AddBitvectorShiftFunction(w, "RotateRight_bv", "ext_rotate_right");
       // conversion functions
       AddBitvectorNatConversionFunction(w);
-      generatedBitwidths.Add(w);
     }
 
     private Bpl.Program DoTranslation(Program p, ModuleDefinition forModule) {

--- a/Test/git-issues/github-issue-2174.dfy
+++ b/Test/git-issues/github-issue-2174.dfy
@@ -1,0 +1,77 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+// Taken from https://github.com/dafny-lang/dafny/issues/2174
+lemma lm(val: bv16, idx: nat)
+  requires 0 <= idx <= 16 - 8
+  requires 0 <= val < (1 << 8)
+  ensures val as bv32 << idx == (val << idx) as bv32 {}
+
+// This example is from issue #2174 but is not yet fast. It's a somewhat
+// convoluted example meant to help diagnose the problem, though, and
+// essentially works around the fix, so it's probably okay that it's
+// still slow.
+/*
+lemma lmnat(val: bv16, idx: nat)
+  requires 0 <= idx <= 8
+  requires 0 <= val < (1 << 8)
+  ensures var idx32 := idx as bv32;
+          val as bv32 << idx32 == (val << idx32) as bv32
+{}
+*/
+
+lemma lmbv(val: bv16, idx: bv32)
+  requires 0 <= idx <= 8
+  requires 0 <= val < (1 << 8)
+  ensures val as bv32 << idx == (val << idx) as bv32
+{}
+
+lemma lmnat'(val: bv16, idx: nat)
+  requires 0 <= idx <= 8
+  requires 0 <= (idx as bv32) <= 8
+  requires 0 <= val < (1 << 8)
+  ensures var idx32 := idx as bv32;
+          val as bv32 << idx32 == (val << idx32) as bv32
+{}
+
+const Half: bv128 := 0xffff_ffff_ffff_ffff;
+const Ones: bv128 := 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff;
+
+method M(i: nat) {
+  if i == 64 {
+    assert Ones << i == Ones << 64;
+  }
+}
+
+lemma CommLShiftUpCast(v: bv64, idx: nat)
+  requires idx <= 64
+  requires v as bv128 << idx < 1 << 64
+  ensures (v << idx) as bv128 == v as bv128 << idx
+{}
+
+// This only succeeds with `requires idx < 64`, differing from the
+// example in issue #2174.
+lemma MaskedCommLShiftUpCast(v: bv64, idx: nat)
+  requires idx < 64
+  ensures (v as bv128 << idx) & Half == (v << idx) as bv128
+{}
+
+lemma PushUpCastIntoLShift(v: bv64, idx: nat)
+  requires idx <= 64
+  requires v as bv128 << idx < 1 << 64
+  ensures (v as bv128 << idx) as bv64 == v as bv64 << idx;
+{}
+
+lemma UpCastLShiftMasking(v: bv64, idx: nat)
+  requires 0 <= idx <= 64
+  ensures v as bv128 << 64 == (v as bv128 << 64) & (Ones << idx);
+{}
+
+lemma UpCastRShiftMasking(v: bv64, idx: nat)
+  requires 0 <= idx <= 64
+  ensures v as bv128 == (v as bv128) & (Ones >> idx);
+{}
+
+lemma RightMask(v: bv64, i: nat)
+  requires 64 <= i <= 128
+  ensures v as bv128 & (Ones >> i) == (v & (0xffff_ffff_ffff_ffff >> i - 64)) as bv128
+{}

--- a/Test/git-issues/github-issue-2174.dfy.expect
+++ b/Test/git-issues/github-issue-2174.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 19 verified, 0 errors

--- a/Test/git-issues/github-issue-2230.dfy
+++ b/Test/git-issues/github-issue-2230.dfy
@@ -1,0 +1,13 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+lemma MergeLShift(v: bv128, i: nat, j: nat)
+  requires i <= 128 && j <= 128 && i + j <= 128
+  ensures v << i << j == v << i + j
+
+method M2(i: nat)
+  requires i <= 64
+{
+  ghost var half: bv128 := 0xffff_ffff_ffff_ffff;
+  MergeLShift(half, 64, 64 - i);
+  assert half << 64 - i << 64 == half << (128 - i);
+}

--- a/Test/git-issues/github-issue-2230.dfy.expect
+++ b/Test/git-issues/github-issue-2230.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors


### PR DESCRIPTION
When translating `x << y` to Boogie, where `x` has width `w`, rather than immediately casting `y` to the type of `x`, instead cast `y` to a bit vector with width `log2(w)` and then cast, a second time, to a bit vector of width `w`. This ensures that the solver knows that most of the bits of the shift amount are zero.

Fixes #2174
Fixes #2230

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
