### PR TITLE
Fix: Labels are no longer compiled in the case of variable declarations

### DIFF
--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -4331,7 +4331,9 @@ namespace Microsoft.Dafny.Compilers {
         //   <prelude>   // filled via copyInstrWriters -- copies out-parameters used in letexpr to local variables
         //   ss          // translation of ss has side effect of filling the top copyInstrWriters
         var w = writer;
-        if (ss.Labels != null) {
+        if (ss.Labels != null && !(ss is VarDeclPattern or VarDeclStmt)) {
+          // We are not breaking out of VarDeclPattern or VarDeclStmt, so the labels there are useless
+          // They were useful for verification
           w = CreateLabeledCode(ss.Labels.Data.AssignUniqueId(idGenerator), false, w);
         }
         var prelude = w.Fork();

--- a/Test/git-issues/git-issue-2608.dfy
+++ b/Test/git-issues/git-issue-2608.dfy
@@ -1,0 +1,30 @@
+// RUN: %dafny_0 /compile:3 /compileTarget:js "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method GetNext(i: int) returns (j: int, possible: bool) {
+  if i == 1 {
+    possible := false;
+    j := 0;
+  } else {
+    possible := true;
+    j := if i % 2 == 0 then  i / 2 else i * 3 + 1;
+  }
+}
+
+method Main()
+{
+  var i := 100;
+  var k := 27;
+  while i > 0
+    invariant i >= 0
+  {
+    label before:
+    var newK, possible := GetNext(k);
+    if(!possible) {
+      break;
+    }
+    k := newK;
+    print k;
+    i := i - 1;
+  }
+}

--- a/Test/git-issues/git-issue-2608.dfy
+++ b/Test/git-issues/git-issue-2608.dfy
@@ -13,7 +13,7 @@ method GetNext(i: int) returns (j: int, possible: bool) {
 
 method Main()
 {
-  var i := 100;
+  var i := 10;
   var k := 27;
   while i > 0
     invariant i >= 0

--- a/Test/git-issues/git-issue-2608.dfy.expect
+++ b/Test/git-issues/git-issue-2608.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 2 verified, 0 errors
+82411246231944714271214

--- a/docs/dev/news/2608.fix
+++ b/docs/dev/news/2608.fix
@@ -1,0 +1,1 @@
+Labels should not be compiled in the case of variable declarations

--- a/docs/dev/news/2608.fix
+++ b/docs/dev/news/2608.fix
@@ -1,1 +1,1 @@
-Labels should not be compiled in the case of variable declarations
+Labels are no longer compiled in the case of variable declarations


### PR DESCRIPTION
This PR fixes #2608 and fixes #2576
I added the corresponding test.

Here is the story. Whenever there is a label `L1` to a statement `S`, the JavaScript compiler wraps the statement with curly braces `{}` and put the label in front of it, like this:
```
L1 {
  [[S]] // Translate S to JavaScript
}
```
The problem was that, if there are labelled variable declarations, they are compiled to `let` and not available after `}`.
Looking carefully at it, we don't have goto in Dafny so labels are used only to break out of loops. But these are no loops, only variable declarations. Hence, I claim it make sense to just remove the labels when compiling variable declarations.
The test now passes.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>