### PR TITLE
Fix formatting regression

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions/Expressions.cs
@@ -922,7 +922,7 @@ public class StringLiteralExpr : LiteralExpr {
   }
 }
 
-public class DatatypeValue : Expression, IHasUsages, ICloneable<DatatypeValue> {
+public class DatatypeValue : Expression, IHasUsages, ICloneable<DatatypeValue>, ICanFormat {
   public readonly string DatatypeName;
   public readonly string MemberName;
   public readonly ActualBindings Bindings;
@@ -986,6 +986,10 @@ public class DatatypeValue : Expression, IHasUsages, ICloneable<DatatypeValue> {
   }
 
   public IToken NameToken => tok;
+  public bool SetIndent(int indentBefore, TokenNewIndentCollector formatter) {
+    formatter.SetMethodLikeIndent(StartToken, OwnedTokens, indentBefore);
+    return true;
+  }
 }
 
 public class ThisExpr : Expression {

--- a/Source/DafnyCore/AST/MemberDecls.cs
+++ b/Source/DafnyCore/AST/MemberDecls.cs
@@ -128,7 +128,7 @@ public class Field : MemberDecl, ICanFormat {
 
   public bool SetIndent(int indentBefore, TokenNewIndentCollector formatter) {
     formatter.SetOpeningIndentedRegion(StartToken, indentBefore);
-    formatter.SetClosingIndentedRegion(EndToken, indentBefore);
+    formatter.SetIndentations(EndToken, below: indentBefore);
     var hasComma = OwnedTokens.Any(token => token.val == ",");
     switch (this) {
       case ConstantField constantField:
@@ -141,7 +141,7 @@ public class Field : MemberDecl, ICanFormat {
                 if (TokenNewIndentCollector.IsFollowedByNewline(token)) {
                   formatter.SetDelimiterInsideIndentedRegions(token, indentBefore);
                 } else if (formatter.ReduceBlockiness && token.Next.val is "{" or "[" or "(") {
-                  if (!hasComma && token.Next.val != "(") {
+                  if (!hasComma) {
                     rightIndent = indentBefore;
                     commaIndent = indentBefore;
                   } else {

--- a/Source/DafnyCore/AST/TokenNewIndentCollector.cs
+++ b/Source/DafnyCore/AST/TokenNewIndentCollector.cs
@@ -1074,7 +1074,7 @@ public class TokenNewIndentCollector : TopDownVisitor<int> {
   ///   // indented
   ///   ; // indented
   /// // not indented
-  private void SetClosingIndentedRegionInside(IToken token, int indent) {
+  public void SetClosingIndentedRegionInside(IToken token, int indent) {
     SetIndentations(token, indent + SpaceTab, indent + SpaceTab, indent);
   }
 

--- a/Source/DafnyPipeline.Test/FormatterForMembers.cs
+++ b/Source/DafnyPipeline.Test/FormatterForMembers.cs
@@ -183,6 +183,8 @@ class T {
   [Fact]
   public void FormatterWorksForConstants() {
     FormatterWorksFor(@"
+const c :=
+  1111111111111111111111111111111111111111
 const ASSIGNED_PLANES := [
   0,
   1,


### PR DESCRIPTION
This PR fixes a formatting regression by actually implementing a missing formatting support for DatatypeValue.

Fixes #3563
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
