### PR TITLE
Undo the '|| true -> !' refactoring

### DIFF
--- a/Test/DafnyTests/RunAllTestsOption.dfy
+++ b/Test/DafnyTests/RunAllTestsOption.dfy
@@ -1,9 +1,9 @@
 // RUN: %baredafny verify %args "%s" > "%t"
-// RUN: ! %baredafny test %args --no-verify --target:cs "%s" >> "%t"
-// RUN: ! %baredafny test %args --no-verify --target:java "%s" >> "%t"
-// RUN: ! %baredafny test %args --no-verify --target:go "%s" >> "%t"
-// RUN: ! %baredafny test %args --no-verify --target:js "%s" >> "%t"
-// RUN: ! %baredafny test %args --no-verify --target:py "%s" >> "%t"
+// RUN: %baredafny test %args --no-verify --target:cs "%s" >> "%t" || true
+// RUN: %baredafny test %args --no-verify --target:java "%s" >> "%t" || true
+// RUN: %baredafny test %args --no-verify --target:go "%s" >> "%t" || true
+// RUN: %baredafny test %args --no-verify --target:js "%s" >> "%t" || true
+// RUN: %baredafny test %args --no-verify --target:py "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t" 
 
 include "../exceptions/VoidOutcomeDt.dfy"

--- a/Test/DafnyTests/TestAttribute.dfy
+++ b/Test/DafnyTests/TestAttribute.dfy
@@ -1,5 +1,5 @@
 // RUN: %dafny_0 /compileVerbose:1 /compile:0 /spillTargetCode:3 /noVerify "%s" > "%t"
-// RUN: ! dotnet test -v:q -noLogo %S >> %t
+// RUN: dotnet test -v:q -noLogo %S >> %t || true
 //
 // RUN: %OutputCheck --file-to-check "%t" "%s"
 // CHECK: .*Error: Post-conditions on function Identity might be unsatisfied when synthesizing code for method mockUnsafe.*

--- a/Test/contract-wrappers/AllExterns.dfy
+++ b/Test/contract-wrappers/AllExterns.dfy
@@ -1,4 +1,4 @@
-// RUN: ! %dafny /compile:4 /noVerify /runAllTests:1 /testContracts:Externs %s %s.externs.cs > %t
+// RUN: %dafny /compile:4 /noVerify /runAllTests:1 /testContracts:Externs %s %s.externs.cs > %t || true
 // RUN: %diff "%s.expect" "%t"
 // RUN: %OutputCheck --file-to-check "%S/AllExterns.cs" "%s"
 // CHECK: .*Foo____dafny__checked\(x\).*

--- a/Test/contract-wrappers/TestedExterns.dfy
+++ b/Test/contract-wrappers/TestedExterns.dfy
@@ -1,4 +1,4 @@
-// RUN: ! %dafny /compile:4 /noVerify /runAllTests:1 /testContracts:TestedExterns %s %s.externs.cs > %t
+// RUN: %dafny /compile:4 /noVerify /runAllTests:1 /testContracts:TestedExterns %s %s.externs.cs > %t || true
 // RUN: %diff "%s.expect" "%t"
 // RUN: %OutputCheck --file-to-check "%S/TestedExterns.cs" "%s"
 // CHECK-NOT: .*Foo____dafny__checked\(x\).*

--- a/Test/dafny0/ForbidNondeterminismCompile.dfy
+++ b/Test/dafny0/ForbidNondeterminismCompile.dfy
@@ -1,4 +1,4 @@
-// RUN: ! %baredafny build %args --enforce-determinism "%s" --target cs > "%t"
+// RUN: %baredafny build %args --enforce-determinism "%s" --target cs > "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 class C {

--- a/Test/dafny0/Include.dfy
+++ b/Test/dafny0/Include.dfy
@@ -1,5 +1,5 @@
-// RUN: ! %baredafny verify %args "%s" > "%t"
-// RUN: ! %baredafny verify %args --verify-included-files "%s" >> "%t"
+// RUN: %baredafny verify %args "%s" > "%t" || true
+// RUN: %baredafny verify %args --verify-included-files "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 include "Includee.dfy"

--- a/Test/dafny0/PrintEffects.dfy
+++ b/Test/dafny0/PrintEffects.dfy
@@ -1,5 +1,5 @@
 // RUN: %baredafny run %args "%s" > "%t"
-// RUN: ! %baredafny run %args --track-print-effects "%s" >> "%t"
+// RUN: %baredafny run %args --track-print-effects "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 method Main() {

