### PR TITLE
Fix: Modifies clauses with set operations can now be proven

### DIFF
--- a/Source/DafnyCore/Verifier/Translator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/Translator.ExpressionTranslator.cs
@@ -1772,6 +1772,7 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), predef.BoxType,
         bool pr;
         if (s is BinaryExpr && aggressive) {
           BinaryExpr bin = (BinaryExpr)s;
+          /*
           switch (bin.ResolvedOp) {
             case BinaryExpr.ResolvedOpcode.Union:
               return Boogie.Expr.Or(TrInSet_Aux(tok, elmt, elmtBox, bin.E0, aggressive, out pr), TrInSet_Aux(tok, elmt, elmtBox, bin.E1, aggressive, out pr));
@@ -1781,7 +1782,7 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), predef.BoxType,
               return Boogie.Expr.And(TrInSet_Aux(tok, elmt, elmtBox, bin.E0, aggressive, out pr), Boogie.Expr.Not(TrInSet_Aux(tok, elmt, elmtBox, bin.E1, aggressive, out pr)));
             default:
               break;
-          }
+          }*/
         } else if (s is SetDisplayExpr) {
           SetDisplayExpr disp = (SetDisplayExpr)s;
           Boogie.Expr disjunction = null;
@@ -1895,9 +1896,6 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), predef.BoxType,
         if (s is BinaryExpr && aggressive) {
           BinaryExpr bin = (BinaryExpr)s;
           switch (bin.ResolvedOp) {
-            case BinaryExpr.ResolvedOpcode.Union:
-            case BinaryExpr.ResolvedOpcode.Intersection:
-            case BinaryExpr.ResolvedOpcode.SetDifference:
             case BinaryExpr.ResolvedOpcode.MultiSetUnion:
             case BinaryExpr.ResolvedOpcode.MultiSetIntersection:
               return true;

--- a/Test/git-issues/git-issue-3265.dfy
+++ b/Test/git-issues/git-issue-3265.dfy
@@ -1,0 +1,3 @@
+// RUN: %baredafny verify %args_0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+

--- a/Test/git-issues/git-issue-3265.dfy
+++ b/Test/git-issues/git-issue-3265.dfy
@@ -1,3 +1,103 @@
-// RUN: %baredafny verify %args_0 "%s" > "%t"
+// RUN: %baredafny verify %args "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
+
+method SetDifferenceTrigger(
+    ghost MainSet: set<object>, Elements: set<object>,
+    ghost MainSet2: set<object>, Elements2: set<object>)
+  modifies MainSet - Elements
+{
+  assume forall o: object | o in MainSet2 - Elements2 ::
+            o in MainSet - Elements;  // Verified
+  forall o <- MainSet2 ensures true {
+    if o !in Elements2 {
+      assert o in MainSet;
+      assert o !in Elements;
+    }
+  }
+}
+
+
+method SetUnionTrigger(
+    ghost MainSet: set<object>, Elements: set<object>,
+    ghost MainSet2: set<object>, Elements2: set<object>)
+  modifies MainSet - Elements
+{
+  var p := MainSet - Elements;
+  var c := MainSet2 - Elements2;
+  assume forall o: object | o in MainSet2 + Elements2 ::
+            o in MainSet + Elements;  // Verified
+  forall o | o in MainSet2 || o in Elements2 ensures true {
+    assert o in MainSet || o in Elements;
+  }
+}
+
+method SetIntersectionTrigger(
+    ghost MainSet: set<object>, Elements: set<object>,
+    ghost MainSet2: set<object>, Elements2: set<object>)
+  modifies MainSet - Elements
+{
+  assume forall o: object | o in (MainSet2 * Elements2) ::
+            o in MainSet * Elements;  // Verified
+  forall o | o in MainSet2 && o in Elements2 ensures true {
+    assert o in MainSet && o in Elements;
+  }
+}
+
+method SetDifferenceElement(
+    ghost MainSet: set<object>, Element: object,
+    ghost MainSet2: set<object>, Element2: object)
+  modifies MainSet - {Element}
+{
+  var p := MainSet - {Element};
+  var c := MainSet2 - {Element2};
+  assume c <= p;
+  assert forall o: object | o in c ::
+            o in p;  // Verified
+  assert c == MainSet2 - {Element2}; // Verified
+  modify MainSet2 - {Element2}; // Modify error
+}
+
+method SetDifference(
+    ghost MainSet: set<object>, Elements: set<object>,
+    ghost MainSet2: set<object>, Elements2: set<object>)
+  modifies MainSet - Elements
+{
+  var p := MainSet - Elements;
+  var c := MainSet2 - Elements2;
+  assume c <= p;
+  assume forall o: object | o in MainSet2 - Elements2 ::
+            o in MainSet - Elements;  // Verified
+  assert c == MainSet2 - Elements2; // Verified
+  modify MainSet2 - Elements2; // Modify error
+}
+
+
+method SetUnion(
+    ghost MainSet: set<object>, Elements: set<object>,
+    ghost MainSet2: set<object>, Elements2: set<object>)
+  modifies MainSet + Elements
+{
+  var p := MainSet + Elements;
+  var c := MainSet2 + Elements2;
+  assume c <= p;
+  assume forall o: object | o in MainSet2 + Elements2 ::
+            o in MainSet + Elements;  // Verified
+  assert c == MainSet2 + Elements2; // Verified
+  modify MainSet2 + Elements2; // Modify error
+}
+
+
+method SetIntersection(
+    ghost MainSet: set<object>, Elements: set<object>,
+    ghost MainSet2: set<object>, Elements2: set<object>)
+  modifies MainSet * Elements
+{
+  var p := MainSet * Elements;
+  var c := MainSet2 * Elements2;
+  assume c <= p;
+  assume forall o: object | o in MainSet2 * Elements2 ::
+            o in MainSet * Elements;  // Verified
+  assert c == MainSet2 * Elements2; // Verified
+  modify MainSet2 * Elements2; // Modify error
+}

--- a/Test/git-issues/git-issue-3265.dfy.expect
+++ b/Test/git-issues/git-issue-3265.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 7 verified, 0 errors

--- a/docs/dev/news/3265.fix
+++ b/docs/dev/news/3265.fix
@@ -1,0 +1,1 @@
+Modifies clauses with set operations can now be proven


### PR DESCRIPTION
This PR fixes #3265
I added the corresponding test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>