### PR TITLE
Bump version number to 3.8 to indicate minor version increment to LSP…

### DIFF
--- a/Source/Dafny/DafnyPipeline.csproj
+++ b/Source/Dafny/DafnyPipeline.csproj
@@ -17,7 +17,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>..\..\Binaries\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <VersionPrefix>3.7.3.40719</VersionPrefix>
+    <VersionPrefix>3.8.0.40729</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/Source/DafnyDriver/DafnyDriver.csproj
+++ b/Source/DafnyDriver/DafnyDriver.csproj
@@ -9,7 +9,7 @@
       <OutputPath>..\..\Binaries\</OutputPath>
       <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
 
-      <VersionPrefix>3.7.3.40719</VersionPrefix>
+      <VersionPrefix>3.8.0.40729</VersionPrefix>
 
       <PackAsTool>true</PackAsTool>
       <ToolCommandName>dafny</ToolCommandName>

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.cs
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.cs
@@ -29,7 +29,10 @@ namespace Microsoft.Dafny.LanguageServer {
 
     public static LanguageServerOptions WithDafnyLanguageServer(this LanguageServerOptions options,
         IConfiguration configuration, Action killLanguageServer) {
-
+      options.ServerInfo = new ServerInfo {
+        Name = "Dafny",
+        Version = DafnyVersion
+      };
       return options
         .WithDafnyLanguage(configuration)
         .WithDafnyWorkspace(configuration)

--- a/Source/version.cs
+++ b/Source/version.cs
@@ -3,5 +3,5 @@ using System.Reflection;
 // When changing this, also be sure to change it in the following files:
 // * Source/DafnyDriver/DafnyDriver.csproj
 // * Source/Dafny/DafnyPipeline.csproj
-[assembly: AssemblyVersion("3.7.3.40719")]
-[assembly: AssemblyFileVersion("3.7.3.40719")]
+[assembly: AssemblyVersion("3.8.0.40729")]
+[assembly: AssemblyFileVersion("3.8.0.40729")]

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -15,7 +15,8 @@
    "3.0.0-alpha") and select an internal version number (e.g.,
    "3.0.0.30203"). The major.minor.patch numbers may already have been
    incremented since the last release, so they do not necessarily need
-   to be updated. The last section is in "ymmdd" format, where "y" is
+   to be updated, but you may want to increment them further,
+   use judgement. The last section is in "ymmdd" format, where "y" is
    the number of years since 2018 and "mmdd" the month and day portions
    of the release date (e.g., a release on January 12th, 2022 would be
    x.y.z.40112). Edit the internal version number in the following

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -13,7 +13,9 @@
 
 2. Select a version number (descriptor) `$VER` (e.g., "3.0.0" or
    "3.0.0-alpha") and select an internal version number (e.g.,
-   "3.0.0.30203"). The last section is in "ymmdd" format, where "y" is
+   "3.0.0.30203"). The major.minor.patch numbers may already have been
+   incremented since the last release, so they do not necessarily need
+   to be updated. The last section is in "ymmdd" format, where "y" is
    the number of years since 2018 and "mmdd" the month and day portions
    of the release date (e.g., a release on January 12th, 2022 would be
    x.y.z.40112). Edit the internal version number in the following


### PR DESCRIPTION
### Changes
- Bump version number to 3.8 to indicate a minor version increment to LSP clients, which they can use to rely on new features.
- Update release instructions to indicate that the major.minor.patch version numbers may already have been incremented.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
