### PR TITLE
Ensure non-parseable SeqIndexs do not throw on parse failure

### DIFF
--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServer.Test.csproj
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServer.Test.csproj
@@ -45,6 +45,9 @@
     <None Update="Various\TestFiles\multi2.dfy">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Various\TestFiles\3048.dfy">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
@@ -1106,9 +1106,9 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
         /* Then, extract the number of non-integral indexed sequences from the repro case... */
         .Count(IsNegativeIndexedSeq);
 
-      Assert.IsTrue(nonIntegralIndexedSeqs > 0,
-"If we do not see at least one non-integral index in this test case, then the backend changed " +
-        "The indices being returned to the Language Server.");
+      Assert.IsTrue(nonIntegralIndexedSeqs > 0, "If we do not see at least one non-integral index in " +
+                                                "this test case, then the backend changed " +
+                                                "The indices being returned to the Language Server.");
     }
 
     /* Helper for the NonIntegerSeqIndices test. */

--- a/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using Microsoft.Dafny.LanguageServer.Handlers.Custom;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OmniSharp.Extensions.LanguageServer.Protocol;
-using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using DafnyServer.CounterexampleGeneration;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Microsoft.Dafny.LanguageServer.Workspace;
 
@@ -1086,6 +1085,47 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
       Assert.IsTrue(counterExamples[0].Variables["c:M.C?"] is
         "(c1 := '\\u1023', c2 := '\\u1023')" or
         "(c2 := '\\u1023', c1 := '\\u1023')");
+    }
+
+    /// <summary>
+    /// Tests that a Dafny program where a sequence with non-integral indices is generated as part of
+    /// a counterexample.  This would previously crash the LSP before #3093.
+    /// For more details, see https://github.com/dafny-lang/dafny/issues/3048 .
+    /// </summary>
+    [TestMethod]
+    public async Task NonIntegerSeqIndices() {
+      string fp = Path.Combine(Directory.GetCurrentDirectory(), "Various", "TestFiles", "3048.dfy");
+      var source = await File.ReadAllTextAsync(fp, CancellationToken);
+      var documentItem = CreateTestDocument(source);
+
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+
+      /* First, ensure we can correctly extract counterexamples without crashing... */
+      var nonIntegralIndexedSeqs = (await RequestCounterExamples(documentItem.Uri))
+        .SelectMany(cet => cet.Variables.ToList())
+        /* Then, extract the number of non-integral indexed sequences from the repro case... */
+        .Count(IsNegativeIndexedSeq);
+
+      /* If we do not see at least one, then the backend changed the indices being returned to the Language Server. */
+      Assert.IsTrue(nonIntegralIndexedSeqs > 0);
+    }
+
+    /* Helper for the NonIntegerSeqIndices test. */
+    private static bool IsNegativeIndexedSeq(KeyValuePair<string, string> kvp) {
+      var r = new Regex(@"\[\(- \d+\)\]");
+      return kvp.Key.Contains("seq<_module.uint8>") && r.IsMatch(kvp.Value);
+    }
+
+    [TestMethod]
+    public void TestIsNegativeIndexedSeq() {
+      Assert.IsFalse(
+        IsNegativeIndexedSeq(new KeyValuePair<string, string>("uint8", "42")));
+      Assert.IsFalse(
+        IsNegativeIndexedSeq(new KeyValuePair<string, string>("seq<_module.uint8>", "(Length := 42, [0] := 42)")));
+      Assert.IsTrue(
+        IsNegativeIndexedSeq(new KeyValuePair<string, string>("seq<_module.uint8>", "(Length := 9899, [(- 1)] := 42)")));
+      Assert.IsTrue(
+        IsNegativeIndexedSeq(new KeyValuePair<string, string>("seq<seq<_module.uint8>>", "(Length := 1123, [(- 12345)] := @12)")));
     }
   }
 }

