### PR TITLE
Feat: conditional verification, detection of trivially false assumptions

### DIFF
--- a/Source/DafnyCore/AST/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions.cs
@@ -3167,6 +3167,7 @@ public class StmtExpr : Expression {
       Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
     }
   }
+  public override IEnumerable<INode> Children => new List<INode> { S, E };
 }
 
 public class ITEExpr : Expression {

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -3864,6 +3864,10 @@ namespace Microsoft.Dafny {
       if (q is LiteralExpr { Value: bool value } && value == truth) {
         return true;
       }
+
+      if (q is UnaryOpExpr unaryOpExpr && unaryOpExpr.Op == UnaryOpExpr.Opcode.Not) {
+        return IsExpressionAlways(unaryOpExpr.E, !truth);
+      }
       if (q is BinaryExpr binaryExpr) {
         var e0 = binaryExpr.E0;
         var e1 = binaryExpr.E1;

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -3851,6 +3851,106 @@ namespace Microsoft.Dafny {
       MakeAssert(tok, q, desc, kv);
     }
 
+    public static bool IsExpressionAlways(Expression q, bool truth) {
+      q = q.WasResolved() ? q.Resolved : q;
+      if (q is ForallExpr forallExpr) {
+        return truth && IsExpressionAlways(Expression.CreateImplies(
+          forallExpr.Range ?? Expression.CreateBoolLiteral(Token.NoToken, true), forallExpr.Term, true), true);
+      }
+      if (q is ExistsExpr existsExpr) {
+        return !truth && IsExpressionAlways(Expression.CreateAnd(
+          existsExpr.Range ?? Expression.CreateBoolLiteral(Token.NoToken, true), existsExpr.Term, true), false);
+      }
+      if (q is LiteralExpr { Value: bool value } && value == truth) {
+        return true;
+      }
+      if (q is BinaryExpr binaryExpr) {
+        var e0 = binaryExpr.E0;
+        var e1 = binaryExpr.E1;
+        switch (binaryExpr.Op) {
+          case BinaryExpr.Opcode.And:
+            return truth
+              ? IsExpressionAlways(e0, true) && IsExpressionAlways(e1, true)
+              : IsExpressionAlways(e0, false) || IsExpressionAlways(e1, false);
+          case BinaryExpr.Opcode.Or:
+            return truth
+              ? IsExpressionAlways(e0, true) || IsExpressionAlways(e1, true)
+              : IsExpressionAlways(e0, false) && IsExpressionAlways(e1, false);
+          case BinaryExpr.Opcode.Imp:
+            return truth
+              ? IsExpressionAlways(e0, false) || IsExpressionAlways(e1, true)
+              : IsExpressionAlways(e0, true) && IsExpressionAlways(e1, false);
+          case BinaryExpr.Opcode.Iff:
+            return truth
+              ? (IsExpressionAlways(e0, false) && IsExpressionAlways(e1, false) ||
+                 IsExpressionAlways(e0, true) && IsExpressionAlways(e1, true))
+              : (IsExpressionAlways(e0, true) && IsExpressionAlways(e1, false) ||
+                 IsExpressionAlways(e0, false) && IsExpressionAlways(e1, true));
+          case BinaryExpr.Opcode.Eq:
+            if (truth) { // Obvious case when A == B is true, when the two representations are the same.
+              return Printer.ExprToString(e0) == Printer.ExprToString(e1);
+            } else {
+              // Cases in which we absolutely know that an equality can't hold
+              // - One expression is a datatype and the other is destructing this datatype
+              // - Two literals that are different
+              if (e0 is LiteralExpr { Value: BigInteger b1 } && e1 is LiteralExpr { Value: BigInteger b2 }) {
+                return b1.CompareTo(b2) != 0;
+              }
+              if (e0 is LiteralExpr { Value: bool bb1 } && e1 is LiteralExpr { Value: bool bb2 }) {
+                return bb1 != bb2;
+              }
+              if (e0.Type.NormalizeExpand().AsIndDatatype is IndDatatypeDecl
+                  && e1.Type.NormalizeExpand().AsIndDatatype is IndDatatypeDecl
+                  && Printer.ExprToString(e0) is var e0str
+                  && Printer.ExprToString(e1) is var e1str
+                  && (e1str.StartsWith(e0str + ".") || (e0str.StartsWith(e1str + ".")))) {
+                return true;
+              }
+              return false;
+            }
+          case BinaryExpr.Opcode.Lt: {
+              if (!truth && Printer.ExprToString(e0) == Printer.ExprToString(e1)) { // Obvious case when A < B is wrong: B == A
+                return true;
+              }
+              // Obvious case when A < B is always true, when A and B are bigintegers
+              if (e0 is LiteralExpr { Value: BigInteger b1 } && e1 is LiteralExpr { Value: BigInteger b2 }) {
+                return truth == (b1.CompareTo(b2) < 0);
+              }
+              return false;
+            }
+          case BinaryExpr.Opcode.Gt: {
+              // Obvious case when A > B is wrong: B == A
+              if (!truth && Printer.ExprToString(e0) == Printer.ExprToString(e1)) {
+                return true;
+              }
+              // Obvious case when A > B is always true, when A and B are bigintegers
+              if (e0 is LiteralExpr { Value: BigInteger b1 } lit1 && e1 is LiteralExpr { Value: BigInteger b2 }) {
+                return truth == (b1.CompareTo(b2) > 0);
+              }
+              return false;
+            }
+          case BinaryExpr.Opcode.Neq: {
+              // Obvious case when A != B is wrong: B == A
+              if (!truth && Printer.ExprToString(e0) == Printer.ExprToString(e1)) {
+                return true;
+              }
+              // Obvious case when A > B is always true, when A and B are bigintegers
+              if (e0 is LiteralExpr { Value: var value1 } && e1 is LiteralExpr { Value: var value2 }) {
+                if (value1 is BigInteger b1 && value2 is BigInteger b2) {
+                  return truth == (b1.CompareTo(b2) != 0);
+                } else if (value1 is bool bb1 && value2 is bool bb2) {
+                  return truth == (bb1 != bb2);
+                }
+              }
+
+              return false;
+            }
+        }
+      }
+
+      return false;
+    }
+
     /// <summary>
     /// Returns true if it can statically determine that the expression q always evaluates to truth
     /// </summary>

--- a/Source/DafnyLanguageServer.Test/GutterStatus/LinearRenderingTest.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/LinearRenderingTest.cs
@@ -51,6 +51,22 @@ public class LinearRenderingTest {
             : LineVerificationStatus.VerifiedVerifying,
         _ => throw new ArgumentOutOfRangeException()
       },
+      // If a node is marked with VerifiedWithAssumption
+      GutterVerificationStatus.VerifiedWithAssumption => currentStatus switch {
+        CurrentStatus.Current => contextHasErrors && isSingleLine
+                                 || !contextHasErrors && contextIsPending && !isSingleLine
+            ? LineVerificationStatus.Nothing
+            : LineVerificationStatus.VerifiedWithAssumption,
+        CurrentStatus.Obsolete => contextHasErrors && isSingleLine
+         || !contextHasErrors && contextIsPending && !isSingleLine
+          ? LineVerificationStatus.Scheduled
+            : LineVerificationStatus.VerifiedWithAssumptionObsolete,
+        CurrentStatus.Verifying => contextHasErrors && isSingleLine ||
+            !contextHasErrors && (contextIsPending && !isSingleLine)
+            ? LineVerificationStatus.Verifying
+            : LineVerificationStatus.VerifiedWithAssumptionVerifying,
+        _ => throw new ArgumentOutOfRangeException()
+      },
       // We don't display inconclusive on the gutter (user should focus on errors),
       // We display an error range instead
       GutterVerificationStatus.Inconclusive => currentStatus switch {
@@ -83,6 +99,8 @@ public class LinearRenderingTest {
               Assert.AreEqual(
                 RenderLineVerificationStatusOriginal(isSingleLine, contextHasError, contextIsPending, currentStatus, verificationStatus),
                 VerificationTree.RenderLineVerificationStatus(isSingleLine, contextHasError, contextIsPending, currentStatus, verificationStatus)
+                , "verificationStatus={0}, currentStatus={1} isSingleLine={2}, contextHasError={3}, contextIsPending={4}",
+                  verificationStatus, currentStatus, isSingleLine, contextHasError, contextIsPending
                 );
               contextIsPending = !contextIsPending;
             } while (!contextIsPending);

--- a/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
@@ -46,7 +46,13 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
     { LineVerificationStatus.AssertionVerifiedInErrorContextObsolete, "[o]" },
     { LineVerificationStatus.AssertionVerifiedInErrorContextVerifying, "[Q]" },
     { LineVerificationStatus.AssertionVerifiedInErrorContext, "[O]" },
-    { LineVerificationStatus.ResolutionError, @"/!\" }
+    { LineVerificationStatus.ResolutionError, @"/!\" },
+    { LineVerificationStatus.VerifiedWithAssumption, " |?" },
+    { LineVerificationStatus.VerifiedWithAssumptionObsolete, " I?" },
+    { LineVerificationStatus.VerifiedWithAssumptionVerifying, " $?" },
+    { LineVerificationStatus.AssumptionInVerifiedContext, " =?" },
+    { LineVerificationStatus.AssumptionInVerifiedContextObsolete, " -?" },
+    { LineVerificationStatus.AssumptionInVerifiedContextVerifying, " ~?" },
   };
 
   private static bool IsNotIndicatingProgress(LineVerificationStatus status) {
@@ -59,7 +65,9 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
            status != LineVerificationStatus.ErrorContextObsolete &&
            status != LineVerificationStatus.ErrorContextVerifying &&
            status != LineVerificationStatus.AssertionVerifiedInErrorContextObsolete &&
-           status != LineVerificationStatus.AssertionVerifiedInErrorContextVerifying;
+           status != LineVerificationStatus.AssertionVerifiedInErrorContextVerifying &&
+           status != LineVerificationStatus.VerifiedWithAssumptionObsolete &&
+           status != LineVerificationStatus.VerifiedWithAssumptionVerifying;
   }
   public static string RenderTrace(List<LineVerificationStatus[]> statusesTrace, string code) {
     var codeLines = new Regex("\r?\n").Split(code);

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -202,10 +202,20 @@ method Foo() ensures false { } ";
   public async Task EnsuresBodyVerifiedWithAssumptionsAreCorrectlyHighlighted() {
     await VerifyTrace(@"
  .  S  S  |? I? I? $?[S][ ]:method Test()
- .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2;
+ .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2
  .  S  S  |? I? I? $?[=][=]:{
  .  S  S  =? -? I? $?[S][ ]:  assume false; //Next:
  .  S  S  |? I? I? $?[S][ ]:}");
+  }
+
+  [TestMethod]
+  public async Task EnsuresBodyWithRequiresFalseCorrectlyHighlighted() {
+    await VerifyTrace(@"
+ .  S  S  |?:method Test()
+ .  S  |  =?:  requires èxists x: int :: true ==> (true && false) || false
+ .  S  S  |?:{
+ .  S  S  =?:  assert true;
+ .  S  S  |?:}");
   }
 
   [TestMethod]

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -198,7 +198,6 @@ method Foo() ensures false { } ";
  .  |  |  | :}");
   }
 
-
   [TestMethod]
   public async Task EnsuresBodyVerifiedWithAssumptionsAreCorrectlyHighlighted() {
     await VerifyTrace(@"
@@ -206,6 +205,17 @@ method Foo() ensures false { } ";
  .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2;
  .  S  S  |? I? I? $?[=][=]:{
  .  S  S  =? -? I? $?[S][ ]:  assume false; //Next:
+ .  S  S  |? I? I? $?[S][ ]:}");
+  }
+
+  [TestMethod]
+  public async Task EnsuresFunctionVerifiedWithAssumptionsAreCorrectlyHighlighted() {
+    await VerifyTrace(@"
+ .  S  S  |? I? I? $?[=][=]:function Test(): int
+ .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2;
+ .  S  S  |? I? I? $?[S][ ]:{
+ .  S  S  =? -? I? $?[S][ ]:  assume false; //Next:
+ .  S  S  |? I? I? $?[S][ ]:  1
  .  S  S  |? I? I? $?[S][ ]:}");
   }
 }

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -197,4 +197,15 @@ method Foo() ensures false { } ";
  .  |  |  | :  true
  .  |  |  | :}");
   }
+
+
+  [TestMethod]
+  public async Task EnsuresBodyVerifiedWithAssumptionsAreCorrectlyHighlighted() {
+    await VerifyTrace(@"
+ .  S  S  |? I? I? $?[S][ ]:method Test()
+ .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2;
+ .  S  S  |? I? I? $?[=][=]:{
+ .  S  S  =? -? I? $?[S][ ]:  assume false; //Next:
+ .  S  S  |? I? I? $?[S][ ]:}");
+  }
 }

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -209,20 +209,103 @@ method Foo() ensures false { } ";
   }
 
   [TestMethod]
+  public async Task EnsureAxiomNotMarkedAndRequiresNotMarked() {
+    await VerifyTrace(@"
+ |?:method Test(i: nat)
+ |?:  requires {:axiom} i >= 1
+ |?:  requires i >= 2
+ |?:  requires {:axiom} i >= 3
+ |?:  requires i >= 4
+ |?:{
+ =?:  assume i >= 5;
+ |?:  assume {:axiom} i >= 6;
+ =?:  assume i >= 7;
+ |?:  assume {:axiom} i >= 8;
+ |?:}", intermediates: false);
+  }
+
+  [TestMethod]
   public async Task EnsuresBodyWithRequiresFalseCorrectlyHighlighted() {
     await VerifyTrace(@"
  .  S  S  |?:method Test()
- .  S  S  =?:  requires exists x: int :: true ==> (true && false) || false
+ .  S  S  =?:  requires exists x: int :: true ==> (true && !true) || false
+ .  S  S  =?:  requires !forall x: int :: true && ((false || !false) && true)
  .  S  S  |?:{
  .  S  |  |?:  assert true;
  .  S  S  |?:}");
   }
 
   [TestMethod]
+  public async Task EnsureArraySameCaught() {
+    await VerifyTrace(@"
+ |?:method Test(a: array<int>, i: nat, j: nat)
+ |?:  requires 0 <= i < a.Length
+ |?:  requires 0 <= j < a.Length
+ =?:  requires a[i] < a[i]
+ =?:  requires a[i] != a[i]
+ =?:  requires a[i] > a[i]
+ =?:  requires 1 > 2
+ |?:  requires i > j
+ |?:{
+ |?:  assert false;
+ |?:}", intermediates: false);
+  }
+
+  [TestMethod]
+  public async Task EnsureDatatypeSameCaught() {
+    await VerifyTrace(@"
+   :datatype List = Nil | Cons(head: int, tail: List)
+   :
+ |?:method Test(a: List)
+ |?:  requires a != Nil
+ =?:  requires a.tail == a
+ =?:  requires a == a.tail
+ |?:{
+ |?:  assert false;
+ |?:}", intermediates: false);
+  }
+
+  [TestMethod]
+  public async Task EnsureDatatypeSameCaughtOnFunctions() {
+    await VerifyTrace(@"
+   :datatype List = Nil | Cons(head: int, tail: List)
+   :
+ |?:function Test(a: List): int
+ |?:  requires a != Nil
+ =?:  requires a.tail == a
+ =?:  requires a == a.tail
+ |?:{
+ |?:  2
+ |?:}", intermediates: false);
+  }
+
+  [TestMethod]
+  public async Task EnsuresEnsuresOnExternMethodDontTriviallyProveFalse() {
+    await VerifyTrace(@"
+   :datatype List = Nil | Cons(head: int, tail: List)
+   :
+ |?:method {:extern} Test() returns (a: List)
+ |?:  ensures a != Nil
+ =?:  ensures a.tail == a
+ =?:  ensures a == a.tail", intermediates: false);
+  }
+
+  [TestMethod]
+  public async Task EnsuresEnsuresOnExternFunctionDontTriviallyProveFalse() {
+    await VerifyTrace(@"
+   :datatype List = Nil | Cons(head: int, tail: List)
+   :
+ |?:function {:extern} Test(): (a: List)
+ |?:  ensures a != Nil
+ =?:  ensures a.tail == a
+ =?:  ensures a == a.tail", intermediates: false);
+  }
+
+  [TestMethod]
   public async Task EnsuresFunctionVerifiedWithAssumptionsAreCorrectlyHighlighted() {
     await VerifyTrace(@"
  .  S  S  |? I? I? $?[=][=]:function Test(): int
- .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2;
+ .  S  |  |? I? I? $?[=][=]:  ensures 1 == 2
  .  S  S  |? I? I? $?[S][ ]:{
  .  S  S  =? -? I? $?[S][ ]:  assume false; //Next:
  .  S  S  |? I? I? $?[S][ ]:  1

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -212,9 +212,9 @@ method Foo() ensures false { } ";
   public async Task EnsuresBodyWithRequiresFalseCorrectlyHighlighted() {
     await VerifyTrace(@"
  .  S  S  |?:method Test()
- .  S  |  =?:  requires èxists x: int :: true ==> (true && false) || false
+ .  S  S  =?:  requires exists x: int :: true ==> (true && false) || false
  .  S  S  |?:{
- .  S  S  =?:  assert true;
+ .  S  |  |?:  assert true;
  .  S  S  |?:}");
   }
 

--- a/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
@@ -11,6 +11,7 @@ using Microsoft.Dafny.LanguageServer.Language;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Constant = Microsoft.Boogie.Constant;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -97,6 +98,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
   public enum GutterVerificationStatus {
     Nothing = 0,
     Verified = 200,
+    VerifiedWithAssumption = 250,
     Inconclusive = 270,
     Error = 400
   }
@@ -119,6 +121,14 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
     VerifiedVerifying = 202,
     // Also applicable for empty spaces if they are not surrounded by errors.
     Verified = 200,
+    // For contexts where there is at least one Assume statement and that were verified.
+    VerifiedWithAssumptionObsolete = 251,
+    VerifiedWithAssumptionVerifying = 252,
+    VerifiedWithAssumption = 250,
+    // For single assumptions that were identified in a method. Will show up only in verified contexts
+    AssumptionInVerifiedContextObsolete = 281,
+    AssumptionInVerifiedContextVerifying = 282,
+    AssumptionInVerifiedContext = 280,
     // For trees containing children with errors (e.g. functions, methods, fields, subset types)
     ErrorContextObsolete = 301,
     ErrorContextVerifying = 302,
@@ -175,7 +185,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
     public string PrefixedDisplayName => Kind + " " + DisplayName;
 
     // Overriden by checking children if there are some
-    public GutterVerificationStatus StatusVerification { get; set; } = GutterVerificationStatus.Nothing;
+    public virtual GutterVerificationStatus StatusVerification { get; set; } = GutterVerificationStatus.Nothing;
 
     // Overriden by checking children if there are some
     public CurrentStatus StatusCurrent { get; set; } = CurrentStatus.Obsolete;
@@ -282,6 +292,14 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
             : contextIsPending && !isFinalError
               ? LineVerificationStatus.Nothing
               : LineVerificationStatus.Verified,
+        GutterVerificationStatus.VerifiedWithAssumption =>
+          contextHasErrors
+            ? isFinalError // Sub-implementations that are verified do not count
+              ? LineVerificationStatus.Nothing
+              : LineVerificationStatus.VerifiedWithAssumption
+            : contextIsPending && !isFinalError
+              ? LineVerificationStatus.Nothing
+              : LineVerificationStatus.VerifiedWithAssumption,
         // We don't display inconclusive on the gutter (user should focus on errors),
         // We display an error range instead
         GutterVerificationStatus.Inconclusive =>
@@ -381,6 +399,10 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
     public ImmutableDictionary<AssertionBatchIndex, AssertionBatchVerificationTree> AssertionBatches { get; private set; } =
       new Dictionary<AssertionBatchIndex, AssertionBatchVerificationTree>().ToImmutableDictionary();
 
+    // At most one of TopLevelDecl and MemberDecl is non-null
+    public INode node;
+    public bool ByMethodBody = false; // true only if MemberDecl != null
+
     public override VerificationTree GetCopyForNotification() {
       if (Finished) {
         return this;// Won't be modified anymore, no need to duplicate
@@ -435,6 +457,66 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
     public int LongestAssertionBatchTime => AssertionBatches.Any() ? AssertionBatchTimes.Max() : 0;
 
     public int LongestAssertionBatchTimeIndex => LongestAssertionBatchTime != 0 ? AssertionBatchTimes.IndexOf(LongestAssertionBatchTime) : -1;
+
+    public override GutterVerificationStatus StatusVerification {
+      get {
+        var baseStatus = base.StatusVerification;
+        if (AssumptionsLines.Any() && baseStatus == GutterVerificationStatus.Verified) {
+          return GutterVerificationStatus.VerifiedWithAssumption;
+        }
+        return baseStatus;
+      }
+      set => base.StatusVerification = value;
+    }
+
+    private IEnumerable<int>? cachedAssumptionsLines = null;
+
+    private IEnumerable<int> AssumptionsLines {
+      get {
+        if (cachedAssumptionsLines != null) {
+          return cachedAssumptionsLines;
+        }
+        IEnumerable<int> CollectAssumeNotTrue(INode n) {
+          if (n is AssumeStmt { Expr: LiteralExpr { Value: not true } } assumeStmt) {
+            return new List<int> { assumeStmt.Tok.line - 1 };
+          }
+
+          return n == null ? Enumerable.Empty<int>() : n.Children.SelectMany(CollectAssumeNotTrue);
+        }
+
+        if (node is Function functionDecl) {
+          if (ByMethodBody) {
+            cachedAssumptionsLines = CollectAssumeNotTrue(functionDecl.ByMethodDecl);
+          } else {
+            cachedAssumptionsLines = functionDecl.Children.Where(child => child != functionDecl.ByMethodDecl).SelectMany(CollectAssumeNotTrue);
+          }
+        } else {
+          cachedAssumptionsLines = CollectAssumeNotTrue(node);
+        }
+
+        return cachedAssumptionsLines;
+      }
+    }
+
+    public override void RenderInto(LineVerificationStatus[] perLineDiagnostics, bool contextHasErrors = false,
+      bool contextIsPending = false, Range? otherRange = null, Range? contextRange = null) {
+      base.RenderInto(perLineDiagnostics, contextHasErrors, contextIsPending, otherRange, contextRange);
+      if (StatusVerification == GutterVerificationStatus.VerifiedWithAssumption) {
+        // Make all assumptions visible
+        foreach (var assumedLine in AssumptionsLines) {
+          LineVerificationStatus newStatus =
+              StatusCurrent switch {
+                CurrentStatus.Current => LineVerificationStatus.AssumptionInVerifiedContext,
+                CurrentStatus.Obsolete => LineVerificationStatus.AssumptionInVerifiedContextObsolete,
+                CurrentStatus.Verifying => LineVerificationStatus.AssumptionInVerifiedContextVerifying,
+                _ => LineVerificationStatus.Nothing
+              };
+          if (assumedLine < perLineDiagnostics.Length && perLineDiagnostics[assumedLine] < newStatus) {
+            perLineDiagnostics[assumedLine] = newStatus;
+          }
+        }
+      }
+    }
   }
 
   // Invariant: There is at least 1 child for every assertion batch

--- a/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
@@ -478,7 +478,8 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
         }
         IEnumerable<int> CollectAssumeNotTrue(INode n) {
           if (n is AssumeStmt { Expr: var expression } assumeStmt &&
-              Translator.IsExpressionAlways(expression, false)) {
+              !Translator.IsExpressionAlways(expression, true) &&
+              !Attributes.Contains(assumeStmt.Attributes, "axiom")) {
             return new List<int> { assumeStmt.Tok.line - 1 };
           }
 
@@ -493,7 +494,15 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
           }
           foreach (var req in functionDecl.Req) {
             if (Translator.IsExpressionAlways(req.E, false)) {
-              cachedAssumptionsLines = cachedAssumptionsLines.Concat(new List<int>() { req.E.tok.line - 2 });
+              cachedAssumptionsLines = cachedAssumptionsLines.Concat(new List<int>() { req.E.tok.line - 1 });
+            }
+          }
+
+          if (functionDecl.Body == null) { // ensures are assumptions
+            foreach (var req in functionDecl.Ens) {
+              if (Translator.IsExpressionAlways(req.E, false)) {
+                cachedAssumptionsLines = cachedAssumptionsLines.Concat(new List<int>() { req.E.tok.line - 1 });
+              }
             }
           }
         } else {
@@ -504,6 +513,14 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
           foreach (var req in methodDecl.Req) {
             if (Translator.IsExpressionAlways(req.E, false)) {
               cachedAssumptionsLines = cachedAssumptionsLines.Concat(new List<int>() { req.E.tok.line - 1 });
+            }
+          }
+
+          if (methodDecl.Body == null) { // ensures are assumptions
+            foreach (var req in methodDecl.Ens) {
+              if (Translator.IsExpressionAlways(req.E, false)) {
+                cachedAssumptionsLines = cachedAssumptionsLines.Concat(new List<int>() { req.E.tok.line - 1 });
+              }
             }
           }
         }

--- a/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
+++ b/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
@@ -75,7 +75,9 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                 ctor.CompileName,
                 ctor.tok.Filename,
                 verificationTreeRange,
-                ctor.tok.GetLspPosition());
+                ctor.tok.GetLspPosition()) {
+                node = topLevelDecl
+              };
               AddAndPossiblyMigrateVerificationTree(verificationTree);
             }
           }
@@ -101,7 +103,9 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                 member.CompileName,
                 member.tok.Filename,
                 verificationTreeRange,
-                member.tok.GetLspPosition());
+                member.tok.GetLspPosition()) {
+                node = member
+              };
               AddAndPossiblyMigrateVerificationTree(verificationTree);
             } else if (member is Method or Function) {
               var verificationTreeRange = member.StartToken.GetLspRange(member.EndToken);
@@ -111,7 +115,9 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                 member.CompileName,
                 member.tok.Filename,
                 verificationTreeRange,
-                member.tok.GetLspPosition());
+                member.tok.GetLspPosition()) {
+                node = member
+              };
               AddAndPossiblyMigrateVerificationTree(verificationTree);
               if (member is Function { ByMethodBody: { } } function) {
                 var verificationTreeRangeByMethod = function.ByMethodTok.GetLspRange(function.ByMethodBody.EndTok);
@@ -121,7 +127,10 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                   member.CompileName + "_by_method",
                   member.tok.Filename,
                   verificationTreeRangeByMethod,
-                  function.ByMethodTok.GetLspPosition());
+                  function.ByMethodTok.GetLspPosition()) {
+                  node = function,
+                  ByMethodBody = true
+                };
                 AddAndPossiblyMigrateVerificationTree(verificationTreeByMethod);
               }
             }
@@ -140,7 +149,9 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
             subsetTypeDecl.CompileName,
             subsetTypeDecl.tok.Filename,
             verificationTreeRange,
-            subsetTypeDecl.tok.GetLspPosition());
+            subsetTypeDecl.tok.GetLspPosition()) {
+            node = subsetTypeDecl
+          };
           AddAndPossiblyMigrateVerificationTree(verificationTree);
         }
       }

