### PR TITLE
fix: Exclude type information for “new object” allocations

### DIFF
--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
@@ -5386,7 +5386,7 @@ namespace Microsoft.Dafny {
             if (cl != null && !(rr.EType.IsTraitType && !rr.EType.NormalizeExpand().IsObjectQ)) {
               // life is good
             } else {
-              reporter.Error(MessageSource.Resolver, stmt, "new can be applied only to class types (got {0})", rr.EType);
+              reporter.Error(MessageSource.Resolver, rr.tok, "new can be applied only to class types (got {0})", rr.EType);
             }
           } else {
             string initCallName = null;
@@ -5410,7 +5410,7 @@ namespace Microsoft.Dafny {
             }
             var cl = (rr.EType as UserDefinedType)?.ResolvedClass as NonNullTypeDecl;
             if (cl == null || rr.EType.IsTraitType) {
-              reporter.Error(MessageSource.Resolver, stmt, "new can be applied only to class types (got {0})", rr.EType);
+              reporter.Error(MessageSource.Resolver, rr.tok, "new can be applied only to class types (got {0})", rr.EType);
             } else {
               // ---------- new C.Init(EE)
               Contract.Assert(initCallName != null);

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -8963,7 +8963,8 @@ namespace Microsoft.Dafny {
         builder.Add(new Bpl.HavocCmd(tok, new List<Bpl.IdentifierExpr> { nw }));
         // assume $nw != null && dtype($nw) == RHS;
         var nwNotNull = Bpl.Expr.Neq(nw, predef.Null);
-        var rightType = DType(nw, TypeToTy(type));
+        // drop the dtype conjunct if the type is "object", because "new object" allocates an object of an arbitrary type
+        var rightType = type.IsObjectQ ? Bpl.Expr.True : DType(nw, TypeToTy(type));
         builder.Add(TrAssumeCmd(tok, Bpl.Expr.And(nwNotNull, rightType)));
       }
       // assume !$Heap[$nw, alloc];

--- a/Test/dafny0/Modules0.dfy.expect
+++ b/Test/dafny0/Modules0.dfy.expect
@@ -16,12 +16,12 @@ Modules0.dfy(84,24): Error: Undeclared top-level type or type parameter: MyClass
 Modules0.dfy(93,19): Error: Undeclared top-level type or type parameter: ClassG (did you forget to qualify a name or declare a module import 'opened'?)
 Modules0.dfy(101,14): Error: Undeclared top-level type or type parameter: MyClassY (did you forget to qualify a name or declare a module import 'opened'?)
 Modules0.dfy(226,15): Error: Undeclared top-level type or type parameter: X (did you forget to qualify a name or declare a module import 'opened'?)
-Modules0.dfy(226,8): Error: new can be applied only to class types (got X)
+Modules0.dfy(226,11): Error: new can be applied only to class types (got X)
 Modules0.dfy(235,13): Error: module 'B' does not declare a type 'X'
 Modules0.dfy(245,13): Error: unresolved identifier: X
 Modules0.dfy(246,15): Error: member 'DoesNotExist' does not exist in class 'X'
 Modules0.dfy(285,19): Error: Undeclared top-level type or type parameter: D (did you forget to qualify a name or declare a module import 'opened'?)
-Modules0.dfy(285,12): Error: new can be applied only to class types (got D)
+Modules0.dfy(285,15): Error: new can be applied only to class types (got D)
 Modules0.dfy(288,25): Error: type of the receiver is not fully determined at this program point
 Modules0.dfy(289,16): Error: type of the receiver is not fully determined at this program point
 Modules0.dfy(289,17): Error: expected method call, found expression
@@ -31,7 +31,7 @@ Modules0.dfy(314,18): Error: second argument to "in" must be a set, multiset, or
 Modules0.dfy(319,11): Error: Undeclared top-level type or type parameter: LongLostModule (did you forget to qualify a name or declare a module import 'opened'?)
 Modules0.dfy(320,11): Error: Undeclared top-level type or type parameter: Wazzup (did you forget to qualify a name or declare a module import 'opened'?)
 Modules0.dfy(321,17): Error: module 'Q_Imp' does not declare a type 'Edon'
-Modules0.dfy(323,10): Error: new can be applied only to class types (got Q_Imp.List<?>)
+Modules0.dfy(323,13): Error: new can be applied only to class types (got Q_Imp.List<?>)
 Modules0.dfy(324,23): Error: member 'Create' does not exist in class 'Klassy'
 Modules0.dfy(324,10): Error: when allocating an object of type 'Klassy', one of its constructor methods must be called
 Modules0.dfy(318,13): Error: arguments must have comparable types (got Q_Imp.Node and Node)

--- a/Test/dafny0/Modules2.dfy.expect
+++ b/Test/dafny0/Modules2.dfy.expect
@@ -1,5 +1,5 @@
 Modules2.dfy(47,17): Error: The name C ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
-Modules2.dfy(47,10): Error: new can be applied only to class types (got C)
+Modules2.dfy(47,13): Error: new can be applied only to class types (got C)
 Modules2.dfy(50,14): Error: the name 'E' denotes a datatype constructor, but does not do so uniquely; add an explicit qualification (for example, 'D.E')
 Modules2.dfy(51,14): Error: The name D ambiguously refers to a type in one of the modules A, B (try qualifying the type name with the module name)
 Modules2.dfy(53,11): Error: The name f ambiguously refers to a static member in one of the modules A, B (try qualifying the member name with the module name)

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -157,7 +157,7 @@ ResolutionErrors.dfy(1132,6): Error: RHS (of type P<int>) not assignable to LHS 
 ResolutionErrors.dfy(1137,13): Error: arguments must have comparable types (got P<int> and P<X>)
 ResolutionErrors.dfy(1138,13): Error: arguments must have comparable types (got P<bool> and P<X>)
 ResolutionErrors.dfy(1139,13): Error: arguments must have comparable types (got P<int> and P<bool>)
-ResolutionErrors.dfy(1150,10): Error: new can be applied only to class types (got JJ)
+ResolutionErrors.dfy(1150,13): Error: new can be applied only to class types (got JJ)
 ResolutionErrors.dfy(1158,31): Error: a set comprehension involved in a function definition is not allowed to depend on the set of allocated references, but values of 'o' may contain references (see documentation for 'older' parameters)
 ResolutionErrors.dfy(1159,38): Error: a set comprehension involved in a function definition is not allowed to depend on the set of allocated references, but values of 'o' may contain references (see documentation for 'older' parameters)
 ResolutionErrors.dfy(1165,27): Error: set comprehensions in non-ghost contexts must be compilable, but Dafny's heuristics can't figure out how to produce or compile a bounded set of values for 'o'

--- a/Test/exports/ExportResolve.dfy.expect
+++ b/Test/exports/ExportResolve.dfy.expect
@@ -111,11 +111,11 @@ ExportResolve.dfy(506,9): Error: This export set is not consistent: ProvideAllAn
 ExportResolve.dfy(582,16): Error: member 'u' has not been imported in this scope and cannot be accessed here
 ExportResolve.dfy(590,16): Error: member 'u' has not been imported in this scope and cannot be accessed here
 ExportResolve.dfy(595,19): Error: member 'FromInt' does not exist in type 'F' or cannot be part of type name
-ExportResolve.dfy(595,8): Error: new can be applied only to class types (got S.F.FromInt)
+ExportResolve.dfy(595,11): Error: new can be applied only to class types (got S.F.FromInt)
 ExportResolve.dfy(599,18): Error: member 'u' has not been imported in this scope and cannot be accessed here
 ExportResolve.dfy(619,6): Error: when allocating an object of type 'D', one of its constructor methods must be called
 ExportResolve.dfy(622,10): Error: when allocating an object of imported type 'E', one of its constructor methods must be called
 ExportResolve.dfy(627,19): Error: member 'FromInt' does not exist in type 'F' or cannot be part of type name
-ExportResolve.dfy(627,8): Error: new can be applied only to class types (got S.F.FromInt)
+ExportResolve.dfy(627,11): Error: new can be applied only to class types (got S.F.FromInt)
 ExportResolve.dfy(631,18): Error: member 'u' has not been imported in this scope and cannot be accessed here
 120 resolution/type errors detected in ExportResolve.dfy

--- a/Test/git-issues/git-issue-3449.dfy
+++ b/Test/git-issues/git-issue-3449.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 2 %dafny "%s" > "%t"
+// RUN: %exits-with 4 %dafny "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 class Basic { }

--- a/Test/git-issues/git-issue-3449.dfy
+++ b/Test/git-issues/git-issue-3449.dfy
@@ -1,0 +1,15 @@
+// RUN: %exits-with 2 %dafny "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class Basic { }
+
+method Test()
+{
+  // "new object" allocates an object of an abitrary type
+  var obj: object := new object;
+  if * {
+    assert !(obj is Basic); // error: no reason to think obj couldn't be a Basic
+  } else {
+    assert !(obj is array<int>); // error: no reason to think obj couldn't be an array<int>
+  }
+}

--- a/Test/git-issues/git-issue-3449.dfy.expect
+++ b/Test/git-issues/git-issue-3449.dfy.expect
@@ -1,3 +1,4 @@
+git-issue-3449.dfy(11,11): Error: assertion might not hold
+git-issue-3449.dfy(13,11): Error: assertion might not hold
 
-Dafny program verifier finished with 1 verified, 0 errors
-Expected exit code 2 , actual result is 0
+Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/git-issues/git-issue-3449.dfy.expect
+++ b/Test/git-issues/git-issue-3449.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+Expected exit code 2 , actual result is 0

--- a/Test/traits/TraitBasix.dfy.expect
+++ b/Test/traits/TraitBasix.dfy.expect
@@ -3,6 +3,6 @@ TraitBasix.dfy(70,8): Error: class 'I0Child' does not implement trait method 'I2
 TraitBasix.dfy(80,8): Error: class 'I0Child2' does not implement trait function 'I2.F'
 TraitBasix.dfy(91,24): Error: Undeclared top-level type or type parameter: IX (did you forget to qualify a name or declare a module import 'opened'?)
 TraitBasix.dfy(101,16): Error: a trait is not allowed to declare a constructor
-TraitBasix.dfy(117,11): Error: new can be applied only to class types (got I1)
+TraitBasix.dfy(117,14): Error: new can be applied only to class types (got I1)
 TraitBasix.dfy(184,6): Error: RHS (of type B) not assignable to LHS (of type Tr<int>) (non-variant type parameter would require int = real)
 7 resolution/type errors detected in TraitBasix.dfy

--- a/Test/traits/TraitResolution1.dfy.expect
+++ b/Test/traits/TraitResolution1.dfy.expect
@@ -1,31 +1,31 @@
 TraitResolution1.dfy(65,22): Error: the type of in-parameter 'x' is different from the type of the corresponding in-parameter in trait method ('int' instead of '(Y, B)')
-TraitResolution1.dfy(89,11): Error: new can be applied only to class types (got A?)
-TraitResolution1.dfy(90,11): Error: new can be applied only to class types (got ASynonym)
-TraitResolution1.dfy(93,11): Error: new can be applied only to class types (got B?)
+TraitResolution1.dfy(89,14): Error: new can be applied only to class types (got A?)
+TraitResolution1.dfy(90,14): Error: new can be applied only to class types (got ASynonym)
+TraitResolution1.dfy(93,14): Error: new can be applied only to class types (got B?)
 TraitResolution1.dfy(93,11): Error: when allocating an object of type 'B', one of its constructor methods must be called
-TraitResolution1.dfy(96,11): Error: new can be applied only to class types (got C?<A>)
-TraitResolution1.dfy(98,11): Error: new can be applied only to class types (got C?<A?>)
-TraitResolution1.dfy(101,11): Error: new can be applied only to class types (got D?<A>)
+TraitResolution1.dfy(96,14): Error: new can be applied only to class types (got C?<A>)
+TraitResolution1.dfy(98,14): Error: new can be applied only to class types (got C?<A?>)
+TraitResolution1.dfy(101,14): Error: new can be applied only to class types (got D?<A>)
 TraitResolution1.dfy(101,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution1.dfy(103,11): Error: new can be applied only to class types (got D?<A?>)
+TraitResolution1.dfy(103,14): Error: new can be applied only to class types (got D?<A?>)
 TraitResolution1.dfy(103,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution1.dfy(105,11): Error: new can be applied only to class types (got D<A>)
+TraitResolution1.dfy(105,14): Error: new can be applied only to class types (got D<A>)
 TraitResolution1.dfy(105,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution1.dfy(107,11): Error: new can be applied only to class types (got D<A?>)
+TraitResolution1.dfy(107,14): Error: new can be applied only to class types (got D<A?>)
 TraitResolution1.dfy(107,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution1.dfy(108,11): Error: new can be applied only to class types (got DSynonym<A?>)
+TraitResolution1.dfy(108,14): Error: new can be applied only to class types (got DSynonym<A?>)
 TraitResolution1.dfy(108,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution1.dfy(109,11): Error: new can be applied only to class types (got DSynonym<A?>)
+TraitResolution1.dfy(109,14): Error: new can be applied only to class types (got DSynonym<A?>)
 TraitResolution1.dfy(109,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution1.dfy(112,11): Error: new can be applied only to class types (got object?)
-TraitResolution1.dfy(113,11): Error: new can be applied only to class types (got ObjectSynonym)
-TraitResolution1.dfy(114,11): Error: new can be applied only to class types (got ObjectWithConstraint)
-TraitResolution1.dfy(117,13): Error: new can be applied only to class types (got array?<int>)
-TraitResolution1.dfy(119,11): Error: new can be applied only to class types (got int)
-TraitResolution1.dfy(121,11): Error: new can be applied only to class types (got Tr<int>)
-TraitResolution1.dfy(122,11): Error: new can be applied only to class types (got Tr?<int>)
-TraitResolution1.dfy(123,11): Error: new can be applied only to class types (got Tr<int>)
-TraitResolution1.dfy(124,11): Error: new can be applied only to class types (got Tr<int>)
+TraitResolution1.dfy(112,14): Error: new can be applied only to class types (got object?)
+TraitResolution1.dfy(113,14): Error: new can be applied only to class types (got ObjectSynonym)
+TraitResolution1.dfy(114,14): Error: new can be applied only to class types (got ObjectWithConstraint)
+TraitResolution1.dfy(117,16): Error: new can be applied only to class types (got array?<int>)
+TraitResolution1.dfy(119,14): Error: new can be applied only to class types (got int)
+TraitResolution1.dfy(121,14): Error: new can be applied only to class types (got Tr<int>)
+TraitResolution1.dfy(122,14): Error: new can be applied only to class types (got Tr?<int>)
+TraitResolution1.dfy(123,14): Error: new can be applied only to class types (got Tr<int>)
+TraitResolution1.dfy(124,14): Error: new can be applied only to class types (got Tr<int>)
 TraitResolution1.dfy(136,8): Error: class 'P' inherits a member named 'data' from both traits 'A' and 'B'
 TraitResolution1.dfy(139,8): Error: duplicate trait parents with the same head type must also have the same type arguments; got C<Even> and C<int>
 TraitResolution1.dfy(140,8): Error: duplicate trait parents with the same head type must also have the same type arguments; got C<int> and C<real>

--- a/Test/traits/TraitResolution2.dfy.expect
+++ b/Test/traits/TraitResolution2.dfy.expect
@@ -1,31 +1,31 @@
 TraitResolution2.dfy(70,22): Error: the type of in-parameter 'x' is different from the type of the corresponding in-parameter in trait method ('int' instead of '(Y, B)')
-TraitResolution2.dfy(94,11): Error: new can be applied only to class types (got A?)
-TraitResolution2.dfy(95,11): Error: new can be applied only to class types (got ASynonym)
-TraitResolution2.dfy(98,11): Error: new can be applied only to class types (got B?)
+TraitResolution2.dfy(94,14): Error: new can be applied only to class types (got A?)
+TraitResolution2.dfy(95,14): Error: new can be applied only to class types (got ASynonym)
+TraitResolution2.dfy(98,14): Error: new can be applied only to class types (got B?)
 TraitResolution2.dfy(98,11): Error: when allocating an object of type 'B', one of its constructor methods must be called
-TraitResolution2.dfy(101,11): Error: new can be applied only to class types (got C?<A>)
-TraitResolution2.dfy(103,11): Error: new can be applied only to class types (got C?<A?>)
-TraitResolution2.dfy(106,11): Error: new can be applied only to class types (got D?<A>)
+TraitResolution2.dfy(101,14): Error: new can be applied only to class types (got C?<A>)
+TraitResolution2.dfy(103,14): Error: new can be applied only to class types (got C?<A?>)
+TraitResolution2.dfy(106,14): Error: new can be applied only to class types (got D?<A>)
 TraitResolution2.dfy(106,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution2.dfy(108,11): Error: new can be applied only to class types (got D?<A?>)
+TraitResolution2.dfy(108,14): Error: new can be applied only to class types (got D?<A?>)
 TraitResolution2.dfy(108,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution2.dfy(110,11): Error: new can be applied only to class types (got D<A>)
+TraitResolution2.dfy(110,14): Error: new can be applied only to class types (got D<A>)
 TraitResolution2.dfy(110,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution2.dfy(112,11): Error: new can be applied only to class types (got D<A?>)
+TraitResolution2.dfy(112,14): Error: new can be applied only to class types (got D<A?>)
 TraitResolution2.dfy(112,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution2.dfy(113,11): Error: new can be applied only to class types (got DSynonym<A?>)
+TraitResolution2.dfy(113,14): Error: new can be applied only to class types (got DSynonym<A?>)
 TraitResolution2.dfy(113,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution2.dfy(114,11): Error: new can be applied only to class types (got DSynonym<A?>)
+TraitResolution2.dfy(114,14): Error: new can be applied only to class types (got DSynonym<A?>)
 TraitResolution2.dfy(114,11): Error: when allocating an object of type 'D', one of its constructor methods must be called
-TraitResolution2.dfy(117,11): Error: new can be applied only to class types (got object?)
-TraitResolution2.dfy(118,11): Error: new can be applied only to class types (got ObjectSynonym)
-TraitResolution2.dfy(119,11): Error: new can be applied only to class types (got ObjectWithConstraint)
-TraitResolution2.dfy(122,13): Error: new can be applied only to class types (got array?<int>)
-TraitResolution2.dfy(124,11): Error: new can be applied only to class types (got int)
-TraitResolution2.dfy(126,11): Error: new can be applied only to class types (got Tr<int>)
-TraitResolution2.dfy(127,11): Error: new can be applied only to class types (got Tr?<int>)
-TraitResolution2.dfy(128,11): Error: new can be applied only to class types (got Tr<int>)
-TraitResolution2.dfy(129,11): Error: new can be applied only to class types (got Tr<int>)
+TraitResolution2.dfy(117,14): Error: new can be applied only to class types (got object?)
+TraitResolution2.dfy(118,14): Error: new can be applied only to class types (got ObjectSynonym)
+TraitResolution2.dfy(119,14): Error: new can be applied only to class types (got ObjectWithConstraint)
+TraitResolution2.dfy(122,16): Error: new can be applied only to class types (got array?<int>)
+TraitResolution2.dfy(124,14): Error: new can be applied only to class types (got int)
+TraitResolution2.dfy(126,14): Error: new can be applied only to class types (got Tr<int>)
+TraitResolution2.dfy(127,14): Error: new can be applied only to class types (got Tr?<int>)
+TraitResolution2.dfy(128,14): Error: new can be applied only to class types (got Tr<int>)
+TraitResolution2.dfy(129,14): Error: new can be applied only to class types (got Tr<int>)
 TraitResolution2.dfy(181,8): Error: field 'civ' is inherited from trait 'Tr' and is not allowed to be re-declared
 TraitResolution2.dfy(182,14): Error: field 'giv' is inherited from trait 'Tr' and is not allowed to be re-declared
 TraitResolution2.dfy(183,10): Error: const field 'cic' is inherited from trait 'Tr' and is not allowed to be re-declared

--- a/docs/dev/news/3450.fix
+++ b/docs/dev/news/3450.fix
@@ -1,0 +1,1 @@
+Exclude verifier's type information for “new object” allocations


### PR DESCRIPTION
Fixes #3449

This PR fixes the verifier so that it does not assume any specific dynamic type of the object allocated by `new object`. This is a special allocation that is supposed to allocate an object of an arbitrary type. (See section 14.1 of the reference manual.)

The PR also improves the source location reported when a program attempts `new X` where `X` is a non-`class`, non-`object` type.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
