### PR TITLE
Don't publish a diagnostics with a negative line and column number

### DIFF
--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -78,12 +78,12 @@ namespace Microsoft.Dafny {
     public int pos { get; set; } // Used by coco, so we can't rename it to Pos
 
     /// <summary>
-    /// One indexed
+    /// One-indexed
     /// </summary>
     public int col { get; set; } // Used by coco, so we can't rename it to Col
 
     /// <summary>
-    /// One indexed
+    /// One-indexed
     /// </summary>
     public int line { get; set; } // Used by coco, so we can't rename it to Line
 

--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -56,19 +56,20 @@ namespace Microsoft.Dafny {
     string LeadingTrivia { get; set; }
   }
 
+  /// <summary>
+  /// Has one-indexed line and column fields
+  /// </summary>
   public record Token : IToken {
     public Token peekedTokens; // Used only internally by Coco when the scanner "peeks" tokens. Normallly null at the end of parsing
     public static readonly IToken NoToken = (IToken)new Token();
 
-    public Token() : this(0, 0) {
-    }
+    public Token() : this(0, 0) { }
 
     public Token(int linenum, int colnum) {
       this.line = linenum;
       this.col = colnum;
-      this.val = "anything so that it is nonnull";
+      this.val = "";
     }
-
 
     public int kind { get; set; } // Used by coco, so we can't rename it to Kind
 
@@ -76,8 +77,14 @@ namespace Microsoft.Dafny {
 
     public int pos { get; set; } // Used by coco, so we can't rename it to Pos
 
+    /// <summary>
+    /// One indexed
+    /// </summary>
     public int col { get; set; } // Used by coco, so we can't rename it to Col
 
+    /// <summary>
+    /// One indexed
+    /// </summary>
     public int line { get; set; } // Used by coco, so we can't rename it to Line
 
     public string val { get; set; } // Used by coco, so we can't rename it to Val

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -967,7 +967,7 @@ Dafny
 		   var fileName = theOptions.UseBaseNameForFileName
                    ? Path.GetFileName(scanner.FullFilename) 
                    : Path.GetRelativePath(Directory.GetCurrentDirectory(), scanner.FullFilename);
-		   errors.Warning(defaultModule.tok, "File contains no code: " + fileName);
+		   errors.Warning(new Token(1, 1) { Filename = la.Filename }, "File contains no code");
 		 }
      DefaultClassDecl defaultClass = null;
      foreach (TopLevelDecl topleveldecl in defaultModule.TopLevelDecls) {

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       var diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);
-      Assert.AreEqual(new Range(0,0,0, 0), diagnostics[0].Range);
+      Assert.AreEqual(new Range(0, 0, 0, 0), diagnostics[0].Range);
     }
 
     [TestMethod]

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -18,6 +18,17 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
   [TestClass]
   public class DiagnosticsTest : ClientBasedLanguageServerTest {
 
+
+    [TestMethod]
+    public async Task EmptyFileNoCodeWarning() {
+      var source = "";
+      //DafnyOptions.O.UseBaseNameForFileName = true;
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);
+      Assert.AreEqual(new Range(0,0,0, 0), diagnostics[0].Range);
+    }
+
     [TestMethod]
     public async Task OpeningFlawlessDocumentReportsNoDiagnostics() {
       var source = @"

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
     [TestMethod]
     public async Task EmptyFileNoCodeWarning() {
       var source = "";
-      //DafnyOptions.O.UseBaseNameForFileName = true;
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       var diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);

--- a/Test/git-issues/git-issue-845.dfy.expect
+++ b/Test/git-issues/git-issue-845.dfy.expect
@@ -1,3 +1,3 @@
-(0,-1): Warning: File contains no code: git-issue-845.dfy
+git-issue-845.dfy(1,0): Warning: File contains no code
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/wishlist/we-should-always-print-tooltips.dfy.expect
+++ b/Test/wishlist/we-should-always-print-tooltips.dfy.expect
@@ -1,3 +1,3 @@
-(0,-1): Warning: File contains no code: we-should-always-print-tooltips.dfy
+we-should-always-print-tooltips.dfy(1,0): Warning: File contains no code
 
 Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Don't publish a diagnostics with a negative line and column number when a file is empty

Fixes #2529

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
