### PR TITLE
fix: Add `{:inline}` to char#IsChar function

### DIFF
--- a/Source/DafnyCore/DafnyPrelude.bpl
+++ b/Source/DafnyCore/DafnyPrelude.bpl
@@ -117,12 +117,12 @@ function {:identity} LitReal(x: real): real { x } uses {
 // ---------------------------------------------------------------
 
 #if UNICODE_CHAR
-function char#IsChar(n: int): bool {
+function {:inline} char#IsChar(n: int): bool {
   (0                  <= n && n < 55296   /* 0xD800 */) || 
   (57344 /* 0xE000 */ <= n && n < 1114112 /* 0x11_0000 */ )
 }
 #else
-function char#IsChar(n: int): bool {
+function {:inline} char#IsChar(n: int): bool {
   0 <= n && n < 65536
 }
 #endif


### PR DESCRIPTION
Without this, even with `--unicode-char` disabled, factoring out the `0 <= n && n < 65536` expression into a separate function can still perturb verification performance unnecessarily.

I can't think of a quick way to test for this unfortunately, but it's a safe enough change I argue it's better to merge now, and revisit testing more thoroughly for such performance regressions in the integration suite.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
