### PR TITLE
Fix: Variable declarations in match cases, formals do not trigger errors anymore

### DIFF
--- a/Source/DafnyCore/Cloner.cs
+++ b/Source/DafnyCore/Cloner.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    public Formal CloneFormal(Formal formal) {
+    public virtual Formal CloneFormal(Formal formal) {
       Formal f = new Formal(Tok(formal.tok), formal.Name, CloneType(formal.Type), formal.InParam, formal.IsGhost,
         CloneExpr(formal.DefaultValue), formal.IsOld, formal.IsNameOnly, formal.IsOlder, formal.NameForCompilation);
       return f;

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
@@ -85,6 +85,53 @@ method CallDoIt() returns () {
 }");
     }
 
+
+    [TestMethod]
+    public async Task HoveringBoundVariablesFormalsLocalVariablesInMatchExprOrStatement() {
+      await AssertHover(@"
+datatype DT = A | B | C
+
+method M(dt: DT) {
+  match dt {
+    case C => 
+    case A | B => var x := (y => y)(1); assert x == 1;
+                      ^[```dafny\nx: int\n```]
+                            ^[```dafny\ny: int\n```]
+                                 ^[```dafny\ny: int\n```]
+  }
+}
+
+method M2(dt: DT) {
+  match dt {
+    case C => 
+    case _ => var x := (y => y)(1); assert x == 1;
+                  ^[```dafny\nx: int\n```]
+                        ^[```dafny\ny: int\n```]
+                             ^[```dafny\ny: int\n```]
+  }
+}
+
+function method F(dt: DT): int {
+  match dt {
+    case C => 0
+    case A | B => var x := (y => y)(1); assert x == 1; 0
+                      ^[```dafny\nx: int\n```]
+                            ^[```dafny\ny: int\n```]
+                                 ^[```dafny\ny: int\n```]
+  }
+}
+function method F2(dt: DT): int {
+  match dt {
+    case C => 0
+    case _ => var x := (y => y)(1); assert x == 1; 0
+                  ^[```dafny\nx: int\n```]
+                        ^[```dafny\ny: int\n```]
+                             ^[```dafny\ny: int\n```]
+  }
+}
+");
+    }
+
     [TestMethod]
     public async Task HoverReturnsBeforeVerificationIsComplete() {
       var documentItem = CreateTestDocument(NeverVerifies);


### PR DESCRIPTION
This PR ensures that, in the case of branch duplication in resolution, exactly one branch reuses the same variables as the original branch (local variable declarations, formals, and bound variables in patterns).

That way, we fix #2905 and moreover fix the previous issue that hovering other variables in match cases was not displaying type information

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
