### PR TITLE
fix: Work around #2429 (incorrect Boogie type in sequence update)

### DIFF
--- a/Source/Dafny/Verifier/Translator.ExpressionTranslator.cs
+++ b/Source/Dafny/Verifier/Translator.ExpressionTranslator.cs
@@ -551,20 +551,18 @@ namespace Microsoft.Dafny {
           Boogie.Expr seq = TrExpr(e.Seq);
           var seqType = e.Seq.Type.NormalizeExpand();
           if (seqType is SeqType) {
-            Type elmtType = cce.NonNull((SeqType)seqType).Arg;
             Boogie.Expr index = TrExpr(e.Index);
             index = translator.ConvertExpression(GetToken(e.Index), index, e.Index.Type, Type.Int);
-            Boogie.Expr val = BoxIfNecessary(GetToken(expr), TrExpr(e.Value), elmtType);
+            Boogie.Expr val = BoxIfNecessary(GetToken(expr), TrExpr(e.Value), e.Type);
             return translator.FunctionCall(GetToken(expr), BuiltinFunction.SeqUpdate, predef.BoxType, seq, index, val);
           } else if (seqType is MapType) {
             MapType mt = (MapType)seqType;
             Boogie.Type maptype = predef.MapType(GetToken(expr), mt.Finite, predef.BoxType, predef.BoxType);
-            Boogie.Expr index = BoxIfNecessary(GetToken(expr), TrExpr(e.Index), mt.Domain);
-            Boogie.Expr val = BoxIfNecessary(GetToken(expr), TrExpr(e.Value), mt.Range);
+            Boogie.Expr index = BoxIfNecessary(GetToken(expr), TrExpr(e.Index), e.Index.Type);
+            Boogie.Expr val = BoxIfNecessary(GetToken(expr), TrExpr(e.Value), e.Value.Type);
             return FunctionCall(GetToken(expr), mt.Finite ? "Map#Build" : "IMap#Build", maptype, seq, index, val);
           } else if (seqType is MultiSetType) {
-            Type elmtType = cce.NonNull((MultiSetType)seqType).Arg;
-            Boogie.Expr index = BoxIfNecessary(GetToken(expr), TrExpr(e.Index), elmtType);
+            Boogie.Expr index = BoxIfNecessary(GetToken(expr), TrExpr(e.Index), e.Index.Type);
             Boogie.Expr val = TrExpr(e.Value);
             return Boogie.Expr.StoreTok(GetToken(expr), seq, index, val);
           } else {

--- a/Test/git-issues/git-issue-2429.dfy
+++ b/Test/git-issues/git-issue-2429.dfy
@@ -1,0 +1,16 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+trait Spec<Q(==, 00)> {
+  method M(t: Q)
+    ensures var t: Q :| true; |multiset{}[t := 1]| == 1
+    ensures |map[t := t][t := t]| == 1
+    ensures |[t][0 := t]| == 1
+}
+
+class Impl extends Spec<object?> {
+  method M(t: object?)
+    ensures var t: object? :| true; |multiset{}[t := 1]| == 1
+    ensures |map[t := t][t := t]| == 1
+    ensures |[t][0 := t]| == 1
+}

--- a/Test/git-issues/git-issue-2429.dfy.expect
+++ b/Test/git-issues/git-issue-2429.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 3 verified, 0 errors


### PR DESCRIPTION
When Dafny translates a class, the override check that it performs mentions the
old ensures clauses, applied to its new arguments.  For example, the following
code:

```dafny
trait T           { method M(a: int) returns (b: int) ensures b > a     }
class C extends T { method M(a: int) returns (b: int) ensures b > a + 1 }
```

… leads to the following check:

```boogie
implementation OverrideCheck(this: ref, a#0: int) returns (b#0: int) {
  assume b#0 > a#0 + 1;
  assert b#0 > a#0;
}
```

Problems pop up when argument types differ between the old and new ensures
clauses, which happens in the presence of type parameters:

```dafny
predicate P<A>(s: seq<A>)
trait T<A> {
  method M(a: A) ensures P([a][0 := a])
}

predicate Q<A>(s: seq<A>)
class C extends T<object> {
  method M(a: object) ensures Q([a][0 := a])
}
```

When translating the original ensures clause (`ensures P([a][0 := a])`) to Boogie
in the override check, Dafny uses the old types in some places, and hence
assumes that `[a]` has type `seq<A>`, not type `seq<object>`.  This causes it to
make a mistake about whether to insert a box, and generate the following Boogie
code:

```boogie
assume _module.__default.Q(Tclass._System.object(),
  Seq#Update(Seq#Build(Seq#Empty(): Seq Box, $Box(a#0)), LitInt(0), $Box(a#0)));
assert _module.__default.P(_module.T$A,
  Seq#Update(Seq#Build(Seq#Empty(): Seq Box, $Box(a#0)), LitInt(0), a#0));
```

Notice how the `assert` line differs from the `assume` one: the former (with the
`Q`) correctly boxes `a#0` twice: once in the sequence construction and once in
the update.  In contrast, the latter (with `P`, corresponding to the trait's
ensures), incorrectly omits the box on the second `a#0` (the argument to
`Seq#Update`).

The reason for the discrepancy is that the translation for `Seq#Build` uses the
type of the element to decide whether to insert a box (which evaluates to
`object` in both statements), whereas the translation for `Seq#Update` uses the
`Arg` field in the type of the sequence itself to decide whether to box `a#0`.
That type evaluates to `object` in the `assume` but to `Q` in the `assert`, and
hence no box is inserted.

This commit cheats by using the type of the parameter, instead of the `Arg`
field of the type of the sequence.  There are surely more places with this
issue, and the "right" fix is most likely to substitute the type parameter `A`
in the type of the ensures before generating the override check, but this is
left for later.

Closes #2429.