### PR TITLE
Allow accessing full name of top-level declaration

### DIFF
--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -960,11 +960,17 @@ public abstract class TopLevelDecl : Declaration, TypeParameter.ParentType {
   }
   public virtual string FullName {
     get {
+      if (EnclosingModuleDefinition is null) {
+        return Name;
+      }
       return EnclosingModuleDefinition.FullName + "." + Name;
     }
   }
   public string FullSanitizedName {
     get {
+      if (EnclosingModuleDefinition is null) {
+        return SanitizedName;
+      }
       return EnclosingModuleDefinition.SanitizedName + "." + SanitizedName;
     }
   }


### PR DESCRIPTION
The `FullName` and `FullSanitizedName` properties are now safe to access when the `EnclosingModuleDefinition` property is null.

This will be necessary in order for the [auditor](https://github.com/dafny-lang/compiler-bootstrap/tree/main/src/Tools/Auditor) to run as a plugin inside a released version of Dafny.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
