### PR TITLE
Fix: crash in language server optimization

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -3,7 +3,7 @@
   <Target Name="RunCoco" BeforeTargets="PreBuildEvent" Outputs="$(ProjectDir)Parser.cs;$(ProjectDir)Scanner.cs" Inputs="$(ProjectDir)Dafny.atg">
     <Exec Command="dotnet tool restore" />
     <Exec Command="dotnet --info" />
-    <Exec Command="dotnet tool run coco $(ProjectDir)Dafny.atg -namespace Microsoft.Dafny -frames &quot;$(ProjectDir)Coco&quot;" />
+    <Exec Command="dotnet tool run coco &quot;$(ProjectDir)Dafny.atg&quot; -namespace Microsoft.Dafny -frames &quot;$(ProjectDir)Coco&quot;" />
     <!-- Recompute files to build according to https://stackoverflow.com/a/44829863/93197 -->
     <ItemGroup>
       <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
@@ -90,22 +90,21 @@ method {:vcs_split_on_every_assert} f(x: int) {
 ", "testfile.dfy");
       await AssertHoverMatches(documentItem, (1, 12),
         @"[**Error:**](???) assertion might not hold  
-This is the only assertion in [batch](???) #2 of 3 in method f  
-[Batch](???) #2 resource usage: ??? RU"
+This is the only assertion in [batch](???) #??? of ??? in method f  
+[Batch](???) #??? resource usage: ??? RU"
       );
       await AssertHoverMatches(documentItem, (2, 12),
         @"<span style='color:green'>**Success:**</span> assertion always holds  
-This is the only assertion in [batch](???) #3 of 3 in method f  
-[Batch](???) #3 resource usage: ??? RU"
+This is the only assertion in [batch](???) #??? of ??? in method f  
+[Batch](???) #??? resource usage: ??? RU"
       );
       await AssertHoverMatches(documentItem, (0, 36),
         @"**Verification performance metrics for method f**:
 
 - Total resource usage: ??? RU  
 - Most costly [assertion batches](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-verification-attributes-on-assert-statements):  
-  - #3/3 with 1 assertion  at line 3, ??? RU  
-  - #2/3 with 1 assertion  at line 2, ??? RU  
-  - #1/3 with 0 assertions at line 1, ??? RU"
+  - #???/??? with 1 assertion  at line ???, ??? RU  
+  - #???/??? with 1 assertion  at line ???, ??? RU  "
       );
     }
 

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -52,6 +52,27 @@ method Multiply(x: int, y: int) returns (product: int)
       await AssertNoDiagnosticsAreComing(CancellationToken);
     }
 
+
+    [TestMethod]
+    public async Task NoCrashWhenPressingEnterAfterSelectingAllTextAndInputtingText() {
+      var source = @"
+predicate method {:opaque} m() {
+  true
+}
+".TrimStart();
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);
+      Assert.AreEqual(0, diagnostics.Length);
+      ApplyChange(ref documentItem, ((0, 0), (3, 0)), "\n");
+      diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);
+      Assert.AreEqual(1, diagnostics.Length);
+      ApplyChange(ref documentItem, ((1, 0), (1, 0)), "const x := 1");
+      diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);
+      Assert.AreEqual(0, diagnostics.Length);
+      await AssertNoDiagnosticsAreComing(CancellationToken);
+    }
+
     [TestMethod]
     public async Task OpeningOpaqueFunctionWorks() {
       var source = @"

--- a/Source/DafnyLanguageServer/Workspace/TextBuffer.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextBuffer.cs
@@ -87,7 +87,7 @@ public class TextBuffer {
         line.LineNumber + lineDelta,
         line.StartIndex + indexDelta,
         line.EndIndex + indexDelta));
-    var newTotalLinesWrong = Lines.Take(changeStartLine.LineNumber).Concat(freshLines).Concat(migratedLinesAfterChange).ToList();*/
+    var newTotalLines = Lines.Take(changeStartLine.LineNumber).Concat(freshLines).Concat(migratedLinesAfterChange).ToList();*/
     var newTotalLines = ComputeLines(newText, 0, 0, newText.Length);
     return new TextBuffer(newText, newTotalLines);
   }

--- a/Source/DafnyLanguageServer/Workspace/TextBuffer.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextBuffer.cs
@@ -73,7 +73,9 @@ public class TextBuffer {
     int startIndex = ToIndex(change.Range.Start);
     int endIndex = ToIndex(change.Range.End);
     var newText = Text[..startIndex] + change.Text + Text[endIndex..];
-    var changeStartLine = IndexToLine(startIndex);
+    // TODO: To reinstate this optimization, we need to prove its equivalence.
+    // Otherwise, bugs have been found (e.g. https://github.com/dafny-lang/dafny/issues/2890)
+    /*var changeStartLine = IndexToLine(startIndex);
     var changeEndLine = IndexToLine(endIndex);
 
     var indexDelta = newText.Length - Text.Length;
@@ -85,7 +87,8 @@ public class TextBuffer {
         line.LineNumber + lineDelta,
         line.StartIndex + indexDelta,
         line.EndIndex + indexDelta));
-    var newTotalLines = Lines.Take(changeStartLine.LineNumber).Concat(freshLines).Concat(migratedLinesAfterChange).ToList();
+    var newTotalLinesWrong = Lines.Take(changeStartLine.LineNumber).Concat(freshLines).Concat(migratedLinesAfterChange).ToList();*/
+    var newTotalLines = ComputeLines(newText, 0, 0, newText.Length);
     return new TextBuffer(newText, newTotalLines);
   }
 

--- a/docs/dev/news/2890.fix
+++ b/docs/dev/news/2890.fix
@@ -1,0 +1,1 @@
+Removed an bogus optimization on the Language Server


### PR DESCRIPTION
This PR removes an optimization to compute the lines based on previous lines, because this transformation has bugs.
Will add tests later
Fixes #2890 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
