### PR TITLE
fix: Extend restrictions from d7c88e434 to avoid unsoundness with null

### DIFF
--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -5047,7 +5047,10 @@ namespace Microsoft.Dafny {
               if (CheckTypeInference_Visitor.IsDetermined(t) &&
                   (fullstrength
                    || !ProxyWithNoSubTypeConstraint(u, resolver)
-                   || (Types[0].NormalizeExpandKeepConstraints().IsNonNullRefType && u is TypeProxy && resolver.HasApplicableNullableRefTypeConstraint(new HashSet<TypeProxy>() { (TypeProxy)u })))) {
+                   || (u is TypeProxy
+                       && Types[0].NormalizeExpandKeepConstraints() is var t0constrained
+                       && (t0constrained.IsNonNullRefType || t0constrained.AsSubsetType != null)
+                       && resolver.HasApplicableNullableRefTypeConstraint(new HashSet<TypeProxy>() { (TypeProxy)u })))) {
                 // This is the best case.  We convert Assignable(t, u) to the subtype constraint base(t) :> u.
                 if (CheckTypeInference_Visitor.IsDetermined(u) && t.IsSubtypeOf(u, false, true) && t.IsRefType) {
                   // But we also allow cases where the rhs is a proper supertype of the lhs, and let the verifier

--- a/Test/git-issues/git-issue-2752.dfy
+++ b/Test/git-issues/git-issue-2752.dfy
@@ -1,0 +1,15 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Empty = x: object | false witness *
+type EmptyQ = x: object? | false witness *
+type EmptyInt = x: int | false witness *
+const x := null as Empty // Error
+const xq := null as EmptyQ // Error
+const i := 0 as EmptyInt // Error
+
+type foo = x: object? | x != null witness *
+
+function method m(): foo {
+  null // Error
+}

--- a/Test/git-issues/git-issue-2752.dfy.expect
+++ b/Test/git-issues/git-issue-2752.dfy.expect
@@ -1,0 +1,6 @@
+git-issue-2752.dfy(7,16): Error: value of expression (of type 'object?') is not known to be an instance of type 'Empty'
+git-issue-2752.dfy(8,17): Error: value of expression (of type 'object?') is not known to be an instance of type 'EmptyQ'
+git-issue-2752.dfy(9,13): Error: result of operation might violate subset type constraint for 'EmptyInt'
+git-issue-2752.dfy(14,2): Error: value of expression (of type 'object?') is not known to be an instance of type 'foo'
+
+Dafny program verifier finished with 0 verified, 4 errors


### PR DESCRIPTION
Closes #2752.

The logic is in keeping with the original code, but I'm not sure why the original code was phrased this way in d7c88e434.  Maybe there a simpler way to ensure that `null` never gets assigned a subset type?
