### PR TITLE
Chore: Support for --nonzero-exit-code

### DIFF
--- a/Source/DafnyDriver/BoogieAffectingOptions/NonZeroExitCodeIfErrorsOption.cs
+++ b/Source/DafnyDriver/BoogieAffectingOptions/NonZeroExitCodeIfErrorsOption.cs
@@ -1,0 +1,18 @@
+namespace Microsoft.Dafny;
+
+public class NonZeroExitCodeIfErrorsOption : BooleanOption {
+  public static readonly NonZeroExitCodeIfErrorsOption Instance = new();
+  public override object DefaultValue => true;
+  public override string LongName => "nonzero-exit-code-if-errors";
+  public override string ShortName => null;
+  public override string ArgumentName => "boolean";
+
+  public override string Description => @"
+if false then always exit with a 0 exit code, regardless of whether errors are found.
+If true (default) then use the appropriate exit code.".TrimStart();
+
+  public override string PostProcess(DafnyOptions options) {
+    options.CountVerificationErrors = Get(options);
+    return null;
+  }
+}

--- a/Source/DafnyDriver/Commands/CommandRegistry.cs
+++ b/Source/DafnyDriver/Commands/CommandRegistry.cs
@@ -22,6 +22,7 @@ static class CommandRegistry {
   public static IReadOnlyList<IOptionSpec> CommonOptions = new List<IOptionSpec>(new IOptionSpec[] {
     CoresOption.Instance,
     VerificationTimeLimitOption.Instance,
+    NonZeroExitCodeIfErrorsOption.Instance,
     LibraryOption.Instance,
     ShowSnippetsOption.Instance,
     PluginOption.Instance,

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -93,6 +93,11 @@ namespace Microsoft.Dafny {
       "--verification-time-limit=300"
     };
 
+    public static readonly string[] NewDefaultArgumentsForTestingWithErrors =
+      NewDefaultArgumentsForTesting.Concat(new[] {
+        "--nonzero-exit-code-if-errors=false"
+      }).ToArray();
+
     public static int Main(string[] args) {
       int ret = 0;
       var thread = new System.Threading.Thread(

--- a/Source/IntegrationTests/LitTests.cs
+++ b/Source/IntegrationTests/LitTests.cs
@@ -100,6 +100,7 @@ namespace IntegrationTests {
         throw new Exception($"Unsupported OS: {RuntimeInformation.OSDescription}");
       }
 
+      substitutions["%args_0"] = DafnyDriver.NewDefaultArgumentsForTestingWithErrors;
       substitutions["%args"] = DafnyDriver.NewDefaultArgumentsForTesting;
 
       var dafnyReleaseDir = Environment.GetEnvironmentVariable("DAFNY_RELEASE");


### PR DESCRIPTION
Until today, all our integration tests are using the old Dafny CLI syntax
This has the following disadvantages:
- We want to fully replace old Dafny CLI syntax, yet, all our tests files are written using this command.
- Tests files are often used as documentation for some features.
- The new Dafny CLI is not as much tested compared to the previous one, so might lack components we might not be aware of.

In this PR, I propose that we move the needle by enabling all the integration tests to run using the new Dafny CLI syntax.
One of the major blocker is the existence of tests that rely on Dafny to generate an error while returning a zero exit code. These can't currently be reproduced in the new CLI because it does not have the necessary option.

My contribution in this PR is to:
- Add an option to replicate in the new CLI an option that was available in the old CLI that we need for tests
- Add a lightweight syntax to refer to this option without mentioning it in the lit format.

Until now, we were using the current option `-countVerificationErrors:0` for these tests. This option is embedded when we write `%dafny_0`. The doc says this option is "deprecated",  but we haven't found a correct workaround to this, have we? 
Some tests are expecting failures, some don't, so it's not like we can change the XUnit test to ignore nonzero exit codes.
To my sense this option should only be hidden to the regular user, not deprecated.

This PR thus does not introduce anything new but simply exposes the equivalent option to the new CLI, named explicitly `--nonzero-exit-code-if-errors`, with a boolean value equals to true by default. We really want users who include this option to completely write `--nonzero-exit-code-if-errors=false`, as this is a behavior that no one would expect - except for the test cases we are running.
I would like to know how to hide it from the regular user @keyboardDrummer as well, if there is such a mechanism, because as of today, this option shows up when running `dafny verify --help`

For the tests themselves, I modify the lit engine so that if we use `%args_0` instead of `%args`, it will include `--nonzero-exit-code-if-error=false`.
Thus, we can now transform

| Previously | Now |
| ------------- | ------------- |
| `%dafny /compile:0 "%s" > "%t"`  | `%baredafny verify %args "%s" > "%t"` |
| `%dafny_0 /compile:0 "%s" > "%t"`  | `%baredafny verify %args_0 "%s" > "%t"` **Missing until this PR**|
|  `%dafny /compile:3 "%s" > "%t"`  | `%baredafny run %args "%s" > "%t"`  |
|  `%dafny /compile:4 "%s" > "%t"`  | `%baredafny run %args --no-verify "%s" > "%t"`  |

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
