### PR TITLE
Fixed bodyless methods gutter icons

### DIFF
--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -3183,6 +3183,7 @@ namespace Microsoft.Dafny {
     public IToken BodyStartTok = Token.NoToken;
     public IToken BodyEndTok = Token.NoToken;
     public IToken StartToken = Token.NoToken;
+    public IToken EndToken = Token.NoToken;
     public IToken TokenWithTrailingDocString = Token.NoToken;
     public readonly string Name;
     public bool IsRefining;

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -1352,6 +1352,7 @@ DatatypeDecl<DeclModifierData dmod, ModuleDefinition/*!*/ module, out DatatypeDe
      dt.BodyStartTok = bodyStart;
      dt.BodyEndTok = t;
      dt.StartToken = dmod.FirstToken;
+     dt.EndToken = t;
      dt.TokenWithTrailingDocString = bodyStart;
   .)
   .
@@ -1369,7 +1370,9 @@ DatatypeMemberDecl<.List<DatatypeCtor/*!*/>/*!*/ ctors.>
   DatatypeMemberName<out id>
   [ FormalsOptionalIds<formals> ]
   (. var ctor = new DatatypeCtor(id, id.val, formals, attrs);
-     ctor.BodyEndTok = t; 
+     ctor.StartToken = id;
+     ctor.BodyEndTok = t;
+     ctor.EndToken = t;
      ctors.Add(ctor); .)
   .
 
@@ -1437,7 +1440,7 @@ ConstantFieldDecl<.DeclModifierData dmod, List<MemberDecl/*!*/>/*!*/ mm, bool mo
                                                 c.StartToken = dmod.FirstToken;
                                                 mm.Add(c);
                                              .)
-  OldSemi                                    (. c.TokenWithTrailingDocString = t; .)
+  OldSemi                                    (. c.TokenWithTrailingDocString = t; c.EndToken = t; .)
   .
 
 /*------------------------------------------------------------------------*/
@@ -1488,7 +1491,8 @@ NewtypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl td>
     [ TypeMembers<module, members> ]
     (. baseType = null; // Base type is not known yet
        td = new NewtypeDecl(id, id.val, module, baseType, members, attrs, isRefining: true);
-       td.StartToken = dmod.FirstToken;        
+       td.StartToken = dmod.FirstToken;
+       td.EndToken = t;
     .)
   )             (. td.TokenWithTrailingDocString = t; .)
   .
@@ -1553,6 +1557,7 @@ SynonymTypeDecl<DeclModifierData dmod, ModuleDefinition module, out TopLevelDecl
      }
      td.BodyEndTok = t;
      td.StartToken = dmod.FirstToken;
+     td.EndToken = t;
      td.TokenWithTrailingDocString = t;
   .)
   (. CheckDeclModifiers(ref dmod, kind, AllowedDeclModifiers.None); .)
@@ -1905,6 +1910,7 @@ MethodDecl<DeclModifierData dmod, bool allowConstructor, out Method/*!*/ m>
      m.BodyStartTok = bodyStart;
      m.BodyEndTok = bodyEnd;
      m.StartToken = dmod.FirstToken;
+     m.EndToken = t;
      m.TokenWithTrailingDocString = tokenWithTrailingDocString;
  .)
   .
@@ -2569,6 +2575,7 @@ FunctionDecl<DeclModifierData dmod, out Function/*!*/ f>
      f.BodyStartTok = bodyStart;
      f.BodyEndTok = bodyEnd;
      f.StartToken = dmod.FirstToken;
