### PR TITLE
Fix: Proper warning that 'new' cannot be used in expressions, instead of a parse error

### DIFF
--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -3911,6 +3911,7 @@ QSep = "::" | '\u2022'.
  */
 Expression<out Expression e, bool allowLemma, bool allowLambda, bool allowBitwiseOps = true>
 = (. Expression e0; IToken endTok; .)
+  [ "new" (. SemErr(t, "Side-effect methods calls such as constructors are not allowed in expressions."); .) ]
   EquivExpression<out e, allowLemma, allowLambda, allowBitwiseOps>
   [ IF(SemiFollowsCall(allowLemma, e))
     /* here we parse the ";E" that is part of a "LemmaCall;E" expression (other "S;E" expressions are parsed elsewhere) */

--- a/Source/XUnitExtensions/Lit/ExitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ExitCommand.cs
@@ -14,7 +14,11 @@ public class ExitCommand : ILitCommand {
 
   public (int, string, string) Execute(ITestOutputHelper? outputHelper, TextReader? inputReader, TextWriter? outputWriter, TextWriter? errorWriter) {
     var (exitCode, output, error) = operand.Execute(outputHelper, inputReader, outputWriter, errorWriter);
-    return (exitCode != expectedExitCode ? 1 : 0, output, error + $"\nMoreover the expected exit code was {expectedExitCode} but got {exitCode}");
+    if (exitCode == expectedExitCode) {
+      return (0, output, error);
+    } else {
+      return (1, output, error + $"\nMoreover the expected exit code was {expectedExitCode} but got {exitCode}");
+    }
   }
 
   public override string ToString() {

--- a/Source/XUnitExtensions/Lit/ExitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ExitCommand.cs
@@ -14,7 +14,7 @@ public class ExitCommand : ILitCommand {
 
   public (int, string, string) Execute(ITestOutputHelper? outputHelper, TextReader? inputReader, TextWriter? outputWriter, TextWriter? errorWriter) {
     var (exitCode, output, error) = operand.Execute(outputHelper, inputReader, outputWriter, errorWriter);
-    return (exitCode != expectedExitCode ? 1 : 0, output, error);
+    return (exitCode != expectedExitCode ? 1 : 0, output, error + $"\nMoreover the expected exit code was {expectedExitCode} but got {exitCode}");
   }
 
   public override string ToString() {

--- a/Test/git-issues/git-issue-3366.dfy
+++ b/Test/git-issues/git-issue-3366.dfy
@@ -1,17 +1,17 @@
-// RUN: %exits-with 1 %baredafny verify %args "%s" > "%t"
+// RUN: %exits-with 2 %baredafny verify %args "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 class C<T> {
-    constructor (x: T) {}
-  }
+  constructor (x: T) {}
+}
 
-  datatype O<T> = Some(x: T) | None
+datatype O<T> = Some(x: T) | None
 
-  method main() {
-    // works
-    var v := new C<nat>(0);
-    var c := Some(v);
+method main() {
+  // works
+  var v := new C<nat>(0);
+  var c := Some(v);
 
-    // fails when inlining v
-    var c2 := Some(new C<nat>(0));
-  }
+  // fails when inlining v
+  var c2 := Some(new C<nat>(0));
+}

--- a/Test/git-issues/git-issue-3366.dfy
+++ b/Test/git-issues/git-issue-3366.dfy
@@ -1,0 +1,17 @@
+// RUN: %exits-with 1 %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class C<T> {
+    constructor (x: T) {}
+  }
+
+  datatype O<T> = Some(x: T) | None
+
+  method main() {
+    // works
+    var v := new C<nat>(0);
+    var c := Some(v);
+
+    // fails when inlining v
+    var c2 := Some(new C<nat>(0));
+  }

--- a/Test/git-issues/git-issue-3366.dfy.expect
+++ b/Test/git-issues/git-issue-3366.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-3366.dfy(16,17): Error: Side-effect methods calls such as constructors are not allowed in expressions.
+1 parse errors detected in git-issue-3366.dfy

--- a/docs/dev/news/3366.fix
+++ b/docs/dev/news/3366.fix
@@ -1,0 +1,1 @@
+Proper warning that 'new' cannot be used in expressions, instead of a parse error


### PR DESCRIPTION
This PR fixes #3366
It does not remove the parse error as it was expected, but it does add an explanation of it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>