### PR TITLE
Reduce verbosity of test logs

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -114,7 +114,7 @@ jobs:
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
         DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafny
       run: |
-        dotnet test -v:n --logger trx dafny/Source/IntegrationTests/IntegrationTests.csproj
+        dotnet test --logger trx dafny/Source/IntegrationTests/IntegrationTests.csproj
     - name: Run integration tests
       if: runner.os != 'Windows'
       env:
@@ -122,7 +122,7 @@ jobs:
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
         DAFNY_RELEASE: ${{ github.workspace }}/unzippedRelease/dafny
       run: |
-        dotnet test -v:n --logger trx dafny/Source/IntegrationTests/IntegrationTests.csproj
+        dotnet test --logger trx dafny/Source/IntegrationTests/IntegrationTests.csproj
     - uses: actions/upload-artifact@v2
       if: always()
       with:

--- a/Test/README.md
+++ b/Test/README.md
@@ -10,16 +10,16 @@ The xUnit LIT test interpreter is run through xUnit `Theory` parameterized tests
 hooks into the general-purpose `dotnet test` command:
 
 ```
-dotnet test -v:n Source/IntegrationTests
+dotnet test --logger "console;verbosity=normal" Source/IntegrationTests
 ```
 
-`-v:n` is optional, and increases the default logging verbosity so that you can see individual tests as the pass.
+`-logger "console;verbosity=normal"` is optional, and increases the default logging verbosity so that you can see individual tests as the pass.
 
 The file path of each test file, relative to the `Test` directory, is used as the display name of its corresponding test.
 This means you can use the `--filter` option to run a subset of tests, or even a single file:
 
 ```
-dotnet test -v:n Source/IntegrationTests --filter DisplayName~comp/Hello.dfy
+dotnet test --logger "console;verbosity=normal" Source/IntegrationTests --filter DisplayName~comp/Hello.dfy
 ```
 
 [See here](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test) for more information about


### PR DESCRIPTION
Our CI logs are often over 5000 lines long; do we actually need all that output?  Most of it is `Copying … to …`