### PR TITLE
fix: GenerateAssemblyInfo in DafnyCore

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -14,7 +14,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>DafnyCore</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>..\..\Binaries\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <TargetFramework>net6.0</TargetFramework>

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
       <OutputType>Exe</OutputType>
       <AssemblyName>DafnyServer</AssemblyName>
-      <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+      <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
       <DefineConstants>TRACE</DefineConstants>
       <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>

--- a/Source/DafnyServer/DafnyServer.csproj
+++ b/Source/DafnyServer/DafnyServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
       <OutputType>Exe</OutputType>
       <AssemblyName>DafnyServer</AssemblyName>
-      <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+      <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <DefineConstants>TRACE</DefineConstants>
       <TargetFramework>net6.0</TargetFramework>
       <OutputPath>..\..\Binaries\</OutputPath>

--- a/Test/git-issues/git-issue-2813.dfy
+++ b/Test/git-issues/git-issue-2813.dfy
@@ -1,0 +1,6 @@
+// RUN: %dafny /version > %t
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+
+// Just make sure the version string is present and not a default like 0.0.0 or 1.0.0.
+// This will have to be changed with each major version but I can live with that :)
+// CHECK: Dafny 3\..*


### PR DESCRIPTION
Fixes #2813

`Assembly.GetExecutingAssembly()` returns the assembly containing the current code, NOT the top-level entry point assembly/tool, so `DafnyCore.dll` needs to have the relevant info rather than `Dafny.dll`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
