### PR TITLE
Fix verification status for function by methods, and two other small issues

### DIFF
--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2608,7 +2608,7 @@ FunctionSpec<.List<AttributedExpression> reqs, List<FrameExpression> reads, List
   .
 
 /*------------------------------------------------------------------------*/
-PredicateResult<string name, out Formal? result>
+PredicateResult<string name, out Formal result>
 = (. Type/*!*/ returnType = new BoolType();
      result = null;
   .)

--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -2334,7 +2334,7 @@ namespace Microsoft.Dafny {
       var receiver = f.IsStatic ? (Expression)new StaticReceiverExpr(tok, cl, true) : new ImplicitThisExpr(tok);
       var fn = new FunctionCallExpr(tok, f.Name, receiver, tok, tok, f.Formals.ConvertAll(Expression.CreateIdentExpr));
       var post = new AttributedExpression(new BinaryExpr(tok, BinaryExpr.Opcode.Eq, r, fn));
-      var method = new Method(tok, f.Name, f.HasStaticKeyword, false, f.TypeArgs,
+      var method = new Method(f.tok, f.Name, f.HasStaticKeyword, false, f.TypeArgs,
         f.Formals, new List<Formal>() { resultVar },
         f.Req, new Specification<FrameExpression>(new List<FrameExpression>(), null), new List<AttributedExpression>() { post }, f.Decreases,
         f.ByMethodBody, f.Attributes, null, true);

--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Progress;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest {
   public class DafnyLanguageServerTestBase : LanguageServerTestBase {

--- a/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
@@ -8,25 +8,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
   [TestClass]
-  public class DocumentSymbolTest : DafnyLanguageServerTestBase {
-    private ILanguageClient client;
-
-    [TestInitialize]
-    public async Task SetUp() {
-      client = await InitializeClient();
-    }
-
-    private IRequestProgressObservable<IEnumerable<SymbolInformationOrDocumentSymbol>, SymbolInformationOrDocumentSymbolContainer> RequestDocumentSymbol(TextDocumentItem documentItem) {
-      return client.RequestDocumentSymbol(
-        new DocumentSymbolParams {
-          TextDocument = documentItem.Uri,
-        },
-        CancellationToken
-      );
-    }
+  public class DocumentSymbolTest : ClientBasedLanguageServerTest {
 
     [TestMethod]
     public async Task LoadCorrectDocumentCreatesSymbols() {
@@ -44,7 +30,7 @@ class Y {
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
 
-      var classSymbol = (await RequestDocumentSymbol(documentItem).AsTask()).Single().DocumentSymbol;
+      var classSymbol = (await RequestDocumentSymbol(documentItem)).Single();
       var classChildren = classSymbol.Children.ToArray();
       Assert.AreEqual("Y", classSymbol.Name);
       Assert.AreEqual(new Range((0, 6), (9, 0)), classSymbol.Range);
@@ -112,7 +98,7 @@ class Y {
         }
       });
 
-      var classSymbol = (await RequestDocumentSymbol(documentItem).AsTask()).Single().DocumentSymbol;
+      var classSymbol = (await RequestDocumentSymbol(documentItem)).Single();
       var classChildren = classSymbol.Children.ToArray();
       Assert.AreEqual("Y", classSymbol.Name);
       Assert.AreEqual(new Range((0, 6), (8, 0)), classSymbol.Range);
@@ -145,7 +131,7 @@ class Y {
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
 
-      var methodSymbol = (await RequestDocumentSymbol(documentItem).AsTask()).Single().DocumentSymbol;
+      var methodSymbol = (await RequestDocumentSymbol(documentItem)).Single();
       Assert.AreEqual("DoIt", methodSymbol.Name);
       Assert.AreEqual(new Range((0, 7), (0, 11)), methodSymbol.Range);
       Assert.AreEqual(SymbolKind.Method, methodSymbol.Kind);
@@ -157,7 +143,7 @@ class Y {
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
 
-      var methodSymbol = (await RequestDocumentSymbol(documentItem).AsTask()).Single().DocumentSymbol;
+      var methodSymbol = (await RequestDocumentSymbol(documentItem)).Single();
       Assert.AreEqual("ConstOne", methodSymbol.Name);
       Assert.AreEqual(new Range((0, 9), (0, 17)), methodSymbol.Range);
       Assert.AreEqual(SymbolKind.Function, methodSymbol.Kind);

--- a/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
@@ -1,17 +1,62 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Microsoft.Dafny.LanguageServer.Language;
 using Microsoft.Dafny.LanguageServer.Workspace;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 
 [TestClass]
 public class VerificationStatusTest : ClientBasedLanguageServerTest {
+
+  [TestMethod]
+  public async Task FunctionByMethodIsSeenAsSingleVerifiable() {
+    var source = @"
+function MultiplyByPlus(x: nat, y: nat): nat {
+  x * y
+} by method {
+  var result: nat := 0;
+  for i := 0 to x 
+    invariant result == i * y {
+    result := result + y;
+  }
+  return result;
+}";
+    var documentItem = CreateTestDocument(source);
+    await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+    var header = (await RequestDocumentSymbol(documentItem)).Single().SelectionRange;
+    var diagnostic = await GetLastDiagnostics(documentItem, CancellationToken);
+    Assert.AreEqual(0, diagnostic.Length);
+    await WaitForStatus(header, PublishedVerificationStatus.Running, CancellationToken);
+    await WaitForStatus(header, PublishedVerificationStatus.Correct, CancellationToken);
+  }
+
+  [TestMethod]
+  public async Task NoDuplicateStaleMessages() {
+    var source = "method m1() { assert false; }";
+    var documentItem = CreateTestDocument(source);
+    await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+
+    var foundStale = false;
+    while (true) {
+      var statusNotification = await verificationStatusReceiver.AwaitNextNotificationAsync(CancellationToken);
+      var status = statusNotification.NamedVerifiables.Single().Status;
+      if (status >= PublishedVerificationStatus.Error) {
+        break;
+      }
+
+      if (status == PublishedVerificationStatus.Stale) {
+        Assert.IsFalse(foundStale);
+        foundStale = true;
+      }
+    }
+  }
 
   [TestMethod]
   public async Task EmptyVerificationTaskListIsPublishedOnOpenAndChange() {

--- a/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +22,7 @@ using OmniSharp.Extensions.LanguageServer.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Progress;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
@@ -42,6 +44,17 @@ public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase {
         return namedVerifiableStatus;
       }
     }
+  }
+
+  public async Task<IEnumerable<DocumentSymbol>> RequestDocumentSymbol(TextDocumentItem documentItem) {
+    var things = await client.RequestDocumentSymbol(
+      new DocumentSymbolParams {
+        TextDocument = documentItem.Uri,
+      },
+      CancellationToken
+    ).ToTask();
+
+    return things.Select(t => t.DocumentSymbol!);
   }
 
   public async Task<Diagnostic[]> GetLastDiagnostics(TextDocumentItem documentItem, CancellationToken cancellationToken) {

--- a/Source/DafnyLanguageServer/Workspace/DafnyDocument.cs
+++ b/Source/DafnyLanguageServer/Workspace/DafnyDocument.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       var result = new DafnyDocument(TextDocumentItem, ParseAndResolutionDiagnostics, SymbolTable, CanDoVerification, GhostDiagnostics,
         Program, WasResolved, LoadCanceled) {
         VerificationTree = VerificationTree,
+        VerificationTasks = VerificationTasks,
         Counterexamples = Counterexamples == null ? null : new(Counterexamples),
         ImplementationIdToView = ImplementationIdToView == null ? null : new(ImplementationIdToView),
         LastTouchedVerifiables = LastTouchedVerifiables,


### PR DESCRIPTION
### Changes
1. Consider a function by method as a single verifiable
1. Stop sending duplicate verification status notifications
1. Fix a warning producing piece of code in Dafny.atg

### Tests
Added tests for 1 and 2.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
