### PR TITLE
fix: ensure postcondition expression is extracted from the right URI

### DIFF
--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using VCGeneration;
 
 namespace Microsoft.Dafny.LanguageServer.Language {
@@ -16,11 +15,14 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     private const string RelatedLocationCategory = "Related location";
     private const string RelatedLocationMessage = RelatedLocationCategory;
 
+    private readonly string entryDocumentsource;
     private readonly DocumentUri entryDocumentUri;
     private readonly Dictionary<DocumentUri, List<Diagnostic>> diagnostics = new();
     private readonly Dictionary<DiagnosticSeverity, int> counts = new();
     private readonly Dictionary<DiagnosticSeverity, int> countsNotVerificationOrCompiler = new();
     private readonly ReaderWriterLockSlim rwLock = new();
+
+    private static readonly string PostConditionFailingMessage = new EnsuresDescription().FailureDescription;
 
     /// <summary>
     /// Creates a new instance with the given uri of the entry document.
@@ -80,39 +82,19 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       );
     }
 
-    public static readonly string PostConditionFailingMessage = new EnsuresDescription().FailureDescription;
-    private readonly string entryDocumentsource;
-
-    public static string FormatRelated(string related) {
-      return $"Could not prove: {related}";
-    }
 
     private IEnumerable<DiagnosticRelatedInformation> CreateDiagnosticRelatedInformationFor(IToken token, string message) {
       var (tokenForMessage, inner) = token is NestedToken nestedToken ? (nestedToken.Outer, nestedToken.Inner) : (token, null);
+
       if (tokenForMessage is RangeToken range) {
+        var tokenUri = tokenForMessage.GetDocumentUri();
         var rangeLength = range.EndToken.pos + range.EndToken.val.Length - range.StartToken.pos;
+        var expr = ReadAndExtractFromUri(tokenUri, range.StartToken.pos, rangeLength);
+
         if (message == PostConditionFailingMessage) {
-          var postcondition = entryDocumentsource.Substring(range.StartToken.pos, rangeLength);
-          message = $"This postcondition might not hold: {postcondition}";
-        } else if (message == "Related location") {
-          var tokenUri = tokenForMessage.GetDocumentUri();
-          if (tokenUri == entryDocumentUri) {
-            message = FormatRelated(entryDocumentsource.Substring(range.StartToken.pos, rangeLength));
-          } else {
-            var fileName = tokenForMessage.GetDocumentUri().GetFileSystemPath();
-            message = "";
-            try {
-              var content = File.ReadAllText(fileName);
-              message = FormatRelated(content.Substring(range.StartToken.pos, rangeLength));
-            } catch (IOException) {
-              message = message + "(could not open file " + fileName + ")";
-            } catch (ArgumentOutOfRangeException) {
-              message = "Related location (could not read position in file " + fileName + ")";
-            }
-            if (message == "") {
-              message = "Related location (could not read file " + fileName + ")";
-            }
-          }
+          message = $"This postcondition might not hold: {expr}";
+        } else if (message == RelatedLocationMessage) {
+          message = $"Could not prove: {expr}";
         }
       }
 
@@ -124,6 +106,28 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         foreach (var nestedInformation in CreateDiagnosticRelatedInformationFor(inner, RelatedLocationMessage)) {
           yield return nestedInformation;
         }
+      }
+    }
+
+    /**
+     * Returns the substring `[pos, pos + len)` from the given URI.  If the URI is the current entry
+     * document, use the cached source; otherwise, read it anew.  On I/O failure, returns a string
+     * representation of that error.
+     */
+    private string ReadAndExtractFromUri(DocumentUri uri, int pos, int len) {
+      if (uri == entryDocumentUri) {
+        return entryDocumentsource.Substring(pos, len);
+      }
+
+      var fileName = uri.GetFileSystemPath();
+
+      try {
+        var content = File.ReadAllText(fileName);
+        return content.Substring(pos, len);
+      } catch (IOException) {
+        return $"(could not open file {fileName})";
+      } catch (ArgumentOutOfRangeException) {
+        return $"(could not read position in {fileName})";
       }
     }
 
@@ -145,7 +149,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       if (tok is NestedToken nestedToken) {
         relatedInformation.AddRange(
           CreateDiagnosticRelatedInformationFor(
-            nestedToken.Inner, nestedToken.Message ?? "Related location")
+            nestedToken.Inner, nestedToken.Message ?? RelatedLocationMessage)
         );
       }
       var item = new Diagnostic {

--- a/docs/dev/news/3044.fix
+++ b/docs/dev/news/3044.fix
@@ -1,0 +1,1 @@
+fix: ensure counterexample postcondition is extracted from the right document


### PR DESCRIPTION
The following bug requires two Dafny files, one containing an abstract module and another one refining it, like these:

```
$ ls -l
total 16
-rw-r--r--  1 ntaylor  staff   81 Nov 10 14:25 module.dfy
-rw-r--r--  1 ntaylor  staff  113 Nov 10 14:25 repro.dfy

$ cat repro.dfy
include "./module.dfy"

module Repro refines M {
    function method Foo(n: nat): nat
    {
        n + 1
    }
}%            
                                                                                                                                                                    
$ cat module.dfy
module M {
    function method Foo(n: nat): nat
        ensures Foo(n) % 2 == 0
}%                                                                                                                                                                                ➜  dafny_repo
```

The command line tool gives reasonable output: it indicates that a postcondition might not hold, and points to the `ensures` in the abstract module by indicating the file, line, and column value:

```
➜  dafny_repo ~/code/dafny/Binaries/Dafny repro.dfy
/Users/ntaylor/school/dafny_repo/repro.dfy(4,20): Error: A postcondition might not hold on this return path.
/Users/ntaylor/school/dafny_repo/./module.dfy(3,27): Related location: This is the postcondition that might not hold.

Dafny program verifier finished with 0 verified, 1 error
➜  dafny_repo
```

However, the language server attempts to concretise the postcondition by slicing a substring out of the failing program source.  The server assumes that the postcondition is in the current document - in the case of module refinement, this isn't the case.  Thus, we get a nonsensical error:

```
[{
	"resource": "/Users/ntaylor/school/dafny_repo/repro.dfy",
...
	"relatedInformation": [
		{
			"startLineNumber": 3,
			"startColumn": 17,
			"endLineNumber": 3,
			"endColumn": 32,
			"message": "This postcondition might not hold: thod Foo(n: nat",
			"resource": "/Users/ntaylor/school/dafny_repo/./module.dfy"
...
}]
```

Those are, of course, the characters corresponding to the postcondition, but in the current file, not the file that actually contains it!  (one can add or remove characters early on in the file and watch the garbage postcondition "slide around").

This patch ensures that when extracting substrings from a document, the right URI is used.  (This patch cleans up a bit of the existing logic: there was a "default" error message for the "Related location" case that would never get hit, etc)

```
[{
	"resource": "/Users/ntaylor/school/dafny_repo/repro.dfy",
...
	"relatedInformation": [
		{
...
			"message": "This postcondition might not hold: Foo(n) % 2 == 0",
			"resource": "/Users/ntaylor/school/dafny_repo/./module.dfy"
		}
	]
}]
```

~I will push another commit with the release notes modified, once I create this pull request and am assigned a PR number from GitHub.~

Additionally: I'm not sure how to write a `git-issue` test for this, since two Dafny files are required to trigger the issue.  What would you like me to do?

Cheers,
Nathan