### PR TITLE
Fix: No more crash when unresolved LHS of :|

### DIFF
--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -13287,7 +13287,11 @@ namespace Microsoft.Dafny {
 
       var lhsSimpleVariables = new HashSet<IVariable>();
       foreach (var lhs in s.Lhss) {
-        CheckIsLvalue(lhs.Resolved, resolutionContext);
+        if (lhs.Resolved != null) {
+          CheckIsLvalue(lhs.Resolved, resolutionContext);
+        } else {
+          Contract.Assert(reporter.ErrorCount > 0);
+        }
         if (lhs.Resolved is IdentifierExpr ide) {
           if (lhsSimpleVariables.Contains(ide.Var)) {
             // syntactically forbid duplicate simple-variables on the LHS

--- a/Test/git-issues/git-issue-2496.dfy
+++ b/Test/git-issues/git-issue-2496.dfy
@@ -1,0 +1,6 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method M() {
+  b1 :| true;
+}

--- a/Test/git-issues/git-issue-2496.dfy.expect
+++ b/Test/git-issues/git-issue-2496.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-2496.dfy(5,2): Error: unresolved identifier: b1
+git-issue-2496.dfy(5,2): Error: an assign-such-that statement (without an 'assume' clause) currently only supports local-variable LHSs
+2 resolution/type errors detected in git-issue-2496.dfy

--- a/docs/dev/news/2496.fix
+++ b/docs/dev/news/2496.fix
@@ -1,0 +1,1 @@
+No more crash when unresolved LHS of :|

--- a/docs/dev/news/2496.fix
+++ b/docs/dev/news/2496.fix
@@ -1,1 +1,1 @@
-No more crash when unresolved LHS of :|
+Resolution errors in the left-hand sign of an assign-such-that statement do not crash Dafny anymore


### PR DESCRIPTION
This PR fixes #2496
The problem was, after reporting the error that the LHS variable of `b1 :| true` was not defined, its `.Resolved` was set to `null`, but immediately afterwards there was a check about this `.Resolved` which failed, and reported an error on the `.Resolved`, which was null, so it did not have a `.tok` property...
The fix was to ensure we don't call this check if `Resolved` is null. To ensure that I am not introducing any soundness issue, I added an `else` that verifies that the number of errors is > 0 if `Resolved` is null.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>