### PR TITLE
Update build to use both Z3 4.8.5 and 4.12.1

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -36,9 +36,10 @@ jobs:
     - name: Load Z3
       run: |
         sudo apt-get install -qq libarchive-tools
-        mkdir dafny/Binaries/z3
-        wget -qO- https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip | bsdtar -xf - -C dafny/Binaries/z3 --strip-components=1
-        chmod +x dafny/Binaries/z3/bin/z3
+        mkdir -p dafny/Binaries/z3/bin
+        wget -qO- https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17/z3-4.8.5-ubuntu-20.04-bin.zip | bsdtar -xf -
+        mv z3-* dafny/Binaries/z3/bin/
+        chmod +x dafny/Binaries/z3/bin/z3-*
     - name: Build Dafny
       run: dotnet build dafny/Source/Dafny.sln
     - name: Check OnlineTutorial examples

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -115,11 +115,12 @@ jobs:
       if: "!inputs.all_platforms"
       run: |
         sudo apt-get install -qq libarchive-tools
-        mkdir dafny/Binaries/z3
-        wget -qO- https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip | bsdtar -xf - -C dafny/Binaries/z3 --strip-components=1
-        chmod +x dafny/Binaries/z3/bin/z3
+        mkdir -p dafny/Binaries/z3/bin
+        wget -qO- https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17/z3-4.8.5-ubuntu-20.04-bin.zip | bsdtar -xf -
+        mv z3-4.8.5 dafny/Binaries/z3/bin/
+        chmod +x dafny/Binaries/z3/bin/z3-4.8.5
         mkdir -p unzippedRelease/dafny/z3/bin
-        ln dafny/Binaries/z3/bin/z3 unzippedRelease/dafny/z3/bin/z3
+        ln dafny/Binaries/z3/bin/z3-4.8.5 unzippedRelease/dafny/z3/bin/z3-4.8.5
     - name: Run integration tests
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/release-downloads-nuget.yml
+++ b/.github/workflows/release-downloads-nuget.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   dotnet-version: 6.0.x # SDK Version for running Dafny (TODO: should this be an older version?)
-  z3BaseUri: https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5
+  z3BaseUri: https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17
 
 jobs:
   test-dafny-cli-tool:
@@ -28,20 +28,16 @@ jobs:
       fail-fast: false
       matrix:
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
-        os: [ ubuntu-latest, ubuntu-20.04, macos-latest, windows-2019 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-11, windows-2019 ]
         include:
-        - os:  'ubuntu-latest'
-          osn: 'ubuntu\-20.04'
-          z3: z3-4.8.5-x64-ubuntu-16.04
+        - os:  'ubuntu-22.04'
+          osn: 'ubuntu\-22.04'
         - os:  'ubuntu-20.04'
           osn: 'ubuntu\-20.04'
-          z3: z3-4.8.5-x64-ubuntu-16.04
         - os:  'macos-latest'
-          osn: 'osx-.*'
-          z3: z3-4.8.5-x64-osx-10.14.2
+          osn: 'osx-11'
         - os:  'windows-2019'
           osn: 'win'
-          z3: z3-4.8.5-x64-win
 
     steps:
     - name: OS
@@ -58,14 +54,20 @@ jobs:
     - name: Load Z3
       shell: pwsh
       run: |
-        Invoke-WebRequest ${{env.z3BaseUri}}/${{matrix.z3}}.zip -OutFile z3.zip
-        Expand-Archive z3.zip .
-        Remove-Item z3.zip
-    - name: Set Z3 permissions
+        Invoke-WebRequest ${{env.z3BaseUri}}/z3-4.8.5-${{matrix.os}}-bin.zip -OutFile z3-4.8.5.zip
+        Invoke-WebRequest ${{env.z3BaseUri}}/z3-4.12.1-${{matrix.os}}-bin.zip -OutFile z3-4.12.1.zip
+        Expand-Archive z3-4.8.5.zip .
+        Expand-Archive z3-4.12.1.zip .
+        Remove-Item z3-4.8.5.zip
+        Remove-Item z3-4.12.1.zip
+    - name: Set up Z3
       run: |
         mkdir bin
-        mv ${{matrix.z3}}/bin/z3* bin/
-        chmod +x bin/z3*
+        mv z3-* bin/
+    - name: Make Z3 executable (non-Windows)
+      run: |
+        chmod +x bin/z3-*
+      if: runner.os != 'Windows'
     - name: Set Path
       if: runner.os != 'Windows'
       run: echo "${PWD}/bin" >> $GITHUB_PATH
@@ -83,7 +85,8 @@ jobs:
     ## Check that dafny and z3 run and that a simple program verifies or fails
     - name: Versions
       run: |
-        z3 -version
+        z3-4.8.5 -version
+        z3-4.12.1 -version
         dafny -version
     - name: Fatch latest release version string
       id: dafny
@@ -139,18 +142,14 @@ jobs:
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
         os: [ ubuntu-latest, ubuntu-20.04, macos-latest, windows-2019 ]
         include:
