### PR TITLE
feat: More hovering information on the LSP

### DIFF
--- a/Source/DafnyCore/AST/DafnyAst.cs
+++ b/Source/DafnyCore/AST/DafnyAst.cs
@@ -116,9 +116,8 @@ namespace Microsoft.Dafny {
               UpdateStartEndToken(node.GetEndToken());
             } else {
               UpdateStartEndToken(node.tok);
+              node.Children.Iter(UpdateStartEndTokRecursive);
             }
-
-            node.Children.Iter(UpdateStartEndTokRecursive);
           }
 
           UpdateStartEndTokRecursive(this);

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
+using Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Microsoft.Dafny.LanguageServer.Workspace.Notifications;
 using Microsoft.Extensions.Configuration;
@@ -15,10 +17,9 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
   [TestClass]
-  public class HoverVerificationTest : DafnyLanguageServerTestBase {
+  public class HoverVerificationTest : SynchronizationTestBase {
     private const int MaxTestExecutionTimeMs = 30000;
 
-    private ILanguageClient client;
     private TestNotificationReceiver<CompilationStatusParams> notificationReceiver;
 
     [TestInitialize]
@@ -26,7 +27,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
 
     public async Task SetUp(Action<DafnyOptions> modifyOptions) {
       notificationReceiver = new();
-      client = await InitializeClient(options => {
+      Client = await InitializeClient(options => {
         options
           .AddHandler(DafnyRequestNames.CompilationStatus, NotificationHandler.For<CompilationStatusParams>(notificationReceiver.NotificationReceived));
       }, modifyOptions);
@@ -57,6 +58,7 @@ Return path: testFile.dfy(6, 5)"
       // because the IDE extension already does it.
       await AssertHoverMatches(documentItem, (5, 4),
         @"[**Error:**](???) A postcondition might not hold on this return path.  
+Could not prove: y >= 0  
 This is assertion #1 of 4 in method Abs  
 Resource usage: ??? RU"
       );
@@ -200,6 +202,74 @@ method f(x: int) {
       );
     }
 
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
+    public async Task DisplayNestedFailingPostconditionsAndPreconditions() {
+      var documentItem = await GetDocumentItem(@"
+predicate P(i: int) {
+  i <= 0
+}
+
+predicate Q(i: int, j: int) {
+  i == j || -i == j
+}
+
+function method Toast(i: int): int
+  requires P(i)
+
+method Test(i: int) returns (j: nat)
+  ensures Q(i, j)
+{
+  if i < 0 {
+    return -i;
+  } else {
+    return Toast(i);
+  }
+}
+", "testfile2.dfy");
+      await AssertHoverMatches(documentItem, (12, 11),
+        @"**Error:**???This postcondition might not hold on a return path.???
+Could not prove: i == j || -i == j???
+Return path: testfile2.dfy(18, 5)"
+      );
+      await AssertHoverMatches(documentItem, (17, 6),
+        @"**Error:**???A postcondition might not hold on this return path.???
+Could not prove: Q(i, j)???
+Could not prove: i == j || -i == j"
+      );
+      await AssertHoverMatches(documentItem, (17, 13),
+        @"**Error:**???function precondition might not hold???
+Could not prove: P(i)???
+Could not prove: i <= 0"
+      );
+    }
+
+    [TestMethod, Timeout(MaxTestExecutionTimeMs)]
+    public async Task DoNotDisplayVerificationIfSyntaxError() {
+      var documentItem = await GetDocumentItem(@"
+predicate P(i: int) {
+  i <= 0
+}
+
+method Test(i: int)
+{
+  assert P(1);
+}
+", "testfile2.dfy");
+      await AssertHoverMatches(documentItem, (6, 11),
+        @"**Error:**???assertion might not hold  
+Could not prove: i <= 0"
+      );
+      await ApplyChangesAndWaitCompletionAsync(
+        documentItem,
+        new TextDocumentContentChangeEvent {
+          Range = ((0, 0), (0, 0)),
+          Text = @"/"
+        });
+      await AssertHoverMatches(documentItem, (6, 11),
+        null
+      );
+    }
+
     [TestMethod, Timeout(5 * MaxTestExecutionTimeMs)]
     public async Task IndicateClickableWarningSignsOnMethodHoverWhenResourceLimitReached10MThreshold() {
       var documentItem = await GetDocumentItem(@"
@@ -232,14 +302,19 @@ lemma {:rlimit 12000} SquareRoot2NotRational(p: nat, q: nat)
     private async Task<TextDocumentItem> GetDocumentItem(string source, string filename) {
       source = source.TrimStart();
       var documentItem = CreateTestDocument(source, filename);
-      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      await Client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       await Documents.GetLastDocumentAsync(documentItem);
       return documentItem;
     }
 
-    private async Task AssertHoverMatches(TextDocumentItem documentItem, Position hoverPosition, string expected) {
+    private async Task AssertHoverMatches(TextDocumentItem documentItem, Position hoverPosition, [CanBeNull] string expected) {
       var hover = await RequestHover(documentItem, hoverPosition);
-      Assert.IsNotNull(hover);
+      if (expected == null) {
+        Assert.IsTrue(hover == null || hover.Contents.MarkupContent is null or { Value: "" },
+          "Did not expect a message at {0}", hoverPosition);
+        return;
+      }
+      Assert.IsNotNull(hover, "No hover message found at {0}", hoverPosition);
       var markup = hover.Contents.MarkupContent;
       Assert.IsNotNull(markup);
       Assert.AreEqual(MarkupKind.Markdown, markup.Kind);
@@ -247,7 +322,7 @@ lemma {:rlimit 12000} SquareRoot2NotRational(p: nat, q: nat)
     }
 
     private void AssertMatchRegex(string expected, string value) {
-      var regexExpected = Regex.Escape(expected).Replace(@"\?\?\?", ".*");
+      var regexExpected = Regex.Escape(expected).Replace(@"\?\?\?", "[\\s\\S]*");
       var matched = new Regex(regexExpected).Match(value).Success;
       if (!matched) {
         // A simple helper to determine what portion of the regex did not match
@@ -262,7 +337,7 @@ lemma {:rlimit 12000} SquareRoot2NotRational(p: nat, q: nat)
     }
 
     private Task<Hover> RequestHover(TextDocumentItem documentItem, Position position) {
-      return client.RequestHover(
+      return Client.RequestHover(
         new HoverParams {
           TextDocument = documentItem.Uri,
           Position = position

--- a/Source/DafnyLanguageServer.Test/Synchronization/SynchronizationTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/SynchronizationTestBase.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
   public class SynchronizationTestBase : DafnyLanguageServerTestBase {
-    protected ILanguageClient Client { get; private set; }
+    protected ILanguageClient Client { get; set; }
 
     protected Task ApplyChangeAndWaitCompletionAsync(TextDocumentItem documentItem, Range range, string newText) {
       return ApplyChangesAndWaitCompletionAsync(

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.Boogie;
 using Microsoft.Dafny.LanguageServer.Language;
 using Microsoft.Dafny.LanguageServer.Workspace.Notifications;
+using Microsoft.Dafny.ProofObligationDescription;
 
 namespace Microsoft.Dafny.LanguageServer.Handlers {
   public class DafnyHoverHandler : HoverHandlerBase {
@@ -69,6 +70,11 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
 
     private string? GetDiagnosticsHover(IdeState state, Position position, out bool areMethodStatistics) {
       areMethodStatistics = false;
+      if (state.Diagnostics.Any(diagnostic =>
+            diagnostic.Source == MessageSource.Parser.ToString() ||
+            diagnostic.Source == MessageSource.Resolver.ToString())) {
+        return null;
+      }
       foreach (var node in state.VerificationTree.Children.OfType<TopLevelDeclMemberVerificationTree>()) {
         if (!node.Range.Contains(position)) {
           continue;
@@ -94,7 +100,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
               if (information != "") {
                 information += "\n\n";
               }
-              information += GetAssertionInformation(position, assertionNode, assertionBatch, assertionIndex, assertionBatchCount, node);
+              information += GetAssertionInformation(state, position, assertionNode, assertionBatch, assertionIndex, assertionBatchCount, node);
             }
 
             assertionIndex++;
@@ -176,7 +182,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       return information;
     }
 
-    private string GetAssertionInformation(Position position, AssertionVerificationTree assertionNode,
+    private string GetAssertionInformation(IdeState ideState, Position position, AssertionVerificationTree assertionNode,
       AssertionBatchVerificationTree assertionBatch, int assertionIndex, int assertionBatchCount,
       TopLevelDeclMemberVerificationTree node) {
       var assertCmd = assertionNode.GetAssertion();
@@ -218,12 +224,48 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
 
       string information = "";
 
+      string CouldProveOrNotPrefix = (assertionNode?.StatusVerification) switch {
+        GutterVerificationStatus.Verified => "Did prove: ",
+        GutterVerificationStatus.Error => "Could not prove: ",
+        GutterVerificationStatus.Inconclusive => "Not able to prove: ",
+        _ => "Unknown: "
+      };
+
+      string MoreInformation(Boogie.IToken? token, bool hoveringPostcondition) {
+        string deltaInformation = "";
+        while (token != null) {
+          var errorToken = token;
+          if (token is NestedToken nestedToken) {
+            errorToken = nestedToken.Outer;
+            token = nestedToken.Inner;
+          } else {
+            token = null;
+          }
+
+          // It's not necessary to restate the postcondition itself if the user is already hovering it
+          // however, nested postconditions should be displayed
+          if (errorToken is RangeToken rangeToken && !hoveringPostcondition) {
+            deltaInformation += "  \n" + CouldProveOrNotPrefix + ideState.TextDocumentItem.Text.Substring(rangeToken.StartToken.pos,
+              rangeToken.EndToken.pos + rangeToken.EndToken.val.Length - rangeToken.StartToken.pos);
+          }
+
+          hoveringPostcondition = false;
+        }
+
+        return deltaInformation;
+      }
+
       if (counterexample is ReturnCounterexample returnCounterexample) {
         information += GetDescription(returnCounterexample.FailingReturn.Description);
+        information += MoreInformation(returnCounterexample.FailingAssert.tok, currentlyHoveringPostcondition);
       } else if (counterexample is CallCounterexample callCounterexample) {
         information += GetDescription(callCounterexample.FailingCall.Description);
+        information += MoreInformation(callCounterexample.FailingRequires.tok, false);
       } else {
         information += GetDescription(assertCmd?.Description);
+        if (assertCmd?.tok is NestedToken) {
+          information += MoreInformation(assertCmd.tok, true);
+        }
       }
 
       information += "  \n";
@@ -246,12 +288,12 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
 
       // Not the main error displayed in diagnostics
       if (currentlyHoveringPostcondition) {
-        information += "  \n" + (assertionNode.SecondaryPosition != null
+        information += "  \n" + (assertionNode?.SecondaryPosition != null
           ? $"Return path: {Path.GetFileName(assertionNode.Filename)}({assertionNode.SecondaryPosition.Line + 1}, {assertionNode.SecondaryPosition.Character + 1})"
           : "");
       }
 
-      if (assertionNode.GetCounterExample() is CallCounterexample) {
+      if (assertionNode?.GetCounterExample() is CallCounterexample) {
         information += "  \n" + (assertionNode.SecondaryPosition != null
           ? $"Failing precondition: {Path.GetFileName(assertionNode.Filename)}({assertionNode.SecondaryPosition.Line + 1}, {assertionNode.SecondaryPosition.Character + 1})"
           : "");

--- a/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     private static GhostDiagnosticsParams GetGhostness(IdeState state) {
+
       return new GhostDiagnosticsParams {
         Uri = state.TextDocumentItem.Uri,
         Version = state.TextDocumentItem.Version,

--- a/docs/dev/news/3281.fix
+++ b/docs/dev/news/3281.fix
@@ -1,0 +1,1 @@
+Language server displays more relevant informations on hovering assertions


### PR DESCRIPTION
Fixes #3281 

Example code:
```dafny
predicate P(i: int) {
  i <= 0
}

predicate Q(i: int, j: int) {
  i == j || -i == j
}

function method Toast(i: int): int
  requires P(i)

method Test(i: int) returns (j: nat)
  ensures Q(i, j)
{
  if i < 0 {
    return -i;
  } else {
    return Toast(i);
  }
}
```

| Before: | After |
| --------|-------|
| Hovering Q(i,j) ![image](https://user-images.githubusercontent.com/3601079/209727765-e3c9c32b-dd27-4707-893b-8534b9ec0698.png) | ![image](https://user-images.githubusercontent.com/3601079/209727590-2f833693-4b9d-44cf-afa8-fe43388e0c3d.png) |
| Hovering the second return ![image](https://user-images.githubusercontent.com/3601079/209727748-5d291a36-7334-4b9c-8c08-c68718fd50f9.png) | ![image](https://user-images.githubusercontent.com/3601079/209727565-19b8a1c6-0f78-41a3-ad85-7e0cbc1538c8.png) |
| Hovering the call to Toast() ![image](https://user-images.githubusercontent.com/3601079/209727700-2e66f345-dd1f-47c5-92ce-cea811d2b8ce.png) | ![image](https://user-images.githubusercontent.com/3601079/209727556-cbfe43c5-9fe2-49c9-a107-7111ef42b00c.png) |
| The resolver error appears after all obsolete verification error<br>![image](https://user-images.githubusercontent.com/3601079/209727781-b3d88e9b-8bad-4e3b-b8fc-e9119837629e.png) | ![image](https://user-images.githubusercontent.com/3601079/209727612-7ebb576c-3fd7-4865-97de-d2a5f2c1d064.png) |

I added language server tests and tested it in VSCode, and it works as expected.

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
