### PR TITLE
Post 3.9.1 cleanup

### DIFF
--- a/.github/workflows/release-downloads-nuget.yml
+++ b/.github/workflows/release-downloads-nuget.yml
@@ -160,4 +160,4 @@ jobs:
     ## Ideally we would have a test project that actually uses part of the public API of each package.
     - name: Check library dependencies
       run: |
-        nuget install ${{ matrix.library-name }}
+        nuget install -Prerelease ${{ matrix.library-name }}

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -83,6 +83,7 @@ jobs:
     ## Check that a simple program compiles and runs on each supported platform
     - name: run quicktests
       run: |
+        npm install bignumber.js
         dafny/quicktest.sh > log.txt
         diff log.txt dafny/quicktest.out
     - name: Check C# compile
@@ -106,7 +107,6 @@ jobs:
         diff expect.txt actual.txt
     - name: Check Javascript compile
       run: |
-        npm install bignumber.js
         dafny/dafny /compile:3 /spillTargetCode:3 /compileTarget:js a.dfy
         node a.js dafny/DafnyRuntime.js > actual.txt
         diff expect.txt actual.txt

--- a/Scripts/prepare_release.py
+++ b/Scripts/prepare_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import json
 import re

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -2,14 +2,17 @@
 
 ## Making a new Github release
 
-0. Ensure that you are in a clean and up-to-date repository, with the `master`
-   branch checked out and up-to-date and no uncommitted changes.
+0. Ensure that you are in a repository that:
+   * is clean and up-to-date with no uncommitted changes,
+   * was cloned with SSH so that you can push to it, and
+   * has the `master` branch checked out.
 
-1. Select a version number `$VER` (e.g., "3.0.0" or "3.0.0-alpha"), then run
-   `Scripts/release.py $VER prepare` from the root of the repository.  The
-   script will check that the repository is in a good state, create and check
-   out a new release branch, update `Source/version.cs` and `RELEASE_NOTES.md`,
-   prepare a release commit, and push it.
+1. Select a version number `$VER` (e.g., "3.0.0" or "3.0.0-alpha"), then
+   run `Scripts/prepare_release.py $VER prepare` from the root of the
+   repository. The script will check that the repository is in a good
+   state, create and check out a new release branch, update
+   `Source/version.cs` and `RELEASE_NOTES.md`, prepare a release commit,
+   and push it.
 
 2. Kick off the deep test suite by navigating to
    <https://github.com/dafny-lang/dafny/actions/workflows/deep-tests.yml>,
@@ -18,13 +21,13 @@
    check for a run of this workflow on the exact commit to release.  (TODO:
    Run this automatically as part of the prepare-release script.)
 
-3. Once the the tests complete, run `Scripts/release.py $VER release` from the
-   root of the repository.  The script will tag the current commit and push
-   it. (TODO: Merge with the two steps above.)  A GitHub action will
-   automatically run in reaction to the tag being pushed, which will build the
-   artifacts and reference manual and then create a draft GitHub release. You
-   can find and watch the progress of this workflow at
-   <https://github.com/dafny-lang/dafny/actions>.
+3. Once the the tests complete, run `Scripts/prepare_release.py $VER
+   release` from the root of the repository. The script will tag the
+   current commit and push it. (TODO: Merge with the two steps above.) A
+   GitHub action will automatically run in reaction to the tag being
+   pushed, which will build the artifacts and reference manual and then
+   create a draft GitHub release. You can find and watch the progress of
+   this workflow at <https://github.com/dafny-lang/dafny/actions>.
 
 4. Once the action completes, you should find the draft release at
    <https://github.com/dafny-lang/dafny/releases>. Edit the release body to add in
@@ -107,23 +110,3 @@ with git commands and concepts is helpful.
    and then execute `dafny /version` see if it has the correct version
    number. Even better is to try this step on a different machine than
    the one on which the `dafny.rb` file was edited
-
-## Updating and releasing a new version of VSCode plugin
-
-1. Build ide-vscode locally from https://github.com/dafny-lang/ide-vscode .
-
-2. Prepare the repository:
-
-       git checkout master
-       git pull origin
-       git checkout -b <some new branch name>
-
-3. Add the new Dafny version number to the `dafny.preferredVersion` list in the `package.json` file.
-
-4. Update the value of the constant `LatestVersion` in the file `src/constants.ts` to the new version number.
-
-5. Before releasing a new version of the VSCode plugin, make sure to add to the release notes in `CHANGELOG.md`
-
-6. Follow the release process detailed in the plugin's repository:
-
-   <https://github.com/dafny-lang/ide-vscode/blob/master/CONTRIBUTING.md>


### PR DESCRIPTION
Clean up a few issues identified in the 3.9.1 release.

* Update release process documentation
    * Correct name of release script
    * Remove VS Code section since it’s now handled by one bullet in the main section.
* Use `python3` instead of `python`
* Install `bignumber.js` earlier in quick tests
* Allow prerelease dependencies when testing NuGet

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
