### PR TITLE
Fix document/verifySymbol handler so it works when symbols have multiple tasks

### DIFF
--- a/Source/DafnyLanguageServer/Handlers/Custom/VerificationHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/Custom/VerificationHandler.cs
@@ -37,8 +37,12 @@ public class VerificationHandler : IJsonRpcRequestHandler<VerificationParams, bo
 
     var translatedDocument = await documentManager.CompilationManager.TranslatedDocument;
     var requestPosition = request.Position;
-    return GetTasksAtPosition(translatedDocument, requestPosition).
-      Any(taskToRun => documentManager.CompilationManager.Verify(translatedDocument, taskToRun));
+    var someTasksAreRunning = false;
+    var tasksAtPosition = GetTasksAtPosition(translatedDocument, requestPosition);
+    foreach (var taskToRun in tasksAtPosition) {
+      someTasksAreRunning |= documentManager.CompilationManager.Verify(translatedDocument, taskToRun);
+    }
+    return someTasksAreRunning;
   }
 
   private static IEnumerable<IImplementationTask> GetTasksAtPosition(DafnyDocument translatedDocument, Position requestPosition) {


### PR DESCRIPTION
### Changes

Fix document/verifySymbol handler so it works when symbols have multiple tasks

### Testing

Added test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
