### PR TITLE
Make the counterExample handler robust against race conditions

### DIFF
--- a/Source/DafnyLanguageServer/Handlers/Custom/DafnyCounterExampleHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/Custom/DafnyCounterExampleHandler.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using DafnyServer.CounterexampleGeneration;
+﻿using DafnyServer.CounterexampleGeneration;
 using Microsoft.Boogie;
-using Microsoft.Dafny.LanguageServer.Language;
 using Microsoft.Dafny.LanguageServer.Workspace;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,9 +28,8 @@ namespace Microsoft.Dafny.LanguageServer.Handlers.Custom {
             documentManager.Compilation.VerifyTask(translatedDocument, task);
           }
 
-          var documentWithCounterExamples = (DocumentAfterTranslation)(await documentManager.LastDocumentAsync);
-          return new CounterExampleLoader(logger, documentWithCounterExamples, request.CounterExampleDepth, cancellationToken)
-            .GetCounterExamples();
+          var state = await documentManager.GetIdeStateAfterVerificationAsync();
+          return new CounterExampleLoader(logger, state, request.CounterExampleDepth, cancellationToken).GetCounterExamples();
         }
 
         logger.LogWarning("counter-examples requested for unloaded document {DocumentUri}",
@@ -48,30 +43,24 @@ namespace Microsoft.Dafny.LanguageServer.Handlers.Custom {
     }
 
     private class CounterExampleLoader {
-      private const string InitialStateName = "<initial>";
-      private static readonly Regex StatePositionRegex = new(
-        @".*\.dfy\((?<line>\d+),(?<character>\d+)\)",
-        RegexOptions.IgnoreCase | RegexOptions.Singleline
-      );
-
       private readonly ILogger logger;
-      private readonly DocumentAfterTranslation document;
+      private readonly IdeState ideState;
       private readonly CancellationToken cancellationToken;
       private readonly int counterExampleDepth;
 
-      public CounterExampleLoader(ILogger logger, DocumentAfterTranslation document, int counterExampleDepth, CancellationToken cancellationToken) {
+      public CounterExampleLoader(ILogger logger, IdeState ideState, int counterExampleDepth, CancellationToken cancellationToken) {
         this.logger = logger;
-        this.document = document;
+        this.ideState = ideState;
         this.cancellationToken = cancellationToken;
         this.counterExampleDepth = counterExampleDepth;
       }
 
       public CounterExampleList GetCounterExamples() {
-        if (!document.Counterexamples!.Any()) {
-          logger.LogDebug("got no counter-examples for document {DocumentUri}", document.Uri);
+        if (!ideState.Counterexamples.Any()) {
+          logger.LogDebug("got no counter-examples for document {DocumentUri}", ideState.Uri);
           return new CounterExampleList();
         }
-        var counterExamples = GetLanguageSpecificModels(document.Counterexamples!)
+        var counterExamples = GetLanguageSpecificModels(ideState.Counterexamples)
           .SelectMany(GetCounterExamples)
           .WithCancellation(cancellationToken)
           .ToArray();

--- a/Source/DafnyLanguageServer/Workspace/Document.cs
+++ b/Source/DafnyLanguageServer/Workspace/Document.cs
@@ -2,6 +2,7 @@
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using Microsoft.Boogie;
 using Microsoft.Dafny.LanguageServer.Language;
@@ -37,6 +38,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     public IdeState InitialIdeState() {
       return ToIdeState(new IdeState(TextDocumentItem, Array.Empty<Diagnostic>(),
         SymbolTable.Empty(TextDocumentItem), new Dictionary<ImplementationId, ImplementationView>(),
+        Array.Empty<Counterexample>(),
         false, Array.Empty<Diagnostic>(),
         new DocumentVerificationTree(TextDocumentItem)));
     }
@@ -140,6 +142,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       return base.ToIdeState(previousState) with {
         ImplementationsWereUpdated = true,
         VerificationTree = VerificationTree,
+        Counterexamples = new List<Counterexample>(Counterexamples),
         ImplementationIdToView = new Dictionary<ImplementationId, ImplementationView>(implementationViewsWithMigratedDiagnostics)
       };
     }

--- a/Source/DafnyLanguageServer/Workspace/DocumentManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentManager.cs
@@ -152,12 +152,18 @@ public class DocumentManager {
     }
   }
 
-  /// <summary>
-  /// Tries to resolve the current document and return it, and otherwise return the last document that was resolved.
-  /// </summary>
-  public async Task<IdeState?> GetSnapshotAfterResolutionAsync() {
+  public async Task<IdeState> GetSnapshotAfterResolutionAsync() {
     try {
-      var resolvedDocument = await Compilation.ResolvedDocument;
+      await Compilation.ResolvedDocument;
+    } catch (OperationCanceledException) {
+    }
+
+    return observer.LastPublishedState;
+  }
+
+  public async Task<IdeState> GetIdeStateAfterVerificationAsync() {
+    try {
+      await Compilation.LastDocument;
     } catch (OperationCanceledException) {
     }
 

--- a/Source/DafnyLanguageServer/Workspace/DocumentManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentManagerDatabase.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Dafny.LanguageServer.Handlers;
 using Microsoft.Dafny.LanguageServer.Language;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -74,7 +73,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     public Task<IdeState?> GetResolvedDocumentAsync(TextDocumentIdentifier documentId) {
       if (documents.TryGetValue(documentId.Uri, out var state)) {
-        return state.GetSnapshotAfterResolutionAsync();
+        return state.GetSnapshotAfterResolutionAsync()!;
       }
       return Task.FromResult<IdeState?>(null);
     }

--- a/Source/DafnyLanguageServer/Workspace/IdeState.cs
+++ b/Source/DafnyLanguageServer/Workspace/IdeState.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Boogie;
 using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Dafny.LanguageServer.Workspace.Notifications;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -16,6 +17,7 @@ public record IdeState(
   IEnumerable<Diagnostic> ResolutionDiagnostics,
   SymbolTable SymbolTable,
   IReadOnlyDictionary<ImplementationId, ImplementationView> ImplementationIdToView,
+  IReadOnlyList<Counterexample> Counterexamples,
   bool ImplementationsWereUpdated,
   IEnumerable<Diagnostic> GhostDiagnostics,
   VerificationTree VerificationTree

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Boogie;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Dafny.LanguageServer.Workspace {
@@ -122,6 +123,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         diagnostics,
         SymbolTable.Empty(textDocument),
         new Dictionary<ImplementationId, ImplementationView>(),
+        Array.Empty<Counterexample>(),
         false,
         Array.Empty<Diagnostic>(),
         new DocumentVerificationTree(textDocument)

--- a/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
+++ b/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
@@ -284,8 +284,6 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
   /// <summary>
   /// Called when a split is finished to be verified
   /// </summary>
-  /// <param name="split">The split that was verified</param>
-  /// <param name="result">The verification results for that split and per assert</param>
   public void ReportAssertionBatchResult(AssertionBatchResult batchResult) {
     lock (LockProcessing) {
       var implementation = batchResult.Implementation;


### PR DESCRIPTION
Make the counterExample handler robust against race conditions such as https://github.com/dafny-lang/dafny/runs/8099783944?check_suite_focus=true

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
