### PR TITLE
Counterexamples involving seqs should present elements ordered by index

### DIFF
--- a/Source/DafnyLanguageServer/CounterExampleGeneration/DafnyModelState.cs
+++ b/Source/DafnyLanguageServer/CounterExampleGeneration/DafnyModelState.cs
@@ -55,8 +55,8 @@ namespace DafnyServer.CounterexampleGeneration {
     /// depth.
     /// </summary>
     /// <param name="maxDepth">The maximum depth up to which to expand the
-    /// variable set. Can be null to indicate that there is no limit</param>
-    /// <returns>List of variables</returns>
+    /// variable set.</param>
+    /// <returns>Set of variables</returns>
     public HashSet<DafnyModelVariable> ExpandedVariableSet(int maxDepth) {
       HashSet<DafnyModelVariable> expandedSet = new();
       // The following is the queue for elements to be added to the set. The 2nd

--- a/docs/dev/news/2975.feat
+++ b/docs/dev/news/2975.feat
@@ -1,0 +1,1 @@
+Counterexamples involving sequences present elements in ascending order by index.


### PR DESCRIPTION
I'm working on debugging a particular counterexample involving a sequence (at least in theory - hence the debugging!) of contiguous intervals, like `[(0, 4), (5, 9), (10, 20)]`.  In this case, figuring out where I'm going wrong really means needing to look at sequence elements in the order that they appear.  This is the counterexample I'm given (extracted to the clipboard with [this IDE patch](https://github.com/dafny-lang/ide-vscode/pull/290)):

```
At "{" (file:///Users/ntaylor/school/smrt/src/Disks/ZonedDisk.dfy:131):
...
    @1:seq<_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64>> = (Length := 6286, [0] := @3, [6285] := @4, [6283] := @5, [6284] := @6)
    @3:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 0, _1 := 2448)
    @4:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 281, _1 := 6135)
    @5:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 2480, _1 := 2481)
    @6:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 6133, _1 := 6134)
```

The particulars of the counterexample aren't of interest, save the indices that Boogie/Z3 generates for me in the sequence itself.  Only after awhile did I notice that the sequence in the counterexample is actually out of order: `@1`'s indices are `0, 6285, 6283, 6284` (Either it's a coincidence or Boogie is giving us the initial and final elements first?).  I would have expected those indices to be in ascending order (i.e. `0, 6283, 6284, 6285`) and would expect the intermediate subexpressions to be ordered similarly.

This patch modifies how the Dafny model expands element variables so that index-by-index sequence generation is sorted:

```
At "{" (file:///Users/ntaylor/school/smrt/src/Disks/ZonedDisk.dfy:131):
...
    @1:seq<_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64>> = (Length := 6286, [0] := @3, [6283] := @4, [6284] := @5, [6285] := @6)
    @3:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 0, _1 := 2448)
    @4:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 2480, _1 := 2481)
    @5:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 6133, _1 := 6134)
    @6:_System.Tuple2<NativeTypes.uint64, NativeTypes.uint64> = _#Make2(_0 := 281, _1 := 6135)
```

I'm not exactly sure of the current behaviour in the "build operator" case, and so I left that code branch unmodified.

(While I was in there, I found an incorrect docstring in an unrelated function related to passing null as an argument, and correspondingly fixed that.)

Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
