### PR TITLE
Fix canonical paths for paths with spaces

### DIFF
--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -43,23 +43,19 @@ namespace Microsoft.Dafny {
         return (new Uri(filePath)).LocalPath;
       }
 
-      if (filePath.StartsWith("file:\\")) {
-        var withoutPrefix = filePath.Substring("file:\\".Length);
-        var tentativeURI = "file:///" + withoutPrefix.Replace("\\", "/");
-        if (Uri.IsWellFormedUriString(tentativeURI, UriKind.RelativeOrAbsolute)) {
-          return (new Uri(tentativeURI)).LocalPath;
+      var potentialPrefixes = new List<string>() { "file:\\", "file:/", "file:" };
+      foreach (var potentialPrefix in potentialPrefixes) {
+        if (filePath.StartsWith(potentialPrefix)) {
+          var withoutPrefix = filePath.Substring(potentialPrefix.Length);
+          var tentativeURI = "file:///" + withoutPrefix.Replace("\\", "/");
+          if (Uri.IsWellFormedUriString(tentativeURI, UriKind.RelativeOrAbsolute)) {
+            return (new Uri(tentativeURI)).LocalPath;
+          }
+          // Recovery mechanisms for the language server
+          return filePath.Substring(potentialPrefix.Length);
         }
-        // Recovery mechanisms for the language server
-        return filePath.Substring("file:\\".Length);
-      } else {
-        var withoutPrefix = filePath.Substring("file:".Length);
-        var tentativeURI = "file:///" + withoutPrefix.Replace("\\", "/");
-        if (Uri.IsWellFormedUriString(tentativeURI, UriKind.RelativeOrAbsolute)) {
-          return (new Uri(tentativeURI)).LocalPath;
-        }
-
-        return filePath.Substring("file:".Length);
       }
+      return filePath.Substring("file:".Length);
     }
     public static List<string> FileNames(IList<DafnyFile> dafnyFiles) {
       var sourceFiles = new List<string>();

--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -44,11 +44,22 @@ namespace Microsoft.Dafny {
       }
 
       if (filePath.StartsWith("file:\\")) {
+        var withoutPrefix = filePath.Substring("file:\\".Length);
+        var tentativeURI = "file:///" + withoutPrefix.Replace("\\", "/");
+        if (Uri.IsWellFormedUriString(tentativeURI, UriKind.RelativeOrAbsolute)) {
+          return (new Uri(tentativeURI)).LocalPath;
+        }
         // Recovery mechanisms for the language server
         return filePath.Substring("file:\\".Length);
-      }
+      } else {
+        var withoutPrefix = filePath.Substring("file:".Length);
+        var tentativeURI = "file:///" + withoutPrefix.Replace("\\", "/");
+        if (Uri.IsWellFormedUriString(tentativeURI, UriKind.RelativeOrAbsolute)) {
+          return (new Uri(tentativeURI)).LocalPath;
+        }
 
-      return filePath.Substring("file:".Length);
+        return filePath.Substring("file:".Length);
+      }
     }
     public static List<string> FileNames(IList<DafnyFile> dafnyFiles) {
       var sourceFiles = new List<string>();

--- a/Source/DafnyPipeline.Test/RelativePaths.cs
+++ b/Source/DafnyPipeline.Test/RelativePaths.cs
@@ -12,12 +12,17 @@ namespace DafnyPipeline.Test {
     }
 
     [Fact]
-    public void TestFileConversion() {
-      var filePath = @"file:\c:\Users\xxx\Documents\with%20space\test.dfy";
-      var filePath1 = @"file:c:\Users\xxx\Documents\with%20space\test.dfy";
+    public void TestFileCanonicalization() {
+      var filePath1 = @"file:\c:\Users\xxx\Documents\with%20space\test.dfy";
+      var filePath2 = @"file:c:\Users\xxx\Documents\with%20space\test.dfy";
       var expected = @"c:\Users\xxx\Documents\with space\test.dfy";
-      Assert.Equal(expected, DafnyFile.Canonicalize(filePath));
       Assert.Equal(expected, DafnyFile.Canonicalize(filePath1));
+      Assert.Equal(expected, DafnyFile.Canonicalize(filePath2));
+      filePath1 = @"file:///home/dev/with%20space/test.dfy";
+      filePath2 = @"file:/home/dev/with%20space/test.dfy";
+      expected = @"/home/dev/with space/test.dfy";
+      Assert.Equal(expected, DafnyFile.Canonicalize(filePath1));
+      Assert.Equal(expected, DafnyFile.Canonicalize(filePath2));
     }
   }
 }

--- a/Source/DafnyPipeline.Test/RelativePaths.cs
+++ b/Source/DafnyPipeline.Test/RelativePaths.cs
@@ -10,5 +10,14 @@ namespace DafnyPipeline.Test {
     public void Test() {
       Assert.Equal(0, DafnyDriver.ThreadMain(new string[] { "/spillTargetCode:3", "warnings-as-errors.dfy" }));
     }
+
+    [Fact]
+    public void TestFileConversion() {
+      var filePath = @"file:\c:\Users\xxx\Documents\with%20space\test.dfy";
+      var filePath1 = @"file:c:\Users\xxx\Documents\with%20space\test.dfy";
+      var expected = @"c:\Users\xxx\Documents\with space\test.dfy";
+      Assert.Equal(expected, DafnyFile.Canonicalize(filePath));
+      Assert.Equal(expected, DafnyFile.Canonicalize(filePath1));
+    }
   }
 }


### PR DESCRIPTION
After testing today's version of Dafny in VSCode, I realized that a path with name triggered an error when attempting to resolve includes. Hence, I added a unit test to catch this regression for next time and fixed the method that transforms file paths (which can be gross URI) to actual file locations

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
