### PR TITLE
Fix: Errors on refined modules displayed in refined modules, not abstracts ones

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
@@ -114,7 +114,8 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
 
   protected async Task<List<LineVerificationStatus[]>> GetAllLineVerificationStatuses(
       TextDocumentItem documentItem,
-      TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver
+      TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver,
+      bool intermediates = true
       ) {
     var traces = new List<LineVerificationStatus[]>();
     var maximumNumberOfTraces = 50;
@@ -133,8 +134,13 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
         continue;
       }
 
-      traces.Add(verificationStatusGutter.PerLineStatus);
-      if (NoMoreNotificationsToAwaitFrom(verificationStatusGutter)) {
+      var noMoreNotificationsExpected = NoMoreNotificationsToAwaitFrom(verificationStatusGutter);
+
+      if (intermediates || noMoreNotificationsExpected) {
+        traces.Add(verificationStatusGutter.PerLineStatus);
+      }
+
+      if (noMoreNotificationsExpected) {
         break;
       }
 
@@ -226,7 +232,8 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
 
   // If testTrace is false, codeAndTree should not contain a trace to test.
   public async Task VerifyTrace(string codeAndTrace, string fileName = null, bool testTrace = true,
-    TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver = null
+    TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver = null,
+    bool intermediates = true
     ) {
     if (verificationStatusGutterReceiver == null) {
       verificationStatusGutterReceiver = this.verificationStatusGutterReceiver;
@@ -239,10 +246,10 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
     var documentItem = CreateTestDocument(code, fileName);
     client.OpenDocument(documentItem);
     var traces = new List<LineVerificationStatus[]>();
-    traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver));
+    traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver, intermediates));
     foreach (var (range, inserted) in changes) {
       ApplyChange(ref documentItem, range, inserted);
-      traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver));
+      traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver, intermediates));
     }
 
     if (testTrace) {

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -15,6 +15,24 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
   // Add '//Next<n>:' to edit a line multiple times
 
   [TestMethod]
+  public async Task GitIssue3329ModuleRefinementBreaksOutlineErrorReporting() {
+    await VerifyTrace(@"
+ | :abstract module Test {
+ | :  method Encrypt()
+ | :    ensures false
+ | :}
+ | :
+ | :module Ok refines Test {
+ | :  function test(): int {
+ | :    2
+ | :  }
+ | :  // Might not work as expected
+[=]:  method Encrypt() {
+[ ]:  }
+   :}", intermediates: false);
+  }
+
+  [TestMethod]
   public async Task NoGutterNotificationsReceivedWhenTurnedOff() {
     var source = @"
 method Foo() ensures false { } ";

--- a/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
+++ b/Source/DafnyLanguageServer/Workspace/VerificationProgressReporter.cs
@@ -73,7 +73,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                 "datatype",
                 ctor.Name,
                 ctor.CompileName,
-                ctor.tok.Filename,
+                ctor.tok.ActualFilename,
                 verificationTreeRange,
                 ctor.tok.GetLspPosition());
               AddAndPossiblyMigrateVerificationTree(verificationTree);
@@ -83,7 +83,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
 
         if (topLevelDecl is TopLevelDeclWithMembers topLevelDeclWithMembers) {
           foreach (var member in topLevelDeclWithMembers.Members) {
-            var memberWasNotIncluded = member.tok.Filename != documentFilePath;
+            var memberWasNotIncluded = member.tok.ActualFilename != documentFilePath;
             if (memberWasNotIncluded) {
               continue;
             }
@@ -99,7 +99,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                 "constant",
                 member.Name,
                 member.CompileName,
-                member.tok.Filename,
+                member.tok.ActualFilename,
                 verificationTreeRange,
                 member.tok.GetLspPosition());
               AddAndPossiblyMigrateVerificationTree(verificationTree);
@@ -109,7 +109,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                 (member is Method ? "method" : "function"),
                 member.Name,
                 member.CompileName,
-                member.tok.Filename,
+                member.tok.ActualFilename,
                 verificationTreeRange,
                 member.tok.GetLspPosition());
               AddAndPossiblyMigrateVerificationTree(verificationTree);
@@ -119,7 +119,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
                   "by method part of function",
                   member.Name,
                   member.CompileName + "_by_method",
-                  member.tok.Filename,
+                  member.tok.ActualFilename,
                   verificationTreeRangeByMethod,
                   function.ByMethodTok.GetLspPosition());
                 AddAndPossiblyMigrateVerificationTree(verificationTreeByMethod);
@@ -129,7 +129,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
         }
 
         if (topLevelDecl is SubsetTypeDecl subsetTypeDecl) {
-          if (subsetTypeDecl.tok.Filename != documentFilePath) {
+          if (subsetTypeDecl.tok.ActualFilename != documentFilePath) {
             continue;
           }
 
@@ -138,7 +138,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
             $"subset type",
             subsetTypeDecl.Name,
             subsetTypeDecl.CompileName,
-            subsetTypeDecl.tok.Filename,
+            subsetTypeDecl.tok.ActualFilename,
             verificationTreeRange,
             subsetTypeDecl.tok.GetLspPosition());
           AddAndPossiblyMigrateVerificationTree(verificationTree);
@@ -305,7 +305,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
         void AddChildOutcome(Counterexample? counterexample, AssertCmd assertCmd, IToken token,
           GutterVerificationStatus status, IToken? secondaryToken, string? assertDisplay = "",
           string assertIdentifier = "") {
-          if (token.Filename != implementationNode.Filename) {
+          if (token.ActualFilename != implementationNode.Filename) {
             return;
           }
 
@@ -320,7 +320,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
           var nodeDiagnostic = new AssertionVerificationTree(
             $"{targetMethodNode.DisplayName}{assertDisplay} #{childrenCount}",
             $"{targetMethodNode.Identifier}_{childrenCount}{assertIdentifier}",
-            token.Filename,
+            token.ActualFilename,
             secondaryOutcomePosition,
             outcomeRange
           ) {
@@ -381,7 +381,7 @@ public class VerificationProgressReporter : IVerificationProgressReporter {
   /// <returns>The top-level verification tree</returns>
   private TopLevelDeclMemberVerificationTree? GetTargetMethodTree(Implementation implementation, out ImplementationVerificationTree? implementationTree, bool nameBased = false) {
     var targetMethodNode = document.VerificationTree.Children.OfType<TopLevelDeclMemberVerificationTree>().FirstOrDefault(
-      node => node?.Position == implementation.tok.GetLspPosition() && node?.Filename == implementation.tok.filename
+      node => node?.Position == implementation.tok.GetLspPosition() && node?.Filename == (implementation.tok is Dafny.IToken refinementToken ? refinementToken.ActualFilename : implementation.tok.filename)
       , null);
     if (nameBased) {
       implementationTree = targetMethodNode?.Children.OfType<ImplementationVerificationTree>().FirstOrDefault(

--- a/docs/dev/news/3329.fix
+++ b/docs/dev/news/3329.fix
@@ -1,0 +1,1 @@
+Errors on refined modules displayed in refined modules, not abstracts ones


### PR DESCRIPTION
This PR fixes #3329

I had to fix several things for that. Here were the problems I fixed:
* Refined declarations were using the same token as their abstract counterpart. This prevented gutter errors to be recorded at all for these declarations.
* Refined tokens' filenames are the filename plus the [moduleName], which interfered with the ability of the gutter icons rendered to consider that refining modules were actually part of the file.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>