### PR TITLE
Fix: No more resolver crash on pattern match with incompatible types

### DIFF
--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -12883,6 +12883,7 @@ namespace Microsoft.Dafny {
         var udt = type.NormalizeExpand() as UserDefinedType;
         if (!(pat is IdPattern)) {
           reporter.Error(MessageSource.Resolver, pat.Tok, "pattern doesn't correspond to a tuple");
+          return;
         }
 
         IdPattern idpat = (IdPattern)pat;
@@ -12914,6 +12915,7 @@ namespace Microsoft.Dafny {
         if (!(pat is IdPattern)) {
           Contract.Assert(pat is LitPattern);
           reporter.Error(MessageSource.Resolver, pat.Tok, "Constant pattern used in place of datatype");
+          return;
         }
         IdPattern idpat = (IdPattern)pat;
 

--- a/Test/git-issues/git-issue-2139.dfy
+++ b/Test/git-issues/git-issue-2139.dfy
@@ -1,0 +1,11 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method a() 
+{
+    var tok := (0,0);
+    match tok {
+      case "B" => 
+      case _ => 
+    }
+}

--- a/Test/git-issues/git-issue-2139.dfy
+++ b/Test/git-issues/git-issue-2139.dfy
@@ -1,6 +1,12 @@
 // RUN: %dafny_0 /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
+datatype T = T(T, T) {
+  predicate P() {
+    match this
+      case T(0, 1) => false
+  }
+}
 method a() 
 {
     var tok := (0,0);

--- a/Test/git-issues/git-issue-2139.dfy.expect
+++ b/Test/git-issues/git-issue-2139.dfy.expect
@@ -1,0 +1,5 @@
+git-issue-2139.dfy(7,13): Error: Constant pattern used in place of datatype
+git-issue-2139.dfy(7,16): Error: Constant pattern used in place of datatype
+git-issue-2139.dfy(14,11): Error: pattern doesn't correspond to a tuple
+git-issue-2139.dfy(4,9): Error: because of cyclic dependencies among constructor argument types, no instances of datatype 'T' can be constructed
+4 resolution/type errors detected in git-issue-2139.dfy

--- a/docs/dev/news/2139.fix
+++ b/docs/dev/news/2139.fix
@@ -1,0 +1,1 @@
+No more resolver crash on pattern match with incompatible types


### PR DESCRIPTION
This PR fixes #2139
Basically, there were two places where we would raise an error if a pattern was not of the right type, but immediately afterwards, we were casting it to that type. I added two return statements.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>