### PR TITLE
Allow --no-verify when using the verify command

### DIFF
--- a/Source/DafnyDriver/Commands/VerifyCommand.cs
+++ b/Source/DafnyDriver/Commands/VerifyCommand.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Dafny;
 class VerifyCommand : ICommandSpec {
   public IEnumerable<IOptionSpec> Options => new IOptionSpec[] {
     BoogieFilterOption.Instance,
-  }.Concat(ICommandSpec.VerificationOptions.Except(new[] { NoVerifyOption.Instance })).
+  }.Concat(ICommandSpec.VerificationOptions).
     Concat(ICommandSpec.CommonOptions);
 
   public Command Create() {


### PR DESCRIPTION
Enables checking only if a Dafny project resolves, without also verifying it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
