### PR TITLE
Use %diff instead of diff for test

### DIFF
--- a/Test/auditor/TestAuditor.dfy
+++ b/Test/auditor/TestAuditor.dfy
@@ -2,9 +2,9 @@
 // RUN: %baredafny audit --report-file "%t.md" --compare-report "%s"
 // RUN: %baredafny audit --report-file "%t.html" "%s"
 // RUN: %baredafny audit --report-file "%t-ietf.md" --report-format markdown-ietf "%s"
-// RUN: diff "%t.md" "%s.md.expect"
-// RUN: diff "%t-ietf.md" "%s-ietf.md.expect"
-// RUN: diff "%t.html" "%s.html.expect"
+// RUN: %diff "%t.md" "%s.md.expect"
+// RUN: %diff "%t-ietf.md" "%s-ietf.md.expect"
+// RUN: %diff "%t.html" "%s.html.expect"
 
 // Method or lemma with a failed proof (top priority, but shown only in reports from later versions of the tool)
 method BadMethod(i: nat) returns (res: nat)


### PR DESCRIPTION
Hopefully this fixes nightly tests on Windows

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