-        - os:  'ubuntu-latest'
-          osn: 'ubuntu\-20.04'
-          z3: z3-4.8.5-x64-ubuntu-16.04
+        - os:  'ubuntu-22.04'
+          osn: 'ubuntu\-22.04'
         - os:  'ubuntu-20.04'
           osn: 'ubuntu\-20.04'
-          z3: z3-4.8.5-x64-ubuntu-16.04
-        - os:  'macos-latest'
+        - os:  'macos-11'
           osn: 'osx-.*'
-          z3: z3-4.8.5-x64-osx-10.14.2
         - os:  'windows-2019'
           osn: 'win'
-          z3: z3-4.8.5-x64-win
 
     steps:
     ## Verify that the dependencies of the libraries we publish (e.g. DafnyLanguageServer)

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -16,11 +16,11 @@ jobs:
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
         os: [ ubuntu-latest, ubuntu-20.04, macos-latest, windows-2019 ]
         include:
-        - os:  'ubuntu-latest'
-          osn: 'ubuntu\-20.04'
+        - os:  'ubuntu-22.04'
+          osn: 'ubuntu\-22.04'
         - os:  'ubuntu-20.04'
           osn: 'ubuntu\-20.04'
-        - os:  'macos-latest'
+        - os:  'macos-11'
           osn: 'x64-osx-.*'
         - os:  'windows-2019'
           osn: 'win'
@@ -62,7 +62,8 @@ jobs:
     ## Check that dafny and z3 run and that a simple program verifies or fails
     - name: Versions
       run: |
-        dafny/z3/bin/z3 -version
+        dafny/z3/bin/z3-4.8.5 -version
+        dafny/z3/bin/z3-4.12.1 -version
         dafny/dafny -version
     - name: Check
       run: dafny/dafny /compileVerbose:0 /compile:0 a.dfy

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -64,10 +64,15 @@ jobs:
         Expand-Archive z3.zip .
         Remove-Item z3.zip
         Copy-Item ${{matrix.z3}} Binaries/z3 -Recurse
-    - name: Set Z3 Permissions
+    - name: Set Z3 Permissions and move (non-Windows)
       if: ${{matrix.chmod}}
       run: |
