### PR TITLE
fix: Exclude ghost variables from free-var substitution

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - fix: Compiled lambdas now close only on non-ghost variables (https://github.com/dafny-lang/dafny/pull/2854)
 - fix: Crash in the LSP in some code that does not parse (https://github.com/dafny-lang/dafny/pull/2833)
+- fix: Exclude ghost variables from compilation of lambda-expression closures (https://github.com/dafny-lang/dafny/pull/2873)
 
 # 3.9.0
 

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -5087,7 +5087,7 @@ namespace Microsoft.Dafny.Compilers {
     void CreateFreeVarSubstitution(Expression expr, out List<BoundVar> bvars, out List<Expression> fexprs, out Substituter su) {
       Contract.Requires(expr != null);
 
-      var fvs = FreeVariablesUtil.ComputeFreeVariables(expr);
+      var fvs = FreeVariablesUtil.ComputeFreeVariables(expr).Where(v => !v.IsGhost).ToList();
       var sm = new Dictionary<IVariable, Expression>();
 
       bvars = new List<BoundVar>();

--- a/Test/git-issues/git-issue-2872.dfy
+++ b/Test/git-issues/git-issue-2872.dfy
@@ -1,0 +1,23 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:py "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module {:options "/functionSyntax:4"} Function4Syntax {
+
+  method Main() {
+    print F(2, 5, 9)(), "\n"; // 11
+  }
+
+  function F(a: int, ghost b: int, c: int): () -> int
+  {
+    () => G(a, b, c)
+  }
+
+  function G(a: int, ghost b: int, c: int): int {
+    a + c
+  }
+}

--- a/Test/git-issues/git-issue-2872.dfy.expect
+++ b/Test/git-issues/git-issue-2872.dfy.expect
@@ -1,0 +1,17 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+11
+
+Dafny program verifier did not attempt verification
+11
+
+Dafny program verifier did not attempt verification
+11
+
+Dafny program verifier did not attempt verification
+11
+
+Dafny program verifier did not attempt verification
+11


### PR DESCRIPTION
This PR excludes ghost variables from the closures that are generated by compiler (for all targets).

Fixes #2872 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
