### PR TITLE
Fix: Support for aliases in module resolution without crashing on imports

### DIFF
--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -595,7 +595,9 @@ public class ModuleQualifiedId {
       this.Sig = null;
     } else {
       this.Decl = m;
-      this.Def = ((LiteralModuleDecl)m).ModuleDef;
+      this.Def = m is AliasModuleDecl ?
+        m.Signature.ModuleDef :
+        ((LiteralModuleDecl)m).ModuleDef;
       this.Sig = m.Signature;
     }
   }

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -595,9 +595,7 @@ public class ModuleQualifiedId {
       this.Sig = null;
     } else {
       this.Decl = m;
-      this.Def = m is AliasModuleDecl ?
-        m.Signature.ModuleDef :
-        ((LiteralModuleDecl)m).ModuleDef;
+      this.Def = m.Signature.ModuleDef;
       this.Sig = m.Signature;
     }
   }

--- a/Test/git-issues/git-issue-2108.dfy
+++ b/Test/git-issues/git-issue-2108.dfy
@@ -1,0 +1,11 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module M0.M1.Base {}
+
+module M0.M2 {
+  import M1.Base
+
+  module Derived refines Base {
+  }
+}

--- a/Test/git-issues/git-issue-2108.dfy.expect
+++ b/Test/git-issues/git-issue-2108.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/docs/dev/news/2108.fix
+++ b/docs/dev/news/2108.fix
@@ -1,0 +1,1 @@
+Support for aliases in module resolution without crashing on imports


### PR DESCRIPTION
This PR fixes #2108
Basically, we were trying to call ModuleQualifiedId.Set() on something else than a LiteralModuleDecl, and it happened it was an AliasModuleDecl. Since we were only interested by the underlying ModuleDefinition, I added a case to ensure it does not crash for AliasModuleDecl

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>