### PR TITLE
Explicitly use python3 in lit tests

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -174,8 +174,8 @@ config.substitutions.append( ('%refmanexamples', os.path.join(repositoryRoot, 'd
 config.substitutions.append( ('%os', os.name) )
 config.substitutions.append( ('%ver', ver ) )
 config.substitutions.append( ('%sed', 'sed -E' ) )
-config.substitutions.append( ('%exits-with', "python " + os.path.join(repositoryRoot, 'Scripts/test-exit.py') ) )
-config.substitutions.append( ('!', "python " + os.path.join(repositoryRoot, 'Scripts/test-exit.py') + " -z" ) )
+config.substitutions.append( ('%exits-with', "python3 " + os.path.join(repositoryRoot, 'Scripts/test-exit.py') ) )
+config.substitutions.append( ('!', "python3 " + os.path.join(repositoryRoot, 'Scripts/test-exit.py') + " -z" ) )
 
 if os.name == "nt":
     config.available_features = [ 'windows' ]


### PR DESCRIPTION
This way the lit tests work by default on my machine. Curious if anyone has concerns.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
