### PR TITLE
fix: string-seq equality in JS runtime

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 - fix: Compiled lambdas now close only on non-ghost variables (https://github.com/dafny-lang/dafny/pull/2854)
 - fix: Crash in the LSP in some code that does not parse (https://github.com/dafny-lang/dafny/pull/2833)
+- fix: Handle sequence-to-string equality correctly in the JavaScript runtime (https://github.com/dafny-lang/dafny/pull/2877)
 
 # 3.9.0
 

--- a/Source/DafnyRuntime/DafnyRuntime.js
+++ b/Source/DafnyRuntime/DafnyRuntime.js
@@ -6,7 +6,12 @@ BigNumber.config({ MODULO_MODE: BigNumber.EUCLID })
 let _dafny = (function() {
   let $module = {};
   $module.areEqual = function(a, b) {
-    if (typeof a !== 'object' || a === null || b === null) {
+    if (typeof a === 'string' && b instanceof _dafny.Seq) {
+      // Seq.equals(string) works as expected,
+      // and the catch-all else block handles that direction.
+      // But the opposite direction doesn't work; handle it here.
+      return b.equals(a);
+    } else if (typeof a !== 'object' || a === null || b === null) {
       return a === b;
     } else if (BigNumber.isBigNumber(a)) {
       return a.isEqualTo(b);

--- a/Test/git-issues/git-issue-2581.dfy
+++ b/Test/git-issues/git-issue-2581.dfy
@@ -1,0 +1,15 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /spillTargetCode:2 /compileTarget:py "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Main() {
+  expect IsEmpty("");
+}
+
+predicate method IsEmpty<T>(s: seq<T>) {
+  s == []
+}

--- a/Test/git-issues/git-issue-2581.dfy.expect
+++ b/Test/git-issues/git-issue-2581.dfy.expect
@@ -1,0 +1,12 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+
+Dafny program verifier did not attempt verification
+
+Dafny program verifier did not attempt verification
+
+Dafny program verifier did not attempt verification
+
+Dafny program verifier did not attempt verification


### PR DESCRIPTION
Fixes #2581.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
