### PR TITLE
Enable warn-shadowing attribute on functions/methods

### DIFF
--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
@@ -3371,7 +3371,7 @@ namespace Microsoft.Dafny {
       // make note of the warnShadowing attribute
       bool warnShadowingOption = DafnyOptions.O.WarnShadowing;  // save the original warnShadowing value
       bool warnShadowing = false;
-      if (Attributes.ContainsBool(f.Attributes, "warnShadowing", ref warnShadowing)) {
+      if (CheckWarnShadowing(f.Attributes, ref warnShadowing)) {
         DafnyOptions.O.WarnShadowing = warnShadowing;  // set the value according to the attribute
       }
 
@@ -3449,6 +3449,10 @@ namespace Microsoft.Dafny {
       DafnyOptions.O.WarnShadowing = warnShadowingOption; // restore the original warnShadowing value
     }
 
+    private static bool CheckWarnShadowing(Attributes attributes, ref bool warnShadowing) {
+      return Attributes.ContainsBool(attributes, "warnShadowing", ref warnShadowing) || Attributes.ContainsBool(attributes, "warn-shadowing", ref warnShadowing);
+    }
+
     void ResolveFrameExpressionTopLevel(FrameExpression fe, FrameExpressionUse use, ICodeContext codeContext) {
       ResolveFrameExpression(fe, use, new ResolutionContext(codeContext, false));
     }
@@ -3501,7 +3505,7 @@ namespace Microsoft.Dafny {
         // make note of the warnShadowing attribute
         bool warnShadowingOption = DafnyOptions.O.WarnShadowing;  // save the original warnShadowing value
         bool warnShadowing = false;
-        if (Attributes.ContainsBool(m.Attributes, "warnShadowing", ref warnShadowing)) {
+        if (CheckWarnShadowing(m.Attributes)) {
           DafnyOptions.O.WarnShadowing = warnShadowing;  // set the value according to the attribute
         }
 


### PR DESCRIPTION
Keeping as a draft since I'm not sure whether we even want this.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
