### PR TITLE
Fix: old() cannot be inferred as a trigger alone

### DIFF
--- a/Source/DafnyCore/AST/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions.cs
@@ -1831,6 +1831,7 @@ public class OldExpr : Expression {
   [Peer]
   public readonly Expression E;
   public readonly string/*?*/ At;
+  [FilledInDuringResolution] public bool Useless = false;
   [FilledInDuringResolution] public Label/*?*/ AtLabel;  // after that, At==null iff AtLabel==null
   [ContractInvariantMethod]
   void ObjectInvariant() {

--- a/Source/DafnyCore/Cloner.cs
+++ b/Source/DafnyCore/Cloner.cs
@@ -372,7 +372,9 @@ namespace Microsoft.Dafny {
 
       } else if (expr is OldExpr) {
         var e = (OldExpr)expr;
-        return new OldExpr(Tok(e.tok), CloneExpr(e.E), e.At);
+        return new OldExpr(Tok(e.tok), CloneExpr(e.E), e.At) {
+          Useless = e.Useless
+        };
 
       } else if (expr is UnchangedExpr) {
         var e = (UnchangedExpr)expr;

--- a/Source/DafnyCore/Substituter.cs
+++ b/Source/DafnyCore/Substituter.cs
@@ -177,7 +177,10 @@ namespace Microsoft.Dafny {
         // BoogieWrapper before calling Substitute.
         Expression se = Substitute(e.E);
         if (se != e.E) {
-          newExpr = new OldExpr(expr.tok, se, e.At) { AtLabel = e.AtLabel ?? oldHeapLabel };
+          newExpr = new OldExpr(expr.tok, se, e.At) {
+            AtLabel = e.AtLabel ?? oldHeapLabel,
+            Useless = e.Useless
+          };
         }
       } else if (expr is UnchangedExpr) {
         var e = (UnchangedExpr)expr;

--- a/Source/DafnyCore/Triggers/QuantifiersCollection.cs
+++ b/Source/DafnyCore/Triggers/QuantifiersCollection.cs
@@ -75,9 +75,7 @@ namespace Microsoft.Dafny.Triggers {
       foreach (var q in quantifiers) {
         var candidates = triggersCollector.CollectTriggers(q.quantifier).Deduplicate(TriggerTerm.Eq);
         // filter out the candidates that was "second-class"
-        var filtered = TriggerUtils.Filter(candidates, tr => tr,
-          (tr, _) => !tr.IsTranslatedToFunctionCall() && !(tr.Expr is OldExpr),
-          (tr, _) => { }).ToList();
+        var filtered = TriggerUtils.Filter(candidates, tr => tr, (tr, _) => !tr.IsTranslatedToFunctionCall(), (tr, _) => { }).ToList();
         // if there are only "second-class" candidates, add them back.
         if (filtered.Count == 0) {
           filtered = candidates;

--- a/Source/DafnyCore/Triggers/QuantifiersCollection.cs
+++ b/Source/DafnyCore/Triggers/QuantifiersCollection.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Dafny.Triggers {
       foreach (var q in quantifiers) {
         var candidates = triggersCollector.CollectTriggers(q.quantifier).Deduplicate(TriggerTerm.Eq);
         // filter out the candidates that was "second-class"
-        var filtered = TriggerUtils.Filter(candidates, tr => tr, (tr, _) => !tr.IsTranslatedToFunctionCall(), (tr, _) => { }).ToList();
+        var filtered = TriggerUtils.Filter(candidates, tr => tr,
+          (tr, _) => !tr.IsTranslatedToFunctionCall() && !(tr.Expr is OldExpr),
+          (tr, _) => { }).ToList();
         // if there are only "second-class" candidates, add them back.
         if (filtered.Count == 0) {
           filtered = candidates;
@@ -86,7 +88,8 @@ namespace Microsoft.Dafny.Triggers {
 
       foreach (var q in quantifiers) {
         q.CandidateTerms = distinctPool; // The list of candidate terms is immutable
-        q.Candidates = TriggerUtils.AllNonEmptySubsets(distinctPool, SubsetGenerationPredicate, q.quantifier.BoundVars).Select(set => set.ToTriggerCandidate()).ToList();
+        q.Candidates = TriggerUtils.AllNonEmptySubsets(distinctPool, SubsetGenerationPredicate, q.quantifier.BoundVars)
+          .Select(set => set.ToTriggerCandidate()).ToList();
       }
     }
 

--- a/Source/DafnyCore/Triggers/TriggersCollector.cs
+++ b/Source/DafnyCore/Triggers/TriggersCollector.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Dafny.Triggers {
                    expr is SeqConstructionExpr) {
           annotation = AnnotateOther(expr, false);
         } else {
-          annotation = AnnotateOther(expr, true);
+          annotation = AnnotateOther(expr, expr is not OldExpr);
         }
       }
 
@@ -245,7 +245,7 @@ namespace Microsoft.Dafny.Triggers {
           expr is SeqSelectExpr ||
           expr is MultiSelectExpr ||
           expr is MemberSelectExpr ||
-          expr is OldExpr ||
+          //expr is OldExpr ||
           expr is ApplyExpr ||
           expr is DisplayExpression ||
           expr is MapDisplayExpr ||

--- a/Source/DafnyCore/Triggers/TriggersCollector.cs
+++ b/Source/DafnyCore/Triggers/TriggersCollector.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Dafny.Triggers {
                    expr is SeqConstructionExpr) {
           annotation = AnnotateOther(expr, false);
         } else {
-          annotation = AnnotateOther(expr, expr is not OldExpr);
+          annotation = AnnotateOther(expr, true);
         }
       }
 
@@ -245,7 +245,7 @@ namespace Microsoft.Dafny.Triggers {
           expr is SeqSelectExpr ||
           expr is MultiSelectExpr ||
           expr is MemberSelectExpr ||
-          //expr is OldExpr ||
+          (expr is OldExpr { Useless: false }) ||
           expr is ApplyExpr ||
           expr is DisplayExpression ||
           expr is MapDisplayExpr ||

--- a/Source/DafnyCore/UselessOldLinter.cs
+++ b/Source/DafnyCore/UselessOldLinter.cs
@@ -12,14 +12,12 @@ using System.Reactive;
 namespace Microsoft.Dafny {
 
   public class UselessOldLinter : IRewriter {
-    internal override void PostResolve(Program program) {
-      base.PostResolve(program);
-      foreach (var moduleDefinition in program.Modules()) {
-        foreach (var topLevelDecl in moduleDefinition.TopLevelDecls.OfType<TopLevelDeclWithMembers>()) {
-          foreach (var callable in topLevelDecl.Members.OfType<ICallable>()) {
-            var visitor = new UselessOldLinterVisitor(this.Reporter);
-            visitor.Visit(callable, Unit.Default);
-          }
+    internal override void PostResolveIntermediate(ModuleDefinition moduleDefinition) {
+      base.PostResolveIntermediate(moduleDefinition);
+      foreach (var topLevelDecl in moduleDefinition.TopLevelDecls.OfType<TopLevelDeclWithMembers>()) {
+        foreach (var callable in topLevelDecl.Members.OfType<ICallable>()) {
+          var visitor = new UselessOldLinterVisitor(this.Reporter);
+          visitor.Visit(callable, Unit.Default);
         }
       }
     }
@@ -41,6 +39,7 @@ namespace Microsoft.Dafny {
         var usesHeap = false;
         FreeVariablesUtil.ComputeFreeVariables(oldExpr.E, fvs, ref usesHeap, true);
         if (!usesHeap) {
+          oldExpr.Useless = true;
           this.reporter.Warning(MessageSource.Rewriter, oldExpr.tok,
             $"Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect");
         }

--- a/Test/allocated1/dafny0/SmallTests.dfy.expect
+++ b/Test/allocated1/dafny0/SmallTests.dfy.expect
@@ -1,5 +1,5 @@
-SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy(599,12): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy(34,11): Error: index out of range
 SmallTests.dfy(65,35): Error: possible division by zero
 SmallTests.dfy(66,50): Error: possible division by zero
@@ -52,7 +52,7 @@ SmallTests.dfy(703,9): Error: cannot establish the existence of LHS values that 
 SmallTests.dfy(716,8): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
 
 Dafny program verifier finished with 51 verified, 46 errors
-SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy.tmp.dprint.dfy(740,12): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found.
 
 Dafny program verifier did not attempt verification

--- a/Test/dafny0/SmallTests.dfy.expect
+++ b/Test/dafny0/SmallTests.dfy.expect
@@ -1,5 +1,5 @@
-SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy(599,12): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+SmallTests.dfy(548,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy(909,14): Error: target object might be null
 SmallTests.dfy(901,14): Error: target object might be null
 SmallTests.dfy(34,11): Error: index out of range
@@ -54,7 +54,7 @@ SmallTests.dfy(703,9): Error: cannot establish the existence of LHS values that 
 SmallTests.dfy(716,8): Error: cannot establish the existence of LHS values that satisfy the such-that predicate
 
 Dafny program verifier finished with 56 verified, 48 errors
-SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found.
 SmallTests.dfy.tmp.dprint.dfy(803,12): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+SmallTests.dfy.tmp.dprint.dfy(450,4): Warning: /!\ No trigger covering all quantified variables found.
 
 Dafny program verifier did not attempt verification

--- a/Test/git-issues/git-issue-2593.dfy
+++ b/Test/git-issues/git-issue-2593.dfy
@@ -1,0 +1,5 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+
+Alas, the program causes Dafny to generate malformed Boogie code, because of the trigger Dafny generates for the quantifier.

--- a/Test/git-issues/git-issue-2593.dfy
+++ b/Test/git-issues/git-issue-2593.dfy
@@ -1,5 +1,7 @@
 // RUN: %dafny_0 /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
+predicate P(x: int)
 
-Alas, the program causes Dafny to generate malformed Boogie code, because of the trigger Dafny generates for the quantifier.
+lemma L()
+  ensures forall y :: P(old(y))

--- a/Test/git-issues/git-issue-2593.dfy.expect
+++ b/Test/git-issues/git-issue-2593.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-2593.dfy(7,24): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+git-issue-2593.dfy(7,24): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/git-issues/git-issue-2593.dfy.expect
+++ b/Test/git-issues/git-issue-2593.dfy.expect
@@ -1,4 +1,4 @@
 git-issue-2593.dfy(7,24): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-git-issue-2593.dfy(7,24): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+git-issue-2593.dfy(7,10): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/triggers/old-is-a-special-case-for-triggers.dfy.expect
+++ b/Test/triggers/old-is-a-special-case-for-triggers.dfy.expect
@@ -1,3 +1,11 @@
+old-is-a-special-case-for-triggers.dfy(15,45): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(20,48): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(21,40): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(21,56): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(21,72): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(25,48): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(26,48): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
+old-is-a-special-case-for-triggers.dfy(26,61): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
 old-is-a-special-case-for-triggers.dfy(15,10): Info: Selected triggers:
    {old(f(c))}, {c in sc}
 old-is-a-special-case-for-triggers.dfy(20,10): Info: Selected triggers:
@@ -38,13 +46,5 @@ old-is-a-special-case-for-triggers.dfy(49,10): Info: Selected triggers:
  Rejected triggers:
    {g(ff(c))} (more specific than {ff(c)})
    {old(g(ff(c)))} (more specific than {old(ff(c))})
-old-is-a-special-case-for-triggers.dfy(15,45): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(20,48): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(21,40): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(21,56): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(21,72): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(25,48): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(26,48): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-old-is-a-special-case-for-triggers.dfy(26,61): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
 
 Dafny program verifier finished with 4 verified, 0 errors

--- a/docs/dev/news/2593.fix
+++ b/docs/dev/news/2593.fix
@@ -1,0 +1,1 @@
+old() cannot be inferred as a trigger alone


### PR DESCRIPTION
This PR fixes #2593
I added the corresponding test. Basically, previously, old(...) was considered as a potential trigger. However, the translation of Boogie of old(...) expressions is not a function, but a previous variable... so this had no meaning
I removed old(...) from the list of potential triggers.

Side notes: 
* Removing old() as a trigger altogether does not work. Even ensuring it's not a trigger killer won't do it. The test dafny1/MatrixFun.dfy fails in both of these cases, because it misses one important trigger
* If there is something like `old(f(y)+1)`, even though `old()` is marked as useless, the trigger `old(f(y))` and `f(y)` will still be created due to special traversal of the tree. This is expected. This traversal will never wrap a variable with `old()` anyway.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>