### PR TITLE
Chore: re-added the --stdin option

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -10,6 +10,9 @@ public class CommonOptionBag {
   public static readonly Option<bool> ManualLemmaInduction =
     new("--manual-lemma-induction", "Turn off automatic induction for lemmas.");
 
+  public static readonly Option<bool> StdIn = new("--stdin", () => false,
+    @"Read standard input and treat it as an input .dfy file.");
+
   public static readonly Option<bool> OptimizeErasableDatatypeWrapper = new("--optimize-erasable-datatype-wrapper", () => true, @"
 false - Include all non-ghost datatype constructors in the compiled code
 true - In the compiled target code, transform any non-extern
@@ -165,6 +168,10 @@ Functionality is still being expanded. Currently only checks contracts on every 
     DafnyOptions.RegisterLegacyBinding(QuantifierSyntax, (options, value) => { options.QuantifierSyntax = value; });
 
     DafnyOptions.RegisterLegacyBinding(Plugin, (options, value) => { options.AdditionalPluginArguments = value; });
+
+    DafnyOptions.RegisterLegacyBinding(StdIn, (options, value) => {
+      options.UseStdin = value;
+    });
 
     DafnyOptions.RegisterLegacyBinding(Prelude, (options, value) => {
       options.DafnyPrelude = value?.FullName;

--- a/Source/DafnyCore/Options/ICommandSpec.cs
+++ b/Source/DafnyCore/Options/ICommandSpec.cs
@@ -17,6 +17,7 @@ public interface ICommandSpec {
   public static Argument<IEnumerable<FileInfo>> FilesArgument { get; }
 
   public static IReadOnlyList<Option> VerificationOptions = new Option[] {
+    CommonOptionBag.StdIn,
     CommonOptionBag.RelaxDefiniteAssignment,
     BoogieOptionBag.VerificationTimeLimit,
     CommonOptionBag.VerifyIncludedFiles,

--- a/Source/XUnitExtensions/Lit/ExitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ExitCommand.cs
@@ -22,6 +22,6 @@ public class ExitCommand : ILitCommand {
   }
 
   public override string ToString() {
-    return $"%exit {expectedExitCode}  {operand}";
+    return $"%exits-with {expectedExitCode}  {operand}";
   }
 }

--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -73,9 +73,9 @@ namespace XUnitExtensions.Lit {
     }
 
     public (int, string, string) Execute(ITestOutputHelper? outputHelper, TextReader? inReader, TextWriter? outWriter, TextWriter? errWriter) {
-      var inputReader = inputFile != null ? new StreamReader(inputFile) : null;
-      var outputWriter = outputFile != null ? new StreamWriter(outputFile, append) : null;
-      var errorWriter = errorFile != null ? new StreamWriter(errorFile, append) : null;
+      var inputReader = inputFile != null ? new StreamReader(inputFile) : inReader;
+      var outputWriter = outputFile != null ? new StreamWriter(outputFile, append) : outWriter;
+      var errorWriter = errorFile != null ? new StreamWriter(errorFile, append) : errWriter;
       var result = command.Execute(outputHelper, inputReader, outputWriter, errorWriter);
       inputReader?.Close();
       outputWriter?.Close();

--- a/Source/XUnitExtensions/Lit/RunCommand.cs
+++ b/Source/XUnitExtensions/Lit/RunCommand.cs
@@ -18,6 +18,10 @@ namespace XUnitExtensions.Lit {
         var operand = ParseArguments(tokens[2..], config);
         return new ExitCommand(ec, operand);
       }
+      if (tokens[0] == "%stdin") {
+        var operand = ParseArguments(tokens[2..], config);
+        return new StdInCommand(tokens[1], operand);
+      }
 
       // Just supporting || for now since it's a precise way to ignore an exit code
       var seqOperatorIndex = Array.IndexOf(tokens, "||");

--- a/Source/XUnitExtensions/Lit/StdInCommand.cs
+++ b/Source/XUnitExtensions/Lit/StdInCommand.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace XUnitExtensions.Lit; 
+
+public class StdInCommand : ILitCommand {
+  private readonly string stdin;
+  private readonly ILitCommand operand;
+
+  public StdInCommand(string stdin, ILitCommand operand) {
+    this.stdin = stdin.Replace("\\n", "\n");
+    this.operand = operand;
+  }
+
+  public (int, string, string) Execute(ITestOutputHelper? outputHelper, TextReader? inputReader, TextWriter? outputWriter, TextWriter? errorWriter) {
+    inputReader = new StringReader(stdin);
+    return operand.Execute(outputHelper, inputReader, outputWriter, errorWriter);
+  }
+
+  public override string ToString() {
+    return $"%stdin \"{stdin.Replace("\n", "\\n")}\"  {operand}";
+  }
+}

--- a/Test/dafny0/Stdin.dfy
+++ b/Test/dafny0/Stdin.dfy
@@ -1,0 +1,3 @@
+// RUN: %exits-with 0 %stdin "module A{}" %baredafny verify --stdin > "%t"
+// RUN: %diff "%s.expect" "%t"
+

--- a/Test/dafny0/Stdin.dfy
+++ b/Test/dafny0/Stdin.dfy
@@ -1,3 +1,4 @@
 // RUN: %exits-with 0 %stdin "module A{}" %baredafny verify --stdin > "%t"
+// RUN: %exits-with 4 %stdin "method a() { assert false; }" %baredafny verify --stdin >> "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/Test/dafny0/Stdin.dfy.expect
+++ b/Test/dafny0/Stdin.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/dafny0/Stdin.dfy.expect
+++ b/Test/dafny0/Stdin.dfy.expect
@@ -1,2 +1,5 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
+<stdin>(1,20): Error: assertion might not hold
+
+Dafny program verifier finished with 0 verified, 1 error


### PR DESCRIPTION
In preparation for the `dafny format` command to support `--stdin`, I re-added this option that was previously not ported.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
