### PR TITLE
Fix: Verification of abstract modules not duplicated when imported

### DIFF
--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -166,6 +166,10 @@ namespace Microsoft.Dafny {
 
       if (d.IsVisibleInScope(verificationScope)) {
         Contract.Assert(d.IsRevealedInScope(verificationScope));
+        if (d is MemberDecl m && m.EnclosingClass.EnclosingModuleDefinition is { IsFacade: true }) {
+          return false;
+        }
+
         return true;
       }
       return false;

--- a/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
@@ -33,4 +33,4 @@ OpaqueFunctions.dfy(367,17): Error: assertion might not hold
 OpaqueFunctions.dfy(214,15): Error: assertion might not hold
 OpaqueFunctions.dfy(229,19): Error: assertion might not hold
 
-Dafny program verifier finished with 27 verified, 31 errors
+Dafny program verifier finished with 20 verified, 31 errors

--- a/Test/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/dafny0/OpaqueFunctions.dfy.expect
@@ -33,4 +33,4 @@ OpaqueFunctions.dfy(367,17): Error: assertion might not hold
 OpaqueFunctions.dfy(214,15): Error: assertion might not hold
 OpaqueFunctions.dfy(229,19): Error: assertion might not hold
 
-Dafny program verifier finished with 27 verified, 31 errors
+Dafny program verifier finished with 20 verified, 31 errors

--- a/Test/dafny2/StoreAndRetrieve.dfy.expect
+++ b/Test/dafny2/StoreAndRetrieve.dfy.expect
@@ -4,7 +4,7 @@ StoreAndRetrieve.dfy(71,13): Warning: the ... refinement feature in statements i
 StoreAndRetrieve.dfy(86,9): Warning: the ... refinement feature in statements is deprecated
 StoreAndRetrieve.dfy(97,9): Warning: the ... refinement feature in statements is deprecated
 
-Dafny program verifier finished with 23 verified, 0 errors
+Dafny program verifier finished with 19 verified, 0 errors
 StoreAndRetrieve.dfy(65,13): Warning: the ... refinement feature in statements is deprecated
 StoreAndRetrieve.dfy(70,9): Warning: the ... refinement feature in statements is deprecated
 StoreAndRetrieve.dfy(71,13): Warning: the ... refinement feature in statements is deprecated

--- a/Test/dafny3/CachedContainer.dfy.expect
+++ b/Test/dafny3/CachedContainer.dfy.expect
@@ -12,7 +12,7 @@ CachedContainer.dfy(172,9): Warning: the ... refinement feature in statements is
 CachedContainer.dfy(183,9): Warning: the ... refinement feature in statements is deprecated
 CachedContainer.dfy(184,13): Warning: the ... refinement feature in statements is deprecated
 
-Dafny program verifier finished with 34 verified, 0 errors
+Dafny program verifier finished with 29 verified, 0 errors
 CachedContainer.dfy(117,13): Warning: the ... refinement feature in statements is deprecated
 CachedContainer.dfy(124,9): Warning: the ... refinement feature in statements is deprecated
 CachedContainer.dfy(127,13): Warning: the ... refinement feature in statements is deprecated

--- a/Test/dafny4/git-issue98.dfy.expect
+++ b/Test/dafny4/git-issue98.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/git-issues/git-issue-2703.dfy
+++ b/Test/git-issues/git-issue-2703.dfy
@@ -3,7 +3,6 @@
 
 abstract module StillAsby {
   import A : Absy
-
 }
 
 abstract module Absy {
@@ -11,4 +10,19 @@ abstract module Absy {
     ensures 2 / 0 == 1 {
     var x := 1;
   }
+}
+
+abstract module Absy2 {
+  function f(): int { 0 / 0 }
+}
+
+abstract module StillAsby2 refines Absy2 {
+}
+
+abstract module Absy3 {
+  function f(): int { 0 / 0 }
+}
+
+abstract module StillAsby3 {
+  import A: Absy3
 }

--- a/Test/git-issues/git-issue-2703.dfy
+++ b/Test/git-issues/git-issue-2703.dfy
@@ -1,0 +1,14 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+abstract module StillAsby {
+  import A : Absy
+
+}
+
+abstract module Absy {
+  method Foo() 
+    ensures 2 / 0 == 1 {
+    var x := 1;
+  }
+}

--- a/Test/git-issues/git-issue-2703.dfy.expect
+++ b/Test/git-issues/git-issue-2703.dfy.expect
@@ -1,0 +1,7 @@
+git-issue-2703.dfy(10,14): Error: possible division by zero
+git-issue-2703.dfy(10,23): Error: A postcondition might not hold on this return path.
+git-issue-2703.dfy(10,18): Related location: This is the postcondition that might not hold.
+git-issue-2703.dfy(16,24): Error: possible division by zero
+git-issue-2703.dfy(23,24): Error: possible division by zero
+
+Dafny program verifier finished with 0 verified, 4 errors

--- a/docs/dev/news/2703.fix
+++ b/docs/dev/news/2703.fix
@@ -1,0 +1,1 @@
+Verification of abstract modules not duplicated when imported


### PR DESCRIPTION
This PR fixes #2703
The story is the following. When abstract importing a module using
`import A: B`
it effectively duplicates the module `B` and creates an inside module named `B.Abs` as a child module.
This module is marked `IsFacade = true`.
The code effectively duplicated all its methods and functions, and they were not filtered out during verification.

In the translator, this PR ensures in the boolean guard `InVerificationScope` that members obtains from facade aren't verified twice.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>