-        chmod +x Binaries/z3/bin/z3
+        mv Binaries/z3/bin/z3 Binaries/z3/bin/z3-4.8.5
+        chmod +x Binaries/z3/bin/z3*
+    - name: Move Z3 (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        mv Binaries/z3/bin/z3.exe Binaries/z3/bin/z3-4.8.5.exe
     - name: Build
       run: dotnet build -warnaserror --no-restore ${{env.solutionPath}}
     - name: Run DafnyLanguageServer Tests

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,26 @@ refman-release:
 	make -C ${DIR}/docs/DafnyRef release
 
 z3-mac:
-	wget https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-osx-10.14.2.zip
-	unzip z3-4.8.5-x64-osx-10.14.2.zip
-	mv z3-4.8.5-x64-osx-10.14.2 ${DIR}/Binaries/z3
-	rm z3-4.8.5-x64-osx-10.14.2.zip
+	mkdir -p ${DIR}Binaries/z3/bin
+	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17/z3-4.12.1-macos-11-bin.zip
+	unzip z3-4.12.1-macos-11-bin.zip
+	rm z3-4.12.1-macos-11-bin.zip
+	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17/z3-4.8.5-macos-11-bin.zip
+	unzip z3-4.8.5-macos-11-bin.zip
+	rm z3-4.8.5-macos-11-bin.zip
+	mv z3-* ${DIR}/Binaries/z3/bin/
+	chmod +x ${DIR}/Binaries/z3/bin/z3-*
 
 z3-ubuntu:
-	wget https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip
-	unzip z3-4.8.5-x64-ubuntu-16.04.zip
-	mv z3-4.8.5-x64-ubuntu-16.04 ${DIR}/Binaries/z3
-	rm z3-4.8.5-x64-ubuntu-16.04.zip
+	mkdir -p ${DIR}Binaries/z3/bin
+	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17/z3-4.12.1-ubuntu-20.04-bin.zip
+	unzip z3-4.12.1-ubuntu-20.04-bin.zip
+	rm z3-4.12.1-ubuntu-20.04-bin.zip
+	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17/z3-4.8.5-ubuntu-20.04-bin.zip
+	unzip z3-4.8.5-ubuntu-20.04-bin.zip
+	rm z3-4.8.5-ubuntu-20.04-bin.zip
+	mv z3-* ${DIR}/Binaries/z3/bin/
+	chmod +x ${DIR}/Binaries/z3/bin/z3-*
 
 format:
 	dotnet tool run dotnet-format -w -s error Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -324,6 +324,8 @@ NoGhost - disable printing of functions, ghost methods, and proof
 
     public bool AuditProgram = false;
 
+    public static string DefaultZ3Version = "4.8.5";
+
     public static readonly ReadOnlyCollection<Plugin> DefaultPlugins = new(new[] { SinglePassCompiler.Plugin });
     private IList<Plugin> cliPluginCache;
     public IList<Plugin> Plugins => cliPluginCache ??= ComputePlugins();
@@ -1096,12 +1098,14 @@ NoGhost - disable printing of functions, ghost methods, and proof
 
       var platform = System.Environment.OSVersion.Platform;
       var isUnix = platform == PlatformID.Unix || platform == PlatformID.MacOSX;
-      var z3binName = isUnix ? "z3" : "z3.exe";
 
       // Next, try looking in a directory relative to Dafny itself.
       if (confirmedProverPath is null) {
         var dafnyBinDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        var z3BinPath = Path.Combine(dafnyBinDir, "z3", "bin", z3binName);
+        var z3LocalBinName = isUnix
+          ? $"z3-{DefaultZ3Version}"
+          : $"z3-{DefaultZ3Version}.exe";
+        var z3BinPath = Path.Combine(dafnyBinDir, "z3", "bin", z3LocalBinName);
 
         if (File.Exists(z3BinPath)) {
           confirmedProverPath = z3BinPath;
@@ -1109,11 +1113,12 @@ NoGhost - disable printing of functions, ghost methods, and proof
       }
 
       // Finally, try looking in the system PATH variable.
+      var z3GlobalBinName = isUnix ? "z3" : "z3.exe";
       if (confirmedProverPath is null) {
         confirmedProverPath = System.Environment
           .GetEnvironmentVariable("PATH")?
           .Split(isUnix ? ':' : ';')
-          .Select(s => Path.Combine(s, z3binName))
+          .Select(s => Path.Combine(s, z3GlobalBinName))
           .FirstOrDefault(File.Exists);
       }
 

--- a/Source/DafnyLanguageServer.Test/Various/ResourceUsageTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ResourceUsageTest.cs
@@ -17,7 +17,7 @@ method Foo()
 {
     assert false;
 }";
-    const string solverProcessName = "z3";
+    string solverProcessName = $"z3-{DafnyOptions.DefaultZ3Version}";
     var processes1 = Process.GetProcessesByName(solverProcessName);
     var documentItem = CreateTestDocument(source);
     await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.cs
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.cs
@@ -71,17 +71,11 @@ namespace Microsoft.Dafny.LanguageServer {
 
     private static void HandleZ3Version(ITelemetryPublisher telemetryPublisher, SMTLibSolverOptions proverOptions) {
       var z3Version = DafnyOptions.GetZ3Version(proverOptions.ProverPath);
-      if (z3Version is null) {
-        return;
-      }
-      var major = z3Version.Major;
-      var minor = z3Version.Minor;
-      var patch = z3Version.Build;
-      if (major <= 4 && (major < 4 || minor <= 8) && (minor < 8 || patch <= 6)) {
+      if (z3Version is null || z3Version < new Version(4, 8, 6)) {
         return;
       }
 
-      telemetryPublisher.PublishZ3Version("Z3 version {major}.{minor}.{patch}");
+      telemetryPublisher.PublishZ3Version($"Z3 version {z3Version}");
 
       var toReplace = "O:model_compress=false";
       var i = DafnyOptions.O.ProverOptions.IndexOf(toReplace);

--- a/Source/IntegrationTests/LitTests.cs
+++ b/Source/IntegrationTests/LitTests.cs
@@ -33,7 +33,7 @@ namespace IntegrationTests {
       "/proverOpt:O:smt.qi.eager_threshold=100",
       "/proverOpt:O:smt.delay_units=true",
       "/proverOpt:O:smt.arith.solver=2",
-      "/proverOpt:PROVER_PATH:" + RepositoryRoot + "../unzippedRelease/dafny/z3/bin/z3"
+      "/proverOpt:PROVER_PATH:" + RepositoryRoot + "../unzippedRelease/dafny/z3/bin/z3-${DafnyOptions.DefaultZ3Version}"
     };
 
     private static readonly LitTestConfiguration Config;
@@ -58,7 +58,7 @@ namespace IntegrationTests {
         { "%diff", "diff" },
         { "%trargs", "--use-basename-for-filename --cores:2 --verification-time-limit:300" },
         { "%binaryDir", "." },
-        { "%z3", Path.Join("z3", "bin", "z3") },
+        { "%z3", Path.Join("z3", "bin", $"z3-{DafnyOptions.DefaultZ3Version}") },
         { "%repositoryRoot", RepositoryRoot.Replace(@"\", "/") },
       };
 

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -215,7 +215,7 @@ solverRoots = os.pathsep.join(
 print(solverRoots)
 
 solverPath = \
-    lit.util.which("z3", solverRoots) or \
+    lit.util.which("z3-4.8.5", solverRoots) or \
     lit.util.which("cvc4", solverRoots)
 
 if not solverPath:


### PR DESCRIPTION
Updates both local builds and CI.

Still defaults to Z3 4.8.5. We'll switch the default to 4.12.1 on a new branch for 4.x.

Doesn't yet update `package.py`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