+     f.EndToken = t;
      f.TokenWithTrailingDocString = tokenWithTrailingDocString;
      theBuiltIns.CreateArrowTypeDecl(formals.Count);
      if (isLeastPredicate || isGreatestPredicate) {

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -116,11 +116,11 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
   [TestMethod/*, Timeout(MaxTestExecutionTimeMs)*/]
   public async Task EnsuresAddingNewlinesMigratesPositions() {
     await VerifyTrace(@"
- .  S [S][ ][I][S][S][ ][I][S][S][ ]:method f(x: int) {
- .  S [S][ ][I][S][S][ ][I][S][S][ ]:  //Next1:\n  //Next2:\n  
- .  S [=][=][I][S][S][ ][I][S][S][ ]:  assert x == 2; }
-            [-][~][=][=][I][S][S][ ]:
-                        [-][~][=][=]:");
+ .  S [S][ ][I][S][ ][I][S][ ]:method f(x: int) {
+ .  S [S][ ][I][S][ ][I][S][ ]:  //Next1:\n  //Next2:\n  
+ .  S [=][=][I][S][ ][I][S][ ]:  assert x == 2; }
+            [-][~][=][I][S][ ]:
+                     [-][~][=]:");
   }
 
   [TestMethod/*, Timeout(MaxTestExecutionTimeMs)*/]
@@ -131,7 +131,7 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
  .  S [=][=][-][~][=][=]:  x > 3 { y := x;
  .  S [S][ ][I][S][S][ ]:  //Next1:\n
  .  S [=][=][-][~][=][ ]:  while(y <= 1) invariant y >= 2 {
- .  S [S][ ][-][~][=][=]:    y := y + 1;
+ .  S [S][ ][-][~][~][=]:    y := y + 1;
  .  S [S][ ][I][S][S][ ]:  }
  .  S [S][ ][I][S][S][ ]:}
             [I][S][S][ ]:");
@@ -144,5 +144,42 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
  .  S [=][=]:  assert false
  .  S [=][=]:    || false;
  .  S [S][ ]:}");
+  }
+
+  [TestMethod]
+  public async Task EnsureBodylessMethodsAreCovered() {
+    await VerifyTrace(@"
+ .  |  |  | :method test() {
+ .  |  |  | :}
+    |  |  | :
+ .  S [S][ ]:method {:extern} test3(a: nat, b: nat)
+ .  S [S][ ]:  ensures true
+ .  S [=][=]:  ensures test2(a - b)
+ .  S [S][ ]:  ensures true
+ .  S [O][O]:  ensures test2(a - b)
+ .  S [S][ ]:  ensures true
+    |  |  | :
+ .  |  |  | :predicate method test2(x: nat) {
+ .  |  |  | :  true
+ .  |  |  | :}");
+  }
+
+
+  [TestMethod]
+  public async Task EnsureBodylessFunctionsAreCovered() {
+    await VerifyTrace(@"
+ .  |  |  | :method test() {
+ .  |  |  | :}
+    |  |  | :
+ .  S [S][ ]:function method {:extern} test4(a: nat, b: nat): nat
+ .  S [S][ ]:  ensures true
+ .  S [=][=]:  ensures test2(a - b)
+ .  S [S][ ]:  ensures true
+ .  S [O][O]:  ensures test2(a - b)
+ .  S [S][ ]:  ensures true
+    |  |  | :
+ .  |  |  | :predicate method test2(x: nat) {
+ .  |  |  | :  true
+ .  |  |  | :}");
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
@@ -143,11 +143,22 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
   /// The verification status consists of two orthogonal concepts:
   /// - StatusVerification: Nothing (initial), Error, Verified, or Inconclusive
   /// - StatusCurrent: Current (Up-to-date), Obsolete (outdated), and Verifying (as notified by the verifier)
+  ///
+  /// The difference between "Range" and "Position" is that "Range" contains two positions that include the entire tree,
+  /// whereas "Position" is a single position that uniquely determines the range, e.g. a symbol position.
+  /// That position typically serves as an placeholder to uniquely determine a method.
+  ///  
+  /// For example:
+  /// 
+  ///     method Test() {}
+  ///     ^Range.Start   ^Range.End
+  ///            ^ Position 
   /// </summary>
   /// <param name="DisplayName">A user-facing name of this node, to be displayed in an IDE explorer</param>
   /// <param name="Identifier">A unique identifier, to be used by the IDE to request re-verification</param>
   /// <param name="Filename">The name of the file this region of the document is contained in</param>
   /// <param name="Range">The range of this region of the document</param>
+  /// <param name="Position">The position that uniquely identify this range</param>
   public record VerificationTree(
      // Method, Function, Subset type, Constant, Document, Assertion...
      string Kind,
@@ -156,9 +167,9 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
      // Used to re-trigger the verification of some diagnostics.
      string Identifier,
      string Filename,
-     // The range of this node. Used to rendering
+     // The start and end of this verification tree
      Range Range,
-     // The position of this node as believed by Boogie (i.e. the symbol name)
+     // The position of the symbol name attached to this node, or Range.Start if it's anonymous
      Position Position
   ) {
     public string PrefixedDisplayName => Kind + " " + DisplayName;

--- a/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
+++ b/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
@@ -77,13 +77,14 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
               destructor => destructor.CorrespondingFormals).Any(
               formal => formal.DefaultValue != null);
             if (aFormalHasADefaultValue) {
-              var verificationTreeRange = ctor.tok.GetLspRange(ctor.BodyEndTok);
+              var verificationTreeRange = ctor.StartToken.GetLspRange(ctor.EndToken);
               var verificationTree = new TopLevelDeclMemberVerificationTree(
                 "datatype",
                 ctor.Name,
                 ctor.CompileName,
                 ctor.tok.Filename,
-                verificationTreeRange);
+                verificationTreeRange,
+                ctor.tok.GetLspPosition());
               AddAndPossiblyMigrateVerificationTree(verificationTree);
             }
           }
@@ -99,22 +100,24 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
               if (constantHasNoBody) {
                 continue; // Nothing to verify
               }
-              var verificationTreeRange = member.tok.GetLspRange(member.BodyEndTok);
+              var verificationTreeRange = member.StartToken.GetLspRange(member.EndToken);
               var verificationTree = new TopLevelDeclMemberVerificationTree(
                 "constant",
                 member.Name,
                 member.CompileName,
                 member.tok.Filename,
-                verificationTreeRange);
+                verificationTreeRange,
+                member.tok.GetLspPosition());
               AddAndPossiblyMigrateVerificationTree(verificationTree);
             } else if (member is Method or Function) {
-              var verificationTreeRange = member.tok.GetLspRange(member.BodyEndTok.line == 0 ? member.tok : member.BodyEndTok);
+              var verificationTreeRange = member.StartToken.GetLspRange(member.EndToken);
               var verificationTree = new TopLevelDeclMemberVerificationTree(
                 (member is Method ? "method" : "function"),
                 member.Name,
                 member.CompileName,
                 member.tok.Filename,
-                verificationTreeRange);
+                verificationTreeRange,
+                member.tok.GetLspPosition());
               AddAndPossiblyMigrateVerificationTree(verificationTree);
               if (member is Function { ByMethodBody: { } } function) {
                 var verificationTreeRangeByMethod = function.ByMethodTok.GetLspRange(function.ByMethodBody.EndTok);
@@ -123,7 +126,8 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                   member.Name,
                   member.CompileName + "_by_method",
                   member.tok.Filename,
-                  verificationTreeRangeByMethod);
+                  verificationTreeRangeByMethod,
+                  function.ByMethodTok.GetLspPosition());
                 AddAndPossiblyMigrateVerificationTree(verificationTreeByMethod);
               }
             }