--- a/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
@@ -1106,7 +1106,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
         /* Then, extract the number of non-integral indexed sequences from the repro case... */
         .Count(IsNegativeIndexedSeq);
 
-      /* If we do not see at least one, then the backend changed the indices being returned to the Language Server. */
       Assert.IsTrue(nonIntegralIndexedSeqs > 0,
 "If we do not see at least one non-integral index in this test case, then the backend changed " +
         "The indices being returned to the Language Server.");

--- a/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
@@ -1107,7 +1107,9 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
         .Count(IsNegativeIndexedSeq);
 
       /* If we do not see at least one, then the backend changed the indices being returned to the Language Server. */
-      Assert.IsTrue(nonIntegralIndexedSeqs > 0);
+      Assert.IsTrue(nonIntegralIndexedSeqs > 0,
+"If we do not see at least one non-integral index in this test case, then the backend changed " +
+        "The indices being returned to the Language Server.");
     }
 
     /* Helper for the NonIntegerSeqIndices test. */

--- a/Source/DafnyLanguageServer.Test/Various/TestFiles/3048.dfy
+++ b/Source/DafnyLanguageServer.Test/Various/TestFiles/3048.dfy
@@ -18,79 +18,75 @@ type Zone = seq<Block>
 
 /* a zone map is a sequence of contiguous half-open intervals. */
 
