### PR TITLE
fix: retain non-method-body block statements when cloning abstract signatures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 - feat: generate warning when 'old' has no effect (https://github.com/dafny-lang/dafny/pull/2610)
 - fix: Missing related position in failing precondition (https://github.com/dafny-lang/dafny/pull/2658)
 - fix: No more IDE crashing on the elephant operator (https://github.com/dafny-lang/dafny/pull/2668)
+- fix: retain non-method-body block statements when cloning abstract signatures (https://github.com/dafny-lang/dafny/pull/2731)
 
 
 # 3.8.1

--- a/Source/DafnyCore/Cloner.cs
+++ b/Source/DafnyCore/Cloner.cs
@@ -1033,8 +1033,14 @@ namespace Microsoft.Dafny {
       return basem;
     }
 
-    public override BlockStmt CloneBlockStmt(BlockStmt stmt) {
+    public override BlockStmt CloneMethodBody(Method m) {
       return null;
+    }
+
+    public override Function CloneFunction(Function f, string newName = null) {
+      var clone = base.CloneFunction(f, newName);
+      clone.Body = null;
+      return clone;
     }
   }
 

--- a/Source/DafnyCore/Cloner.cs
+++ b/Source/DafnyCore/Cloner.cs
@@ -1036,12 +1036,6 @@ namespace Microsoft.Dafny {
     public override BlockStmt CloneMethodBody(Method m) {
       return null;
     }
-
-    public override Function CloneFunction(Function f, string newName = null) {
-      var clone = base.CloneFunction(f, newName);
-      clone.Body = null;
-      return clone;
-    }
   }
 
 

--- a/Test/git-issues/git-issue-1639.dfy
+++ b/Test/git-issues/git-issue-1639.dfy
@@ -1,0 +1,13 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Foo {
+    function Fun(): () {
+        calc { 0; }
+        ()
+    }
+}
+
+abstract module Bar {
+    import Foo' : Foo
+}

--- a/Test/git-issues/git-issue-1639.dfy
+++ b/Test/git-issues/git-issue-1639.dfy
@@ -1,4 +1,4 @@
-// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %dafny /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Foo {

--- a/Test/git-issues/git-issue-1639.dfy.expect
+++ b/Test/git-issues/git-issue-1639.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/git-issues/git-issue-1639.dfy.expect
+++ b/Test/git-issues/git-issue-1639.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/git-issues/git-issue-1639.dfy.expect
+++ b/Test/git-issues/git-issue-1639.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
Fixes #1639 by changing `AbstractSignatureCloner` to specifically delete only method bodies, instead of all block statements. This avoid breaking AST invariants of  other block statements (e.g. that hints of a `calc` statement are non-null).

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
