### PR TITLE
Fix: Support for Z3 solver path with spaces

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 - fix: Improved hints and error messages regarding variance/cardinality preservation (https://github.com/dafny-lang/dafny/pull/2774)
 - feat: New behavior for `import opened M` where `M` contains a top-level declaration `M`, see PR for a full description (https://github.com/dafny-lang/dafny/pull/2355)
 - fix: The DafnyServer package is now published to NuGet as well, which fixes the previously-broken version of the DafnyLanguageServer package. (https://github.com/dafny-lang/dafny/pull/2787)
+- fix: Support for spaces in the path to Z3 (https://github.com/dafny-lang/dafny/pull/2812)
 - deprecate: Statement-level refinement syntax (e.g. `assert ...`) is deprecated (https://github.com/dafny-lang/dafny/pull/2756)
 - deprecate: The form of the modify statement with a block statement is deprecated
 

--- a/Source/DafnyLanguageServer/Workspace/DocumentManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentManagerDatabase.cs
@@ -32,14 +32,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       // Initialises DafnyOptions.O
       services.GetRequiredService<IDafnyParser>();
 
-      DafnyOptions.O.ProverOptions = GetProverOptions(this.documentOptions);
-    }
-
-    private static List<string> GetProverOptions(DocumentOptions options) {
-      return options.ProverOptions.Split(
-        new[] { " ", "\n", "\t" },
-        StringSplitOptions.RemoveEmptyEntries
-      ).ToList();
+      DafnyOptions.O.ProverOptions = this.documentOptions.AugmentedProverOptions;
     }
 
     public void OpenDocument(DocumentTextBuffer document) {

--- a/Source/DafnyLanguageServer/Workspace/DocumentOptions.cs
+++ b/Source/DafnyLanguageServer/Workspace/DocumentOptions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Boogie;
 
 namespace Microsoft.Dafny.LanguageServer.Workspace {
@@ -24,9 +26,11 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       DafnyOptions.O.ShowSnippets = true;
     }
 
-    public string ProverOptions =>
-      string.Join(" ", DafnyOptions.O.ProverOptions) +
-      " O:model_compress=false" + " O:model.completion=true" +
-      " O:model_evaluator.completion=true";
+    public List<string> AugmentedProverOptions =>
+      DafnyOptions.O.ProverOptions.Concat(new List<string>() {
+        "O:model_compress=false",
+        "O:model.completion=true",
+        "O:model_evaluator.completion=true"
+      }).ToList();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/dafny-lang/ide-vscode/issues/272

There was a weird totally useless conversion from `List<String>` to `String` and vice-versa, that would split on spaces. I removed the conversion used only in this place and this works as expected.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
