### PR TITLE
fix: Revert old buffer workaround for calling `node`

### DIFF
--- a/Source/DafnyCore/Compilers/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/Compiler-js.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Diagnostics.Contracts;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Microsoft.Dafny.Compilers {
@@ -2476,8 +2477,11 @@ namespace Microsoft.Dafny.Compilers {
       TextWriter outputWriter) {
       Contract.Requires(targetFilename != null || otherFileNames.Count == 0);
 
-      var psi = PrepareProcessStartInfo("node");
-      psi.RedirectStandardInput = true;
+      var psi = new ProcessStartInfo("node", "") {
+        RedirectStandardInput = true,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+      };
 
       try {
         Process nodeProcess = Process.Start(psi);
@@ -2492,12 +2496,27 @@ namespace Microsoft.Dafny.Compilers {
         }
         nodeProcess.StandardInput.Flush();
         nodeProcess.StandardInput.Close();
-        return 0 == WaitForExit(nodeProcess, outputWriter);
+        // Fixes a problem of Node on Windows, where Node does not prints to the parent console its standard outputs.
+        var errorProcessing = Task.Run(() => {
+          PassthroughBuffer(nodeProcess.StandardError, Console.Error);
+        });
+        PassthroughBuffer(nodeProcess.StandardOutput, Console.Out);
+        nodeProcess.WaitForExit();
+        errorProcessing.Wait();
+        return nodeProcess.ExitCode == 0;
       } catch (System.ComponentModel.Win32Exception e) {
         outputWriter.WriteLine("Error: Unable to start node.js ({0}): {1}", psi.FileName, e.Message);
         return false;
       }
     }
 
+    // We read character by character because we did not find a way to ensure
+    // final newlines are kept when reading line by line
+    private static void PassthroughBuffer(TextReader input, TextWriter output) {
+      int current;
+      while ((current = input.Read()) != -1) {
+        output.Write((char)current);
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