--- a/Test/expectations/Expect.dfy
+++ b/Test/expectations/Expect.dfy
@@ -1,8 +1,8 @@
-// RUN: ! %baredafny run --target=cs %args "%s" > "%t"
-// RUN: ! %baredafny run --target=go %args "%s" >> "%t"
-// RUN: ! %baredafny run --target=java %args "%s" >> "%t"
-// RUN: ! %baredafny run --target=js %args "%s" >> "%t"
-// RUN: ! %baredafny run --target=py %args "%s" >> "%t"
+// RUN: %baredafny run --target=cs %args "%s" > "%t" || true
+// RUN: %baredafny run --target=go %args "%s" >> "%t" || true
+// RUN: %baredafny run --target=java %args "%s" >> "%t" || true
+// RUN: %baredafny run --target=js %args "%s" >> "%t" || true
+// RUN: %baredafny run --target=py %args "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 datatype OOAgent = | OO7 {

--- a/Test/expectations/ExpectAndExceptions.dfy
+++ b/Test/expectations/ExpectAndExceptions.dfy
@@ -1,7 +1,7 @@
-// RUN: ! %dafny /compile:3 /compileTarget:cs "%s" > "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:go "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:java "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /compile:3 /compileTarget:cs "%s" > "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:go "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:java "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:js "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 include "../exceptions/NatOutcomeDt.dfy"

--- a/Test/expectations/ExpectWithMessage.dfy
+++ b/Test/expectations/ExpectWithMessage.dfy
@@ -1,7 +1,7 @@
-// RUN: ! %dafny /compile:3 /compileTarget:cs "%s" > "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:go "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:java "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:js "%s" >> "%t"
+// RUN: %dafny /compile:3 /compileTarget:cs "%s" > "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:go "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:java "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:js "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 method Main() {

--- a/Test/expectations/ExpectWithNonStringMessage.dfy
+++ b/Test/expectations/ExpectWithNonStringMessage.dfy
@@ -1,9 +1,9 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:py "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:py "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 datatype Option<T> = None | Some(get: T)

--- a/Test/git-issues/git-issue-1564.dfy
+++ b/Test/git-issues/git-issue-1564.dfy
@@ -1,9 +1,9 @@
-// RUN: ! %baredafny verify %args --function-syntax:3 "%s" > "%t"
-// RUN: ! %baredafny verify %args --function-syntax:migration3to4 "%s" >> "%t"
-// RUN: ! %baredafny verify %args --function-syntax:4 "%s" >> "%t"
-// RUN: ! %baredafny verify %args --function-syntax:experimentalDefaultGhost "%s" >> "%t"
-// RUN: ! %baredafny verify %args --function-syntax:experimentalDefaultCompiled "%s" >> "%t"
-// RUN: ! %baredafny verify %args --function-syntax:experimentalPredicateAlwaysGhost "%s" >> "%t"
+// RUN: %baredafny verify %args --function-syntax:3 "%s" > "%t" || true
+// RUN: %baredafny verify %args --function-syntax:migration3to4 "%s" >> "%t" || true
+// RUN: %baredafny verify %args --function-syntax:4 "%s" >> "%t" || true
+// RUN: %baredafny verify %args --function-syntax:experimentalDefaultGhost "%s" >> "%t" || true
+// RUN: %baredafny verify %args --function-syntax:experimentalDefaultCompiled "%s" >> "%t" || true
+// RUN: %baredafny verify %args --function-syntax:experimentalPredicateAlwaysGhost "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 function F0(): int // error: 3to4

--- a/Test/git-issues/git-issue-401a.dfy
+++ b/Test/git-issues/git-issue-401a.dfy
@@ -1,5 +1,5 @@
 // Dafny should emit exit value 1
-// RUN: ! %dafny /compile:0 /proverOpt:PROVER_PATH=Output/binz/z3 "%s" > "%t"
+// RUN: %dafny /compile:0 /proverOpt:PROVER_PATH=Output/binz/z3 "%s" > "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 method m() {

--- a/Test/git-issues/git-issue-555.dfy
+++ b/Test/git-issues/git-issue-555.dfy
@@ -1,8 +1,8 @@
 // RUN: %dafny_0 /compile:0 "%s" > "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 

--- a/Test/git-issues/git-issue-590.dfy
+++ b/Test/git-issues/git-issue-590.dfy
@@ -1,3 +1,3 @@
 // dafny should emit exit value 1
-// RUN: ! %dafny /compile:3 x.cs > "%t"
+// RUN: %dafny /compile:3 x.cs > "%t" || true
 // RUN: %diff "%s.expect" "%t"