--- a/docs/dev/news/3089.feat
+++ b/docs/dev/news/3089.feat
@@ -1,0 +1,1 @@
+Support for detecting statically "assume false" or equivalents.


### PR DESCRIPTION
Fixes #3089

Dafny's proofs are meant to be sound, but what happens if one assumes falsehood? Verification passes without a single warning.
While this is the desired behavior when developing proofs and "commenting out" certain branches for the verifier, not being shown even just a warning about them is concerning

Currently, the only safety net Dafny provides is that the compiler will not compile Dafny programs containing `assume XXXX` not marked as `{:axiom}`. However, the following reasons makes it hard to swallow that Dafny does not react at all when encountering `assume XXXX` for every assumption.

- After verifying a branch, the VSCode extension displays a green gutter, even if there are more branches to verify. So yes, it's sound, but it's not useful for a user.
- It can be even misleading: For proofs that take days, users reported they would forget about an assume false somewhere, and be bitten by it much later.
- It can be disastrous: Some users reported that they wrote `ensures` clause on externs that trivially assumes false, but they did not see it and it caused all proofs calling this external code to pass. Very dangerous. There is no safety net even for a compiler.

While there might be a place to insert warnings (and we can discuss that below, see future work), this PR's first aim is to introduce a more accurate gutter icon feedback when encountering assumptions.
The design of the gutter icons is not yet ready, but I approached several users to validate the user experience already. Here is what will happen, which is what this PR implements:

