### PR TITLE
Turn off Async suffix warning, and treat warnings as errors in CI build

### DIFF
--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         chmod +x Binaries/z3/bin/z3
     - name: Build
-      run: dotnet build --no-restore ${{env.solutionPath}}
+      run: dotnet build -warnaserror --no-restore ${{env.solutionPath}}
     - name: Run DafnyLanguageServer Tests
       run: |
         dotnet test --no-restore --verbosity normal --logger trx Source/DafnyLanguageServer.Test

--- a/Source/DafnyDriver/Commands/CommandRegistry.cs
+++ b/Source/DafnyDriver/Commands/CommandRegistry.cs
@@ -45,7 +45,7 @@ static class CommandRegistry {
   }
 
   [CanBeNull]
-  public static async Task<ParseArgumentResult> Create(string[] arguments) {
+  public static ParseArgumentResult Create(string[] arguments) {
 
     bool allowHidden = true;
     if (arguments.Length != 0) {
@@ -131,7 +131,9 @@ static class CommandRegistry {
 
     }
 
-    var exitCode = await rootCommand.InvokeAsync(arguments);
+#pragma warning disable VSTHRD002
+    var exitCode = rootCommand.InvokeAsync(arguments).Result;
+#pragma warning restore VSTHRD002
     if (optionFailure != null) {
       Console.WriteLine(optionFailure);
       return new ParseArgumentFailure(DafnyDriver.CommandLineArgumentsResult.PREPROCESSING_ERROR);

--- a/Source/DafnyDriver/Commands/CommandRegistry.cs
+++ b/Source/DafnyDriver/Commands/CommandRegistry.cs
@@ -5,6 +5,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Microsoft.Dafny;
@@ -44,7 +45,7 @@ static class CommandRegistry {
   }
 
   [CanBeNull]
-  public static ParseArgumentResult Create(string[] arguments) {
+  public static async Task<ParseArgumentResult> Create(string[] arguments) {
 
     bool allowHidden = true;
     if (arguments.Length != 0) {
@@ -130,7 +131,7 @@ static class CommandRegistry {
 
     }
 
-    var exitCode = rootCommand.InvokeAsync(arguments).Result;
+    var exitCode = await rootCommand.InvokeAsync(arguments);
     if (optionFailure != null) {
       Console.WriteLine(optionFailure);
       return new ParseArgumentFailure(DafnyDriver.CommandLineArgumentsResult.PREPROCESSING_ERROR);

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -165,7 +165,9 @@ namespace Microsoft.Dafny {
       otherFiles = new List<string>();
 
       try {
-        switch (CommandRegistry.Create(args)) {
+#pragma warning disable VSTHRD002
+        switch (CommandRegistry.Create(args).Result) {
+#pragma warning restore VSTHRD002
           case ParseArgumentSuccess success:
             options = success.DafnyOptions;
             break;

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -165,9 +165,7 @@ namespace Microsoft.Dafny {
       otherFiles = new List<string>();
 
       try {
-#pragma warning disable VSTHRD002
-        switch (CommandRegistry.Create(args).Result) {
-#pragma warning restore VSTHRD002
+        switch (CommandRegistry.Create(args)) {
           case ParseArgumentSuccess success:
             options = success.DafnyOptions;
             break;

--- a/Source/DafnyServer/DafnyHelper.cs
+++ b/Source/DafnyServer/DafnyHelper.cs
@@ -68,7 +68,9 @@ namespace Microsoft.Dafny {
 
         //NOTE: We could capture errors instead of printing them (pass a delegate instead of null)
         switch (engine.InferAndVerify(Console.Out, boogieProgram, new PipelineStatistics(),
+#pragma warning disable VSTHRD002
                   "ServerProgram_" + moduleName, null, DateTime.UtcNow.Ticks.ToString()).Result) {
+#pragma warning restore VSTHRD002
           case PipelineOutcome.Done:
           case PipelineOutcome.VerificationCompleted:
             return true;

--- a/Source/DafnyTestGeneration/BlockBasedModification.cs
+++ b/Source/DafnyTestGeneration/BlockBasedModification.cs
@@ -31,7 +31,7 @@ namespace DafnyTestGeneration {
       string? line;
       var stringReader = new StringReader(log);
       var newBlocksCovered = false;
-      while ((line = stringReader.ReadLine()) != null) {
+      while ((line = await stringReader.ReadLineAsync()) != null) {
         if (!line.StartsWith("Block |")) {
           continue;
         }

--- a/Source/DafnyTestGeneration/DafnyTestGeneration.csproj
+++ b/Source/DafnyTestGeneration/DafnyTestGeneration.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <AssemblyName>DafnyTestGeneration</AssemblyName>
-        <IsPackable>false</IsPackable>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <DefineConstants>TRACE</DefineConstants>
-        <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
-      <ProjectReference Include="..\DafnyPipeline\DafnyPipeline.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AssemblyName>DafnyTestGeneration</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <DefineConstants>TRACE</DefineConstants>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\DafnyServer\DafnyServer.csproj" />
+    <ProjectReference Include="..\DafnyPipeline\DafnyPipeline.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,6 +4,7 @@
     <!-- Target framework -->
     <TargetFramework>net6.0</TargetFramework>
     <VersionPrefix>3.9.0.41003<!--Version 3.9.0, year 2018+4, month 10, day 3.--></VersionPrefix>
+    <NoWarn>1701;1702;VSTHRD200</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Let's get rid of those annoying warnings that clutter CI and our build logs.

### Changes

- Turn off the warning '"Async" suffix required for Task methods' in all projects
- Add some one time warning disable pragma's at sync/async boundaries.

### Testing
- Turn on treat warnings as errors in CI

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
