### PR TITLE
Fix: Added missing check to prevent crash during resolution

### DIFF
--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -16595,6 +16595,9 @@ namespace Microsoft.Dafny {
       MemberDecl member = null;
 
       var name = resolutionContext.InReveal ? "reveal_" + expr.SuffixName : expr.SuffixName;
+      if (!expr.Lhs.WasResolved()) {
+        return null;
+      }
       var lhs = expr.Lhs.Resolved;
       if (lhs != null && lhs.Type is Resolver_IdentifierExpr.ResolverType_Module) {
         var ri = (Resolver_IdentifierExpr)lhs;

--- a/Test/git-issues/git-issue-2111.dfy
+++ b/Test/git-issues/git-issue-2111.dfy
@@ -1,0 +1,8 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype DT = C(s: string) {
+  predicate F() {
+    C.XYZ()
+  }
+}

--- a/Test/git-issues/git-issue-2111.dfy.expect
+++ b/Test/git-issues/git-issue-2111.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-2111.dfy(6,4): Error: wrong number of arguments (datatype constructor 'C' expects 1, got 0)
+1 resolution/type errors detected in git-issue-2111.dfy

--- a/docs/dev/news/2111.fix
+++ b/docs/dev/news/2111.fix
@@ -1,0 +1,1 @@
+Added missing check to prevent crash during resolution


### PR DESCRIPTION
This PR fixes #2111
Basically, after the error on the expr.Lhs was reported, we tried to access the `.Resolved` property, which threw an exception because of failed contracts.
So I added the test to verify that `.WasResolved()` before, so that we don't continue if the LHS is not resolved.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>