### PR TITLE
Revert "Let `DafnyRuntime` target more frameworks (#2604)"

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -45,9 +45,7 @@ jobs:
         ref: v${{ steps.regex-match.outputs.group1 }}
     - name: Build Dafny with local Boogie
       working-directory: dafny
-      run: |
-        dotnet build Source/Dafny.sln
-        dotnet build -f netstandard2.0 Source/DafnyRuntime/DafnyRuntime.csproj
+      run: dotnet build Source/Dafny.sln
     - name: Check whitespace and style
       working-directory: dafny
       run: dotnet tool run dotnet-format -w -s error --check Source/Dafny.sln --exclude Dafny/Scanner.cs --exclude Dafny/Parser.cs

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -55,11 +55,11 @@ jobs:
       uses: actions/setup-dotnet@v1.9.0
       with:
         dotnet-version: ${{env.dotnet-version}}
-    - name: C++ on ubuntu 18.04
+    - name: C++ for ubuntu 18.04
       if: matrix.os == 'ubuntu-18.04'
       run: |
         sudo apt-get install -y build-essential
-    - name: Choose the right C++ on ubuntu 18.04
+    - name: Choose the right C++ for ubuntu 18.04
       if: matrix.os == 'ubuntu-18.04'
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 60
@@ -74,7 +74,6 @@ jobs:
     - name: Build Dafny
       run: |
         dotnet build dafny/Source/Dafny.sln
-        dotnet build -f netstandard2.0 dafny/Source/DafnyRuntime/DafnyRuntime.csproj
         rm dafny/Binaries/*.nupkg
     - name: Create release NuGet package (for uploading)
       if: ${{ !inputs.prerelease }}

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -7,7 +7,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <DefineConstants>TRACE;ISDAFNYRUNTIMELIB</DefineConstants>
       <VersionPrefix>1.2.0</VersionPrefix>
-      <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+      <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>
       <LangVersion>7.3</LangVersion>
       <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This reverts commit 709ed5a2669233195a488dceebda2594ee5eb5e5. (PR #2604)

Resolving the issue that Rider no longer builds:

```
Build started 09/08/2022 10:58:29.
Logging verbosity is set to: Normal.     1>Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" on node 1 (build target(s)).
     1>BuildDafnyRuntimeJar:
         Compiling DafnyRuntimeJava to DafnyRuntimeJava/build/libs/DafnyRuntime.jar...
         ./gradlew -q build
       GenerateTargetFrameworkMonikerAttribute:
       Skipping target "GenerateTargetFrameworkMonikerAttribute" because all output files are up-to-date with respect to the input files.
       CoreCompile:
       Skipping target "CoreCompile" because all output files are up-to-date with respect to the input files.
       _CopyOutOfDateSourceItemsToOutputDirectory:
       Skipping target "_CopyOutOfDateSourceItemsToOutputDirectory" because all output files are up-to-date with respect to the input files.
       _CopyOutOfDateSourceItemsToOutputDirectoryAlways:
         Copying file from "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.cs" to "/Users/rwillems/Documents/SourceCode/dafny/Binaries/net6.0/DafnyRuntime.cs".
       GenerateBuildDependencyFile:
       Skipping target "GenerateBuildDependencyFile" because all output files are up-to-date with respect to the input files.
       CopyFilesToOutputDirectory:
         DafnyRuntime -> /Users/rwillems/Documents/SourceCode/dafny/Binaries/net6.0/DafnyRuntime.dll
     1>Done Building Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (build target(s)).
   1:2>Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" on node 1 (Pack target(s)).
   1:2>Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (1:2) is building "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (1:9) on node 1 (_GetFrameworkAssemblyReferences target(s)).
     1>BuildDafnyRuntimeJar:
         Compiling DafnyRuntimeJava to DafnyRuntimeJava/build/libs/DafnyRuntime.jar...
         ./gradlew -q build
     1>Done Building Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (_GetFrameworkAssemblyReferences target(s)).
   1:2>Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (1:2) is building "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (1:10) on node 1 (_GetFrameworkAssemblyReferences target(s)).
     1>/usr/local/share/dotnet/sdk/6.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(267,5): error NETSDK1005: Assets file '/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/obj/project.assets.json' doesn't have a target for 'netstandard2.0'. Ensure that restore has run and that you have included 'netstandard2.0' in the TargetFrameworks for your project.
     1>Done Building Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (_GetFrameworkAssemblyReferences target(s)) -- FAILED.
     1>Done Building Project "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (Pack target(s)) -- FAILED.

Build FAILED.

       "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (Pack target) (1:2) ->
       "/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/DafnyRuntime.csproj" (_GetFrameworkAssemblyReferences target) (1:10) ->
       (ResolvePackageAssets target) -> 
         /usr/local/share/dotnet/sdk/6.0.201/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(267,5): error NETSDK1005: Assets file '/Users/rwillems/Documents/SourceCode/dafny/Source/DafnyRuntime/obj/project.assets.json' doesn't have a target for 'netstandard2.0'. Ensure that restore has run and that you have included 'netstandard2.0' in the TargetFrameworks for your project.
```

I've reproduced this issue on a fresh Dafny checkout.

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
