### PR TITLE
Move towards a return value based style for our code generating methods

### DIFF
--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -1083,7 +1083,7 @@ namespace Microsoft.Dafny.Compilers {
       if (nt.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var wrWitness = new ConcreteSyntaxTree();
         var wStmts = w.Fork();
-        TrExpr(nt.Witness, wrWitness, false, wStmts);
+        wrWitness.Append(Expr(nt.Witness, false, wStmts));
         var witness = wrWitness.ToString();
         string typeName;
         if (nt.NativeType == null) {
@@ -1103,7 +1103,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var sw = new ConcreteSyntaxTree(cw.InstanceMemberWriter.RelativeIndentLevel);
         var wStmts = cw.InstanceMemberWriter.Fork();
-        TrExpr(sst.Witness, sw, false, wStmts);
+        sw.Append(Expr(sst.Witness, false, wStmts));
         var witness = sw.ToString();
         var typeName = TypeName(sst.Rhs, cw.StaticMemberWriter, sst.tok);
         if (sst.TypeArgs.Count == 0) {
@@ -1889,7 +1889,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write(SymbolDisplay.FormatLiteral(ErrorReporter.TokenToString(tok) + ": ", true) + " + ");
       }
 
-      TrExpr(messageExpr, wr, false, wStmts);
+      wr.Append(Expr(messageExpr, false, wStmts));
       if (UnicodeCharEnabled && messageExpr.Type.IsStringType) {
         wr.Write(".ToVerbatimString(false)");
       }
@@ -2588,9 +2588,9 @@ namespace Microsoft.Dafny.Compilers {
       var xType = source.Type.NormalizeExpand();
       if (xType is MapType) {
         var inner = wr.Write(TypeHelperName(xType, wr, source.tok) + ".Select").ForkInParens();
-        TrExpr(source, inner, inLetExprBody, wStmts);
+        inner.Append(Expr(source, inLetExprBody, wStmts));
         inner.Write(",");
-        TrExpr(index, inner, inLetExprBody, wStmts);
+        inner.Append(Expr(index, inLetExprBody, wStmts));
       } else {
         TrParenExpr(source, wr, inLetExprBody, wStmts);
         TrParenExpr(".Select", index, wr, inLetExprBody, wStmts);
@@ -3040,7 +3040,7 @@ namespace Microsoft.Dafny.Compilers {
               ConvertFromChar(e.E, wr, inLetExprBody, wStmts);
             } else {
               // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-              TrExpr(e.E, wr, inLetExprBody, wStmts);
+              wr.Append(Expr(e.E, inLetExprBody, wStmts));
             }
           } else if (fromNative != null && toNative == null) {
             // native (int or bv) -> big-integer (int or bv)
@@ -3086,7 +3086,7 @@ namespace Microsoft.Dafny.Compilers {
         if (e.ToType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
-          TrExpr(e.E, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(e.E, inLetExprBody, wStmts));
         } else {
           // real -> (int or bv or char or ordinal)
           if (e.ToType.IsCharType) {
@@ -3099,7 +3099,7 @@ namespace Microsoft.Dafny.Compilers {
         }
       } else if (e.E.Type.IsBigOrdinalType) {
         if (e.ToType.IsNumericBased(Type.NumericPersuasion.Int) || e.ToType.IsBigOrdinalType) {
-          TrExpr(e.E, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(e.E, inLetExprBody, wStmts));
         } else if (e.ToType.IsCharType) {
           wr.Write($"({CharTypeName})");
           TrParenExpr(e.E, wr, inLetExprBody, wStmts);

--- a/Source/DafnyCore/Compilers/CSharp/Synthesizer-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Synthesizer-Csharp.cs
@@ -150,7 +150,7 @@ public class CsharpSynthesizer {
   private void SynthesizeExpression(ConcreteSyntaxTree wr, Expression expr, ConcreteSyntaxTree wStmts) {
     switch (expr) {
       case LiteralExpr literalExpr:
-        compiler.TrExpr(literalExpr, wr, false, wStmts);
+        wr.Append(compiler.Expr(literalExpr, false, wStmts));
         break;
       case ApplySuffix applySuffix:
         SynthesizeExpression(wr, applySuffix, wStmts);
@@ -196,7 +196,7 @@ public class CsharpSynthesizer {
       if (bound != null) { // if true, arg is a bound variable
         wr.Write(bound.Item2);
       } else {
-        compiler.TrExpr(arg, wr, false, wStmts);
+        wr.Append(compiler.Expr(arg, false, wStmts));
       }
       if (i != applySuffix.Args.Count - 1) {
         wr.Write(", ");
@@ -226,7 +226,7 @@ public class CsharpSynthesizer {
         ErrorWriter, fieldName, obj.Name, lastSynthesizedMethod.Name);
       var tmpId = compiler.idGenerator.FreshId("tmp");
       wr.Format($"{objectToMockName[obj]}.SetupGet({tmpId} => {tmpId}.@{fieldName}).Returns( ");
-      compiler.TrExpr(binaryExpr.E1, wr, false, wStmts);
+      wr.Append(compiler.Expr(binaryExpr.E1, false, wStmts));
       wr.WriteLine(");");
       return;
     }
@@ -252,7 +252,7 @@ public class CsharpSynthesizer {
       }
     }
     wr.Write(")=>");
-    compiler.TrExpr(binaryExpr.E1, wr, false, wStmts);
+    wr.Append(compiler.Expr(binaryExpr.E1, false, wStmts));
     wr.WriteLine(");");
   }
 
@@ -282,7 +282,7 @@ public class CsharpSynthesizer {
     switch (binaryExpr.Op) {
       case BinaryExpr.Opcode.Imp:
         wr.Write("\treturn ");
-        compiler.TrExpr(binaryExpr.E0, wr, false, wStmts);
+        wr.Append(compiler.Expr(binaryExpr.E0, false, wStmts));
         wr.WriteLine(";");
         binaryExpr = (BinaryExpr)binaryExpr.E1;
         break;

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     private void EmitToString(ConcreteSyntaxTree wr, Expression arg, ConcreteSyntaxTree wStmts) {
-      TrExpr(arg, wr, false, wStmts);
+      wr = Expr(arg, false, wStmts);
     }
 
     protected override void EmitReturn(List<Formal> outParams, ConcreteSyntaxTree wr) {
@@ -478,7 +478,7 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function,
         List<Expression> arguments, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrExpr(function, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(function, inLetExprBody, wStmts));
       TrExprList(arguments, wr, inLetExprBody, wStmts);
     }
 

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -936,7 +936,7 @@ namespace Microsoft.Dafny.Compilers {
         var wStmts = wWitness.Fork();
         wWitness.Write("return ");
         if (nt.NativeType == null) {
-          TrExpr(nt.Witness, wWitness, false, wStmts);
+          wWitness.Append(Expr(nt.Witness, false, wStmts));
           wWitness.WriteLine();
         } else {
           TrParenExpr(nt.Witness, wWitness, false, wStmts);
@@ -959,7 +959,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
-        TrExpr(sst.Witness, witness, false, wStmts);
+        witness.Append(Expr(sst.Witness, false, wStmts));
         DeclareField("Witness", false, true, true, sst.Rhs, sst.tok, witness.ToString(), cw.ClassName, cw.StaticFieldWriter, cw.StaticFieldInitWriter, cw.ConcreteMethodWriter);
       }
       // RTD
@@ -1803,17 +1803,17 @@ namespace Microsoft.Dafny.Compilers {
       var wStmts = wr.Fork();
       if (isString && UnicodeCharEnabled) {
         wr.Write("_dafny.Print(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.WriteLine(".VerbatimString(false))");
       } else if (!isString ||
                  (arg.Resolved is MemberSelectExpr mse &&
                   mse.Member.IsExtern(out _, out _))) {
         wr.Write("_dafny.Print(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.WriteLine(")");
       } else {
         wr.Write("_dafny.Print((");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.Write(")");
         if (!UnicodeCharEnabled) {
           wr.Write(".SetString()");
@@ -1831,7 +1831,7 @@ namespace Microsoft.Dafny.Compilers {
       var w = EmitReturnExpr(wr);
       var fromType = thisContext == null ? expr.Type : expr.Type.Subst(thisContext.ParentFormalTypeParametersToActuals);
       w = EmitCoercionIfNecessary(fromType, resultType, expr.tok, w);
-      TrExpr(expr, w, inLetExprBody, wStmts);
+      w.Append(Expr(expr, inLetExprBody, wStmts));
     }
 
     protected void EmitReturnWithCoercions(List<Formal> outParams, List<Formal>/*?*/ overriddenOutParams, Dictionary<TypeParameter, Type>/*?*/ typeMap, ConcreteSyntaxTree wr) {
@@ -2264,8 +2264,8 @@ namespace Microsoft.Dafny.Compilers {
           wFirstArg = wr.Fork();
           wr.Write(").{0}(", isRotateLeft ? "Lrot" : "Rrot");
         }
-        TrExpr(e0, wFirstArg, inLetExprBody, wStmts);
-        TrExpr(e1, wr, inLetExprBody, wStmts);
+        wFirstArg.Append(Expr(e0, inLetExprBody, wStmts));
+        wr.Append(Expr(e1, inLetExprBody, wStmts));
         wr.Write(", {0})", bv.Width);
 
         if (needsCast) {
@@ -2476,13 +2476,13 @@ namespace Microsoft.Dafny.Compilers {
     protected override void EmitITE(Expression guard, Expression thn, Expression els, Type resultType, bool inLetExprBody,
         ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("(func () {0} {{ if ", TypeName(resultType, wr, null));
-      TrExpr(guard, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(guard, inLetExprBody, wStmts));
       wr.Write(" { return ");
       var wBranch = EmitCoercionIfNecessary(thn.Type, resultType, thn.tok, wr);
-      TrExpr(thn, wBranch, inLetExprBody, wStmts);
+      wBranch.Append(Expr(thn, inLetExprBody, wStmts));
       wr.Write(" }; return ");
       wBranch = EmitCoercionIfNecessary(els.Type, resultType, thn.tok, wr);
-      TrExpr(els, wBranch, inLetExprBody, wStmts);
+      wBranch.Append(Expr(els, inLetExprBody, wStmts));
       wr.Write(" })() ");
     }
 
@@ -2796,7 +2796,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write(".Uint32()");
         } else {
           wr.Write("uint32(");
-          TrExpr(expr, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(expr, inLetExprBody, wStmts));
           wr.Write(")");
         }
       }
@@ -2813,14 +2813,14 @@ namespace Microsoft.Dafny.Compilers {
       } else if (type is MultiSetType) {
         TrParenExpr(source, wr, inLetExprBody, wStmts);
         wr.Write(".Multiplicity(");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
         wr.Write(")");
       } else {
         Contract.Assert(type is MapType);
         // map or imap
         TrParenExpr(source, wr, inLetExprBody, wStmts);
         wr.Write(".Get(");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
         wr.Write(").({0})", TypeName(((MapType)type).Range, wr, null));
       }
     }
@@ -2829,17 +2829,17 @@ namespace Microsoft.Dafny.Compilers {
         CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (source.Type.AsSeqType != null) {
         wr.Write($"{DafnySequenceCompanion}.Update(");
-        TrExpr(source, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(source, inLetExprBody, wStmts));
         wr.Write(", ");
         TrExprToSizeT(index, inLetExprBody, wr, wStmts);
         wr.Write(", ");
-        TrExpr(value, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(value, inLetExprBody, wStmts));
         wr.Write(")");
       } else {
         EmitIndexCollectionUpdate(source.Type, out var wSource, out var wIndex, out var wValue, wr, false);
         TrParenExpr(source, wSource, inLetExprBody, wSource);
-        TrExpr(index, wIndex, inLetExprBody, wSource);
-        TrExpr(value, wValue, inLetExprBody, wSource);
+        wIndex.Append(Expr(index, inLetExprBody, wSource));
+        wValue.Append(Expr(value, inLetExprBody, wSource));
       }
     }
 
@@ -2864,7 +2864,7 @@ namespace Microsoft.Dafny.Compilers {
         bool fromArray, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromArray) {
         wr.Write("_dafny.ArrayRangeToSeq(");
-        TrExpr(source, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(source, inLetExprBody, wStmts));
         wr.Write(", ");
 
         if (lo == null) {
@@ -2959,7 +2959,7 @@ namespace Microsoft.Dafny.Compilers {
       var tParam = new UserDefinedType(expr.tok, new TypeParameter(expr.tok, "X", TypeParameter.TPVarianceSyntax.NonVariant_Strict));
       var toType = new ArrowType(expr.tok, atd, new List<Type>() { Type.Int }, tParam);
       var initWr = EmitCoercionIfNecessary(fromType, toType, expr.tok, wr);
-      TrExpr(expr.Initializer, initWr, inLetExprBody, wStmts);
+      initWr.Append(Expr(expr.Initializer, inLetExprBody, wStmts));
       wr.Write(")");
       if (fromType.Result.IsCharType && !UnicodeCharEnabled) {
         // Tag this sequence as being a string at runtime,
@@ -3420,7 +3420,7 @@ namespace Microsoft.Dafny.Compilers {
             if (toNative == null) {
               // char -> big-integer (int or bv or ORDINAL)
               wr.Write("_dafny.IntOfInt32(rune(");
-              TrExpr(e.E, wr, inLetExprBody, wStmts);
+              wr.Append(Expr(e.E, inLetExprBody, wStmts));
               wr.Write("))");
             } else {
               // char -> native
@@ -3429,12 +3429,12 @@ namespace Microsoft.Dafny.Compilers {
             }
           } else if (fromNative == null && toNative == null) {
             // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-            TrExpr(e.E, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(e.E, inLetExprBody, wStmts));
           } else if (fromNative != null) {
             Contract.Assert(toNative == null); // follows from other checks
             // native (int or bv) -> big-integer (int or bv)
             wr.Write("_dafny.IntOf{0}(", Capitalize(GetNativeTypeName(fromNative)));
-            TrExpr(e.E, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(e.E, inLetExprBody, wStmts));
             wr.Write(')');
           } else {
             // any (int or bv) -> native (int or bv)
@@ -3453,7 +3453,7 @@ namespace Microsoft.Dafny.Compilers {
             } else if (m != null && m.MemberName == "Length" && m.Obj.Type.IsArrayType) {
               // Optimize .Length to avoid intermediate BigInteger
               wr.Write("{0}(_dafny.ArrayLenInt(", GetNativeTypeName(toNative));
-              TrExpr(m.Obj, wr, inLetExprBody, wStmts);
+              wr.Append(Expr(m.Obj, inLetExprBody, wStmts));
               wr.Write(", 0))");
             } else {
               // no optimization applies; use the standard translation
@@ -3467,7 +3467,7 @@ namespace Microsoft.Dafny.Compilers {
         if (e.ToType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
-          TrExpr(e.E, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(e.E, inLetExprBody, wStmts));
         } else if (e.ToType.IsCharType) {
           wr.Write($"{CharTypeName}(");
           TrParenExpr(e.E, wr, inLetExprBody, wStmts);
@@ -3667,9 +3667,9 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("_dafny.NewMapBuilder()");
       foreach (ExpressionPair p in elements) {
         wr.Write(".Add(");
-        TrExpr(p.A, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.A, inLetExprBody, wStmts));
         wr.Write(", ");
-        TrExpr(p.B, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.B, inLetExprBody, wStmts));
         wr.Write(')');
       }
       wr.Write(".ToMap()");
@@ -3689,7 +3689,7 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assume(ct is SetType || ct is MultiSetType);  // follows from precondition
       var wStmts = wr.Fork();
       wr.Write("{0}.Add(", collName);
-      TrExpr(elmt, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(elmt, inLetExprBody, wStmts));
       wr.WriteLine(")");
     }
 
@@ -3698,7 +3698,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("{0}.Add(", collName);
       var termLeftWriter = wr.Fork();
       wr.Write(",");
-      TrExpr(term, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(term, inLetExprBody, wStmts));
       wr.WriteLine(")");
       return termLeftWriter;
     }

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -273,14 +273,14 @@ namespace Microsoft.Dafny.Compilers {
       var wrTuple = EmitAddTupleToList(ingredients, tupleTypeArgs, wr);
       wrTuple.Write($"{L}<{tupleTypeArgs}>(");
       if (s0.Lhs is MemberSelectExpr lhs1) {
-        TrExpr(lhs1.Obj, wrTuple, false, wStmts);
+        wrTuple.Append(Expr(lhs1.Obj, false, wStmts));
       } else if (s0.Lhs is SeqSelectExpr lhs2) {
-        TrExpr(lhs2.Seq, wrTuple, false, wStmts);
+        wrTuple.Append(Expr(lhs2.Seq, false, wStmts));
         wrTuple.Write(", ");
         TrParenExpr(lhs2.E0, wrTuple, false, wStmts);
       } else {
         var lhs = (MultiSelectExpr)s0.Lhs;
-        TrExpr(lhs.Array, wrTuple, false, wStmts);
+        wrTuple.Append(Expr(lhs.Array, false, wStmts));
         foreach (var t in lhs.Indices) {
           wrTuple.Write(", ");
           TrParenExpr(t, wrTuple, false, wStmts);
@@ -293,7 +293,7 @@ namespace Microsoft.Dafny.Compilers {
         wrTuple.Write($"({TypeName(t, wrTuple, rhs.tok)})");
       }
 
-      TrExpr(rhs, wrTuple, false, wStmts);
+      wrTuple.Append(Expr(rhs, false, wStmts));
       return wrOuter;
     }
 
@@ -376,7 +376,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var sw = new ConcreteSyntaxTree(cw.InstanceMemberWriter.RelativeIndentLevel);
         var wStmts = cw.InstanceMemberWriter.Fork();
-        TrExpr(sst.Witness, sw, false, wStmts);
+        sw.Append(Expr(sst.Witness, false, wStmts));
         var witness = sw.ToString();
         var typeName = TypeName(sst.Rhs, cw.StaticMemberWriter, sst.tok);
         if (sst.TypeArgs.Count == 0) {
@@ -462,7 +462,7 @@ namespace Microsoft.Dafny.Compilers {
       }
       var wStmts = wr.Fork();
       var w = DeclareLocalVar(name, type, tok, wr);
-      TrExpr(rhs, w, inLetExprBody, wStmts);
+      w.Append(Expr(rhs, inLetExprBody, wStmts));
     }
 
     public ConcreteSyntaxTree /*?*/ CreateGetterSetter(string name, Type resultType, IToken tok,
@@ -1224,7 +1224,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write(sep);
         var elementWriter = wr.Fork();
         elementWriter = EmitCoercionIfNecessary(e.Type, NativeObjectType, Token.NoToken, elementWriter);
-        TrExpr(e, elementWriter, inLetExprBody, wStmts);
+        elementWriter.Append(Expr(e, inLetExprBody, wStmts));
         sep = ", ";
       }
       wr.Write(")");
@@ -1238,9 +1238,9 @@ namespace Microsoft.Dafny.Compilers {
       foreach (ExpressionPair p in elements) {
         wr.Write(sep);
         wr.Write($"new {DafnyTupleClass(2)}(");
-        TrExpr(p.A, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.A, inLetExprBody, wStmts));
         wr.Write(", ");
-        TrExpr(p.B, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.B, inLetExprBody, wStmts));
         wr.Write(")");
         sep = ", ";
       }
@@ -1566,7 +1566,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write($"{DafnyMultiSetClass}.<{BoxedTypeName(source.Type.AsMultiSetType.Arg, wr, Token.NoToken)}>multiplicity(");
         TrParenExpr(source, wr, inLetExprBody, wStmts);
         wr.Write(", ");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
         wr.Write(")");
       } else if (source.Type.AsMapType != null) {
         wr = EmitCoercionIfNecessary(from: NativeObjectType, to: source.Type.AsMapType.Range, tok: source.tok, wr: wr);
@@ -1590,27 +1590,27 @@ namespace Microsoft.Dafny.Compilers {
         CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (source.Type.AsSeqType != null) {
         wr.Write($"{DafnySeqClass}.<{BoxedTypeName(resultCollectionType.Arg, wr, Token.NoToken)}>update(");
-        TrExpr(source, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(source, inLetExprBody, wStmts));
         wr.Write(", ");
         TrExprAsInt(index, wr, inLetExprBody, wStmts);
       } else if (source.Type.AsMapType != null) {
         var mapType = (MapType)resultCollectionType;
         wr.Write($"{DafnyMapClass}.<{BoxedTypeName(mapType.Domain, wr, Token.NoToken)}, {BoxedTypeName(mapType.Range, wr, Token.NoToken)}>update(");
-        TrExpr(source, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(source, inLetExprBody, wStmts));
         wr.Write(", ");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
       } else if (source.Type.AsMultiSetType != null) {
         wr.Write($"{DafnyMultiSetClass}.<{BoxedTypeName(resultCollectionType.Arg, wr, Token.NoToken)}>update(");
-        TrExpr(source, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(source, inLetExprBody, wStmts));
         wr.Write(", ");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
       } else {
         TrParenExpr(source, wr, inLetExprBody, wStmts);
         wr.Write(".update(");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
       }
       wr.Write(", ");
-      TrExpr(value, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(value, inLetExprBody, wStmts));
       wr.Write(")");
     }
 
@@ -2118,22 +2118,22 @@ namespace Microsoft.Dafny.Compilers {
         switch (AsNativeType(arg.Type).Sel) {
           case NativeType.Selection.Byte:
             wr.Write("java.lang.Integer.toUnsignedString(java.lang.Byte.toUnsignedInt(");
-            TrExpr(arg, wr, false, wStmts);
+            wr.Append(Expr(arg, false, wStmts));
             wr.Write("))");
             break;
           case NativeType.Selection.UShort:
             wr.Write("java.lang.Integer.toUnsignedString(java.lang.Short.toUnsignedInt(");
-            TrExpr(arg, wr, false, wStmts);
+            wr.Append(Expr(arg, false, wStmts));
             wr.Write("))");
             break;
           case NativeType.Selection.UInt:
             wr.Write("java.lang.Integer.toUnsignedString(");
-            TrExpr(arg, wr, false, wStmts);
+            wr.Append(Expr(arg, false, wStmts));
             wr.Write(")");
             break;
           case NativeType.Selection.ULong:
             wr.Write("java.lang.Long.toUnsignedString(");
-            TrExpr(arg, wr, false, wStmts);
+            wr.Append(Expr(arg, false, wStmts));
             wr.Write(")");
             break;
           default:
@@ -2149,15 +2149,15 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write(".verbatimString()");
         } else if (arg.Type.IsCharType && UnicodeCharEnabled) {
           wr.Write($"{DafnyHelpersClass}.ToCharLiteral(");
-          TrExpr(arg, wr, false, wStmts);
+          wr.Append(Expr(arg, false, wStmts));
           wr.Write(")");
         } else if (isGeneric && !UnicodeCharEnabled) {
           wr.Write($"((java.util.function.Function<{DafnySeqClass}<?>,String>)(_s -> (_s.elementType().defaultValue().getClass() == java.lang.Character.class ? _s.verbatimString() : String.valueOf(_s)))).apply(");
-          TrExpr(arg, wr, false, wStmts);
+          wr.Append(Expr(arg, false, wStmts));
           wr.Write(")");
         } else {
           wr.Write("java.lang.String.valueOf(");
-          TrExpr(arg, wr, false, wStmts);
+          wr.Append(Expr(arg, false, wStmts));
           wr.Write(")");
         }
       }
@@ -3302,7 +3302,7 @@ namespace Microsoft.Dafny.Compilers {
         var wStmts = wr.Fork();
         wr.Write($"{collName}.add(");
         var coercedWr = EmitCoercionIfNecessary(elmt.Type, NativeObjectType, elmt.tok, wr);
-        TrExpr(elmt, coercedWr, inLetExprBody, wStmts);
+        coercedWr.Append(Expr(elmt, inLetExprBody, wStmts));
         wr.WriteLine(");");
       } else {
         Contract.Assume(false);  // unexpected collection type
@@ -3376,7 +3376,7 @@ namespace Microsoft.Dafny.Compilers {
       if (nt.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var wStmts = w.Fork();
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
-        TrExpr(nt.Witness, witness, false, wStmts);
+        witness.Append(Expr(nt.Witness, false, wStmts));
         if (nt.NativeType == null) {
           cw.DeclareField("Witness", nt, true, true, nt.BaseType, nt.tok, witness.ToString(), null);
         } else {
@@ -3409,7 +3409,7 @@ namespace Microsoft.Dafny.Compilers {
     private void TrExprAsInt(Expression expr, ConcreteSyntaxTree wr, bool inLetExprBody, ConcreteSyntaxTree wStmts,
       bool checkRange = false, string msg = null) {
       var wrExpr = new ConcreteSyntaxTree();
-      TrExpr(expr, wrExpr, inLetExprBody, wStmts);
+      wrExpr.Append(Expr(expr, inLetExprBody, wStmts));
       TrExprAsInt(wrExpr.ToString(), expr.Type, wr, checkRange, msg);
     }
 
@@ -3725,16 +3725,16 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write($"{collName}.put(");
       var termLeftWriter = wr.Fork();
       wr.Write(",");
-      TrExpr(term, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(term, inLetExprBody, wStmts));
       wr.WriteLine(");");
       return termLeftWriter;
     }
 
     protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write($"{DafnySeqClass}.Create({TypeDescriptor(expr.Type.AsCollectionType.Arg, wr, expr.tok)}, ");
-      TrExpr(expr.N, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(expr.N, inLetExprBody, wStmts));
       wr.Write(", ");
-      TrExpr(expr.Initializer, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(expr.Initializer, inLetExprBody, wStmts));
       wr.Write(")");
     }
 
@@ -3764,10 +3764,10 @@ namespace Microsoft.Dafny.Compilers {
             TrParenExpr(arg, wr, inLetExprBody, wStmts);
             wr.Write(", java.math.BigInteger.ONE)");
           } else if (fromType.IsCharType) {
-            TrExpr(arg, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(arg, inLetExprBody, wStmts));
             wr.Write(", 1)");
           } else {
-            TrExpr(arg, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(arg, inLetExprBody, wStmts));
             wr.Write(", java.math.BigInteger.ONE)");
           }
         } else if (toType.IsCharType) {
@@ -3796,7 +3796,7 @@ namespace Microsoft.Dafny.Compilers {
               TrParenExpr(arg, wr, inLetExprBody, wStmts);
             } else {
               // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-              TrExpr(arg, wr, inLetExprBody, wStmts);
+              wr.Append(Expr(arg, inLetExprBody, wStmts));
             }
           } else if (fromNative != null && toNative == null) {
             // native (int or bv) -> big-integer (int or bv)
@@ -3875,7 +3875,7 @@ namespace Microsoft.Dafny.Compilers {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(toType) == null);
-          TrExpr(arg, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(arg, inLetExprBody, wStmts));
         } else if (toType.IsCharType) {
           // real -> char
           // Painfully, Java sign-extends bytes when casting to chars ...
@@ -3909,7 +3909,7 @@ namespace Microsoft.Dafny.Compilers {
         } else if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // ordinal -> real
           wr.Write($"new {DafnyBigRationalClass}(");
-          TrExpr(arg, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(arg, inLetExprBody, wStmts));
           wr.Write(", java.math.BigInteger.ONE)");
         } else if (toType.IsBitVectorType) {
           // ordinal -> bv

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -1538,7 +1538,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("_this");
     }
 
-    protected override ConcreteSyntaxTree EmitCast(Type toType, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitCast(ICanRender toType, ConcreteSyntaxTree wr) {
       return wr;
     }
 

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Dafny.Compilers {
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
         if (nt.NativeType == null) {
-          TrExpr(nt.Witness, witness, false, wStmts);
+          witness.Append(Expr(nt.Witness, false, wStmts));
         } else {
           TrParenExpr(nt.Witness, witness, false, wStmts);
           witness.Write(".toNumber()");
@@ -576,7 +576,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var sw = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
-        TrExpr(sst.Witness, sw, false, wStmts);
+        sw.Append(Expr(sst.Witness, false, wStmts));
         DeclareField("Witness", true, true, sst.Rhs, sst.tok, sw.ToString(), w);
         d = TypeName_UDT(FullTypeName(udt), udt, wr, udt.tok) + ".Witness";
       } else {
@@ -1081,7 +1081,7 @@ namespace Microsoft.Dafny.Compilers {
       if (isStringLiteral && !UnicodeCharEnabled) {
         // process.stdout.write(_dafny.toString(x));
         wr.Write("process.stdout.write(_dafny.toString(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.WriteLine("));");
       } else if (isString) {
         if (UnicodeCharEnabled) {
@@ -1090,7 +1090,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.WriteLine(".toVerbatimString(false));");
         } else {
           wr.Write($"process.stdout.write(_dafny.toString({DafnySeqClass}.JoinIfPossible(");
-          TrExpr(arg, wr, false, wStmts);
+          wr.Append(Expr(arg, false, wStmts));
           wr.WriteLine(")));");
         }
       } else if (isGeneric && !UnicodeCharEnabled) {
@@ -1098,24 +1098,24 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write("try { process.stdout.write(_dafny.toString(");
         wr.Write("(");
         wr.Write("(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.Write(") instanceof Array && typeof((");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.Write(")[0]) == \"string\") ? ");
         wr.Write("(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.Write(").join(\"\")");
         wr.Write(":");
         wr.Write("(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.Write(")));");
         wr.Write("} catch (_error) { process.stdout.write(_dafny.toString(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.WriteLine("));}");
       } else { // !isString && !isGeneric
         // process.stdout.write(_dafny.toString(x));
         wr.Write("process.stdout.write(_dafny.toString(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.WriteLine("));");
       }
     }
@@ -1757,13 +1757,13 @@ namespace Microsoft.Dafny.Compilers {
       var w = wr.Fork();
       if (indices.Count == 1) {
         wr.Write("[");
-        TrExpr(indices[0], wr, inLetExprBody, wStmts);
+        wr.Append(Expr(indices[0], inLetExprBody, wStmts));
         wr.Write("]");
       } else {
         wr.Write(".elmts");
         foreach (var index in indices) {
           wr.Write("[");
-          TrExpr(index, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(index, inLetExprBody, wStmts));
           wr.Write("]");
         }
       }
@@ -1785,12 +1785,12 @@ namespace Microsoft.Dafny.Compilers {
       if (source.Type.NormalizeExpand() is SeqType) {
         // seq
         wr.Write("[");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
         wr.Write("]");
       } else {
         // map or imap
         wr.Write(".get(");
-        TrExpr(index, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(index, inLetExprBody, wStmts));
         wr.Write(")");
       }
     }
@@ -1799,15 +1799,15 @@ namespace Microsoft.Dafny.Compilers {
         CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (source.Type.AsSeqType != null) {
         wr.Write($"{DafnySeqClass}.update(");
-        TrExpr(source, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(source, inLetExprBody, wStmts));
         wr.Write(", ");
       } else {
         TrParenExpr(source, wr, inLetExprBody, wStmts);
         wr.Write(".update(");
       }
-      TrExpr(index, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(index, inLetExprBody, wStmts));
       wr.Write(", ");
-      TrExpr(value, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(value, inLetExprBody, wStmts));
       wr.Write(")");
     }
 
@@ -1819,15 +1819,15 @@ namespace Microsoft.Dafny.Compilers {
       TrParenExpr(source, wr, inLetExprBody, wStmts);
       if (lo != null) {
         wr.Write(".slice(");
-        TrExpr(lo, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(lo, inLetExprBody, wStmts));
         if (hi != null) {
           wr.Write(", ");
-          TrExpr(hi, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(hi, inLetExprBody, wStmts));
         }
         wr.Write(")");
       } else if (hi != null) {
         wr.Write(".slice(0, ");
-        TrExpr(hi, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(hi, inLetExprBody, wStmts));
         wr.Write(")");
       } else if (fromArray) {
         wr.Write(".slice()");
@@ -1840,9 +1840,9 @@ namespace Microsoft.Dafny.Compilers {
     protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var fromType = (ArrowType)expr.Initializer.Type.NormalizeExpand();
       wr.Write($"{DafnySeqClass}.Create(");
-      TrExpr(expr.N, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(expr.N, inLetExprBody, wStmts));
       wr.Write(", ");
-      TrExpr(expr.Initializer, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(expr.Initializer, inLetExprBody, wStmts));
       wr.Write(")");
       if (fromType.Result.IsCharType && !UnicodeCharEnabled) {
         wr.Write(".join('')");
@@ -1933,7 +1933,7 @@ namespace Microsoft.Dafny.Compilers {
             wr.Write("0");
           } else {
             wr.Write("_dafny.BitwiseNot(");
-            TrExpr(expr, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(expr, inLetExprBody, wStmts));
             wr.Write(", {0})", expr.Type.AsBitVectorType.Width);
           }
           break;
@@ -2290,7 +2290,7 @@ namespace Microsoft.Dafny.Compilers {
           var toNative = AsNativeType(e.ToType);
           if (fromNative != null && toNative != null) {
             // from a native, to a native -- simple!
-            TrExpr(e.E, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(e.E, inLetExprBody, wStmts));
           } else if (e.E.Type.IsCharType) {
             Contract.Assert(fromNative == null);
             if (toNative == null) {
@@ -2305,7 +2305,7 @@ namespace Microsoft.Dafny.Compilers {
             }
           } else if (fromNative == null && toNative == null) {
             // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-            TrExpr(e.E, wr, inLetExprBody, wStmts);
+            wr.Append(Expr(e.E, inLetExprBody, wStmts));
           } else if (fromNative != null && toNative == null) {
             // native (int or bv) -> big-integer (int or bv)
             wr.Write("new BigNumber");
@@ -2339,7 +2339,7 @@ namespace Microsoft.Dafny.Compilers {
         if (e.ToType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(e.ToType) == null);
-          TrExpr(e.E, wr, inLetExprBody, wStmts);
+          wr.Append(Expr(e.E, inLetExprBody, wStmts));
         } else if (e.ToType.IsCharType) {
           wr.Write($"{CharFromNumberMethodName()}(");
           TrParenExpr(e.E, wr, inLetExprBody, wStmts);
@@ -2357,7 +2357,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write($"{CharFromNumberMethodName()}((");
         }
 
-        TrExpr(e.E, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(e.E, inLetExprBody, wStmts));
         if (e.ToType.IsCharType) {
           wr.Write(").toNumber())");
         }
@@ -2422,7 +2422,7 @@ namespace Microsoft.Dafny.Compilers {
         string sep = "";
         foreach (var e in elements) {
           wrElements.Write(sep);
-          TrExpr(e, wrElements, inLetExprBody, wStmts);
+          wrElements.Append(Expr(e, inLetExprBody, wStmts));
           sep = ", ";
         }
       }
@@ -2435,9 +2435,9 @@ namespace Microsoft.Dafny.Compilers {
       foreach (ExpressionPair p in elements) {
         wr.Write(sep);
         wr.Write("[");
-        TrExpr(p.A, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.A, inLetExprBody, wStmts));
         wr.Write(",");
-        TrExpr(p.B, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.B, inLetExprBody, wStmts));
         wr.Write("]");
         sep = ", ";
       }
@@ -2458,7 +2458,7 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assume(ct is SetType || ct is MultiSetType);  // follows from precondition
       var wStmts = wr.Fork();
       wr.Write("{0}.add(", collName);
-      TrExpr(elmt, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(elmt, inLetExprBody, wStmts));
       wr.WriteLine(");");
     }
 
@@ -2467,7 +2467,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("{0}.push([", collName);
       var termLeftWriter = wr.Fork();
       wr.Write(",");
-      TrExpr(term, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(term, inLetExprBody, wStmts));
       wr.WriteLine("]);");
       return termLeftWriter;
     }

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Dafny.Compilers {
       var wStmts = block.Fork();
       block.Write("return ");
       if (witnessKind == SubsetTypeDecl.WKind.Compiled) {
-        TrExpr(witness, block, false, wStmts);
+        block.Append(Expr(witness, false, wStmts));
       } else {
         block.Write(TypeInitializationValue(udt, wr, d.tok, false, false));
       }
@@ -822,7 +822,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write(".VerbatimString(False)");
       } else {
         wr.Write($"{DafnyRuntimeModule}.string_of(");
-        TrExpr(arg, wr, false, wStmts);
+        wr.Append(Expr(arg, false, wStmts));
         wr.Write(")");
       }
     }
@@ -1295,7 +1295,7 @@ namespace Microsoft.Dafny.Compilers {
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       TrParenExpr(source, wr, inLetExprBody, wStmts);
       wr.Write("[");
-      TrExpr(index, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(index, inLetExprBody, wStmts));
       wr.Write("]");
     }
 
@@ -1303,9 +1303,9 @@ namespace Microsoft.Dafny.Compilers {
       CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       TrParenExpr(source, wr, inLetExprBody, wStmts);
       wr.Write(".set(");
-      TrExpr(index, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(index, inLetExprBody, wStmts));
       wr.Write(", ");
-      TrExpr(value, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(value, inLetExprBody, wStmts));
       wr.Write(")");
     }
 
@@ -1314,9 +1314,9 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write($"{DafnySeqMakerFunction}(");
       TrParenExpr(source, wr, inLetExprBody, wStmts);
       wr.Write("[");
-      if (lo != null) { TrExpr(lo, wr, inLetExprBody, wStmts); }
+      if (lo != null) { wr.Append(Expr(lo, inLetExprBody, wStmts)); }
       wr.Write(":");
-      if (hi != null) { TrExpr(hi, wr, inLetExprBody, wStmts); }
+      if (hi != null) { wr.Append(Expr(hi, inLetExprBody, wStmts)); }
 
       wr.Write(":])");
     }
@@ -1342,7 +1342,7 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function,
         List<Expression> arguments, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrExpr(function, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(function, inLetExprBody, wStmts));
       TrExprList(arguments, wr, inLetExprBody, wStmts);
     }
 
@@ -1620,7 +1620,7 @@ namespace Microsoft.Dafny.Compilers {
         }
       }
       wr.Write(pre);
-      TrExpr(e.E, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(e.E, inLetExprBody, wStmts));
       wr.Write(post);
     }
 
@@ -1669,9 +1669,9 @@ namespace Microsoft.Dafny.Compilers {
       var sep = "";
       foreach (var p in elements) {
         wr.Write(sep);
-        TrExpr(p.A, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.A, inLetExprBody, wStmts));
         wr.Write(": ");
-        TrExpr(p.B, wr, inLetExprBody, wStmts);
+        wr.Append(Expr(p.B, inLetExprBody, wStmts));
         sep = ", ";
       }
       wr.Write("})");
@@ -1729,7 +1729,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override void EmitSingleValueGenerator(Expression e, bool inLetExprBody, string type,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("[");
-      TrExpr(e, wr, inLetExprBody, wStmts);
+      wr.Append(Expr(e, inLetExprBody, wStmts));
       wr.Write("]");
     }
 

--- a/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
+++ b/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
@@ -86,6 +86,10 @@ namespace Microsoft.Dafny {
 
     static string anchorUUID = "20e34a49-f40b-4547-ba7a-3a1955826af2";
 
+    public static ConcreteSyntaxTree Create(FormattableString input) {
+      return new ConcreteSyntaxTree().Format(input);
+    }
+
     public ConcreteSyntaxTree Format(FormattableString input) {
       var anchorValues = new List<ConcreteSyntaxTree>();
       // Because template strings are difficult to process, we use the existing string.Format to do the processing


### PR DESCRIPTION
The methods in Dafny's code generating back-ends often use side-effects to emit generated code.

And example is the method `TrExpr`:

```c#
void TrExpr(Expression expr, ConcreteSyntaxTree wr, bool inLetExprBody, ConcreteSyntaxTree wStmts) 
```

Instead of returning a value, it writes its output to `ConcreteSyntaxTree wr`.

The goal of this PR is not to make a particular code change, but to hopefully convince the reader that we should switch away from the above side-effect style, and instead move to a _more_ pure style, in which `TrExpr` looks like:

```c#
ConcreteSyntaxTree Expr(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wStmts) 
```

There's two advantages to the more pure style, one is readability and the other is reusability.

### Readability 
This side-effect style sometimes leads to hard to read code, such as:

```c#
if (opString != null) {
  var nativeType = AsNativeType(e.Type);
  string nativeName = null, literalSuffix = null;
  bool needsCast = false;
  if (nativeType != null) {
    GetNativeInfo(nativeType.Sel, out nativeName, out literalSuffix, out needsCast);
  }

  var inner = wr;
  if (needsCast) {
    inner = wr.Write("(" + nativeName + ")").ForkInParens();
  }
  inner.Write(preOpString);
  TrParenExpr(e0, inner, inLetExprBody, wStmts);
  inner.Write(" {0} ", opString);
  if (convertE1_to_int) {
    EmitExprAsNativeInt(e1, inLetExprBody, inner, wStmts);
  } else {
    TrParenExpr(e1, inner, inLetExprBody, wStmts);
  }
  wr.Write(postOpString);
} else if (callString != null) {
  wr.Write(preOpString);
  TrParenExpr(e0, wr, inLetExprBody, wStmts);
  wr.Write(".{0}(", callString);
  if (convertE1_to_int) {
    EmitExprAsNativeInt(e1, inLetExprBody, wr, wStmts);
  } else {
    TrParenExpr(e1, wr, inLetExprBody, wStmts);
  }
  wr.Write(")");
  wr.Write(postOpString);
} else if (staticCallString != null) {
  wr.Write(preOpString);
  wr.Write("{0}(", staticCallString);
  TrExpr(e0, wr, inLetExprBody, wStmts);
  wr.Write(", ");
  TrExpr(e1, wr, inLetExprBody, wStmts);
  wr.Write(")");
  wr.Write(postOpString);
}
```

We can make that looks much nicer using a pure style of `TrExpr`, which we'll call `Expr`, that returns an `ICanRender` object.

```c#
var left = Expr(e0, inLetExprBody, wStmts);
var right = convertE1_to_int ? ExprAsNativeInt(e1, inLetExprBody, wStmts) : Expr(e1, inLetExprBody, wStmts);

wr.Write(preOpString);
if (opString != null) {
  var nativeType = AsNativeType(e.Type);
  string nativeName = null;
  bool needsCast = false;
  if (nativeType != null) {
    GetNativeInfo(nativeType.Sel, out nativeName, out _, out needsCast);
  }

  var opResult = ConcreteSyntaxTree.Create($"{left} {opString} {right}");
  if (needsCast) {
    opResult = Cast(new LineSegment(nativeName), opResult);
  }

  wr.Append(opResult);
} else if (callString != null) {
  wr.Format($"{left}.{callString}({right})");
} else if (staticCallString != null) {
  wr.Format($"{staticCallString}({left}, {right})");
}
wr.Write(postOpString);
```

### Reusability

The side-effect style of compilation is problematic when trying to generalise the code so it can be used to create an AST.

To construct an AST we want to be able to write code such as:

```c#
PythonBinaryExpr Binary(BinaryExpr binary) {
  var left = Expr(binary);
  var right = Expr(binary)
  return new PythonBinaryExpr(left, right, ...);
}
```

Note that we're using an `Expr` method that returns a value. If instead we had used a method `TrExpr` that rights its results to some store, we would have needed code like the following to produce an AST, which is hard to read and write:

```c#
void Binary(BinaryExpr binary, Stack<PythonExpresion> results) {
  TrExpr(binary, results);
  TrExpr(binary, results)
  results.Push(new PythonBinaryExpr(results.Pop(), results.Pop(), ...);
}
```

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
