### PR TITLE
Add a missing expression clone

### DIFF
--- a/Source/DafnyCore/AST/Statements/Statements.cs
+++ b/Source/DafnyCore/AST/Statements/Statements.cs
@@ -483,7 +483,7 @@ public class TypeRhs : AssignmentRhs, ICloneable<TypeRhs> {
     if (original.ArrayDimensions != null) {
       if (original.InitDisplay != null) {
         Contract.Assert(original.ArrayDimensions.Count == 1);
-        ArrayDimensions = new List<Expression> { original.ArrayDimensions[0] };
+        ArrayDimensions = new List<Expression> { cloner.CloneExpr(original.ArrayDimensions[0]) };
         InitDisplay = original.InitDisplay.ConvertAll(cloner.CloneExpr);
       } else {
         ArrayDimensions = original.ArrayDimensions.Select(cloner.CloneExpr).ToList();

--- a/Test/git-issues/github-issue-3343.dfy
+++ b/Test/git-issues/github-issue-3343.dfy
@@ -1,0 +1,6 @@
+// RUN: %baredafny run "%s" -t:java > "%t"
+// RUN: %diff "%s.expect" "%t"
+method Bug() {
+    var zero := 0;
+    var a := new int[zero] [];
+}

--- a/Test/git-issues/github-issue-3343.dfy.expect
+++ b/Test/git-issues/github-issue-3343.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
During PR #2734, a refactoring of the cloner mistakenly omitted a clone call for one sub-expression of TypeRHS, leading to issue #3343.

This PR reinstates that clone.

Fixes #3343.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
