### PR TITLE
Revert "Run `dotnet pack` before `dotnet publish` (#2501)"

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -70,28 +70,6 @@ jobs:
         java-version: 1.8
     - uses: actions/setup-node@v1
     - run: npm install bignumber.js
-
-    - name: Create release NuGet package (for uploading)
-      if: ${{ !inputs.prerelease }}
-      run: dotnet pack dafny/Source/Dafny.sln
-    - name: Create prerelease NuGet package (for uploading)
-      if: ${{ inputs.prerelease }}
-      # NuGet will consider any package with a version-suffix as a prerelease
-      run: dotnet pack --version-suffix ${{ inputs.name }} dafny/Source/Dafny.sln
-
-    - name: Make NuGet package available as an artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: nuget-packages
-        path: dafny/Binaries/*.nupkg
-
-    - name: Upload package to NuGet
-      if: ${{ inputs.release_nuget }}
-      # Need --skip-duplicate for cases where we release a new Dafny
-      # version but the runtime hasn't changed and is still the old
-      # version.
-      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json
-
     - name: Install latex pandoc
       run: |
         brew install pandoc
@@ -116,6 +94,8 @@ jobs:
     # and that perturbs the path enough that `python` above would resolve to an older built-in Python version.
     # Additionally, since the refman build scripts expect to find Dafny in its usual Binaries/ folder (not in
     # a platform-specific directory), we build Dafny once here.
+    - name: Build Dafny
+      run: dotnet build dafny/Source/Dafny.sln
     - name: Build reference manual
       run: |
         eval "$(/usr/libexec/path_helper)"
@@ -133,3 +113,24 @@ jobs:
           dafny/Package/dafny-${{ inputs.name }}*
           dafny/docs/DafnyRef/DafnyRef.pdf
         fail_on_unmatched_files: true
+
+    - name: Create release NuGet package (for uploading)
+      if: ${{ !inputs.prerelease }}
+      run: dotnet pack --no-build dafny/Source/Dafny.sln
+    - name: Create prerelease NuGet package (for uploading)
+      if: ${{ inputs.prerelease }}
+      # NuGet will consider any package with a version-suffix as a prerelease
+      run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
+
+    - name: Make NuGet package available as an artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: nuget-packages-${{ matrix.os }}
+        path: dafny/Binaries/*.nupkg
+
+    - name: Upload package to NuGet
+      if: ${{ inputs.release_nuget }}
+      # Need --skip-duplicate for cases where we release a new Dafny
+      # version but the runtime hasn't changed and is still the old
+      # version.
+      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,10 +2,10 @@
 
 - fix: Don't use native division and modulo operators for non-native int-based newtypes in Java and C#.
   (https://github.com/dafny-lang/dafny/pull/2416)
-- feat: New option `-diagnosticsFormat:json` to print Dafny error messages as JSON objects (one per line).
-  (https://github.com/dafny-lang/dafny/pull/2363)
 - feat: Dafny now supports disjunctive (“or”) patterns in match statements and expressions.  Cases are separated by `|` characters.  Disjunctive patterns may not appear within other patterns and may not bind variables.
   (https://github.com/dafny-lang/dafny/pull/2448)
+- feat: New option `-diagnosticsFormat:json` to print Dafny error messages as JSON objects (one per line).
+  (https://github.com/dafny-lang/dafny/pull/2363)
 
 # 3.7.3
 


### PR DESCRIPTION
This reverts commit 1837d64ff4b5fb3d1a3fbcffefd794ae27c48b57.

_Hopefully_ fixes broken nightly publish step: https://github.com/dafny-lang/dafny/runs/7554903871?check_suite_focus=true

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
