### PR TITLE
Remove the use of Boogie's XML output

### DIFF
--- a/Source/Dafny/DafnyOptions.cs
+++ b/Source/Dafny/DafnyOptions.cs
@@ -157,8 +157,6 @@ namespace Microsoft.Dafny {
     [CanBeNull] private TestGenerationOptions testGenOptions = null;
     public bool ExtractCounterexample = false;
     public List<string> VerificationLoggerConfigs = new();
-    // Working around the fact that xmlFilename is private
-    public string BoogieXmlFilename = null;
 
     public static readonly ReadOnlyCollection<Plugin> DefaultPlugins = new(new[] { Compilers.SinglePassCompiler.Plugin });
     public List<Plugin> Plugins = new(DefaultPlugins);
@@ -660,15 +658,6 @@ namespace Microsoft.Dafny {
 
     public override void ApplyDefaultOptions() {
       base.ApplyDefaultOptions();
-
-      if (VerificationLoggerConfigs.Any()) {
-        if (XmlSink != null) {
-          throw new Exception("The /verificationLogger and /xml options cannot be used at the same time.");
-        }
-
-        BoogieXmlFilename = Path.GetTempFileName();
-        XmlSink = new Bpl.XmlSink(this, BoogieXmlFilename);
-      }
 
       Compiler ??= new CsharpCompiler();
 

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Dafny {
     private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e) {
       writer.WriteLine("TestResult.DisplayName,TestResult.Outcome,TestResult.Duration,TestResult.ResourceCount");
       foreach (var result in results.OrderByDescending(r => r.Duration)) {
-        var resCount = result.GetPropertyValue(BoogieXmlConvertor.ResourceCountProperty);
+        var resCount = result.GetPropertyValue(VerificationResultConvertor.ResourceCountProperty);
         writer.WriteLine($"{result.TestCase.DisplayName},{result.Outcome},{result.Duration},{resCount}");
       }
 

--- a/Source/DafnyDriver/CSVTestLogger.cs
+++ b/Source/DafnyDriver/CSVTestLogger.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Dafny {
     private void TestRunCompleteHandler(object sender, TestRunCompleteEventArgs e) {
       writer.WriteLine("TestResult.DisplayName,TestResult.Outcome,TestResult.Duration,TestResult.ResourceCount");
       foreach (var result in results.OrderByDescending(r => r.Duration)) {
-        var resCount = result.GetPropertyValue(VerificationResultConvertor.ResourceCountProperty);
+        var resCount = result.GetPropertyValue(VerificationResultLogger.ResourceCountProperty);
         writer.WriteLine($"{result.TestCase.DisplayName},{result.Outcome},{result.Duration},{resCount}");
       }
 

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Dafny {
 
       if (DafnyOptions.O.VerificationLoggerConfigs.Any()) {
         try {
-          VerificationResultConvertor.RaiseTestLoggerEvents(DafnyOptions.O.VerificationLoggerConfigs);
+          VerificationResultLogger.RaiseTestLoggerEvents(DafnyOptions.O.VerificationLoggerConfigs);
         } catch (ArgumentException ae) {
           DafnyOptions.O.Printer.ErrorWriteLine(Console.Out, $"*** Error: {ae.Message}");
           exitValue = ExitValue.PREPROCESSING_ERROR;

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -125,6 +125,8 @@ namespace Microsoft.Dafny {
           throw new ArgumentOutOfRangeException();
       }
 
+      DafnyOptions.O.XmlSink?.Close();
+
       if (DafnyOptions.O.VerificationLoggerConfigs.Any()) {
         try {
           VerificationResultConvertor.RaiseTestLoggerEvents(DafnyOptions.O.VerificationLoggerConfigs);

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -125,16 +125,12 @@ namespace Microsoft.Dafny {
           throw new ArgumentOutOfRangeException();
       }
 
-      if (DafnyOptions.O.XmlSink != null) {
-        DafnyOptions.O.XmlSink.Close();
-        if (DafnyOptions.O.VerificationLoggerConfigs.Any()) {
-          try {
-            BoogieXmlConvertor.RaiseTestLoggerEvents(DafnyOptions.O.BoogieXmlFilename,
-                                                     DafnyOptions.O.VerificationLoggerConfigs);
-          } catch (ArgumentException ae) {
-            DafnyOptions.O.Printer.ErrorWriteLine(Console.Out, $"*** Error: {ae.Message}");
-            exitValue = ExitValue.PREPROCESSING_ERROR;
-          }
+      if (DafnyOptions.O.VerificationLoggerConfigs.Any()) {
+        try {
+          BoogieXmlConvertor.RaiseTestLoggerEvents( DafnyOptions.O.VerificationLoggerConfigs);
+        } catch (ArgumentException ae) {
+          DafnyOptions.O.Printer.ErrorWriteLine(Console.Out, $"*** Error: {ae.Message}");
+          exitValue = ExitValue.PREPROCESSING_ERROR;
         }
       }
       if (DafnyOptions.O.Wait) {

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Dafny {
 
       if (DafnyOptions.O.VerificationLoggerConfigs.Any()) {
         try {
-          BoogieXmlConvertor.RaiseTestLoggerEvents( DafnyOptions.O.VerificationLoggerConfigs);
+          VerificationResultConvertor.RaiseTestLoggerEvents(DafnyOptions.O.VerificationLoggerConfigs);
         } catch (ArgumentException ae) {
           DafnyOptions.O.Printer.ErrorWriteLine(Console.Out, $"*** Error: {ae.Message}");
           exitValue = ExitValue.PREPROCESSING_ERROR;

--- a/Source/DafnyDriver/VerificationResultConvertor.cs
+++ b/Source/DafnyDriver/VerificationResultConvertor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Dafny {
   ///  * CSV files, which are easier to parse and summarize. 
   ///  * human-readable text output.
   /// </summary>
-  public static class BoogieXmlConvertor {
+  public static class VerificationResultConvertor {
 
     public static TestProperty ResourceCountProperty = TestProperty.Register("TestResult.ResourceCount", "TestResult.ResourceCount", typeof(int), typeof(TestResult));
 

--- a/Source/DafnyDriver/VerificationResultLogger.cs
+++ b/Source/DafnyDriver/VerificationResultLogger.cs
@@ -18,14 +18,12 @@ using VC;
 namespace Microsoft.Dafny {
 
   /// <summary>
-  /// Utility to translate verification results into test logger events,
-  /// allowing us to deliver them through common loggers on the .NET
-  /// platform. For now we support three formats:
+  /// Utility to translate verification results into logs in several formats:
   ///  * TRX files, which can be understood and visualized by various .NET tools.
   ///  * CSV files, which are easier to parse and summarize. 
   ///  * human-readable text output.
   /// </summary>
-  public static class VerificationResultConvertor {
+  public static class VerificationResultLogger {
 
     public static TestProperty ResourceCountProperty = TestProperty.Register("TestResult.ResourceCount", "TestResult.ResourceCount", typeof(int), typeof(TestResult));
 


### PR DESCRIPTION
Now that verification results are aggregated into a data structure returned to Dafny, using Boogie's XML output is no longer necessary.

Fixes #1950

This is a refactoring that should still pass existing tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