# User experience.

Here are some principles I validated
* If a method/function/declaration has some errors, there is no need to report any assumption to the user. That would be extra information that is not yet useful. They have a more important problem to solve, which is to make verification pass given their assumption. Thus, icons are unchanged when there is at least one error in the context.
* Only if the method/function/declaration has no verification error, then it is time to show the user the remaining assumptions.
* Since assumptions can be out of view, it's imperative that the normally "green and vertical" line for the entire method/function/declaration is changed to something meaning "There are still assumptions remaining"
* In this context of "Context verified with assumptions", assumptions should be clearly visible.
* Are marked as "assumptions" the following
  * Any `assume` that is not _trivially true_ and that is not marked as `{:axiom}`. I have seen users using  `assume {:split_here} true;` for example, they should not be marked as assumptions
  * Any `requires` that is _trivially false_.
  * Any `ensures` of a method or a function without body (`{:extern}` or not) whose condition is trivially false
* _trivially_ means, in the context of this PR, the static function `Translator.IsExpressionAlways`:
  * `false` is trivially false
  * `true` is trivially true
  * `!X` is trivially true if `X` is trivially false, and trivially false if `X` is trivially true
  * `X && Y` is trivially true if both `X` and `Y` are trivially true, and trivially false if `X` or `Y` are trivially false.
  * `X || Y` is trivially true if either `X` or `Y` is trivially true, and trivially false if both `X` and`Y` are trivially false.
  * `X ==> Y` is trivially true if either `!X` or `Y` is trivially true, and trivially false if both `!X` and`Y` are trivially false.
  * `X <==> Y` is trivially true if both `X` and `Y` are trivially true or both false, and trivially false if both `!X` and`Y` have opposite trivial boolean values.
  * `X == Y` is trivially true if `X` and `Y` are booleans and `X <==> Y` is trivially true, or if rendering the expression X and Y results in the same string. It's trivially false if `Y = X.field` for some field. (or reverse)
  * `X < Y` is trivially false if the string representation of X and the string representation of Y are the same
     It also contains a trivial test when X and Y are literals
  * `X != Y` is trivially false if the string representation of X and the string representation of Y are the same
     It also contains a trivial test when X and Y are literals  It's trivially true if `Y = X.field` for some field (or reverse)
  * `X > Y` is trivially false if the string representation of X and the string representation of Y are the same
     It also contains a trivial test when X and Y are literals
  * `forall ... | Z :: X` is trivially true if `Z ==> X` is trivially true, but never trivially false (we would first need to show that the collection is non-empty, we could do this in some case, not sure it's useful)
  * `exists... | Z :: X` is trivially false if `Z && X` is trivially false, but never trivially true(we would first need to show that the collection is non-empty, we could do this in some case, not sure it's useful)

I've left out any closure `requires` as it's not harmful to define a closure without calling it in any context, so the requires false would be easily detected.

# Benefits that this PR brings:

* Once a branch is verified, a user will not be misled into thinking that nothing left needs to be verified, if they left some `assume false`.
* `requires` that are trivially `false` are flagged
* Assumptions become visible when the method is verified
* No warnings on `assume false` in case it's desired (and it often is)
* Trivially false `ensures` of bodiless methods are flagged and become visible.

# Caveats of this PR.

I would like to echo @dijkstracula 's comment

> There could be a concern that users might expect the precondition contradiction checker to be smarter than it is, and rely on it for more complicated cases than it knows about. For instance, suppose that array indexing equality was not part of the hardcoded syntactic checks (as it isn't listed in the above set of expressions): I might conclude that the issue in my project was elsewhere from the requires a[i] < a[i] case, since I might assume that Dafny catches precondition contradictions in general. I don't know how often users trip over things like this.

# How this PR was tested

I created tests in the language server that illustrate all of the conditions above exhaustively.

I also created a draft visual in VSCode to view the behavior, and ask users questions about their usage of assumptions, and about what they thought of the user experience. Most were supportive. Those who did not know if they should support this or not were ones who were not used to using assumptions in the code, so they wouldn't be harmed anyway.

Note that this PR is a draft until there is proper icon support for VSCode. Otherwise, such contexts would appear as if no verification was made (which is not bad, but not a great user experience)

# Future visual considerations when designing gutter icons for this PR.

* This visual, let's call it "Context verified with assumptions", identified as ` |?` in the tests (compared to ` | ` for verified context) should be closer to "verified" than to "error with context". Indeed, since `assume false` is part of the development cycle, the cycle is usually: "Error with context" (yellow lines) => "Context verified with assumptions" => Navigate to other assumptions => Remove or weaken the assumptions => "Error with context" (yellow lines) => Proof => etc. Hence, every time users finish the branch of a proof, they should be at least "rewarded" with the design "Context verified with assumptions".
  Hence, this visual should be closer to green, possibly green-yellowish.
  Moreover, it's not helpful to dim the green or split the green in two, because it reduces visibility like when verification is "stale". We need another visual
* The visual of remaining assumptions should be obvious, prominent and for example yellow (to indicate a warning)

# Future work

* If we agree, we could also turn some of this feedback as real warnings. This can be a separate PR though, I'm happy to do it.
* In the future, one might also use these gutter icons for other purposes, such as [identifying localized proofs](https://github.com/dafny-lang/dafny/issues/3095) 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
