### PR TITLE
Remove StaticReceiverExpr.OriginalResolved, to see where it is used

### DIFF
--- a/Source/DafnyCore/AST/Expressions/StaticReceiverExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/StaticReceiverExpr.cs
@@ -68,7 +68,6 @@ public class StaticReceiverExpr : LiteralExpr {
     }
     UnresolvedType = Type;
     Implicit = isImplicit;
-    OriginalResolved = lhs;
   }
 
   public override bool IsImplicit {


### PR DESCRIPTION
Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
