### PR TITLE
Fix: Other CLI files that are not found do not trigger exceptions

### DIFF
--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -78,6 +78,9 @@ namespace Microsoft.Dafny {
     }
 
     private static string GetDafnySourceAttributeText(string dllPath) {
+      if (!File.Exists(dllPath)) {
+        throw new IllegalDafnyFile();
+      }
       using var dllFs = new FileStream(dllPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
       using var dllPeReader = new PEReader(dllFs);
       var dllMetadataReader = dllPeReader.GetMetadataReader();

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -259,7 +259,13 @@ namespace Microsoft.Dafny {
 
         var supportedExtensions = options.Compiler.SupportedExtensions;
         if (supportedExtensions.Contains(extension)) {
-          otherFiles.Add(file);
+          if (File.Exists(file)) {
+            otherFiles.Add(file);
+          } else {
+            options.Printer.ErrorWriteLine(Console.Out,
+              "*** Error: file " + file + " not found");
+            return CommandLineArgumentsResult.PREPROCESSING_ERROR;
+          }
         } else if (!isDafnyFile) {
           if (string.IsNullOrEmpty(extension) && file.Length > 0 && (file[0] == '/' || file[0] == '-')) {
             options.Printer.ErrorWriteLine(Console.Out,

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -259,7 +259,8 @@ namespace Microsoft.Dafny {
 
         var supportedExtensions = options.Compiler.SupportedExtensions;
         if (supportedExtensions.Contains(extension)) {
-          if (File.Exists(file)) {
+          // .h files are not part of the build, they are just emitted as includes
+          if (File.Exists(file) || extension == ".h") {
             otherFiles.Add(file);
           } else {
             options.Printer.ErrorWriteLine(Console.Out,

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -263,8 +263,7 @@ namespace Microsoft.Dafny {
           if (File.Exists(file) || extension == ".h") {
             otherFiles.Add(file);
           } else {
-            options.Printer.ErrorWriteLine(Console.Out,
-              "*** Error: file " + file + " not found");
+            options.Printer.ErrorWriteLine(Console.Out, $"*** Error: file {file} not found");
             return CommandLineArgumentsResult.PREPROCESSING_ERROR;
           }
         } else if (!isDafnyFile) {

--- a/Test/git-issues/git-issue-2719.dfy
+++ b/Test/git-issues/git-issue-2719.dfy
@@ -1,4 +1,2 @@
 // RUN: %exits-with 1 %baredafny foobar.dll "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-
-method IrrelevantStartsOnlyFakeFoobarDll() {}

--- a/Test/git-issues/git-issue-2719.dfy
+++ b/Test/git-issues/git-issue-2719.dfy
@@ -1,4 +1,4 @@
-// RUN: %baredafny verify %args_0 "%s" > "%t"
+// RUN: %exits-with 1 %baredafny foobar.dll "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-method Test() {}
+method IrrelevantStartsOnlyFakeFoobarDll() {}

--- a/Test/git-issues/git-issue-2719.dfy
+++ b/Test/git-issues/git-issue-2719.dfy
@@ -1,0 +1,4 @@
+// RUN: %baredafny verify %args_0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Test() {}

--- a/Test/git-issues/git-issue-2719.dfy.expect
+++ b/Test/git-issues/git-issue-2719.dfy.expect
@@ -1,0 +1,1 @@
+*** Error: file foobar.dll not found

--- a/Test/git-issues/git-issue-590.dfy.expect
+++ b/Test/git-issues/git-issue-590.dfy.expect
@@ -1,1 +1,1 @@
-*** Error: The command-line contains no .dfy files
+*** Error: file x.cs not found

--- a/docs/dev/news/2719.fix
+++ b/docs/dev/news/2719.fix
@@ -1,0 +1,1 @@
+Other CLI files that are not found do not trigger exceptions

--- a/docs/dev/news/2719.fix
+++ b/docs/dev/news/2719.fix
@@ -1,1 +1,1 @@
-Other CLI files that are not found do not trigger exceptions
+Nonexistent files passed on the CLI result in a graceful exit


### PR DESCRIPTION
This PR fixes #2719
I added the corresponding test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>