### PR TITLE
chore: A crash in the resolver now reports an error to the user

### DIFF
--- a/Source/DafnyLanguageServer/Workspace/DocumentDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentDatabase.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// Only delta updates are supported and the API is not thread-safe.
   /// </remarks>
   public class DocumentDatabase : IDocumentDatabase {
+    public const string DafnyInternalErrorHelper = "Dafny encountered an internal error. Please report it at <https://github.com/dafny-lang/dafny/issues>.\n";
     private readonly ILogger logger;
     private readonly ITelemetryPublisher telemetryPublisher;
     private readonly INotificationPublisher notificationPublisher;
@@ -302,7 +303,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
               LoadCanceled = false,
               ParseAndResolutionDiagnostics = previousDiagnostics.Concat(new Diagnostic[] {
                 new() {
-                  Message = "Dafny encountered an internal error. Please report it at <https://github.com/dafny-lang/dafny/issues>.\n" + t.Exception,
+                  Message = DafnyInternalErrorHelper + t.Exception,
                   Severity = DiagnosticSeverity.Error,
                   Range = lastPublishedDocument.Program.GetFirstTopLevelToken().GetLspRange(),
                   Source = "Crash"

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -164,14 +164,32 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
           wasResolved: true, loadCanceled: false);
       }
 
-      var compilationUnit = symbolResolver.ResolveSymbols(textDocument, program, out var canDoVerification, cancellationToken);
-      var symbolTable = symbolTableFactory.CreateFrom(program, compilationUnit, cancellationToken);
-      if (errorReporter.HasErrors) {
+      CompilationUnit compilationUnit;
+      SymbolTable symbolTable;
+      bool canDoVerification;
+      try {
+        compilationUnit =
+          symbolResolver.ResolveSymbols(textDocument, program, out canDoVerification, cancellationToken);
+        symbolTable = symbolTableFactory.CreateFrom(program, compilationUnit, cancellationToken);
+        if (errorReporter.HasErrors) {
+          statusPublisher.SendStatusNotification(textDocument, CompilationStatus.ResolutionFailed);
+        } else {
+          statusPublisher.SendStatusNotification(textDocument, CompilationStatus.CompilationSucceeded);
+        }
+      } catch (Exception e) {
+        if (e is OperationCanceledException) {
+          throw;
+        }
+
+        errorReporter.Message(MessageSource.Resolver, ErrorLevel.Error, program.GetFirstTopLevelToken(),
+          DocumentDatabase.DafnyInternalErrorHelper + e);
         statusPublisher.SendStatusNotification(textDocument, CompilationStatus.ResolutionFailed);
-      } else {
-        statusPublisher.SendStatusNotification(textDocument, CompilationStatus.CompilationSucceeded);
+        return CreateDocumentWithEmptySymbolTable(loggerFactory.CreateLogger<SymbolTable>(), textDocument,
+          errorReporter.GetDiagnostics(textDocument.Uri), program,
+          wasResolved: true, loadCanceled: false);
       }
-      var ghostDiagnostics = ghostStateDiagnosticCollector.GetGhostStateDiagnostics(symbolTable, cancellationToken).ToArray();
+      var ghostDiagnostics = ghostStateDiagnosticCollector.GetGhostStateDiagnostics(symbolTable, cancellationToken)
+        .ToArray();
 
       return new DafnyDocument(textDocument,
         errorReporter.GetDiagnostics(textDocument.Uri),


### PR DESCRIPTION
We don't expect a crash in the resolver, but when I was developing a feature and testing it in VSCode, it would be stuck on "Resolving..." and display no clue that the resolution had crashed.
This PR fixes that, but I don't have a test for it. It did the job in my case.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
