### PR TITLE
Fix: Tail recursion not activated if cannot

### DIFF
--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -2650,10 +2650,11 @@ namespace Microsoft.Dafny.Compilers {
         // finally, the jump back to the head of the function
         EmitJumpToTailCallStart(wr);
 
-      } else if (expr is BinaryExpr bin && bin.AccumulatesForTailRecursion != BinaryExpr.AccumulationOperand.None) {
-        Contract.Assert(accumulatorVar != null);
-        Contract.Assert(enclosingFunction != null);
-        Contract.Assert(enclosingFunction.IsAccumulatorTailRecursive);
+      } else if (expr is BinaryExpr bin
+                 && bin.AccumulatesForTailRecursion != BinaryExpr.AccumulationOperand.None
+                 && accumulatorVar != null
+                 && enclosingFunction != null
+                 && enclosingFunction.IsAccumulatorTailRecursive) {
         Expression tailTerm;
         Expression rhs;
         var acc = new IdentifierExpr(expr.tok, accumulatorVar);

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -2652,9 +2652,8 @@ namespace Microsoft.Dafny.Compilers {
 
       } else if (expr is BinaryExpr bin
                  && bin.AccumulatesForTailRecursion != BinaryExpr.AccumulationOperand.None
-                 && accumulatorVar != null
-                 && enclosingFunction != null
-                 && enclosingFunction.IsAccumulatorTailRecursive) {
+                 && enclosingFunction is { IsAccumulatorTailRecursive: true }) {
+        Contract.Assert(accumulatorVar != null);
         Expression tailTerm;
         Expression rhs;
         var acc = new IdentifierExpr(expr.tok, accumulatorVar);

--- a/Test/git-issues/git-issue-2726.dfy
+++ b/Test/git-issues/git-issue-2726.dfy
@@ -1,0 +1,15 @@
+// RUN: %dafny_0 /compile:1 /compileTarget:cs "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Formula =
+  | And(left: Formula, right: Formula)
+  | Not(underlying: Formula)
+  | True
+{
+  function method size(): nat {
+    match this
+    case And(l, r) => l.size() + r.size()
+    case Not(u) => u.size() + 1
+    case True => 1
+  }
+}

--- a/Test/git-issues/git-issue-2726.dfy.expect
+++ b/Test/git-issues/git-issue-2726.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue-2726a.dfy
+++ b/Test/git-issues/git-issue-2726a.dfy
@@ -1,0 +1,20 @@
+// RUN: %dafny_0 /compile:3 /compileTarget:cs "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+const digits := ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+function method IntToString(i: int): string   
+  decreases i < 0, if i<0 then -i else i
+{
+  if i < 0 then ("-" + IntToString(-i))
+  else if i < 10 then digits[i]  
+  else if i < 100 then (digits[i/10] + digits[i%10])
+  //else ("DDD" + digits[i%10])
+  else (IntToString(i/10) + digits[i%10])  // CRASHES
+}
+
+method Main() {
+  print IntToString(4), "\n";
+  print IntToString(42), "\n";
+  print IntToString(422), "\n";
+}

--- a/Test/git-issues/git-issue-2726a.dfy.expect
+++ b/Test/git-issues/git-issue-2726a.dfy.expect
@@ -1,0 +1,5 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+4
+42
+422

--- a/docs/dev/news/2726.fix
+++ b/docs/dev/news/2726.fix
@@ -1,1 +1,1 @@
-Tail recursion optimization not wrongly applied in the case of mixed tail-recursive code and non-tail-recursive code.
+Dafny now compiles functions that mix tail- and non-tail-recursive calls without crashing

--- a/docs/dev/news/2726.fix
+++ b/docs/dev/news/2726.fix
@@ -1,0 +1,1 @@
+Tail recursion not activated if cannot

--- a/docs/dev/news/2726.fix
+++ b/docs/dev/news/2726.fix
@@ -1,1 +1,1 @@
-Tail recursion not activated if cannot
+Tail recursion optimization not wrongly applied in the case of mixed tail-recursive code and non-tail-recursive code.


### PR DESCRIPTION
This PR fixes #2726 and fixes #2706
I converted contracts to if-conditions, since the next case is the default non-recursive case.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>