### PR TITLE
Fix: Function by method with the same name as a method won't crash resolver

### DIFF
--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -3606,10 +3606,16 @@ namespace Microsoft.Dafny {
               }
             } else {
               var m = f.ByMethodDecl;
-              Contract.Assert(m != null && !m.IsGhost);
-              ComputeGhostInterest(m.Body, false, null, m);
-              CheckExpression(m.Body, this, m);
-              DetermineTailRecursion(m);
+              if (m != null) {
+                Contract.Assert(!m.IsGhost);
+                ComputeGhostInterest(m.Body, false, null, m);
+                CheckExpression(m.Body, this, m);
+                DetermineTailRecursion(m);
+              } else {
+                // m should not be null, unless an error has been reported
+                // (e.g. function-by-method and method with the same name) 
+                Contract.Assert(reporter.ErrorCount > 0);
+              }
             }
           }
           if (prevErrCnt == reporter.Count(ErrorLevel.Error) && member is ICodeContext) {
@@ -10289,8 +10295,14 @@ namespace Microsoft.Dafny {
 
         if (f.ByMethodBody != null) {
           var method = f.ByMethodDecl;
-          Contract.Assert(method != null); // this should have been filled in by now
-          ResolveMethod(method);
+          if (method != null) {
+            ResolveMethod(method);
+          } else {
+            // method should have been filled in by now,
+            // unless there was a function by method and a method of the same name
+            // but then this error must have been reported.
+            Contract.Assert(reporter.ErrorCount >= 1);
+          }
         }
       }
 

--- a/Source/DafnyCore/Resolver.cs
+++ b/Source/DafnyCore/Resolver.cs
@@ -10301,7 +10301,7 @@ namespace Microsoft.Dafny {
             // method should have been filled in by now,
             // unless there was a function by method and a method of the same name
             // but then this error must have been reported.
-            Contract.Assert(reporter.ErrorCount >= 1);
+            Contract.Assert(reporter.ErrorCount > 0);
           }
         }
       }

--- a/Test/git-issues/git-issue-2019.dfy
+++ b/Test/git-issues/git-issue-2019.dfy
@@ -1,0 +1,28 @@
+// RUN: %dafny_0 /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method f(x: seq<int>) returns (res: seq<int>)
+  ensures x == res
+{
+  var y := [];
+  for i := 0 to |x|
+    invariant |y| == i
+    invariant x[..i] == y[..i]
+  {
+    y := y + [x[i]];
+  }
+  return y;
+}
+
+function f(x: seq<int>): seq<int> {
+  x
+} by method {
+  var y := [];
+  for i := 0 to |x|
+    invariant |y| == i
+    invariant x[..i] == y[..i]
+  {
+    y := y + [x[i]];
+  }
+  return y;
+}

--- a/Test/git-issues/git-issue-2019.dfy.expect
+++ b/Test/git-issues/git-issue-2019.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-2019.dfy(17,9): Error: Duplicate member name: f
+1 resolution/type errors detected in git-issue-2019.dfy

--- a/docs/dev/news/2019.fix
+++ b/docs/dev/news/2019.fix
@@ -1,0 +1,1 @@
+Function by method with the same name as a method won't crash resolver


### PR DESCRIPTION
This PR fixes #2019
I added the corresponding test.
The story was that, if a function by method and a method had the same name, the function by method's resolved method was null. However, there were two places in the resolver, before it gives up, that were asserting that the function by method's method was not null, so I added a conditional instead and ensured that the number of reported errors was greater than zero.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>