### PR TITLE
Revert "Cok retry induction tests (#3307)"

### DIFF
--- a/Source/IntegrationTests/LitTests.cs
+++ b/Source/IntegrationTests/LitTests.cs
@@ -124,7 +124,8 @@ namespace IntegrationTests {
 
     [FileTheory]
     [FileData(Includes = new[] { "**/*.dfy", "**/*.transcript" },
-              Excludes = new[] { "**/Inputs/**/*", "**/Output/**/*"
+              Excludes = new[] { "**/Inputs/**/*", "**/Output/**/*",
+                "examples/induction-principle-code/*"
               })]
     public void LitTest(string path) {
       LitTestCase.Run(path, Config, output);


### PR DESCRIPTION
I see nightly is failing again: https://github.com/dafny-lang/dafny/actions/runs/3909011490/jobs/6679674161

I'm guessing it's because of the following commit, since that's what caused the exact same issue, namely the win-4 run timing out, so I'll revert that: 790bf7824a66d6ae7ff97faffe7addefbb0de995.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
