### PR TITLE
Do not publish verification symbol status for unresolved documents

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/ReorderingVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/ReorderingVerificationGutterStatusTester.cs
@@ -108,7 +108,7 @@ method m5() { assert false; } //Remove4:
     "m3 m1 m2 m4 m5\n" +
     "m4 m3 m1 m2 m5\n" +
     "null\n" +
-    "migrated\n" +
+    "null\n" +
     "m2 m4 m3 m1"
   );
   }

--- a/Source/DafnyLanguageServer.Test/GutterStatus/ReorderingVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/ReorderingVerificationGutterStatusTester.cs
@@ -188,8 +188,8 @@ method m5() { assert false; } //Remove4:
 
       } catch (OperationCanceledException) {
         Console.WriteLine("count: " + count);
-        Console.WriteLine("foundStatus after timeout: " + string.Join(", ", foundStatus!.NamedVerifiables));
-        Console.WriteLine($"History was: {string.Join("\n", verificationStatusReceiver.History)}");
+        Console.WriteLine("Found status before timeout: " + string.Join(", ", foundStatus!.NamedVerifiables));
+        Console.WriteLine($"\nHistory was: {string.Join("\n", verificationStatusReceiver.History)}");
         throw;
       }
 

--- a/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
@@ -13,6 +13,39 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 [TestClass]
 public class VerificationStatusTest : ClientBasedLanguageServerTest {
 
+
+  [TestMethod]
+  public async Task NoVerificationStatusPublishedForUnparsedDocument() {
+    var source = @"
+method m1() {
+  assert 3 == 55;
+}".TrimStart();
+    var documentItem = CreateTestDocument(source);
+    await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+
+    await WaitUntilAllStatusAreCompleted(documentItem);
+    ApplyChange(ref documentItem, new Range(0, 11, 0, 11), "blargh");
+    ApplyChange(ref documentItem, new Range(0, 0, 0, 0), "\n");
+
+    await AssertNoVerificationStatusIsComing(documentItem, CancellationToken);
+  }
+
+  [TestMethod]
+  public async Task NoVerificationStatusPublishedForUnresolvedDocument() {
+    var source = @"
+method m1() {
+  assert 3 == 55;
+}".TrimStart();
+    var documentItem = CreateTestDocument(source);
+    await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+
+    await WaitUntilAllStatusAreCompleted(documentItem);
+    ApplyChange(ref documentItem, new Range(1, 9, 1, 10), "foo");
+    ApplyChange(ref documentItem, new Range(0, 0, 0, 0), "\n");
+
+    await AssertNoVerificationStatusIsComing(documentItem, CancellationToken);
+  }
+
   [TestMethod]
   public async Task ManyConcurrentVerificationRuns() {
     var source = @"

--- a/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
@@ -158,14 +158,14 @@ public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase {
     await client.OpenDocumentAndWaitAsync(verificationDocumentItem, CancellationToken.None);
     var resolutionReport = await diagnosticsReceiver.AwaitNextNotificationAsync(cancellationToken);
     Assert.AreEqual(verificationDocumentItem.Uri, resolutionReport.Uri,
-      "Unexpected diagnostics were received whereas none were expected:\n" +
+      "1) Unexpected diagnostics were received whereas none were expected:\n" +
       string.Join(",", resolutionReport.Diagnostics.Select(diagnostic => diagnostic.ToString())));
     client.DidCloseTextDocument(new DidCloseTextDocumentParams {
       TextDocument = verificationDocumentItem
     });
     var hideReport = await diagnosticsReceiver.AwaitNextNotificationAsync(cancellationToken);
     Assert.AreEqual(verificationDocumentItem.Uri, hideReport.Uri,
-      "Unexpected diagnostics were received whereas none were expected:\n" +
+      "2) Unexpected diagnostics were received whereas none were expected:\n" +
       string.Join(",", hideReport.Diagnostics.Select(diagnostic => diagnostic.ToString())));
   }
 

--- a/Source/DafnyLanguageServer/Workspace/CompilationManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/CompilationManager.cs
@@ -269,6 +269,7 @@ public class CompilationManager {
       if (VerifierOptions.GutterStatus) {
         document.GutterProgressReporter!.ReportEndVerifyImplementation(implementationTask.Implementation, verificationResult);
       }
+      logger.LogInformation($"Verification of Boogie implementation {implementationTask.Implementation.Name} completed.");
     } else {
       var existingView = document.ImplementationIdToView!.GetValueOrDefault(id) ??
                          new ImplementationView(implementationRange, status, Array.Empty<Diagnostic>());

--- a/Source/DafnyLanguageServer/Workspace/DocumentObserver.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentObserver.cs
@@ -38,7 +38,7 @@ class DocumentObserver : IObserver<DafnyDocument> {
 
   public void OnError(Exception exception) {
     if (exception is OperationCanceledException) {
-      logger.LogWarning(exception, "document processing cancelled.");
+      logger.LogInformation("document processing cancelled.");
       return;
     }
 

--- a/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
@@ -28,6 +28,10 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     private void PublishVerificationStatus(DafnyDocument previousDocument, DafnyDocument document) {
+      if (!document.WasResolved) {
+        return;
+      }
+
       var notification = GetFileVerificationStatus(document);
       var previous = GetFileVerificationStatus(previousDocument);
       if (previous.Version > notification.Version ||

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         statusPublisher.SendStatusNotification(textDocument, CompilationStatus.ParsingFailed);
         return CreateDocumentWithEmptySymbolTable(loggerFactory.CreateLogger<SymbolTable>(), textDocument,
           errorReporter.GetDiagnostics(textDocument.Uri), program,
-          wasResolved: true, loadCanceled: false);
+          wasResolved: false, loadCanceled: false);
       }
 
       var compilationUnit = symbolResolver.ResolveSymbols(textDocument, program, out var canDoVerification, cancellationToken);
@@ -109,7 +109,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         errorReporter.GetDiagnostics(textDocument.Uri),
         symbolTable,
         canDoVerification,
-        ghostDiagnostics, program, WasResolved: true);
+        ghostDiagnostics, program, WasResolved: !errorReporter.HasErrors);
     }
 
     private static void IncludePluginLoadErrors(DiagnosticErrorReporter errorReporter, Dafny.Program program) {


### PR DESCRIPTION
Fix: prevents the LSP client from thinking things are verified when really they're not even resolving.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
