### PR TITLE
Build DafnyLanguageServer as a NuGet package

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
   (https://github.com/dafny-lang/dafny/pull/2416)
 - feat: Dafny now supports disjunctive (“or”) patterns in match statements and expressions.  Cases are separated by `|` characters.  Disjunctive patterns may not appear within other patterns and may not bind variables.
   (https://github.com/dafny-lang/dafny/pull/2448)
-- feat: The Dafny Language Server used by the VSCode IDE plugin is now available as a NuGet package called `DafnyLanguageServer` (https://github.com/dafny-lang/dafny/pull/2600)
+- feat: The Dafny Language Server used by the VSCode IDE extension is now available as a NuGet package called `DafnyLanguageServer` (https://github.com/dafny-lang/dafny/pull/2600)
 - fix: Counterexamples - fix an integer parsing bug and correctly extract datatype and field names (https://github.com/dafny-lang/dafny/pull/2461)
 - feat: New option `-diagnosticsFormat:json` to print Dafny error messages as JSON objects (one per line).
   (https://github.com/dafny-lang/dafny/pull/2363)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
   (https://github.com/dafny-lang/dafny/pull/2416)
 - feat: Dafny now supports disjunctive (“or”) patterns in match statements and expressions.  Cases are separated by `|` characters.  Disjunctive patterns may not appear within other patterns and may not bind variables.
   (https://github.com/dafny-lang/dafny/pull/2448)
+- feat: The Dafny Language Server used by the VSCode IDE plugin is now available as a NuGet package called `DafnyLanguageServer` (https://github.com/dafny-lang/dafny/pull/2600)
 - fix: Counterexamples - fix an integer parsing bug and correctly extract datatype and field names (https://github.com/dafny-lang/dafny/pull/2461)
 - feat: New option `-diagnosticsFormat:json` to print Dafny error messages as JSON objects (one per line).
   (https://github.com/dafny-lang/dafny/pull/2363)

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -7,7 +7,8 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Dafny.LanguageServer</RootNamespace>
     <OutputPath>..\..\Binaries\</OutputPath>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <VersionPrefix>3.8.0.40729</VersionPrefix>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 

--- a/Source/version.cs
+++ b/Source/version.cs
@@ -3,5 +3,6 @@ using System.Reflection;
 // When changing this, also be sure to change it in the following files:
 // * Source/DafnyDriver/DafnyDriver.csproj
 // * Source/Dafny/DafnyPipeline.csproj
+// * Source/DafnyLanguageServer/DafnyLanguageServer.csproj
 [assembly: AssemblyVersion("3.8.0.40729")]
 [assembly: AssemblyFileVersion("3.8.0.40729")]

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -28,6 +28,8 @@
 
    * `Source/Dafny/DafnyPipeline.csproj`
 
+   * `Source/DafnyLanguageServer/DafnyLanguageServer.csproj`
+
    Put the public version number in place of the "Upcoming" header in
    `RELEASE_NOTES.md`, and add a new "Upcoming" header above it.
 


### PR DESCRIPTION
Adds a NuGet package for `DafnyLanguageServer`, to make it easier use an IDE with a version of the language server known to match a `dafny` CLI executable installed with NuGet.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
