### PR TITLE
fix: Name collision in `datatype`s of some compilers

### DIFF
--- a/Source/Dafny/Compilers/Compiler-Csharp.cs
+++ b/Source/Dafny/Compilers/Compiler-Csharp.cs
@@ -1533,7 +1533,7 @@ namespace Microsoft.Dafny.Compilers {
           return $"(({TypeName(xType, wr, udt.tok)})null)";
         }
       } else if (cl is DatatypeDecl dt) {
-        var s = FullTypeName(udt, ignoreInterface: true);
+        var s = FullTypeName(udt, ignoreInterface: true, forceFullName: true);
         var nonGhostTypeArgs = SelectNonGhost(dt, udt.TypeArgs);
         if (nonGhostTypeArgs.Count != 0) {
           s += "<" + TypeNames(nonGhostTypeArgs, wr, udt.tok) + ">";
@@ -2278,7 +2278,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override string FullTypeName(UserDefinedType udt, MemberDecl /*?*/ member = null) {
       return FullTypeName(udt, member);
     }
-    private string FullTypeName(UserDefinedType udt, MemberDecl/*?*/ member = null, bool ignoreInterface = false) {
+    private string FullTypeName(UserDefinedType udt, MemberDecl/*?*/ member = null, bool ignoreInterface = false, bool forceFullName = false) {
       Contract.Assume(udt != null);  // precondition; this ought to be declared as a Requires in the superclass
       if (udt is ArrowType) {
         return ArrowType.Arrow_FullCompileName;
@@ -2299,7 +2299,7 @@ namespace Microsoft.Dafny.Compilers {
         return (cl.EnclosingModuleDefinition.IsDefaultModule ? "" : IdProtect(cl.EnclosingModuleDefinition.CompileName) + ".") + DtTypeName(cl, false);
       }
 
-      if (cl.EnclosingModuleDefinition.IsDefaultModule) {
+      if (cl.EnclosingModuleDefinition.IsDefaultModule && !forceFullName) {
         return IdProtect(cl.CompileName);
       }
 

--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -775,7 +775,7 @@ namespace Microsoft.Dafny.Compilers {
       return FullTypeName(udt, member, false);
     }
 
-    protected string FullTypeName(UserDefinedType udt, MemberDecl member, bool useCompanionName) {
+    private string FullTypeName(UserDefinedType udt, MemberDecl member, bool useCompanionName, bool forceFullName = false) {
       Contract.Requires(udt != null);
       if (udt.IsBuiltinArrowType) {
         functions.Add(udt.TypeArgs.Count - 1);
@@ -795,7 +795,7 @@ namespace Microsoft.Dafny.Compilers {
         return DafnyTupleClass(tupleDecl.NonGhostDims);
       } else if (cl is TraitDecl && useCompanionName) {
         return IdProtect(udt.FullCompanionCompileName);
-      } else if (cl.EnclosingModuleDefinition.CompileName == ModuleName || cl.EnclosingModuleDefinition.IsDefaultModule) {
+      } else if ((cl.EnclosingModuleDefinition.CompileName == ModuleName || cl.EnclosingModuleDefinition.IsDefaultModule) && !forceFullName) {
         return IdProtect(cl.CompileName);
       } else {
         return IdProtect(cl.EnclosingModuleDefinition.CompileName) + "." + IdProtect(cl.CompileName);
@@ -804,7 +804,7 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override string TypeNameArrayBrackets(int dims) {
       var name = "[";
-      for (int i = 1; i < dims; i++) {
+      for (var i = 1; i < dims; i++) {
         name += "][";
       }
 
@@ -3132,7 +3132,7 @@ namespace Microsoft.Dafny.Compilers {
           return $"({BoxedTypeName(xType, wr, udt.tok)}) null";
         }
       } else if (cl is DatatypeDecl dt) {
-        var s = FullTypeName(udt);
+        var s = FullTypeName(udt, null, false, forceFullName: true);
         var typeargs = "";
         var nonGhostTypeArgs = SelectNonGhost(cl, udt.TypeArgs);
         if (nonGhostTypeArgs.Count != 0) {

--- a/Test/git-issues/git-issue-2441.dfy
+++ b/Test/git-issues/git-issue-2441.dfy
@@ -1,0 +1,8 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype A = A(B: B)
+datatype B = X
+

--- a/Test/git-issues/git-issue-2441.dfy.expect
+++ b/Test/git-issues/git-issue-2441.dfy.expect
@@ -1,0 +1,6 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+
+Dafny program verifier did not attempt verification


### PR DESCRIPTION
Also fixes #2441.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
