### PR TITLE
Fix construction of FrameExpression

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions/Expressions.cs
@@ -2759,8 +2759,7 @@ public class FrameExpression : INode, IHasUsages {
   public FrameExpression(IToken tok, Expression e, string fieldName) {
     Contract.Requires(tok != null);
     Contract.Requires(e != null);
-    Debug.Assert(!(e is WildcardExpr) || fieldName == null);
-    Debug.Assert(!(e is ImplicitThisExpr) || fieldName != null);
+    Contract.Requires(!(e is WildcardExpr) || fieldName == null);
     this.tok = tok;
     E = e;
     FieldName = fieldName;


### PR DESCRIPTION
Fixes `02-DoubleRead.dfy` and other tests from failing in DEBUG build by reverting an unintentional change made here: https://github.com/dafny-lang/dafny/pull/3117/files#diff-99ac3ad316fe9cac2a05db0a8db42d2b1fe665fb21403fb25b02e50916005c3fR2762

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
