### PR TITLE
Retry running gradle wrapper

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeJava/gradlew
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/gradlew
@@ -169,4 +169,4 @@ if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
   cd "$(dirname "$0")"
 fi
 
-exec "$JAVACMD" "$@"
+for i in 1 2 3 4 5; do "$JAVACMD" "$@" && break || sleep 15; done

--- a/Source/DafnyRuntime/DafnyRuntimeJava/gradlew.bat
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/gradlew.bat
@@ -65,8 +65,15 @@ set CMD_LINE_ARGS=%*
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
-@rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+@rem Execute Gradle, trying at least 5 times
+for %%i in (1 2 3 4 5) do (
+  "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+  if errorlevel 1 (
+    sleep 15
+  ) else (
+    goto end
+  )
+)
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
Attempt to fix issues such as this one: https://github.com/dafny-lang/dafny/issues/3247 and this failure: https://github.com/dafny-lang/dafny/actions/runs/3757266491/jobs/6384280545

Works both in Unix systems as well as Windows systems

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
