### PR TITLE
fix: handle null seq type arg in error message

### DIFF
--- a/Source/DafnyCore/Resolver/TypeConstraint.cs
+++ b/Source/DafnyCore/Resolver/TypeConstraint.cs
@@ -45,25 +45,6 @@ namespace Microsoft.Dafny {
         Contract.Requires(reporter != null);
         Contract.Requires(suffix != null);
 
-        object[] RemoveAmbiguity(object[] msgArgs) {
-          var renderedInterpolated = new HashSet<string>();
-          var ambiguity = false;
-          foreach (var x in msgArgs) {
-            var str = x.ToString();
-            if (renderedInterpolated.Contains(str)) {
-              ambiguity = true;
-            }
-
-            renderedInterpolated.Add(str);
-          }
-          if (ambiguity) {
-            return msgArgs.Select(x =>
-              (object)(x is UserDefinedType udt ? udt.FullName : x.ToString())
-            ).ToArray();
-          } else {
-            return msgArgs;
-          }
-        }
         if (this is ErrorMsgWithToken) {
           var err = (ErrorMsgWithToken)this;
           Contract.Assert(err.Tok != null);
@@ -74,22 +55,39 @@ namespace Microsoft.Dafny {
         }
         reported = true;
       }
+      protected object[] RemoveAmbiguity(object[] msgArgs) {
+        var renderedInterpolated = new HashSet<string>();
+        var ambiguity = false;
+        foreach (var x in msgArgs) {
+          var str = x.ToString();
+          if (renderedInterpolated.Contains(str)) {
+            ambiguity = true;
+          }
+
+          renderedInterpolated.Add(str);
+        }
+        if (ambiguity) {
+          return msgArgs.Select(x =>
+            (object)(x is UserDefinedType udt ? udt.FullName : x.ToString())
+          ).ToArray();
+        }
+        return msgArgs;
+      }
 
       protected abstract string ApproximateErrorMessage();
     }
     public class ErrorMsgWithToken : ErrorMsg {
       readonly IToken tok;
-      public override IToken Tok {
-        get { return tok; }
-      }
-      public readonly string Msg;
+      public override IToken Tok => tok;
+      readonly string msg;
+      public virtual string Msg => msg;
       public readonly object[] MsgArgs;
       public ErrorMsgWithToken(IToken tok, string msg, params object[] msgArgs) {
         Contract.Requires(tok != null);
         Contract.Requires(msg != null);
         Contract.Requires(msgArgs != null);
         this.tok = tok;
-        this.Msg = msg;
+        this.msg = msg;
         this.MsgArgs = msgArgs;
       }
 

--- a/Test/git-issues/git-issue-1887.dfy.expect
+++ b/Test/git-issues/git-issue-1887.dfy.expect
@@ -1,3 +1,3 @@
-git-issue-1887.dfy(6,9): Error: selected element has type T which is incompatible with expected type char (seq<T> is incompatible with seq<char>)
+git-issue-1887.dfy(6,9): Error: sequence has type seq<T> which is incompatible with expected type seq<char> (element type T is incompatible with char)
 git-issue-1887.dfy(11,8): Error: multi-selection has type seq<T> which is incompatible with expected type seq<char>
 2 resolution/type errors detected in git-issue-1887.dfy

--- a/Test/git-issues/git-issue-2828.dfy
+++ b/Test/git-issues/git-issue-2828.dfy
@@ -1,0 +1,7 @@
+// RUN: %dafny_0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method M()
+{
+  assert arr[0];
+}

--- a/Test/git-issues/git-issue-2828.dfy.expect
+++ b/Test/git-issues/git-issue-2828.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-2828.dfy(6,9): Error: unresolved identifier: arr
+git-issue-2828.dfy(6,13): Error: incorrect type for selection into ? (got int)
+git-issue-2828.dfy(6,12): Error: sequence has type ? which is incompatible with expected type bool
+3 resolution/type errors detected in git-issue-2828.dfy


### PR DESCRIPTION
Fixes #2828 by including sequences' element types in an error message only if those types have been resolved.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