--- a/Test/git-issues/git-issue-643.dfy
+++ b/Test/git-issues/git-issue-643.dfy
@@ -1,8 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 method Main() {

--- a/Test/git-issues/git-issue-643a.dfy
+++ b/Test/git-issues/git-issue-643a.dfy
@@ -1,8 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 method Main() {

--- a/Test/git-issues/git-issue-645.dfy
+++ b/Test/git-issues/git-issue-645.dfy
@@ -1,4 +1,4 @@
 // dafny should emit exit value 1
-// RUN: ! %dafny /xyz    > "%t"
+// RUN: %dafny /xyz    > "%t" || true
 // RUN: %diff "%s.expect" "%t"
 // UNSUPPORTED: windows

--- a/Test/git-issues/git-issue-856.dfy
+++ b/Test/git-issues/git-issue-856.dfy
@@ -1,8 +1,8 @@
 // RUN: %dafny /compile:0 "%s" > "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs "%s" >> "%t" || true
 // RUN: %dafny_0 /noVerify /compile:4 /compileTarget:js "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 method Main()

--- a/Test/metatests/InconsistentCompilerBehavior.dfy
+++ b/Test/metatests/InconsistentCompilerBehavior.dfy
@@ -1,4 +1,4 @@
-// RUN: ! %testDafnyForEachCompiler "%s" > "%t"
+// RUN: %testDafnyForEachCompiler "%s" > "%t" || true
 // RUN: %diff "%s.testdafny.expect" "%t"
 
 // A %testdafny test case expected to fail, since at the time of

--- a/Test/unicodechars/expectations/Expect.dfy
+++ b/Test/unicodechars/expectations/Expect.dfy
@@ -1,7 +1,7 @@
-// RUN: ! %baredafny run --target=cs --unicode-char %args "%s" > "%t"
-// RUN: ! %baredafny run --target=go --unicode-char %args "%s" >> "%t"
-// RUN: ! %baredafny run --target=java --unicode-char %args "%s" >> "%t"
-// RUN: ! %baredafny run --target=js --unicode-char %args "%s" >> "%t"
-// RUN: ! %baredafny run --target=py --unicode-char %args "%s" >> "%t"
+// RUN: %baredafny run --target=cs --unicode-char %args "%s" > "%t" || true
+// RUN: %baredafny run --target=go --unicode-char %args "%s" >> "%t" || true
+// RUN: %baredafny run --target=java --unicode-char %args "%s" >> "%t" || true
+// RUN: %baredafny run --target=js --unicode-char %args "%s" >> "%t" || true
+// RUN: %baredafny run --target=py --unicode-char %args "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 include "../../expectations/Expect.dfy"

--- a/Test/unicodechars/expectations/ExpectAndExceptions.dfy
+++ b/Test/unicodechars/expectations/ExpectAndExceptions.dfy
@@ -1,7 +1,7 @@
-// RUN: ! %dafny /compile:3 /compileTarget:cs /unicodeChar:1 "%s" > "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:go /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:java /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:js /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:py /unicodeChar:1 "%s" >> "%t"
+// RUN: %dafny /compile:3 /compileTarget:cs /unicodeChar:1 "%s" > "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:go /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:java /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:js /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:py /unicodeChar:1 "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 include "../../expectations/ExpectAndExceptions.dfy"

--- a/Test/unicodechars/expectations/ExpectWithMessage.dfy
+++ b/Test/unicodechars/expectations/ExpectWithMessage.dfy
@@ -1,7 +1,7 @@
-// RUN: ! %dafny /compile:3 /compileTarget:cs /unicodeChar:1 "%s" > "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:go /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:java /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:js /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /compile:3 /compileTarget:py /unicodeChar:1 "%s" >> "%t"
+// RUN: %dafny /compile:3 /compileTarget:cs /unicodeChar:1 "%s" > "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:go /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:java /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:js /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /compile:3 /compileTarget:py /unicodeChar:1 "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 include "../../expectations/ExpectWithMessage.dfy"

--- a/Test/unicodechars/expectations/ExpectWithNonStringMessage.dfy
+++ b/Test/unicodechars/expectations/ExpectWithNonStringMessage.dfy
@@ -1,9 +1,9 @@
 // RUN: %dafny /compile:0 /verifyAllModules "%s" > "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:cs /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:go /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:java /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:js /unicodeChar:1 "%s" >> "%t"
-// RUN: ! %dafny /noVerify /compile:4 /compileTarget:py /unicodeChar:1 "%s" >> "%t"
+// RUN: %dafny /noVerify /compile:4 /compileTarget:cs /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:go /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:java /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:js /unicodeChar:1 "%s" >> "%t" || true
+// RUN: %dafny /noVerify /compile:4 /compileTarget:py /unicodeChar:1 "%s" >> "%t" || true
 // RUN: %diff "%s.expect" "%t"
 
 // Note this is one good example of printing regressing with /unicodeChar:1

--- a/Test/verification/filter.dfy
+++ b/Test/verification/filter.dfy
@@ -1,5 +1,5 @@
 // RUN: %baredafny verify %args --boogie-filter='*Succeeds*' --bprint:"%t.bpl" %s > %t
-// RUN: ! %baredafny verify %args %s >> %t
+// RUN: %baredafny verify %args %s >> %t || true
 // RUN: %diff "%s.expect" "%t"
 
 method Succeeds()


### PR DESCRIPTION
I can't get the nightly build to pass reliably anymore, so reverting this recent change.

Fixes #3107

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
