### PR TITLE
Fix: Recursive constant initialization was not checked if in constructor

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -3,7 +3,7 @@
   <Target Name="RunCoco" BeforeTargets="PreBuildEvent" Outputs="$(ProjectDir)Parser.cs;$(ProjectDir)Scanner.cs" Inputs="$(ProjectDir)Dafny.atg">
     <Exec Command="dotnet tool restore" />
     <Exec Command="dotnet --info" />
-    <Exec Command="dotnet tool run coco $(ProjectDir)Dafny.atg -namespace Microsoft.Dafny -frames &quot;$(ProjectDir)Coco&quot;" />
+    <Exec Command="dotnet tool run coco &quot;$(ProjectDir)Dafny.atg&quot; -namespace Microsoft.Dafny -frames &quot;$(ProjectDir)Coco&quot;" />
     <!-- Recompute files to build according to https://stackoverflow.com/a/44829863/93197 -->
     <ItemGroup>
       <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />

--- a/Test/git-issues/git-issue-2727.dfy
+++ b/Test/git-issues/git-issue-2727.dfy
@@ -1,0 +1,34 @@
+// RUN: %dafny_0 -compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class C {
+  const a := b + b
+  const b: int
+
+  constructor (x: int) {
+    var k := a;
+    print a, "\n";
+    b := x;
+    assert k == a;
+    print a, "\n";
+    if k != a {
+      var y := 5 / 0; // this can crash
+    }
+  }
+}
+
+class D {
+  const a: int := b
+  const b: int
+
+  constructor () {
+    b := a + 1;
+    new;
+    assert false;
+  }
+}
+
+method Main() {
+  var c := new C(5);
+  var d := new D();
+}

--- a/Test/git-issues/git-issue-2727.dfy.expect
+++ b/Test/git-issues/git-issue-2727.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-2727.dfy(9,13): Error: Constant not initialized yet. Missing initialization of field through the dependency a -> b, which needs to be assigned at this point.
+git-issue-2727.dfy(25,11): Error: Constant not initialized yet. Missing initialization of field through the dependency a -> b, which needs to be assigned at this point.
+2 resolution/type errors detected in git-issue-2727.dfy


### PR DESCRIPTION
This PR fixes #2727 by adding an appropriate error message if constants are initialized in the wrong order.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
