### PR TITLE
fix: Force UTF-8 encoding in C# lit runner

### DIFF
--- a/Source/XUnitExtensions/Lit/ShellLitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ShellLitCommand.cs
@@ -33,12 +33,69 @@ namespace XUnitExtensions.Lit {
       process.StartInfo.RedirectStandardInput = true;
       process.StartInfo.RedirectStandardOutput = true;
       process.StartInfo.RedirectStandardError = true;
-      process.StartInfo.CreateNoWindow = true;
 
       process.StartInfo.EnvironmentVariables.Clear();
       foreach (var passthrough in passthroughEnvironmentVariables) {
         process.StartInfo.EnvironmentVariables.Add(passthrough, Environment.GetEnvironmentVariable(passthrough));
       }
+
+      // Getting console encodings right is tricky on Windows.
+      //
+      // Some background: the current console has a codepage, which is what
+      // programs that output text are supposed to use.  The command `chcp` can
+      // be used to test or set it:
+      //
+      // > chcp
+      // Active code page: 1252
+      //
+      // So, if the console has its codepage set to 850 (the old IBM codepage),
+      // then a program that wants to print `é` (U+00E9, Latin Small Letter E
+      // With Acute) should output a single byte, #x82.  But if the codepage is
+      // 1252 (Latin 1), then that same program should output the single
+      // byte `#xE9`.  Finally, if the codepage is 65001 (UTF8), then that same
+      // program should output `#xC3 #xA9`.
+      //
+      // Thankfully, the C# runtime takes care of this for us.  It uses
+      // `GetConsoleCP` to determine what encoding to use, then uses that when
+      // `Console.WriteLine` is called (and replaces unsupported characters by
+      // the fallback character `?`).  Here is a concrete demo, with character
+      // U+20AC (€) (which is supported by codepage 85001 but not 850):
+      //
+      // > mkdir demo
+      // > cd demo
+      // > dotnet new console
+      // > ECHO Console.WriteLine(new char[] { (char)0x20AC }); > Program.cs
+      // > chcp 65001 && dotnet run
+      // Active code page: 65001
+      // €
+      // > chcp 850 && dotnet run
+      // Active code page: 850
+      // ?
+      //
+      // So, the proper way to run a program that might print non-ASCII
+      // characters is to set the console's code page to 65001.  This is done by
+      // the user before calling dotnet run, so nothing to do here.
+      //
+      // … but this is not enough, because some processes change the codepage
+      // when they invoke a subprocess.  For example, Process.Start reuses the
+      // current codepage, *unless* `CreateNoWindow` is true (in that case, the
+      // codepage is reset to the default (this is explained nicely at
+      // https://stackoverflow.com/questions/5094003/).
+      //
+      // So, one needs to set `CreateNoWindow` to false to avoid dreaded `?`
+      // output, as is done below.
+      //
+      // … but this is not enough, because dotnet run (or XUnit) also resets the
+      // codepage.  That's a bug there, and in the meantime the best hack we
+      // have is to override that codepage by setting `OutputEncoding`.
+
+      process.StartInfo.CreateNoWindow = false;
+      Console.OutputEncoding = System.Text.Encoding.UTF8;
+
+      // Finally, for Java + Ubuntu, we make sure to forward LANG:
+      process.StartInfo.EnvironmentVariables.Add("LANG", "C.UTF-8");
+      // … and For Python + Windows, we set PYTHONIOENCODING
+      process.StartInfo.EnvironmentVariables.Add("PYTHONIOENCODING", "UTF-8");
 
       process.Start();
       if (inputReader != null) {

--- a/Source/XUnitExtensions/Lit/ShellLitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ShellLitCommand.cs
@@ -59,7 +59,7 @@ namespace XUnitExtensions.Lit {
       // `GetConsoleCP` to determine what encoding to use, then uses that when
       // `Console.WriteLine` is called (and replaces unsupported characters by
       // the fallback character `?`).  Here is a concrete demo, with character
-      // U+20AC (€) (which is supported by codepage 85001 but not 850):
+      // U+20AC (€) (which is supported by codepage 65001 but not 850):
       //
       // > mkdir demo
       // > cd demo
@@ -92,7 +92,7 @@ namespace XUnitExtensions.Lit {
       process.StartInfo.CreateNoWindow = false;
       Console.OutputEncoding = System.Text.Encoding.UTF8;
 
-      // Finally, for Java + Ubuntu, we make sure to forward LANG:
+      // Finally, for Java + Ubuntu, we make sure to set LANG:
       process.StartInfo.EnvironmentVariables.Add("LANG", "C.UTF-8");
       // … and For Python + Windows, we set PYTHONIOENCODING
       process.StartInfo.EnvironmentVariables.Add("PYTHONIOENCODING", "UTF-8");

--- a/Test/metatests/OutputEncoding.dfy
+++ b/Test/metatests/OutputEncoding.dfy
@@ -1,0 +1,10 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %baredafny run --no-verify --target=cs %args "%s" >> "%t"
+// RUN: %baredafny run --no-verify --target=js %args  "%s" >> "%t"
+// RUN: %baredafny run --no-verify --target=go %args  "%s" >> "%t"
+// RUN: %baredafny run --no-verify --target=py %args  "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Main() {
+  print "Euro sign: " + [0x20AC as char], "\n"; // €
+}

--- a/Test/metatests/OutputEncoding.dfy.expect
+++ b/Test/metatests/OutputEncoding.dfy.expect
@@ -1,0 +1,14 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier did not attempt verification
+Euro sign: €
+
+Dafny program verifier did not attempt verification
+Euro sign: €
+
+Dafny program verifier did not attempt verification
+Euro sign: €
+
+Dafny program verifier did not attempt verification
+Euro sign: €


### PR DESCRIPTION
This is intended to make it possible to test Unicode output.  I skipped Java because Java needs a separate patch (since it doesn't respect the current encoding / codepage, see https://github.com/dafny-lang/dafny/issues/2976)