-predicate zone_map_well_formed(n_blocks: uint64, zone_map: seq<(uint64, uint64)>)
-{
-    && 0 < |zone_map| as int
-    && zone_map[0].0 == 0
-    && zone_map[|zone_map| - 1].1 == n_blocks
-    && zone_map_ordered_total(zone_map)
+predicate zone_map_well_formed(n_blocks: uint64, zone_map: seq<(uint64, uint64)>) {
+  && 0 < |zone_map| as int
+  && zone_map[0].0 == 0
+  && zone_map[|zone_map| - 1].1 == n_blocks
+  && zone_map_ordered_total(zone_map)
 }
 
-predicate zone_map_ordered_total(zone_map: seq<(uint64, uint64)>)
-{
-    && 0 < |zone_map| as int
-    && (forall i :: 0 <  i < |zone_map| ==> zone_map[i-1].1 == zone_map[i].0)
-    && (forall i :: 0 <= i < |zone_map| ==> zone_map[i].0 < zone_map[i].1)
-    && (forall i :: 0 <= i < |zone_map| ==> (zone_map[i].1 - zone_map[i].0) as int < UINT64_MAX)
+predicate zone_map_ordered_total(zone_map: seq<(uint64, uint64)>) {
+  && 0 < |zone_map| as int
+  && (forall i :: 0 <  i < |zone_map| ==> zone_map[i-1].1 == zone_map[i].0)
+  && (forall i :: 0 <= i < |zone_map| ==> zone_map[i].0 < zone_map[i].1)
+  && (forall i :: 0 <= i < |zone_map| ==> (zone_map[i].1 - zone_map[i].0) as int < UINT64_MAX)
 }
 
 /* State transitions take Constants as, well, constant. */
 
 datatype Constants = Constants(
-    n_blocks: uint64,
-    zone_map: seq<(uint64, uint64)> // [b, e)
+  n_blocks: uint64,
+  zone_map: seq<(uint64, uint64)> // [b, e)
 )
 
 /* Meanwhile, States change as we transition, well, states. */
 
 datatype State = State(
-        /* A zone is a contiguous region of a disk. */
-        zones: seq<Zone>,
+  /* A zone is a contiguous region of a disk. */
+  zones: seq<Zone>,
 
-        /* Which buffer will we fault the next write's zone over into? */
-        buffer_zone: int,
+  /* Which buffer will we fault the next write's zone over into? */
+  buffer_zone: int,
 
-        /* Logical zone -> physical zone remapping (to account for the
-         * buffer zone, which will float around as writes happen) */
-        buffer_map: seq<int>
+  /* Logical zone -> physical zone remapping (to account for the
+   * buffer zone, which will float around as writes happen) */
+  buffer_map: seq<int>
 )
 
-predicate Valid(c: Constants, s: State)
-{
-    && zone_map_well_formed(c.n_blocks, c.zone_map)
-    && |s.zones| == |c.zone_map|
-    && (forall z :: 0 <= z < |s.zones| ==>
-        |s.zones[z]| == (c.zone_map[z].1 - c.zone_map[z].0) as int)
+predicate Valid(c: Constants, s: State) {
+  && zone_map_well_formed(c.n_blocks, c.zone_map)
+  && |s.zones| == |c.zone_map|
+  && (forall z :: 0 <= z < |s.zones| ==>
+      |s.zones[z]| == (c.zone_map[z].1 - c.zone_map[z].0) as int)
 }
 
 
 predicate Write(c: Constants, s: State, s': State, lba: uint64, val: Block)
-    requires Valid(c, s)
-    requires 0 <= lba < c.n_blocks
+  requires Valid(c, s)
+  requires 0 <= lba < c.n_blocks
 {
-    //var p :| resolve_lba(c, lba, p);
-    var (lzone, off) := (0,0);
-    var pzone := s.buffer_map[lzone];
+  var (lzone, off) := (0,0);
+  var pzone := s.buffer_map[lzone];
 
-    var src_zone := s.zones[pzone];
-    var dst_zone := src_zone[ off := val ];
+  var src_zone := s.zones[pzone];
+  var dst_zone := src_zone[ off := val ];
 
-    && |s.zones| == |s'.zones|
+  && |s.zones| == |s'.zones|
 
-    // The zone containing the block we want to destructively write
-    // is now the new buffer zone
+  // The zone containing the block we want to destructively write
+  // is now the new buffer zone
 
-    // Our former buffer zone now contains the zone with the
-    // destructive update
-    && s'.zones[s.buffer_zone] == dst_zone
+  // Our former buffer zone now contains the zone with the
+  // destructive update
+  && s'.zones[s.buffer_zone] == dst_zone
 
-    // No other zones are touched
-    && (forall i :: 0 <= i < |s'.zones| ==>
-        (i != pzone && i != s.buffer_zone ==> s.zones[i] == s'.zones[i]))
+  // No other zones are touched
+  && (forall i :: 0 <= i < |s'.zones| ==>
+      (i != pzone && i != s.buffer_zone ==> s.zones[i] == s'.zones[i]))
 }
 
 lemma WritePreservesValid(c: Constants, s: State, s': State, lba: uint64, val: Block)
-    requires Valid(c, s)
-    requires Write(c, s, s', lba, val);
-    ensures Valid(c, s')
+  requires Valid(c, s)
+  requires Write(c, s, s', lba, val);
+  ensures Valid(c, s')
 {}

--- a/Source/DafnyLanguageServer.Test/Various/TestFiles/3048.dfy
+++ b/Source/DafnyLanguageServer.Test/Various/TestFiles/3048.dfy
@@ -1,0 +1,96 @@
+/* Repro test case for https://github.com/dafny-lang/dafny/issues/3048
+ * author: Nathan Taylor <ntaylor@cs.utexas.edu>
+ *
+ * This file should not pass the resolver and provide a counterexample,
+ * but should not crash the language server either.
+ */
+
+/* Types */
+
+newtype{:nativeType "ulong"} uint64 = i:int | 0 <= i <= UINT64_MAX
+const UINT64_MAX := 0x1_0000_0000_0000_0000 - 1
+
+newtype{:nativeType "ulong"} uint8 = i:int | 0 <= i <= UINT8_MAX
+const UINT8_MAX := 0x100 - 1
+
+type Block = seq<uint8>
+type Zone = seq<Block>
+
+/* a zone map is a sequence of contiguous half-open intervals. */
+
+predicate zone_map_well_formed(n_blocks: uint64, zone_map: seq<(uint64, uint64)>)
+{
+    && 0 < |zone_map| as int
+    && zone_map[0].0 == 0
+    && zone_map[|zone_map| - 1].1 == n_blocks
+    && zone_map_ordered_total(zone_map)
+}
+
+predicate zone_map_ordered_total(zone_map: seq<(uint64, uint64)>)
+{
+    && 0 < |zone_map| as int
+    && (forall i :: 0 <  i < |zone_map| ==> zone_map[i-1].1 == zone_map[i].0)
+    && (forall i :: 0 <= i < |zone_map| ==> zone_map[i].0 < zone_map[i].1)
+    && (forall i :: 0 <= i < |zone_map| ==> (zone_map[i].1 - zone_map[i].0) as int < UINT64_MAX)
+}
+
+/* State transitions take Constants as, well, constant. */
+
+datatype Constants = Constants(
+    n_blocks: uint64,
+    zone_map: seq<(uint64, uint64)> // [b, e)
+)
+
+/* Meanwhile, States change as we transition, well, states. */
+
+datatype State = State(
+        /* A zone is a contiguous region of a disk. */
+        zones: seq<Zone>,
+
+        /* Which buffer will we fault the next write's zone over into? */
+        buffer_zone: int,
+
+        /* Logical zone -> physical zone remapping (to account for the
+         * buffer zone, which will float around as writes happen) */
+        buffer_map: seq<int>
+)
+
+predicate Valid(c: Constants, s: State)
+{
+    && zone_map_well_formed(c.n_blocks, c.zone_map)
+    && |s.zones| == |c.zone_map|
+    && (forall z :: 0 <= z < |s.zones| ==>
+        |s.zones[z]| == (c.zone_map[z].1 - c.zone_map[z].0) as int)
+}
+
+
+predicate Write(c: Constants, s: State, s': State, lba: uint64, val: Block)
+    requires Valid(c, s)
+    requires 0 <= lba < c.n_blocks
+{
+    //var p :| resolve_lba(c, lba, p);
+    var (lzone, off) := (0,0);
+    var pzone := s.buffer_map[lzone];
+
+    var src_zone := s.zones[pzone];
+    var dst_zone := src_zone[ off := val ];
+
+    && |s.zones| == |s'.zones|
+
+    // The zone containing the block we want to destructively write
+    // is now the new buffer zone
+
+    // Our former buffer zone now contains the zone with the
+    // destructive update
+    && s'.zones[s.buffer_zone] == dst_zone
+
+    // No other zones are touched
+    && (forall i :: 0 <= i < |s'.zones| ==>
+        (i != pzone && i != s.buffer_zone ==> s.zones[i] == s'.zones[i]))
+}
+
+lemma WritePreservesValid(c: Constants, s: State, s': State, lba: uint64, val: Block)
+    requires Valid(c, s)
+    requires Write(c, s, s', lba, val);
+    ensures Valid(c, s')
+{}

--- a/docs/dev/news/3048.fix
+++ b/docs/dev/news/3048.fix
@@ -1,1 +1,1 @@
-Do not sort SeqIndices that are not parseable as integers
+Counter-examples with non-integer sequence indices do not crash Dafny anymore.

--- a/docs/dev/news/3048.fix
+++ b/docs/dev/news/3048.fix
@@ -1,0 +1,1 @@
+Do not sort SeqIndices that are not parseable as integers


### PR DESCRIPTION
Occasionally the language server is passed a seq index that is not parseable as an integer.  While the root cause has not yet been determined, it's still causing an LSP crash.  This patch ensures that non-parseable indices are handled separately from those that are parseable.

After this patch, any non-integral indices are appended to the end of the sorted output: [the crashing test](https://gist.github.com/dijkstracula/b2863891f53650fcf4607abd2b35991f) in #3048 now produces,

```
@4:seq<seq<seq<_module.uint8>>> = (Length := 9899, [0] := @14, [8100] := @15, [9898] := @16, [(- 1)] := @17)
```

Fixes #3048

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
