### PR TITLE
fix: Check extreme predicates and constants in all types, not just classes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
   (https://github.com/dafny-lang/dafny/pull/2448)
 - feat: New option `-diagnosticsFormat:json` to print Dafny error messages as JSON objects (one per line).
   (https://github.com/dafny-lang/dafny/pull/2363)
+- fix: Check extreme predicates and constants in all types, not just classes
+  (https://github.com/dafny-lang/dafny/pull/2515)
 
 # 3.7.3
 

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -3381,8 +3381,8 @@ namespace Microsoft.Dafny {
         // And check that const initializers are not cyclic.
         var cycleErrorHasBeenReported = new HashSet<ICallable>();
         foreach (var d in declarations) {
-          if (d is ClassDecl) {
-            foreach (var member in ((ClassDecl)d).Members) {
+          if (d is TopLevelDeclWithMembers { Members: var members }) {
+            foreach (var member in members) {
               if (member is ExtremePredicate) {
                 var fn = (ExtremePredicate)member;
                 // Check here for the presence of any 'ensures' clauses, which are not allowed (because we're not sure
@@ -3419,7 +3419,9 @@ namespace Microsoft.Dafny {
                 }
               }
             }
-          } else if (d is RedirectingTypeDecl) {
+          }
+
+          if (d is RedirectingTypeDecl) {
             var dd = (RedirectingTypeDecl)d;
             if (d.EnclosingModuleDefinition.CallGraph.GetSCCSize(dd) != 1) {
               var r = d.EnclosingModuleDefinition.CallGraph.GetSCCRepresentative(dd);

--- a/Test/git-issues/git-issue-2506.dfy
+++ b/Test/git-issues/git-issue-2506.dfy
@@ -1,0 +1,86 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Class {
+  class T {
+    static const a := 1 + b; // const definition contains a cycle: T.a -> T.b -> T.a
+    static const b := 2 + a;
+
+    static predicate F() decreases 0 { !L() }
+    static least predicate L() { F() }
+      // a recursive call from a least predicate can go only to other least predicates
+
+    static least predicate Negative() { !Negative() }
+      // a least predicate can be called recursively only in positive positions
+    static least predicate Ensures() ensures false { Ensures() }
+      // a least predicate is not allowed to declare any ensures clause
+  }
+
+  method Oops0() ensures false { var _ := T.Ensures(); }
+  method Oops1() ensures false { var _ := T.a; }
+  method Oops2() ensures false { var _ := T.F(); }
+  method Oops3() ensures false { var _ := T.Negative(); }
+}
+
+module Datatype {
+  datatype T = A {
+    static const a := 1 + b; // const definition contains a cycle: T.a -> T.b -> T.a
+    static const b := 2 + a;
+
+    static predicate F() decreases 0 { !L() }
+    static least predicate L() { F() }
+      // a recursive call from a least predicate can go only to other least predicates
+
+    static least predicate Negative() { !Negative() }
+      // a least predicate can be called recursively only in positive positions
+    static least predicate Ensures() ensures false { Ensures() }
+      // a least predicate is not allowed to declare any ensures clause
+  }
+
+  method Oops0() ensures false { var _ := T.Ensures(); }
+  method Oops1() ensures false { var _ := T.a; }
+  method Oops2() ensures false { var _ := T.F(); }
+  method Oops3() ensures false { var _ := T.Negative(); }
+}
+
+module Newtype {
+  newtype T = int {
+    static const a := 1 + b; // const definition contains a cycle: T.a -> T.b -> T.a
+    static const b := 2 + a;
+
+    static predicate F() decreases 0 { !L() }
+    static least predicate L() { F() }
+      // a recursive call from a least predicate can go only to other least predicates
+
+    static least predicate Negative() { !Negative() }
+      // a least predicate can be called recursively only in positive positions
+    static least predicate Ensures() ensures false { Ensures() }
+      // a least predicate is not allowed to declare any ensures clause
+  }
+
+  method Oops0() ensures false { var _ := T.Ensures(); }
+  method Oops1() ensures false { var _ := T.a; }
+  method Oops2() ensures false { var _ := T.F(); }
+  method Oops3() ensures false { var _ := T.Negative(); }
+}
+
+module AbstractType {
+  type T {
+    static const a := 1 + b; // const definition contains a cycle: T.a -> T.b -> T.a
+    static const b := 2 + a;
+
+    static predicate F() decreases 0 { !L() }
+    static least predicate L() { F() }
+      // a recursive call from a least predicate can go only to other least predicates
+
+    static least predicate Negative() { !Negative() }
+      // a least predicate can be called recursively only in positive positions
+    static least predicate Ensures() ensures false { Ensures() }
+      // a least predicate is not allowed to declare any ensures clause
+  }
+
+  method Oops0() ensures false { var _ := T.Ensures(); }
+  method Oops1() ensures false { var _ := T.a; }
+  method Oops2() ensures false { var _ := T.F(); }
+  method Oops3() ensures false { var _ := T.Negative(); }
+}

--- a/Test/git-issues/git-issue-2506.dfy.expect
+++ b/Test/git-issues/git-issue-2506.dfy.expect
@@ -1,0 +1,17 @@
+git-issue-2506.dfy(6,17): Error: const definition contains a cycle: T.a -> T.b -> T.a
+git-issue-2506.dfy(10,33): Error: a recursive call from a least predicate can go only to other least predicates
+git-issue-2506.dfy(13,41): Error: a least predicate can be called recursively only in positive positions
+git-issue-2506.dfy(15,45): Error: a least predicate is not allowed to declare any ensures clause
+git-issue-2506.dfy(27,17): Error: const definition contains a cycle: T.a -> T.b -> T.a
+git-issue-2506.dfy(31,33): Error: a recursive call from a least predicate can go only to other least predicates
+git-issue-2506.dfy(34,41): Error: a least predicate can be called recursively only in positive positions
+git-issue-2506.dfy(36,45): Error: a least predicate is not allowed to declare any ensures clause
+git-issue-2506.dfy(48,17): Error: const definition contains a cycle: T.a -> T.b -> T.a
+git-issue-2506.dfy(52,33): Error: a recursive call from a least predicate can go only to other least predicates
+git-issue-2506.dfy(55,41): Error: a least predicate can be called recursively only in positive positions
+git-issue-2506.dfy(57,45): Error: a least predicate is not allowed to declare any ensures clause
+git-issue-2506.dfy(69,17): Error: const definition contains a cycle: T.a -> T.b -> T.a
+git-issue-2506.dfy(73,33): Error: a recursive call from a least predicate can go only to other least predicates
+git-issue-2506.dfy(76,41): Error: a least predicate can be called recursively only in positive positions
+git-issue-2506.dfy(78,45): Error: a least predicate is not allowed to declare any ensures clause
+16 resolution/type errors detected in git-issue-2506.dfy


### PR DESCRIPTION
The bug was latent in 923f8120 (for datatypes), but the issue with `const` only
became exploitable in c5562f28 (previous to that Boogie's own cyclicity checks
replaced the missing ones in Dafny).

* `Source/Dafny/Resolver.cs` (`ResolveTopLevelDecls_Core`):
  Run member checks on all declarations with members — not just on classes.

Closes #2506.

We were running none of the extreme lemma checks for datatypes, newtypes, and abstract type members.  I added tests, but for casual readers, here are four examples:

```
  datatype T = A {
    static const a := 1 + b;
    static const b := 2 + a;

    static predicate F() decreases 0 { !L() }
    static least predicate L() { F() }

    static least predicate Negative() { !Negative() }
    static least predicate Ensures() ensures false { Ensures() }
  }

  method Oops0() ensures false { var _ := T.Ensures(); }
  method Oops1() ensures false { var _ := T.a; }
  method Oops2() ensures false { var _ := T.F(); }
  method Oops3() ensures false { var _ := T.Negative(); }
```
