### PR TITLE
Add warn-shadowing and warnings-as-errors options

### DIFF
--- a/Source/DafnyCore/Options/WarnShadowingOption.cs
+++ b/Source/DafnyCore/Options/WarnShadowingOption.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.Dafny;
+
+public class WarnShadowingOption : BooleanOption {
+  public static readonly WarnShadowingOption Instance = new();
+  public override string LongName => "warn-shadowing";
+
+  public override string Description => @"
+Emit a warning if the name of a declared variable caused another variable to be shadowed.".TrimStart();
+
+  public override string PostProcess(DafnyOptions options) {
+    options.WarnShadowing = Get(options);
+    return null;
+  }
+}

--- a/Source/DafnyCore/Options/WarningsAsErrorsOption.cs
+++ b/Source/DafnyCore/Options/WarningsAsErrorsOption.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.Dafny;
+
+public class WarningsAsErrorsOption : BooleanOption {
+  public static readonly WarningsAsErrorsOption Instance = new();
+
+  public override string LongName => "warnings-as-errors";
+
+  public override string Description => "Treat warnings as errors.";
+
+  public override string PostProcess(DafnyOptions options) {
+    options.WarningsAsErrors = Get(options);
+    return null;
+  }
+}

--- a/Source/DafnyDriver/Commands/CommandRegistry.cs
+++ b/Source/DafnyDriver/Commands/CommandRegistry.cs
@@ -27,13 +27,18 @@ static class CommandRegistry {
     PluginOption.Instance,
     BoogieOption.Instance,
     PreludeOption.Instance,
+
+    // Related to warnings
+    StrictDefiniteAssignmentOption.Instance,
+    EnforceDeterminismOption.Instance,
+    WarnShadowingOption.Instance,
+    WarningsAsErrorsOption.Instance,
+
+    // Hidden
     UseBaseFileNameOption.Instance,
     PrintOption.Instance,
     ResolvedPrintOption.Instance,
     BoogiePrintOption.Instance,
-    InputsOption.Instance,
-    StrictDefiniteAssignmentOption.Instance,
-    EnforceDeterminismOption.Instance,
   });
 
   static void AddCommand(ICommandSpec command) {

--- a/Source/DafnyDriver/Commands/RunCommand.cs
+++ b/Source/DafnyDriver/Commands/RunCommand.cs
@@ -12,6 +12,7 @@ class RunCommand : ICommandSpec {
     new IOptionSpec[] {
       TargetOption.Instance,
       NoVerifyOption.Instance,
+      InputsOption.Instance,
     }.Concat(CommandRegistry.CommonOptions);
 
   public RunCommand() {

--- a/Test/dafny0/warnings-as-errors.dfy
+++ b/Test/dafny0/warnings-as-errors.dfy
@@ -1,4 +1,4 @@
-// RUN: %dafny_0 /compile:0 /print:"%t.print" /dprint:"%t.dprint" /warnShadowing /warningsAsErrors "%s" > "%t"
+// RUN: %baredafny verify %args --warn-shadowing --warnings-as-errors %s > "%t" || true
 // RUN: %diff "%s.expect" "%t"
 method f(x: int) {
   var x := 0;

--- a/Test/git-issues/git-issue-289.dfy
+++ b/Test/git-issues/git-issue-289.dfy
@@ -1,6 +1,6 @@
-// RUN: %baredafny build %args "%s"                                                        > "%t"
-// RUN: %baredafny build %args "%s" --compile-verbose=true --input %S/"git-issue-289b.dfy" >> "%t"
-// RUN: %baredafny build %args                                     %S/"git-issue-289b.dfy" >> "%t"
+// RUN: %baredafny build %args "%s"                                                > "%t"
+// RUN: %baredafny build %args "%s" --compile-verbose=true %S/"git-issue-289b.dfy" >> "%t"
+// RUN: %baredafny build %args                             %S/"git-issue-289b.dfy" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 include "git-issue-289b.dfy"


### PR DESCRIPTION
### Changes

Add warn-shadowing and warnings-as-errors options to the new CLI

### Testing

Updated an existing test to use the new options

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
