### PR TITLE
Fix: Ghost diagnostics are always up to date

### DIFF
--- a/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     public void PublishNotifications(IdeState previousState, IdeState state) {
       PublishVerificationStatus(previousState, state);
       PublishDocumentDiagnostics(previousState, state);
-      PublishGhostDiagnostics(previousState, state);
+      PublishGhostDiagnostics(state);
     }
 
     private void PublishVerificationStatus(IdeState previousState, IdeState state) {
@@ -108,13 +108,10 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       languageServer.TextDocument.SendNotification(verificationStatusGutter);
     }
 
-    private void PublishGhostDiagnostics(IdeState previousState, IdeState state) {
-
+    private void PublishGhostDiagnostics(IdeState state) {
       var newParams = GetGhostness(state);
-      var previousParams = GetGhostness(previousState);
-      if (previousParams.Diagnostics.SequenceEqual(newParams.Diagnostics)) {
-        return;
-      }
+      // We don't check if the diagnostics are the same because otherwise this might
+      // lead to inconsistencies
       languageServer.TextDocument.SendNotification(newParams);
     }
 

--- a/docs/dev/news/3041.fix
+++ b/docs/dev/news/3041.fix
@@ -1,0 +1,1 @@
+Ghost highlights are always up-to-date


### PR DESCRIPTION
Fixes #3041 

What happened was that, if the ghost highlights did not change, no notification was sent to VSCode.
This is problematic, because VSCode believes that text inserted at the end of decorations is part of the decoration itself,
and ghost diagnostics are a decoration. That means that, if you type a non-ghost sentence after a ghost sentence, the non-ghost sentence will be highlighted as ghost.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
