### PR TITLE
Chore: Fixed flacky test that had concurrent issues

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/ConcurrentLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/ConcurrentLinearVerificationGutterStatusTester.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Diagnostics;
 
 [TestClass]
 public class ConcurrentLinearVerificationGutterStatusTester : LinearVerificationGutterStatusTester {
-  private const int MaxSimultaneousVerificationTasks = 3;
+  private const int MaxSimultaneousVerificationTasks = 10;
 
   protected TestNotificationReceiver<VerificationStatusGutter>[] verificationStatusGutterReceivers =
     new TestNotificationReceiver<VerificationStatusGutter>[MaxSimultaneousVerificationTasks];


### PR DESCRIPTION
Fixes a CI issue where a test was sometimes failing randomly.

The reason was, there was a shared variable that was mutated by three different threads. I converted it to a concurrent dictionary, and everything works smoothly for even 10 threads.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
