### PR TITLE
Revert "feat: Add #nullable disable to generated C# code to avoid warnings (#2444)"

### DIFF
--- a/Source/DafnyCore/Compilers/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/Compiler-Csharp.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Dafny.Compilers {
       wr.WriteLine("// Optionally, you may want to include compiler switches like");
       wr.WriteLine("//     /debug /nowarn:162,164,168,183,219,436,1717,1718");
       wr.WriteLine();
-      wr.WriteLine("#nullable disable");
       wr.WriteLine("using System;");
       wr.WriteLine("using System.Numerics;");
       wr.WriteLine("using System.Collections;");


### PR DESCRIPTION
This reverts commit ecd825e5dfcc97a7dd8f8342a014a0c8ed4954de.

The `#nullable enable` annotation is a recent C# feature, so that commit broke compatibility with some client code.

Fixes #2781