@@ -133,13 +137,14 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
           if (subsetTypeDecl.tok.Filename != documentFilePath) {
             continue;
           }
-          var verificationTreeRange = subsetTypeDecl.tok.GetLspRange(subsetTypeDecl.BodyEndTok);
+          var verificationTreeRange = subsetTypeDecl.StartToken.GetLspRange(subsetTypeDecl.EndToken);
           var verificationTree = new TopLevelDeclMemberVerificationTree(
             $"subset type",
             subsetTypeDecl.Name,
             subsetTypeDecl.CompileName,
             subsetTypeDecl.tok.Filename,
-            verificationTreeRange);
+            verificationTreeRange,
+            subsetTypeDecl.tok.GetLspPosition());
           AddAndPossiblyMigrateVerificationTree(verificationTree);
         }
       }
@@ -190,7 +195,8 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
         newDisplayName,
         implementation.Name,
         targetMethodNode.Filename,
-        targetMethodNode.Range
+        targetMethodNode.Range,
+        targetMethodNode.Position
       ).WithImplementation(implementation);
       if (oldImplementationNode != null) {
         newImplementationNode.Children = oldImplementationNode.Children;


### PR DESCRIPTION
Fixes #2533 
For that, I also added EndToken for top-level declarations, and split the Range of VerificationTree into a Range and a token. The token is the one that is used for finding the place of a tree and is included in the range, but it is not its start anymore.

It seems that some tests have changed because of this refactoring but I have no idea why. Their results seem better than before though.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
