### PR TITLE
Fix: Better reporting if 'this' used in a subset type - and no crash

### DIFF
--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1167,6 +1167,10 @@ public abstract class TopLevelDeclWithMembers : TopLevelDecl {
       tr.AddTraitAncestors(s);
     }
   }
+
+  // True if non-static members can access the underlying object "this"
+  // False if all members are implicitly static (e.g. in a default class declaration)
+  public abstract bool AcceptThis { get; }
 }
 
 public class TraitDecl : ClassDecl {
@@ -1261,6 +1265,7 @@ public class ClassDecl : TopLevelDeclWithMembers, RevealableTypeDecl {
 
   public TopLevelDecl AsTopLevelDecl => this;
   public TypeDeclSynonymInfo SynonymInfo { get; set; }
+  public override bool AcceptThis => this is not DefaultClassDecl;
 }
 
 public class DefaultClassDecl : ClassDecl {
@@ -1404,6 +1409,8 @@ public class IndDatatypeDecl : DatatypeDecl {
     Contract.Requires(cce.NonNullElements(members));
     Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
   }
+
+  public override bool AcceptThis => true;
 }
 
 public class CoDatatypeDecl : DatatypeDecl {
@@ -1425,6 +1432,8 @@ public class CoDatatypeDecl : DatatypeDecl {
   public override DatatypeCtor GetGroundingCtor() {
     return Ctors.FirstOrDefault(ctor => ctor.IsGhost, Ctors[0]);
   }
+
+  public override bool AcceptThis => true;
 }
 
 /// <summary>
@@ -1800,6 +1809,7 @@ public class OpaqueTypeDecl : TopLevelDeclWithMembers, TypeParameter.ParentType,
 
   public TopLevelDecl AsTopLevelDecl => this;
   public TypeDeclSynonymInfo SynonymInfo { get; set; }
+  public override bool AcceptThis => true;
 }
 
 public interface RedirectingTypeDecl : ICallable {
@@ -1947,6 +1957,8 @@ public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, Redirect
     get { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
     set { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
   }
+
+  public override bool AcceptThis => true;
 }
 
 public abstract class TypeSynonymDeclBase : TopLevelDecl, RedirectingTypeDecl {

--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -2750,9 +2750,7 @@ namespace Microsoft.Dafny {
               if (field.Rhs != null) {
                 var ec = reporter.Count(ErrorLevel.Error);
                 scope.PushMarker();
-                if ((currentClass is ClassDecl cd && !cd.IsDefaultClass) || currentClass is DatatypeDecl ||
-                    currentClass is OpaqueTypeDecl) {
-                } else {
+                if (currentClass == null || !currentClass.AcceptThis) {
                   scope.AllowInstance = false;
                 }
                 ResolveExpression(field.Rhs, resolutionContext);
@@ -2805,7 +2803,9 @@ namespace Microsoft.Dafny {
             var prevErrCnt = reporter.Count(ErrorLevel.Error);
             var codeContext = new CodeContextWrapper(dd, dd.WitnessKind == SubsetTypeDecl.WKind.Ghost);
             scope.PushMarker();
-            scope.AllowInstance = false;
+            if (d is not TopLevelDeclWithMembers topLevelDecl || !topLevelDecl.AcceptThis) {
+              scope.AllowInstance = false;
+            }
             ResolveExpression(dd.Witness, new ResolutionContext(codeContext, false));
             scope.PopMarker();
             ConstrainSubtypeRelation(dd.Var.Type, dd.Witness.Type, dd.Witness, "witness expression must have type '{0}' (got '{1}')", dd.Var.Type, dd.Witness.Type);

--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -2800,7 +2800,10 @@ namespace Microsoft.Dafny {
           if (dd.Witness != null) {
             var prevErrCnt = reporter.Count(ErrorLevel.Error);
             var codeContext = new CodeContextWrapper(dd, dd.WitnessKind == SubsetTypeDecl.WKind.Ghost);
+            scope.PushMarker();
+            scope.AllowInstance = false;
             ResolveExpression(dd.Witness, new ResolutionContext(codeContext, false));
+            scope.PopMarker();
             ConstrainSubtypeRelation(dd.Var.Type, dd.Witness.Type, dd.Witness, "witness expression must have type '{0}' (got '{1}')", dd.Var.Type, dd.Witness.Type);
             SolveAllTypeConstraints();
             if (reporter.Count(ErrorLevel.Error) == prevErrCnt) {

--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -2750,7 +2750,11 @@ namespace Microsoft.Dafny {
               if (field.Rhs != null) {
                 var ec = reporter.Count(ErrorLevel.Error);
                 scope.PushMarker();
-                scope.AllowInstance = currentClass is ClassDecl cd && !cd.IsDefaultClass;
+                if ((currentClass is ClassDecl cd && !cd.IsDefaultClass) || currentClass is DatatypeDecl ||
+                    currentClass is OpaqueTypeDecl) {
+                } else {
+                  scope.AllowInstance = false;
+                }
                 ResolveExpression(field.Rhs, resolutionContext);
                 scope.PopMarker();
                 if (reporter.Count(ErrorLevel.Error) == ec) {

--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -2714,7 +2714,6 @@ namespace Microsoft.Dafny {
 
         } else if (d is SubsetTypeDecl) {
           var dd = (SubsetTypeDecl)d;
-
           allTypeParameters.PushMarker();
           ResolveTypeParameters(d.TypeArgs, false, d);
           ResolveAttributes(d, new ResolutionContext(new NoContext(d.EnclosingModuleDefinition), false));
@@ -14875,7 +14874,11 @@ namespace Microsoft.Dafny {
         if (currentClass is ClassDecl cd && cd.IsDefaultClass) {
           // there's no type
         } else {
-          expr.Type = GetThisType(expr.tok, currentClass);  // do this regardless of scope.AllowInstance, for better error reporting
+          if (currentClass == null) {
+            reporter.Error(MessageSource.Resolver, expr.tok, "there is no enclosing type that 'this' can refer to");
+          } else {
+            expr.Type = GetThisType(expr.tok, currentClass);  // do this regardless of scope.AllowInstance, for better error reporting
+          }
         }
 
       } else if (expr is IdentifierExpr) {

--- a/Test/git-issues/git-issue-2068.dfy
+++ b/Test/git-issues/git-issue-2068.dfy
@@ -1,8 +1,10 @@
 // RUN: %dafny_0 /compile:0 "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-type St = s:St_ | (forall o | o in s :: o.i(this))
+type A = s: object | true witness this
+const x: object := this
 type St_ = map<nat,Ob>
 type Ob {
     predicate i(s:St_)
 }
+type St = s:St_ | (forall o | o in s.Values :: o.i(this))

--- a/Test/git-issues/git-issue-2068.dfy
+++ b/Test/git-issues/git-issue-2068.dfy
@@ -1,0 +1,8 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type St = s:St_ | (forall o | o in s :: o.i(this))
+type St_ = map<nat,Ob>
+type Ob {
+    predicate i(s:St_)
+}

--- a/Test/git-issues/git-issue-2068.dfy.expect
+++ b/Test/git-issues/git-issue-2068.dfy.expect
@@ -1,3 +1,3 @@
-git-issue-2068.dfy(4,42): Error: type int does not have a member i
-git-issue-2068.dfy(4,44): Error: there is no enclosing type that 'this' can refer to
+git-issue-2068.dfy(10,51): Error: 'this' is not allowed in a 'static' context
+git-issue-2068.dfy(5,19): Error: 'this' is not allowed in a 'static' context
 2 resolution/type errors detected in git-issue-2068.dfy

--- a/Test/git-issues/git-issue-2068.dfy.expect
+++ b/Test/git-issues/git-issue-2068.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-2068.dfy(4,42): Error: type int does not have a member i
+git-issue-2068.dfy(4,44): Error: there is no enclosing type that 'this' can refer to
+2 resolution/type errors detected in git-issue-2068.dfy

--- a/Test/git-issues/git-issue-2068.dfy.expect
+++ b/Test/git-issues/git-issue-2068.dfy.expect
@@ -1,3 +1,4 @@
 git-issue-2068.dfy(10,51): Error: 'this' is not allowed in a 'static' context
 git-issue-2068.dfy(5,19): Error: 'this' is not allowed in a 'static' context
-2 resolution/type errors detected in git-issue-2068.dfy
+git-issue-2068.dfy(4,34): Error: 'this' is not allowed in a 'static' context
+3 resolution/type errors detected in git-issue-2068.dfy

--- a/docs/dev/news/2068.fix
+++ b/docs/dev/news/2068.fix
@@ -1,0 +1,1 @@
+Better reporting if 'this' used in a subset type - and no crash


### PR DESCRIPTION
This PR fixes #2068
I added the corresponding test. The case of a "this" inside a subset type is not allowed, but there was no error mechanism to detect it. This PR solves that problem.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>