### PR TITLE
Another attempt at building NuGet package first

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Make NuGet package available as an artifact
       uses: actions/upload-artifact@v2
       with:
-        name: nuget-packages-${{ matrix.os }}
+        name: nuget-packages
         path: dafny/Binaries/*.nupkg
 
     - name: Upload package to NuGet

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -71,17 +71,13 @@ jobs:
     - uses: actions/setup-node@v1
     - run: npm install bignumber.js
 
-    - name: Build Dafny
-      run: |
-        dotnet build dafny/Source/Dafny.sln
-        rm dafny/Binaries/*.nupkg
     - name: Create release NuGet package (for uploading)
       if: ${{ !inputs.prerelease }}
-      run: dotnet pack --no-build dafny/Source/Dafny.sln
+      run: dotnet pack dafny/Source/Dafny.sln
     - name: Create prerelease NuGet package (for uploading)
       if: ${{ inputs.prerelease }}
       # NuGet will consider any package with a version-suffix as a prerelease
-      run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
+      run: dotnet pack --version-suffix ${{ inputs.name }} dafny/Source/Dafny.sln
 
     - name: Make NuGet package available as an artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Build Dafny
       run: |
         dotnet build dafny/Source/Dafny.sln
-        rm Binaries/*.nupkg
+        rm dafny/Binaries/*.nupkg
     - name: Create release NuGet package (for uploading)
       if: ${{ !inputs.prerelease }}
       run: dotnet pack --no-build dafny/Source/Dafny.sln

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -70,6 +70,30 @@ jobs:
         java-version: 1.8
     - uses: actions/setup-node@v1
     - run: npm install bignumber.js
+
+    - name: Build Dafny
+      run: dotnet build dafny/Source/Dafny.sln
+    - name: Create release NuGet package (for uploading)
+      if: ${{ !inputs.prerelease }}
+      run: dotnet pack --no-build dafny/Source/Dafny.sln
+    - name: Create prerelease NuGet package (for uploading)
+      if: ${{ inputs.prerelease }}
+      # NuGet will consider any package with a version-suffix as a prerelease
+      run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
+
+    - name: Make NuGet package available as an artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: nuget-packages-${{ matrix.os }}
+        path: dafny/Binaries/*.nupkg
+
+    - name: Upload package to NuGet
+      if: ${{ inputs.release_nuget }}
+      # Need --skip-duplicate for cases where we release a new Dafny
+      # version but the runtime hasn't changed and is still the old
+      # version.
+      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json
+
     - name: Install latex pandoc
       run: |
         brew install pandoc
@@ -94,8 +118,6 @@ jobs:
     # and that perturbs the path enough that `python` above would resolve to an older built-in Python version.
     # Additionally, since the refman build scripts expect to find Dafny in its usual Binaries/ folder (not in
     # a platform-specific directory), we build Dafny once here.
-    - name: Build Dafny
-      run: dotnet build dafny/Source/Dafny.sln
     - name: Build reference manual
       run: |
         eval "$(/usr/libexec/path_helper)"
@@ -113,24 +135,3 @@ jobs:
           dafny/Package/dafny-${{ inputs.name }}*
           dafny/docs/DafnyRef/DafnyRef.pdf
         fail_on_unmatched_files: true
-
-    - name: Create release NuGet package (for uploading)
-      if: ${{ !inputs.prerelease }}
-      run: dotnet pack --no-build dafny/Source/Dafny.sln
-    - name: Create prerelease NuGet package (for uploading)
-      if: ${{ inputs.prerelease }}
-      # NuGet will consider any package with a version-suffix as a prerelease
-      run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
-
-    - name: Make NuGet package available as an artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: nuget-packages-${{ matrix.os }}
-        path: dafny/Binaries/*.nupkg
-
-    - name: Upload package to NuGet
-      if: ${{ inputs.release_nuget }}
-      # Need --skip-duplicate for cases where we release a new Dafny
-      # version but the runtime hasn't changed and is still the old
-      # version.
-      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -105,6 +105,10 @@ jobs:
         which latex || echo NOT FOUND latex
         which xelatex || echo NOT FOUND xelatex
         sudo gem install rouge
+    - name: Reuild Dafny
+      run: |
+        dotnet clean dafny/Source/Dafny.sln
+        dotnet build dafny/Source/Dafny.sln
     # First we build the ZIPs (which do not include the refman)
     - name: Package release files (release)
       if: ${{ !inputs.prerelease }}

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -72,7 +72,9 @@ jobs:
     - run: npm install bignumber.js
 
     - name: Build Dafny
-      run: dotnet build dafny/Source/Dafny.sln
+      run: |
+        dotnet build dafny/Source/Dafny.sln
+        rm Binaries/*.nupkg
     - name: Create release NuGet package (for uploading)
       if: ${{ !inputs.prerelease }}
       run: dotnet pack --no-build dafny/Source/Dafny.sln

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -105,10 +105,8 @@ jobs:
         which latex || echo NOT FOUND latex
         which xelatex || echo NOT FOUND xelatex
         sudo gem install rouge
-    - name: Reuild Dafny
-      run: |
-        dotnet clean dafny/Source/Dafny.sln
-        dotnet build dafny/Source/Dafny.sln
+    - name: Clean Dafny
+      run: dotnet clean dafny/Source/Dafny.sln
     # First we build the ZIPs (which do not include the refman)
     - name: Package release files (release)
       if: ${{ !inputs.prerelease }}
@@ -122,6 +120,8 @@ jobs:
     # and that perturbs the path enough that `python` above would resolve to an older built-in Python version.
     # Additionally, since the refman build scripts expect to find Dafny in its usual Binaries/ folder (not in
     # a platform-specific directory), we build Dafny once here.
+    - name: Re-build Dafny
+      run: dotnet build dafny/Source/Dafny.sln
     - name: Build reference manual
       run: |
         eval "$(/usr/libexec/path_helper)"

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -71,13 +71,17 @@ jobs:
     - uses: actions/setup-node@v1
     - run: npm install bignumber.js
 
+    - name: Build Dafny
+      run: |
+        dotnet build dafny/Source/Dafny.sln
+        rm dafny/Binaries/*.nupkg
     - name: Create release NuGet package (for uploading)
       if: ${{ !inputs.prerelease }}
-      run: dotnet pack dafny/Source/Dafny.sln
+      run: dotnet pack --no-build dafny/Source/Dafny.sln
     - name: Create prerelease NuGet package (for uploading)
       if: ${{ inputs.prerelease }}
       # NuGet will consider any package with a version-suffix as a prerelease
-      run: dotnet pack --version-suffix ${{ inputs.name }} dafny/Source/Dafny.sln
+      run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
 
     - name: Make NuGet package available as an artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,10 +33,7 @@ jobs:
       sha: ${{ github.sha }}
       tag_name: ${{ github.ref }}
       draft: true
-      # Currently automated NuGet uploads have overly strict .NET
-      # version dependencies. Skipping until that's fixed. See here:
-      # https://github.com/dafny-lang/dafny/issues/2423
-      release_nuget: false
+      release_nuget: true
       # We can probably automate pulling this out of RELEASE_NOTES.md in the future
       release_notes: ""
     secrets:

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -6,7 +6,7 @@
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <DefineConstants>TRACE;ISDAFNYRUNTIMELIB</DefineConstants>
-      <PackageVersion>1.2.0</PackageVersion>
+      <VersionPrefix>1.2.0</VersionPrefix>
       <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
       <LangVersion>7.3</LangVersion>


### PR DESCRIPTION
The `dotnet publish` process that runs as part of `package.py` adds a too-strict runtime version dependency that is then inherited by the created `.nupkg` files. By building the `.nupkg` files first, we avoid this problem.

I've run the nightly build process manually on this branch, and confirmed that it succeeded and produced `.nupkg` files with the appropriate version constraints.

Fixes #2423

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>