### PR TITLE
Add `--verbosity` and `--solver-opt` flags

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -30,7 +30,7 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.1" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -30,7 +30,7 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.0" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -11,6 +11,9 @@ public class CommonOptionBag {
   public static readonly Option<int> VerificationErrorLimit =
     new("--error-limit", () => 5, "Set the maximum number of verification errors to report (0 for unlimited).");
 
+  public static readonly Option<Boogie.CoreOptions.VerbosityLevel> Verbosity =
+    new("--verbosity", () => CoreOptions.VerbosityLevel.Normal, "Set the level of output produced. Ranges from nothing (Silent) to detailed (Trace). With 'Normal', produce warnings, errors, and some extra information. With 'Quiet', produce only errors and warnings.");
+
   public static readonly Option<bool> ManualLemmaInduction =
     new("--manual-lemma-induction", "Turn off automatic induction for lemmas.");
 
@@ -28,10 +31,6 @@ true - In the compiled target code, transform any non-extern
     non-ghost parameter into just that parameter. For example, the type
         datatype Record = Record(x: int)
     is transformed into just 'int' in the target code.".TrimStart());
-
-  public static readonly Option<bool> Verbose = new("--verbose",
-    "Print additional information such as which files are emitted where.") {
-  };
 
   public static readonly Option<bool> DisableNonLinearArithmetic = new("--disable-nonlinear-arithmetic",
     @"
@@ -186,6 +185,10 @@ Functionality is still being expanded. Currently only checks contracts on every 
       (options, value) => { options.DisallowConstructorCaseWithoutParentheses = value; });
     DafnyOptions.RegisterLegacyBinding(WarningAsErrors, (options, value) => { options.WarningsAsErrors = value; });
     DafnyOptions.RegisterLegacyBinding(VerificationErrorLimit, (options, value) => { options.ErrorLimit = value; });
+    DafnyOptions.RegisterLegacyBinding(Verbosity, (options, value) => {
+      options.Verbosity = value;
+      options.CompileVerbose = value >= CoreOptions.VerbosityLevel.Trace;
+    });
     DafnyOptions.RegisterLegacyBinding(VerifyIncludedFiles,
       (options, value) => { options.VerifyAllModules = value; });
 
@@ -217,7 +220,6 @@ Functionality is still being expanded. Currently only checks contracts on every 
       (options, value) => { options.LibraryFiles = value.ToHashSet(); });
     DafnyOptions.RegisterLegacyBinding(Output, (options, value) => { options.DafnyPrintCompiledFile = value?.FullName; });
 
-    DafnyOptions.RegisterLegacyBinding(Verbose, (o, v) => o.CompileVerbose = v);
     DafnyOptions.RegisterLegacyBinding(DisableNonLinearArithmetic, (o, v) => o.DisableNLarith = v);
 
     DafnyOptions.RegisterLegacyBinding(VerificationLogFormat, (o, v) => o.VerificationLoggerConfigs = v);

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -62,6 +62,7 @@ The `text` format also includes a more detailed breakdown of what assertions app
   public static readonly Option<uint> SolverResourceLimit = new("--resource-limit", @"Specify the maximum resource limit (rlimit) value to pass to Z3. A resource limit is a deterministic alternative to a time limit. The output produced by `--log-format csv` includes the resource use of each proof effort, which you can use to determine an appropriate limit for your program. Multiplied by 1000 before sending to Z3.");
   public static readonly Option<string> SolverPlugin = new("--solver-plugin", @"Specify a plugin to use to solve verification conditions (instead of an external Z3 process).");
   public static readonly Option<string> SolverLog = new("--solver-log", @"Specify a file to use to log the SMT-Lib text sent to the solver.");
+  public static readonly Option<IList<string>> SolverOpt = new("--solver-opt", @"Specify an option to control how the solver works.");
 
   public static readonly Option<IList<string>> Libraries = new("--library",
     @"
@@ -232,6 +233,11 @@ Functionality is still being expanded. Currently only checks contracts on every 
       }
     });
     DafnyOptions.RegisterLegacyBinding(SolverLog, (o, v) => o.ProverLogFilePath = v);
+    DafnyOptions.RegisterLegacyBinding(SolverOpt, (o, v) => {
+      if (v is not null) {
+        o.ProverOptions.AddRange(v);
+      }
+    });
 
     DafnyOptions.RegisterLegacyBinding(EnforceDeterminism, (options, value) => {
       options.ForbidNondeterminism = value;

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Dafny;
 
 public class CommonOptionBag {
 
-  public static readonly Option<int> ErrorLimit =
-    new("--error-limit", () => 5, "Set the maximum number of errors to report (0 for unlimited).");
+  public static readonly Option<int> VerificationErrorLimit =
+    new("--error-limit", () => 5, "Set the maximum number of verification errors to report (0 for unlimited).");
 
   public static readonly Option<bool> ManualLemmaInduction =
     new("--manual-lemma-induction", "Turn off automatic induction for lemmas.");
@@ -185,7 +185,7 @@ Functionality is still being expanded. Currently only checks contracts on every 
     DafnyOptions.RegisterLegacyBinding(WarnMissingConstructorParenthesis,
       (options, value) => { options.DisallowConstructorCaseWithoutParentheses = value; });
     DafnyOptions.RegisterLegacyBinding(WarningAsErrors, (options, value) => { options.WarningsAsErrors = value; });
-    DafnyOptions.RegisterLegacyBinding(ErrorLimit, (options, value) => { options.ErrorLimit = value; });
+    DafnyOptions.RegisterLegacyBinding(VerificationErrorLimit, (options, value) => { options.ErrorLimit = value; });
     DafnyOptions.RegisterLegacyBinding(VerifyIncludedFiles,
       (options, value) => { options.VerifyAllModules = value; });
 

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -60,7 +60,7 @@ The `text` format also includes a more detailed breakdown of what assertions app
     ArgumentHelpName = "configuration"
   };
 
-  public static readonly Option<uint> SolverResourceLimit = new("--resource-limit", @"Specify the maximum resource limit (rlimit) value to pass to Z3. Multiplied by 1000 before sending to Z3.");
+  public static readonly Option<uint> SolverResourceLimit = new("--resource-limit", @"Specify the maximum resource limit (rlimit) value to pass to Z3. A resource limit is a deterministic alternative to a time limit. The output produced by `--log-format csv` includes the resource use of each proof effort, which you can use to determine an appropriate limit for your program. Multiplied by 1000 before sending to Z3.");
   public static readonly Option<string> SolverPlugin = new("--solver-plugin", @"Specify a plugin to use to solve verification conditions (instead of an external Z3 process).");
   public static readonly Option<string> SolverLog = new("--solver-log", @"Specify a file to use to log the SMT-Lib text sent to the solver.");
 

--- a/Source/DafnyCore/Options/ICommandSpec.cs
+++ b/Source/DafnyCore/Options/ICommandSpec.cs
@@ -35,6 +35,7 @@ public interface ICommandSpec {
     CommonOptionBag.SolverResourceLimit,
     CommonOptionBag.SolverPlugin,
     CommonOptionBag.SolverLog,
+    CommonOptionBag.SolverOpt,
     CommonOptionBag.VerificationErrorLimit,
   }.ToList();
 

--- a/Source/DafnyCore/Options/ICommandSpec.cs
+++ b/Source/DafnyCore/Options/ICommandSpec.cs
@@ -18,7 +18,6 @@ public interface ICommandSpec {
 
   public static IEnumerable<Option> FormatOptions => new Option[] {
     CommonOptionBag.Check,
-    CommonOptionBag.Verbose,
     CommonOptionBag.FormatPrint,
     DeveloperOptionBag.UseBaseFileName
   }.Concat(ParserOptions);
@@ -60,6 +59,7 @@ public interface ICommandSpec {
     DeveloperOptionBag.BoogiePrint,
     Printer.PrintMode,
     CommonOptionBag.WarningAsErrors,
+    CommonOptionBag.Verbosity
   });
 
   public static IReadOnlyList<Option> ParserOptions = new List<Option>(new Option[] {

--- a/Source/DafnyCore/Options/ICommandSpec.cs
+++ b/Source/DafnyCore/Options/ICommandSpec.cs
@@ -36,6 +36,7 @@ public interface ICommandSpec {
     CommonOptionBag.SolverResourceLimit,
     CommonOptionBag.SolverPlugin,
     CommonOptionBag.SolverLog,
+    CommonOptionBag.VerificationErrorLimit,
   }.ToList();
 
   public static IReadOnlyList<Option> TranslationOptions = new Option[] {
@@ -70,7 +71,6 @@ public interface ICommandSpec {
     Function.FunctionSyntaxOption,
     CommonOptionBag.QuantifierSyntax,
     CommonOptionBag.UnicodeCharacters,
-    CommonOptionBag.ErrorLimit,
   });
 
   public static IReadOnlyList<Option> ResolverOptions = new List<Option>(new Option[] {

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -10738,7 +10738,7 @@ namespace Microsoft.Dafny {
             Names.Add(nm);
           }
         }
-        return base.VisitBinderExpr(node);
+        return (BinderExpr)base.VisitBinderExpr(node);
       }
     }
 

--- a/Source/DafnyDriver/Commands/BuildCommand.cs
+++ b/Source/DafnyDriver/Commands/BuildCommand.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Dafny;
 class BuildCommand : ICommandSpec {
   public IEnumerable<Option> Options => new Option[] {
     CommonOptionBag.Output,
-    CommonOptionBag.Verbose,
   }.Concat(ICommandSpec.ExecutionOptions).
     Concat(ICommandSpec.ConsoleOutputOptions).
     Concat(ICommandSpec.ResolverOptions);

--- a/Source/DafnyDriver/Commands/MeasureComplexityCommand.cs
+++ b/Source/DafnyDriver/Commands/MeasureComplexityCommand.cs
@@ -13,7 +13,7 @@ public class MeasureComplexityCommand : ICommandSpec {
     Concat(ICommandSpec.ResolverOptions);
 
   static MeasureComplexityCommand() {
-    DafnyOptions.RegisterLegacyBinding(Iterations, (o, v) => o.RandomSeedIterations = (int)v);
+    DafnyOptions.RegisterLegacyBinding(Iterations, (o, v) => o.RandomizeVcIterations = (int)v);
     DafnyOptions.RegisterLegacyBinding(RandomSeed, (o, v) => o.RandomSeed = (int)v);
   }
 

--- a/Source/DafnyDriver/Commands/TranslateCommand.cs
+++ b/Source/DafnyDriver/Commands/TranslateCommand.cs
@@ -9,7 +9,6 @@ class TranslateCommand : ICommandSpec {
   public IEnumerable<Option> Options =>
     new Option[] {
       CommonOptionBag.Output,
-      CommonOptionBag.Verbose,
       CommonOptionBag.IncludeRuntime,
     }.Concat(ICommandSpec.TranslationOptions).
       Concat(ICommandSpec.ConsoleOutputOptions).

--- a/Test/allocated1/dafny0/Array.dfy.expect
+++ b/Test/allocated1/dafny0/Array.dfy.expect
@@ -13,11 +13,11 @@ Array.dfy(160,5): Error: insufficient reads clause to read array element
 Array.dfy(168,5): Error: insufficient reads clause to read array element
 Array.dfy(184,5): Error: assignment might update an array element not in the enclosing context's modifies clause
 Array.dfy(191,5): Error: assignment might update an array element not in the enclosing context's modifies clause
-Array.dfy(216,0): Error: A postcondition might not hold on this return path.
+Array.dfy(216,0): Error: a postcondition could not be proved on this return path
 Array.dfy(215,10): Related location: This is the postcondition that might not hold.
-Array.dfy(240,0): Error: A postcondition might not hold on this return path.
+Array.dfy(240,0): Error: a postcondition could not be proved on this return path
 Array.dfy(239,10): Related location: This is the postcondition that might not hold.
-Array.dfy(246,0): Error: A postcondition might not hold on this return path.
+Array.dfy(246,0): Error: a postcondition could not be proved on this return path
 Array.dfy(245,10): Related location: This is the postcondition that might not hold.
 Array.dfy(255,12): Error: value does not satisfy the subset constraints of 'nat'
 Array.dfy(256,5): Error: value does not satisfy the subset constraints of 'nat'

--- a/Test/allocated1/dafny0/AutoContracts.dfy.expect
+++ b/Test/allocated1/dafny0/AutoContracts.dfy.expect
@@ -1,26 +1,26 @@
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
-AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(50,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
+AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
+AutoContracts.dfy(12,14): Related location
+AutoContracts.dfy(50,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(49,24): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(79,21): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(79,21): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(60,16): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy[N1](65,14): Related location
-AutoContracts.dfy(79,21): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(79,21): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(60,16): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy[N1](65,14): Related location
-AutoContracts.dfy(79,21): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(79,21): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(60,16): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 37 verified, 9 errors

--- a/Test/allocated1/dafny0/BindingGuards.dfy.expect
+++ b/Test/allocated1/dafny0/BindingGuards.dfy.expect
@@ -1,4 +1,4 @@
-BindingGuards.dfy(85,10): Error: A postcondition might not hold on this return path.
+BindingGuards.dfy(85,10): Error: a postcondition could not be proved on this return path
 BindingGuards.dfy(71,12): Related location: This is the postcondition that might not hold.
 BindingGuards.dfy(134,9): Error: assertion might not hold
 BindingGuards.dfy(6,8): Related location

--- a/Test/allocated1/dafny0/ChainingDisjointTests.dfy.expect
+++ b/Test/allocated1/dafny0/ChainingDisjointTests.dfy.expect
@@ -1,4 +1,4 @@
-ChainingDisjointTests.dfy(49,2): Error: A postcondition might not hold on this return path.
+ChainingDisjointTests.dfy(49,2): Error: a postcondition could not be proved on this return path
 ChainingDisjointTests.dfy(48,14): Related location: This is the postcondition that might not hold.
 ChainingDisjointTests.dfy(42,22): Related location
 ChainingDisjointTests.dfy(58,13): Error: assertion might not hold

--- a/Test/allocated1/dafny0/CoPrefix.dfy.expect
+++ b/Test/allocated1/dafny0/CoPrefix.dfy.expect
@@ -1,6 +1,6 @@
-CoPrefix.dfy(164,2): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(164,2): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(163,14): Related location: This is the postcondition that might not hold.
-CoPrefix.dfy(169,2): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(169,2): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(168,14): Related location: This is the postcondition that might not hold.
 CoPrefix.dfy(176,10): Error: cannot prove termination; try supplying a decreases clause
 CoPrefix.dfy(205,6): Error: the calculation step between the previous line and this line might not hold
@@ -8,13 +8,13 @@ CoPrefix.dfy(207,6): Error: the calculation step between the previous line and t
 CoPrefix.dfy(220,12): Error: ORDINAL subtraction might underflow a limit ordinal (that is, RHS might be too large)
 CoPrefix.dfy(63,56): Error: decreases clause might not decrease
 CoPrefix.dfy(76,55): Error: cannot prove termination; try supplying a decreases clause
-CoPrefix.dfy(114,0): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(114,0): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(113,10): Related location: This is the postcondition that might not hold.
 CoPrefix.dfy(101,16): Related location
 CoPrefix.dfy(138,24): Error: assertion might not hold
 CoPrefix.dfy(142,24): Error: assertion might not hold
 CoPrefix.dfy(117,22): Related location
-CoPrefix.dfy(151,0): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(151,0): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(150,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 13 verified, 12 errors

--- a/Test/allocated1/dafny0/CoinductiveProofs.dfy.expect
+++ b/Test/allocated1/dafny0/CoinductiveProofs.dfy.expect
@@ -4,13 +4,13 @@ CoinductiveProofs.dfy(13,16): Related location
 CoinductiveProofs.dfy(44,11): Error: assertion might not hold
 CoinductiveProofs.dfy(48,11): Error: assertion might not hold
 CoinductiveProofs.dfy(13,16): Related location
-CoinductiveProofs.dfy(78,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(78,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(77,10): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(73,2): Related location
 CoinductiveProofs.dfy(94,11): Error: assertion might not hold
 CoinductiveProofs.dfy(87,29): Related location
 CoinductiveProofs.dfy(73,2): Related location
-CoinductiveProofs.dfy(127,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(127,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(126,10): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(115,2): Related location
 CoinductiveProofs.dfy(136,11): Error: assertion might not hold
@@ -20,13 +20,13 @@ CoinductiveProofs.dfy(149,11): Error: assertion might not hold
 CoinductiveProofs.dfy(115,2): Related location
 CoinductiveProofs.dfy(153,11): Error: assertion might not hold
 CoinductiveProofs.dfy(115,2): Related location
-CoinductiveProofs.dfy(164,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(164,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(163,10): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(159,2): Related location
-CoinductiveProofs.dfy(203,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(203,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(202,21): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(4,23): Related location
-CoinductiveProofs.dfy(209,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(209,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(208,21): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(4,23): Related location
 

--- a/Test/allocated1/dafny0/ComputationsNeg.dfy.expect
+++ b/Test/allocated1/dafny0/ComputationsNeg.dfy.expect
@@ -1,7 +1,7 @@
 ComputationsNeg.dfy(7,2): Error: decreases clause might not decrease
-ComputationsNeg.dfy(11,0): Error: A postcondition might not hold on this return path.
+ComputationsNeg.dfy(11,0): Error: a postcondition could not be proved on this return path
 ComputationsNeg.dfy(10,16): Related location: This is the postcondition that might not hold.
-ComputationsNeg.dfy(23,0): Error: A postcondition might not hold on this return path.
+ComputationsNeg.dfy(23,0): Error: a postcondition could not be proved on this return path
 ComputationsNeg.dfy(22,10): Related location: This is the postcondition that might not hold.
 ComputationsNeg.dfy(19,28): Related location
 ComputationsNeg.dfy(19,62): Related location

--- a/Test/allocated1/dafny0/ControlStructures.dfy.expect
+++ b/Test/allocated1/dafny0/ControlStructures.dfy.expect
@@ -10,7 +10,7 @@ ControlStructures.dfy(238,29): Error: assertion might not hold
 ControlStructures.dfy(241,16): Error: assertion might not hold
 ControlStructures.dfy(350,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 ControlStructures.dfy(381,2): Error: cannot prove termination; try supplying a decreases clause for the loop
-ControlStructures.dfy(448,16): Error: This loop invariant might not be maintained by the loop.
+ControlStructures.dfy(448,16): Error: this invariant could not be proved to be maintained by the loop
 ControlStructures.dfy(448,16): Related message: loop invariant violation
 
 Dafny program verifier finished with 18 verified, 13 errors

--- a/Test/allocated1/dafny0/DTypes.dfy.expect
+++ b/Test/allocated1/dafny0/DTypes.dfy.expect
@@ -6,7 +6,7 @@ DTypes.dfy(231,14): Warning: the type of the other operand is a non-null type, s
 DTypes.dfy(232,14): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'false' (to make it possible for variable 'c' to have the value 'null', declare its type to be 'Cell?<MyClass>')
 DTypes.dfy(233,14): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'false' (to make it possible for variable 'd' to have the value 'null', declare its type to be 'Cell?<MyClass>')
 DTypes.dfy(64,13): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'true' (to make it possible for variable 'a' to have the value 'null', declare its type to be 'CP?<int, C>')
-DTypes.dfy(179,2): Error: A postcondition might not hold on this return path.
+DTypes.dfy(179,2): Error: a postcondition could not be proved on this return path
 DTypes.dfy(178,14): Related location: This is the postcondition that might not hold.
 DTypes.dfy(18,13): Error: assertion might not hold
 DTypes.dfy(56,17): Error: assertion might not hold

--- a/Test/allocated1/dafny0/Datatypes.dfy.expect
+++ b/Test/allocated1/dafny0/Datatypes.dfy.expect
@@ -1,4 +1,4 @@
-Datatypes.dfy(297,9): Error: A postcondition might not hold on this return path.
+Datatypes.dfy(297,9): Error: a postcondition could not be proved on this return path
 Datatypes.dfy(295,14): Related location: This is the postcondition that might not hold.
 Datatypes.dfy(298,11): Error: missing case in match expression: Appendix(_)
 Datatypes.dfy(349,4): Error: missing case in match expression: Cons(_, _)

--- a/Test/allocated1/dafny0/Definedness.dfy.expect
+++ b/Test/allocated1/dafny0/Definedness.dfy.expect
@@ -6,12 +6,12 @@ Definedness.dfy(29,16): Error: possible division by zero
 Definedness.dfy(36,15): Error: target object might be null
 Definedness.dfy(45,15): Error: target object might be null
 Definedness.dfy(53,17): Error: target object might be null
-Definedness.dfy(54,2): Error: A postcondition might not hold on this return path.
+Definedness.dfy(54,2): Error: a postcondition could not be proved on this return path
 Definedness.dfy(53,21): Related location: This is the postcondition that might not hold.
 Definedness.dfy(60,17): Error: target object might be null
-Definedness.dfy(61,2): Error: A postcondition might not hold on this return path.
+Definedness.dfy(61,2): Error: a postcondition could not be proved on this return path
 Definedness.dfy(60,21): Related location: This is the postcondition that might not hold.
-Definedness.dfy(68,2): Error: A postcondition might not hold on this return path.
+Definedness.dfy(68,2): Error: a postcondition could not be proved on this return path
 Definedness.dfy(67,21): Related location: This is the postcondition that might not hold.
 Definedness.dfy(88,6): Error: target object might be null
 Definedness.dfy(89,4): Error: function precondition might not hold
@@ -31,25 +31,25 @@ Definedness.dfy(123,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
 Definedness.dfy(133,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
-Definedness.dfy(133,21): Error: This loop invariant might not hold on entry.
+Definedness.dfy(133,21): Error: this loop invariant could not be proved on entry
 Definedness.dfy(133,21): Related message: loop invariant violation
 Definedness.dfy(134,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
 Definedness.dfy(143,14): Error: possible division by zero
 Definedness.dfy(162,14): Error: possible division by zero
-Definedness.dfy(175,27): Error: This loop invariant might not hold on entry.
+Definedness.dfy(175,27): Error: this loop invariant could not be proved on entry
 Definedness.dfy(175,27): Related message: loop invariant violation
 Definedness.dfy(181,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
 Definedness.dfy(196,18): Error: possible division by zero
-Definedness.dfy(196,22): Error: This loop invariant might not hold on entry.
+Definedness.dfy(196,22): Error: this loop invariant could not be proved on entry
 Definedness.dfy(196,22): Related message: loop invariant violation
 Definedness.dfy(196,27): Error: possible division by zero
-Definedness.dfy(215,9): Error: A postcondition might not hold on this return path.
+Definedness.dfy(215,9): Error: a postcondition could not be proved on this return path
 Definedness.dfy(217,48): Related location: This is the postcondition that might not hold.
 Definedness.dfy(224,21): Error: target object might be null
 Definedness.dfy(224,21): Error: target object might not be allocated
-Definedness.dfy(237,9): Error: A postcondition might not hold on this return path.
+Definedness.dfy(237,9): Error: a postcondition could not be proved on this return path
 Definedness.dfy(240,23): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 9 verified, 38 errors

--- a/Test/allocated1/dafny0/DirtyLoops.dfy.expect
+++ b/Test/allocated1/dafny0/DirtyLoops.dfy.expect
@@ -82,7 +82,7 @@ DirtyLoops.dfy(321,13): Error: assertion might not hold
 DirtyLoops.dfy(356,13): Error: assertion might not hold
 DirtyLoops.dfy(369,13): Error: assertion might not hold
 DirtyLoops.dfy(380,9): Error: assertion might not hold
-DirtyLoops.dfy(401,18): Error: This loop invariant might not hold on entry.
+DirtyLoops.dfy(401,18): Error: this loop invariant could not be proved on entry
 DirtyLoops.dfy(401,18): Related message: loop invariant violation
 DirtyLoops.dfy(414,16): Error: target object might be null
 DirtyLoops.dfy(506,22): Error: assertion might not hold

--- a/Test/allocated1/dafny0/FunctionSpecifications.dfy.expect
+++ b/Test/allocated1/dafny0/FunctionSpecifications.dfy.expect
@@ -1,15 +1,15 @@
-FunctionSpecifications.dfy(35,24): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(35,24): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(31,12): Related location: This is the postcondition that might not hold.
-FunctionSpecifications.dfy(45,2): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(45,2): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(40,23): Related location: This is the postcondition that might not hold.
 FunctionSpecifications.dfy(53,10): Error: cannot prove termination; try supplying a decreases clause
-FunctionSpecifications.dfy(60,9): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(60,9): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(61,21): Related location: This is the postcondition that might not hold.
 FunctionSpecifications.dfy(109,22): Error: assertion might not hold
 FunctionSpecifications.dfy(112,22): Error: assertion might not hold
 FunctionSpecifications.dfy(127,26): Error: assertion might not hold
 FunctionSpecifications.dfy(131,26): Error: assertion might not hold
-FunctionSpecifications.dfy(136,19): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(136,19): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(138,28): Related location: This is the postcondition that might not hold.
 FunctionSpecifications.dfy(147,2): Error: decreases clause might not decrease
 FunctionSpecifications.dfy(154,2): Error: decreases clause might not decrease

--- a/Test/allocated1/dafny0/Inverses.dfy.expect
+++ b/Test/allocated1/dafny0/Inverses.dfy.expect
@@ -1,12 +1,12 @@
-Inverses.dfy(70,2): Error: A postcondition might not hold on this return path.
+Inverses.dfy(70,2): Error: a postcondition could not be proved on this return path
 Inverses.dfy(67,10): Related location: This is the postcondition that might not hold.
 Inverses.dfy(67,40): Related location
 Inverses.dfy(67,66): Related location
-Inverses.dfy(82,2): Error: A postcondition might not hold on this return path.
+Inverses.dfy(82,2): Error: a postcondition could not be proved on this return path
 Inverses.dfy(79,10): Related location: This is the postcondition that might not hold.
 Inverses.dfy(79,40): Related location
 Inverses.dfy(79,66): Related location
-Inverses.dfy(193,2): Error: A postcondition might not hold on this return path.
+Inverses.dfy(193,2): Error: a postcondition could not be proved on this return path
 Inverses.dfy(191,15): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 31 verified, 3 errors

--- a/Test/allocated1/dafny0/Matrix-OOB.dfy.expect
+++ b/Test/allocated1/dafny0/Matrix-OOB.dfy.expect
@@ -1,7 +1,7 @@
 Matrix-OOB.dfy(11,10): Info: Selected triggers: {m[i, j]}
 Matrix-OOB.dfy(11,27): Error: index 0 out of range
 Matrix-OOB.dfy(11,30): Error: index 1 out of range
-Matrix-OOB.dfy(12,0): Error: A postcondition might not hold on this return path.
+Matrix-OOB.dfy(12,0): Error: a postcondition could not be proved on this return path
 Matrix-OOB.dfy(11,10): Related location: This is the postcondition that might not hold.
 Matrix-OOB.dfy(11,33): Related location
 

--- a/Test/allocated1/dafny0/MultiSets.dfy.expect
+++ b/Test/allocated1/dafny0/MultiSets.dfy.expect
@@ -1,9 +1,9 @@
 MultiSets.dfy(177,19): Error: new number of occurrences might be negative
 MultiSets.dfy(268,23): Error: assertion might not hold
 MultiSets.dfy(291,15): Error: assertion might not hold
-MultiSets.dfy(158,2): Error: A postcondition might not hold on this return path.
+MultiSets.dfy(158,2): Error: a postcondition could not be proved on this return path
 MultiSets.dfy(157,14): Related location: This is the postcondition that might not hold.
-MultiSets.dfy(164,2): Error: A postcondition might not hold on this return path.
+MultiSets.dfy(164,2): Error: a postcondition could not be proved on this return path
 MultiSets.dfy(163,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 34 verified, 5 errors

--- a/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/allocated1/dafny0/OpaqueFunctions.dfy.expect
@@ -1,11 +1,11 @@
 OpaqueFunctions.dfy(38,15): Error: assertion might not hold
-OpaqueFunctions.dfy(69,7): Error: A precondition for this call might not hold.
+OpaqueFunctions.dfy(69,7): Error: a precondition for this call could not be proved
 OpaqueFunctions.dfy(35,15): Related location: This is the precondition that might not hold.
 OpaqueFunctions.dfy(75,19): Error: assertion might not hold
 OpaqueFunctions.dfy(77,20): Error: assertion might not hold
 OpaqueFunctions.dfy(80,20): Error: assertion might not hold
 OpaqueFunctions.dfy(96,22): Error: assertion might not hold
-OpaqueFunctions.dfy(98,11): Error: A precondition for this call might not hold.
+OpaqueFunctions.dfy(98,11): Error: a precondition for this call could not be proved
 OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
 OpaqueFunctions.dfy(102,17): Error: assertion might not hold
 OpaqueFunctions.dfy(109,19): Error: assertion might not hold
@@ -13,7 +13,7 @@ OpaqueFunctions.dfy(111,20): Error: assertion might not hold
 OpaqueFunctions.dfy(114,20): Error: assertion might not hold
 OpaqueFunctions.dfy(123,31): Error: assertion might not hold
 OpaqueFunctions.dfy(146,20): Error: assertion might not hold
-OpaqueFunctions.dfy(148,9): Error: A precondition for this call might not hold.
+OpaqueFunctions.dfy(148,9): Error: a precondition for this call could not be proved
 OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
 OpaqueFunctions.dfy(155,19): Error: assertion might not hold
 OpaqueFunctions.dfy(157,20): Error: assertion might not hold

--- a/Test/allocated1/dafny0/Parallel.dfy.expect
+++ b/Test/allocated1/dafny0/Parallel.dfy.expect
@@ -2,7 +2,7 @@ Parallel.dfy(267,4): Warning: a forall statement with no bound variables is depr
 Parallel.dfy(279,4): Warning: a forall statement with no bound variables is deprecated; use an 'assert by' statement instead
 Parallel.dfy(286,4): Warning: a forall statement with no bound variables is deprecated; use an 'assert by' statement instead
 Parallel.dfy(293,21): Error: assertion might not hold
-Parallel.dfy(33,9): Error: A precondition for this call might not hold.
+Parallel.dfy(33,9): Error: a precondition for this call could not be proved
 Parallel.dfy(59,13): Related location: This is the precondition that might not hold.
 Parallel.dfy(37,4): Error: target object might be null
 Parallel.dfy(41,17): Error: possible violation of postcondition of forall statement

--- a/Test/allocated1/dafny0/Predicates.dfy.expect
+++ b/Test/allocated1/dafny0/Predicates.dfy.expect
@@ -1,10 +1,10 @@
 Predicates.dfy(62,15): Error: assertion might not hold
 Predicates.dfy(66,13): Error: assertion might not hold
 Predicates.dfy(94,31): Error: target object might not be allocated
-Predicates.dfy(95,4): Error: A postcondition might not hold on this return path.
+Predicates.dfy(95,4): Error: a postcondition could not be proved on this return path
 Predicates.dfy(94,14): Related location: This is the postcondition that might not hold.
 Predicates.dfy(94,31): Related location
-Predicates.dfy(105,4): Error: A postcondition might not hold on this return path.
+Predicates.dfy(105,4): Error: a postcondition could not be proved on this return path
 Predicates.dfy(104,14): Related location: This is the postcondition that might not hold.
 Predicates.dfy(104,39): Related location
 Predicates.dfy(104,45): Related location

--- a/Test/allocated1/dafny0/Refinement.dfy.expect
+++ b/Test/allocated1/dafny0/Refinement.dfy.expect
@@ -16,15 +16,15 @@ Refinement.dfy(264,7): Warning: the ... refinement feature in statements is depr
 Refinement.dfy(269,7): Warning: the ... refinement feature in statements is deprecated
 Refinement.dfy(276,7): Warning: the ... refinement feature in statements is deprecated
 Refinement.dfy(233,4): Warning: note, this loop has no body (loop frame: i)
-Refinement.dfy(15,4): Error: A postcondition might not hold on this return path.
+Refinement.dfy(15,4): Error: a postcondition could not be proved on this return path
 Refinement.dfy(14,16): Related location: This is the postcondition that might not hold.
-Refinement.dfy[B](15,4): Error: A postcondition might not hold on this return path.
+Refinement.dfy[B](15,4): Error: a postcondition could not be proved on this return path
 Refinement.dfy(33,19): Related location: This is the postcondition that might not hold.
 Refinement.dfy(69,15): Error: assertion might not hold
 Refinement.dfy(80,16): Error: assertion might not hold
-Refinement.dfy(99,11): Error: A postcondition might not hold on this return path.
+Refinement.dfy(99,11): Error: a postcondition could not be proved on this return path
 Refinement.dfy(78,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(102,2): Error: A postcondition might not hold on this return path.
+Refinement.dfy(102,2): Error: a postcondition could not be proved on this return path
 Refinement.dfy(83,14): Related location: This is the postcondition that might not hold.
 Refinement.dfy(198,6): Error: assertion might not hold
 Refinement.dfy[IncorrectConcrete](122,18): Related location
@@ -32,13 +32,13 @@ Refinement.dfy(204,6): Error: assertion might not hold
 Refinement.dfy[IncorrectConcrete](131,18): Related location
 Refinement.dfy(209,6): Error: assertion might not hold
 Refinement.dfy[IncorrectConcrete](137,23): Related location
-Refinement.dfy(253,6): Error: A postcondition might not hold on this return path.
+Refinement.dfy(253,6): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](223,19): Related location: This is the postcondition that might not hold.
-Refinement.dfy(261,6): Error: A postcondition might not hold on this return path.
+Refinement.dfy(261,6): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](230,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(268,4): Error: A postcondition might not hold on this return path.
+Refinement.dfy(268,4): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](238,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(274,6): Error: A postcondition might not hold on this return path.
+Refinement.dfy(274,6): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](244,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 28 verified, 13 errors

--- a/Test/allocated1/dafny0/Skeletons.dfy.expect
+++ b/Test/allocated1/dafny0/Skeletons.dfy.expect
@@ -5,7 +5,7 @@ Skeletons.dfy(32,10): Warning: the ... refinement feature in statements is depre
 Skeletons.dfy(60,7): Warning: the ... refinement feature in statements is deprecated
 Skeletons.dfy(62,6): Warning: the ... refinement feature in statements is deprecated
 Skeletons.dfy(64,7): Warning: the ... refinement feature in statements is deprecated
-Skeletons.dfy(45,2): Error: A postcondition might not hold on this return path.
+Skeletons.dfy(45,2): Error: a postcondition could not be proved on this return path
 Skeletons.dfy(44,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 4 verified, 1 error

--- a/Test/allocated1/dafny0/SmallTests.dfy.expect
+++ b/Test/allocated1/dafny0/SmallTests.dfy.expect
@@ -24,7 +24,7 @@ SmallTests.dfy(240,30): Error: assertion might not hold
 SmallTests.dfy(243,30): Error: assertion might not hold
 SmallTests.dfy(253,25): Error: assertion might not hold
 SmallTests.dfy(255,30): Error: assertion might not hold
-SmallTests.dfy(303,23): Error: A precondition for this call might not hold.
+SmallTests.dfy(303,23): Error: a precondition for this call could not be proved
 SmallTests.dfy(281,16): Related location: This is the precondition that might not hold.
 SmallTests.dfy(408,11): Error: assertion might not hold
 SmallTests.dfy(418,11): Error: assertion might not hold
@@ -32,13 +32,13 @@ SmallTests.dfy(428,5): Error: cannot prove termination; try supplying a decrease
 SmallTests.dfy(733,13): Error: assertion might not hold
 SmallTests.dfy(754,13): Error: assertion might not hold
 SmallTests.dfy(757,13): Error: assertion might not hold
-SmallTests.dfy(338,2): Error: A postcondition might not hold on this return path.
+SmallTests.dfy(338,2): Error: a postcondition could not be proved on this return path
 SmallTests.dfy(332,10): Related location: This is the postcondition that might not hold.
 SmallTests.dfy(332,40): Related location
 SmallTests.dfy(379,11): Error: assertion might not hold
 SmallTests.dfy(386,9): Error: assertion might not hold
 SmallTests.dfy(396,3): Error: cannot prove termination; try supplying a decreases clause
-SmallTests.dfy(440,9): Error: A postcondition might not hold on this return path.
+SmallTests.dfy(440,9): Error: a postcondition could not be proved on this return path
 SmallTests.dfy(443,40): Related location: This is the postcondition that might not hold.
 SmallTests.dfy(604,11): Error: assertion might not hold
 SmallTests.dfy(618,19): Error: left-hand sides n.next and n.next.next might refer to the same location

--- a/Test/allocated1/dafny0/Superposition.dfy.expect
+++ b/Test/allocated1/dafny0/Superposition.dfy.expect
@@ -5,12 +5,12 @@ Verifying M0.C.M (correctness) ...
 
 Verifying M0.C.Q (well-formedness) ...
   [3 proof obligations]  error
-Superposition.dfy(20,14): Error: A postcondition might not hold on this return path.
+Superposition.dfy(20,14): Error: a postcondition could not be proved on this return path
 Superposition.dfy(21,25): Related location: This is the postcondition that might not hold.
 
 Verifying M0.C.R (well-formedness) ...
   [3 proof obligations]  error
-Superposition.dfy(26,14): Error: A postcondition might not hold on this return path.
+Superposition.dfy(26,14): Error: a postcondition could not be proved on this return path
 Superposition.dfy(27,25): Related location: This is the postcondition that might not hold.
 
 Verifying M1.C.M (correctness) ...

--- a/Test/allocated1/dafny0/TypeAntecedents.dfy.expect
+++ b/Test/allocated1/dafny0/TypeAntecedents.dfy.expect
@@ -1,5 +1,5 @@
 TypeAntecedents.dfy(35,12): Error: assertion might not hold
-TypeAntecedents.dfy(58,0): Error: A postcondition might not hold on this return path.
+TypeAntecedents.dfy(58,0): Error: a postcondition could not be proved on this return path
 TypeAntecedents.dfy(57,14): Related location: This is the postcondition that might not hold.
 TypeAntecedents.dfy(66,15): Error: assertion might not hold
 TypeAntecedents.dfy(80,47): Error: target object might not be allocated

--- a/Test/allocated1/dafny0/TypeParameters.dfy.expect
+++ b/Test/allocated1/dafny0/TypeParameters.dfy.expect
@@ -10,7 +10,7 @@ TypeParameters.dfy(144,4): Related location
 TypeParameters.dfy(144,14): Related location
 TypeParameters.dfy(161,11): Error: assertion might not hold
 TypeParameters.dfy(146,7): Related location
-TypeParameters.dfy(175,14): Error: This loop invariant might not be maintained by the loop.
+TypeParameters.dfy(175,14): Error: this invariant could not be proved to be maintained by the loop
 TypeParameters.dfy(175,37): Related location
 TypeParameters.dfy(175,14): Related message: loop invariant violation
 TypeParameters.dfy(175,37): Related location

--- a/Test/allocated1/dafny0/one-message-per-failed-precondition.dfy.expect
+++ b/Test/allocated1/dafny0/one-message-per-failed-precondition.dfy.expect
@@ -1,6 +1,6 @@
-one-message-per-failed-precondition.dfy(13,3): Error: A precondition for this call might not hold.
+one-message-per-failed-precondition.dfy(13,3): Error: a precondition for this call could not be proved
 one-message-per-failed-precondition.dfy(8,13): Related location: This is the precondition that might not hold.
-one-message-per-failed-precondition.dfy(13,3): Error: A precondition for this call might not hold.
+one-message-per-failed-precondition.dfy(13,3): Error: a precondition for this call could not be proved
 one-message-per-failed-precondition.dfy(9,13): Related location: This is the precondition that might not hold.
 one-message-per-failed-precondition.dfy(20,27): Error: function precondition might not hold
 one-message-per-failed-precondition.dfy(17,13): Related location

--- a/Test/cli/diagnosticsFormats.dfy.expect
+++ b/Test/cli/diagnosticsFormats.dfy.expect
@@ -1,22 +1,22 @@
 diagnosticsFormats.dfy(11,0): Warning: module-level const declarations are always non-instance, so the 'static' keyword is not allowed here
 diagnosticsFormats.dfy(12,17): Error: result of operation might violate newtype constraint for 'byte'
-diagnosticsFormats.dfy(15,16): Error: A precondition for this call might not hold.
+diagnosticsFormats.dfy(15,16): Error: a precondition for this call could not be proved
 diagnosticsFormats.dfy(14,35): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 2 errors
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":11,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":12,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":16}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":16}}},"severity":1,"message":"Error: a precondition for this call could not be proved","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
 
 Dafny program verifier finished with 1 verified, 2 errors
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":11,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":10,"character":8}}},"severity":4,"message":"newtype byte resolves as {:nativeType \u0022byte\u0022} (Detected Range: 0 .. 256)","source":"Resolver","relatedInformation":[]}
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":12,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":16}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":16}}},"severity":1,"message":"Error: a precondition for this call could not be proved","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
 
 Dafny program verifier finished with 1 verified, 2 errors
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":11,"character":0}}},"severity":2,"message":"module-level const declarations are always non-instance, so the \u0027static\u0027 keyword is not allowed here","source":"Parser","relatedInformation":[]}
 {"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":12,"character":17}}},"severity":1,"message":"Error: result of operation might violate newtype constraint for \u0027byte\u0027","source":"Verifier","relatedInformation":[]}
-{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":14},"end":{"line":15,"character":18}}},"severity":1,"message":"Error: A precondition for this call might not hold.","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35},"end":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
+{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":15,"character":14},"end":{"line":15,"character":18}}},"severity":1,"message":"Error: a precondition for this call could not be proved","source":"Verifier","relatedInformation":[{"location":{"filename":"diagnosticsFormats.dfy","range":{"start":{"line":14,"character":35},"end":{"line":14,"character":35}}},"message":"Related location: This is the precondition that might not hold."}]}
 
 Dafny program verifier finished with 1 verified, 2 errors

--- a/Test/cli/solverOptTrace.dfy
+++ b/Test/cli/solverOptTrace.dfy
@@ -1,0 +1,12 @@
+// RUN: %exits-with 4 %baredafny verify %args --verbosity Trace --solver-opt BATCH_MODE=true "%s" > "%t"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK: Running in batch mode.
+method m(x: int) {
+  if x == 1 {
+    assert x != 1;
+  } else if x == 2 {
+    assert x != 2;
+  } else if x == 3 {
+    assert x != 3;
+  }
+}

--- a/Test/cli/zeroCores.dfy.expect
+++ b/Test/cli/zeroCores.dfy.expect
@@ -4,19 +4,19 @@ Could not parse number earga
 
 Could not parse percentage earga%
 
-zeroCores.dfy(10,27): Error: A postcondition might not hold on this return path.
+zeroCores.dfy(10,27): Error: a postcondition could not be proved on this return path
 zeroCores.dfy(10,21): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error
-zeroCores.dfy(10,27): Error: A postcondition might not hold on this return path.
+zeroCores.dfy(10,27): Error: a postcondition could not be proved on this return path
 zeroCores.dfy(10,21): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error
-zeroCores.dfy(10,27): Error: A postcondition might not hold on this return path.
+zeroCores.dfy(10,27): Error: a postcondition could not be proved on this return path
 zeroCores.dfy(10,21): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error
-zeroCores.dfy(10,27): Error: A postcondition might not hold on this return path.
+zeroCores.dfy(10,27): Error: a postcondition could not be proved on this return path
 zeroCores.dfy(10,21): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/dafny0/Array.dfy.expect
+++ b/Test/dafny0/Array.dfy.expect
@@ -17,11 +17,11 @@ Array.dfy(332,4): Error: assignment might update an object not in the enclosing 
 Array.dfy(338,5): Error: assignment might update an array element not in the enclosing context's modifies clause
 Array.dfy(353,17): Error: assertion might not hold
 Array.dfy(358,17): Error: left-hand sides that.x and this.x might refer to the same location
-Array.dfy(216,0): Error: A postcondition might not hold on this return path.
+Array.dfy(216,0): Error: a postcondition could not be proved on this return path
 Array.dfy(215,10): Related location: This is the postcondition that might not hold.
-Array.dfy(240,0): Error: A postcondition might not hold on this return path.
+Array.dfy(240,0): Error: a postcondition could not be proved on this return path
 Array.dfy(239,10): Related location: This is the postcondition that might not hold.
-Array.dfy(246,0): Error: A postcondition might not hold on this return path.
+Array.dfy(246,0): Error: a postcondition could not be proved on this return path
 Array.dfy(245,10): Related location: This is the postcondition that might not hold.
 Array.dfy(255,12): Error: value does not satisfy the subset constraints of 'nat'
 Array.dfy(256,5): Error: value does not satisfy the subset constraints of 'nat'

--- a/Test/dafny0/AutoContracts.dfy.expect
+++ b/Test/dafny0/AutoContracts.dfy.expect
@@ -562,30 +562,30 @@ module N2 refines N1 {
   type {:axiom} C(==) = c: C? | c != null /*special witness*/
   */
 }
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
-AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy(12,14): Related location
-AutoContracts.dfy(17,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
+AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
+AutoContracts.dfy(12,14): Related location
+AutoContracts.dfy(17,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(17,4): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy(12,14): Related location
 AutoContracts.dfy(5,25): Related location
-AutoContracts.dfy(50,4): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(50,4): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(49,24): Related location: This is the postcondition that might not hold.
-AutoContracts.dfy(79,21): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(79,21): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(60,16): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy[N1](65,14): Related location
-AutoContracts.dfy(79,21): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(79,21): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(60,16): Related location: This is the postcondition that might not hold.
 AutoContracts.dfy[N1](65,14): Related location
-AutoContracts.dfy(79,21): Error: A postcondition might not hold on this return path.
+AutoContracts.dfy(79,21): Error: a postcondition could not be proved on this return path
 AutoContracts.dfy(60,16): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 37 verified, 9 errors

--- a/Test/dafny0/BindingGuards.dfy.expect
+++ b/Test/dafny0/BindingGuards.dfy.expect
@@ -302,7 +302,7 @@ method AltSyntax9(x: int, y: int, c: Color)
   }
   z := x + y;
 }
-BindingGuards.dfy(85,10): Error: A postcondition might not hold on this return path.
+BindingGuards.dfy(85,10): Error: a postcondition could not be proved on this return path
 BindingGuards.dfy(71,12): Related location: This is the postcondition that might not hold.
 BindingGuards.dfy(134,9): Error: assertion might not hold
 BindingGuards.dfy(6,8): Related location

--- a/Test/dafny0/ByMethod.dfy.expect
+++ b/Test/dafny0/ByMethod.dfy.expect
@@ -1,18 +1,18 @@
-ByMethod.dfy(38,18): Error: This loop invariant might not be maintained by the loop.
+ByMethod.dfy(38,18): Error: this invariant could not be proved to be maintained by the loop
 ByMethod.dfy(38,18): Related message: loop invariant violation
-ByMethod.dfy(42,4): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(42,4): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(35,7): Related location: This is the postcondition that might not hold.
-ByMethod.dfy(47,11): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(47,11): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(48,12): Related location: This is the postcondition that might not hold.
-ByMethod.dfy(55,11): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(55,11): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(56,12): Related location: This is the postcondition that might not hold.
-ByMethod.dfy(60,4): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(60,4): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(59,7): Related location: This is the postcondition that might not hold.
-ByMethod.dfy(63,12): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(63,12): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(64,27): Related location: This is the postcondition that might not hold.
-ByMethod.dfy(68,4): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(68,4): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(67,7): Related location: This is the postcondition that might not hold.
-ByMethod.dfy(71,12): Error: A postcondition might not hold on this return path.
+ByMethod.dfy(71,12): Error: a postcondition could not be proved on this return path
 ByMethod.dfy(72,27): Related location: This is the postcondition that might not hold.
 ByMethod.dfy(93,11): Error: decreases clause might not decrease
 ByMethod.dfy(102,11): Error: decreases clause might not decrease

--- a/Test/dafny0/ChainingDisjointTests.dfy.expect
+++ b/Test/dafny0/ChainingDisjointTests.dfy.expect
@@ -1,4 +1,4 @@
-ChainingDisjointTests.dfy(49,2): Error: A postcondition might not hold on this return path.
+ChainingDisjointTests.dfy(49,2): Error: a postcondition could not be proved on this return path
 ChainingDisjointTests.dfy(48,14): Related location: This is the postcondition that might not hold.
 ChainingDisjointTests.dfy(42,22): Related location
 ChainingDisjointTests.dfy(58,13): Error: assertion might not hold

--- a/Test/dafny0/CoPrefix.dfy.expect
+++ b/Test/dafny0/CoPrefix.dfy.expect
@@ -1,6 +1,6 @@
-CoPrefix.dfy(164,2): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(164,2): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(163,14): Related location: This is the postcondition that might not hold.
-CoPrefix.dfy(169,2): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(169,2): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(168,14): Related location: This is the postcondition that might not hold.
 CoPrefix.dfy(176,10): Error: cannot prove termination; try supplying a decreases clause
 CoPrefix.dfy(205,6): Error: the calculation step between the previous line and this line might not hold
@@ -8,13 +8,13 @@ CoPrefix.dfy(207,6): Error: the calculation step between the previous line and t
 CoPrefix.dfy(220,12): Error: ORDINAL subtraction might underflow a limit ordinal (that is, RHS might be too large)
 CoPrefix.dfy(63,56): Error: decreases clause might not decrease
 CoPrefix.dfy(76,55): Error: cannot prove termination; try supplying a decreases clause
-CoPrefix.dfy(114,0): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(114,0): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(113,10): Related location: This is the postcondition that might not hold.
 CoPrefix.dfy(101,16): Related location
 CoPrefix.dfy(138,24): Error: assertion might not hold
 CoPrefix.dfy(142,24): Error: assertion might not hold
 CoPrefix.dfy(117,22): Related location
-CoPrefix.dfy(151,0): Error: A postcondition might not hold on this return path.
+CoPrefix.dfy(151,0): Error: a postcondition could not be proved on this return path
 CoPrefix.dfy(150,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 13 verified, 12 errors

--- a/Test/dafny0/CoinductiveProofs.dfy.expect
+++ b/Test/dafny0/CoinductiveProofs.dfy.expect
@@ -4,13 +4,13 @@ CoinductiveProofs.dfy(13,16): Related location
 CoinductiveProofs.dfy(44,11): Error: assertion might not hold
 CoinductiveProofs.dfy(48,11): Error: assertion might not hold
 CoinductiveProofs.dfy(13,16): Related location
-CoinductiveProofs.dfy(78,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(78,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(77,10): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(73,2): Related location
 CoinductiveProofs.dfy(94,11): Error: assertion might not hold
 CoinductiveProofs.dfy(87,29): Related location
 CoinductiveProofs.dfy(73,2): Related location
-CoinductiveProofs.dfy(127,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(127,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(126,10): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(115,2): Related location
 CoinductiveProofs.dfy(136,11): Error: assertion might not hold
@@ -20,13 +20,13 @@ CoinductiveProofs.dfy(149,11): Error: assertion might not hold
 CoinductiveProofs.dfy(115,2): Related location
 CoinductiveProofs.dfy(153,11): Error: assertion might not hold
 CoinductiveProofs.dfy(115,2): Related location
-CoinductiveProofs.dfy(164,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(164,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(163,10): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(159,2): Related location
-CoinductiveProofs.dfy(203,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(203,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(202,21): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(4,23): Related location
-CoinductiveProofs.dfy(209,0): Error: A postcondition might not hold on this return path.
+CoinductiveProofs.dfy(209,0): Error: a postcondition could not be proved on this return path
 CoinductiveProofs.dfy(208,21): Related location: This is the postcondition that might not hold.
 CoinductiveProofs.dfy(4,23): Related location
 

--- a/Test/dafny0/ComputationsNeg.dfy.expect
+++ b/Test/dafny0/ComputationsNeg.dfy.expect
@@ -1,7 +1,7 @@
 ComputationsNeg.dfy(7,2): Error: decreases clause might not decrease
-ComputationsNeg.dfy(11,0): Error: A postcondition might not hold on this return path.
+ComputationsNeg.dfy(11,0): Error: a postcondition could not be proved on this return path
 ComputationsNeg.dfy(10,16): Related location: This is the postcondition that might not hold.
-ComputationsNeg.dfy(23,0): Error: A postcondition might not hold on this return path.
+ComputationsNeg.dfy(23,0): Error: a postcondition could not be proved on this return path
 ComputationsNeg.dfy(22,10): Related location: This is the postcondition that might not hold.
 ComputationsNeg.dfy(19,28): Related location
 ComputationsNeg.dfy(19,62): Related location

--- a/Test/dafny0/ControlStructures.dfy.expect
+++ b/Test/dafny0/ControlStructures.dfy.expect
@@ -10,7 +10,7 @@ ControlStructures.dfy(238,29): Error: assertion might not hold
 ControlStructures.dfy(241,16): Error: assertion might not hold
 ControlStructures.dfy(350,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 ControlStructures.dfy(381,2): Error: cannot prove termination; try supplying a decreases clause for the loop
-ControlStructures.dfy(448,16): Error: This loop invariant might not be maintained by the loop.
+ControlStructures.dfy(448,16): Error: this invariant could not be proved to be maintained by the loop
 ControlStructures.dfy(448,16): Related message: loop invariant violation
 
 Dafny program verifier finished with 18 verified, 13 errors

--- a/Test/dafny0/CustomErrorMesage.dfy.expect
+++ b/Test/dafny0/CustomErrorMesage.dfy.expect
@@ -2,17 +2,17 @@ CustomErrorMesage.dfy(6,45): Error: m: x must be positive
 CustomErrorMesage.dfy(10,45): Error: f: x must be positive
 CustomErrorMesage.dfy(15,2): Error: when calling foo, you must supply a positive x
 CustomErrorMesage.dfy(19,71): Related location
-CustomErrorMesage.dfy(18,9): Error: A postcondition might not hold on this return path.
+CustomErrorMesage.dfy(18,9): Error: a postcondition could not be proved on this return path
 CustomErrorMesage.dfy(20,85): Related location: cannot establish that return value of foo is always negative
-CustomErrorMesage.dfy(26,14): Error: A precondition for this call might not hold.
+CustomErrorMesage.dfy(26,14): Error: a precondition for this call could not be proved
 CustomErrorMesage.dfy(30,71): Related location: when calling bar, you must supply a positive x
-CustomErrorMesage.dfy(32,0): Error: A postcondition might not hold on this return path.
+CustomErrorMesage.dfy(32,0): Error: a postcondition could not be proved on this return path
 CustomErrorMesage.dfy(31,85): Related location: cannot establish that return value of bar is always negative
-CustomErrorMesage.dfy(42,63): Error: This loop invariant might not hold on entry.
+CustomErrorMesage.dfy(42,63): Error: this loop invariant could not be proved on entry
 CustomErrorMesage.dfy(42,63): Related message: position variable out of range
-CustomErrorMesage.dfy(42,63): Error: This loop invariant might not be maintained by the loop.
+CustomErrorMesage.dfy(42,63): Error: this invariant could not be proved to be maintained by the loop
 CustomErrorMesage.dfy(42,63): Related message: position variable out of range
-CustomErrorMesage.dfy(43,63): Error: This loop invariant might not be maintained by the loop.
+CustomErrorMesage.dfy(43,63): Error: this invariant could not be proved to be maintained by the loop
 CustomErrorMesage.dfy(43,63): Related message: output array doesn't match input arry
 
 Dafny program verifier finished with 1 verified, 9 errors

--- a/Test/dafny0/DTypes.dfy.expect
+++ b/Test/dafny0/DTypes.dfy.expect
@@ -6,7 +6,7 @@ DTypes.dfy(231,14): Warning: the type of the other operand is a non-null type, s
 DTypes.dfy(232,14): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'false' (to make it possible for variable 'c' to have the value 'null', declare its type to be 'Cell?<MyClass>')
 DTypes.dfy(233,14): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'false' (to make it possible for variable 'd' to have the value 'null', declare its type to be 'Cell?<MyClass>')
 DTypes.dfy(64,13): Warning: the type of the other operand is a non-null type, so this comparison with 'null' will always return 'true' (to make it possible for variable 'a' to have the value 'null', declare its type to be 'CP?<int, C>')
-DTypes.dfy(179,2): Error: A postcondition might not hold on this return path.
+DTypes.dfy(179,2): Error: a postcondition could not be proved on this return path
 DTypes.dfy(178,14): Related location: This is the postcondition that might not hold.
 DTypes.dfy(18,13): Error: assertion might not hold
 DTypes.dfy(56,17): Error: assertion might not hold

--- a/Test/dafny0/Datatypes.dfy.expect
+++ b/Test/dafny0/Datatypes.dfy.expect
@@ -1,4 +1,4 @@
-Datatypes.dfy(297,9): Error: A postcondition might not hold on this return path.
+Datatypes.dfy(297,9): Error: a postcondition could not be proved on this return path
 Datatypes.dfy(295,14): Related location: This is the postcondition that might not hold.
 Datatypes.dfy(298,11): Error: missing case in match expression: Appendix(_)
 Datatypes.dfy(349,4): Error: missing case in match expression: Cons(_, _)

--- a/Test/dafny0/DefaultParameters.dfy.expect
+++ b/Test/dafny0/DefaultParameters.dfy.expect
@@ -1,7 +1,7 @@
 DefaultParameters.dfy(55,30): Error: default-value expression is not allowed to involve recursive or mutually recursive calls
 DefaultParameters.dfy(63,42): Error: default value might not be allocated in the two-state function's previous state
 DefaultParameters.dfy(67,38): Error: default value might not be allocated in the two-state lemma's previous state
-DefaultParameters.dfy(92,2): Error: A postcondition might not hold on this return path.
+DefaultParameters.dfy(92,2): Error: a postcondition could not be proved on this return path
 DefaultParameters.dfy(91,16): Related location: This is the postcondition that might not hold.
 DefaultParameters.dfy(102,15): Error: assertion might not hold
 DefaultParameters.dfy(110,15): Error: assertion might not hold
@@ -41,7 +41,7 @@ DefaultParameters.dfy(241,4): Error: decreases clause might not decrease
 DefaultParameters.dfy(251,25): Error: insufficient reads clause to read field
 DefaultParameters.dfy(258,34): Error: default-value expression is not allowed to involve recursive or mutually recursive calls
 DefaultParameters.dfy(267,35): Error: possible division by zero
-DefaultParameters.dfy(320,39): Error: A precondition for this call might not hold.
+DefaultParameters.dfy(320,39): Error: a precondition for this call could not be proved
 DefaultParameters.dfy(319,15): Related location: This is the precondition that might not hold.
 DefaultParameters.dfy(326,36): Error: insufficient reads clause to read array element
 DefaultParameters.dfy(327,54): Error: insufficient reads clause to read array element
@@ -68,7 +68,7 @@ DefaultParameters.dfy(453,32): Error: default-value expression is not allowed to
 DefaultParameters.dfy(481,32): Error: default-value expression is not allowed to involve recursive or mutually recursive calls
 DefaultParameters.dfy(494,32): Error: value does not satisfy the subset constraints of 'nat'
 DefaultParameters.dfy(493,18): Error: value does not satisfy the subset constraints of 'nat'
-DefaultParameters.dfy(500,15): Error: A precondition for this call might not hold.
+DefaultParameters.dfy(500,15): Error: a precondition for this call could not be proved
 DefaultParameters.dfy(503,13): Related location: This is the precondition that might not hold.
 DefaultParameters.dfy(520,38): Error: insufficient reads clause to read field
 DefaultParameters.dfy(548,38): Error: insufficient reads clause to read field

--- a/Test/dafny0/Definedness.dfy.expect
+++ b/Test/dafny0/Definedness.dfy.expect
@@ -6,12 +6,12 @@ Definedness.dfy(29,16): Error: possible division by zero
 Definedness.dfy(36,15): Error: target object might be null
 Definedness.dfy(45,15): Error: target object might be null
 Definedness.dfy(53,17): Error: target object might be null
-Definedness.dfy(54,2): Error: A postcondition might not hold on this return path.
+Definedness.dfy(54,2): Error: a postcondition could not be proved on this return path
 Definedness.dfy(53,21): Related location: This is the postcondition that might not hold.
 Definedness.dfy(60,17): Error: target object might be null
-Definedness.dfy(61,2): Error: A postcondition might not hold on this return path.
+Definedness.dfy(61,2): Error: a postcondition could not be proved on this return path
 Definedness.dfy(60,21): Related location: This is the postcondition that might not hold.
-Definedness.dfy(68,2): Error: A postcondition might not hold on this return path.
+Definedness.dfy(68,2): Error: a postcondition could not be proved on this return path
 Definedness.dfy(67,21): Related location: This is the postcondition that might not hold.
 Definedness.dfy(88,6): Error: target object might be null
 Definedness.dfy(89,4): Error: function precondition might not hold
@@ -31,24 +31,24 @@ Definedness.dfy(123,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
 Definedness.dfy(133,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
-Definedness.dfy(133,21): Error: This loop invariant might not hold on entry.
+Definedness.dfy(133,21): Error: this loop invariant could not be proved on entry
 Definedness.dfy(133,21): Related message: loop invariant violation
 Definedness.dfy(134,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
 Definedness.dfy(143,14): Error: possible division by zero
 Definedness.dfy(162,14): Error: possible division by zero
-Definedness.dfy(175,27): Error: This loop invariant might not hold on entry.
+Definedness.dfy(175,27): Error: this loop invariant could not be proved on entry
 Definedness.dfy(175,27): Related message: loop invariant violation
 Definedness.dfy(181,16): Error: function precondition might not hold
 Definedness.dfy(79,15): Related location
 Definedness.dfy(196,18): Error: possible division by zero
-Definedness.dfy(196,22): Error: This loop invariant might not hold on entry.
+Definedness.dfy(196,22): Error: this loop invariant could not be proved on entry
 Definedness.dfy(196,22): Related message: loop invariant violation
 Definedness.dfy(196,27): Error: possible division by zero
-Definedness.dfy(215,9): Error: A postcondition might not hold on this return path.
+Definedness.dfy(215,9): Error: a postcondition could not be proved on this return path
 Definedness.dfy(217,45): Related location: This is the postcondition that might not hold.
 Definedness.dfy(224,21): Error: target object might be null
-Definedness.dfy(237,9): Error: A postcondition might not hold on this return path.
+Definedness.dfy(237,9): Error: a postcondition could not be proved on this return path
 Definedness.dfy(240,23): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 9 verified, 37 errors

--- a/Test/dafny0/DirtyLoops.dfy.expect
+++ b/Test/dafny0/DirtyLoops.dfy.expect
@@ -85,7 +85,7 @@ DirtyLoops.dfy(321,13): Error: assertion might not hold
 DirtyLoops.dfy(356,13): Error: assertion might not hold
 DirtyLoops.dfy(369,13): Error: assertion might not hold
 DirtyLoops.dfy(380,9): Error: assertion might not hold
-DirtyLoops.dfy(401,18): Error: This loop invariant might not hold on entry.
+DirtyLoops.dfy(401,18): Error: this loop invariant could not be proved on entry
 DirtyLoops.dfy(401,18): Related message: loop invariant violation
 DirtyLoops.dfy(414,16): Error: target object might be null
 DirtyLoops.dfy(506,22): Error: assertion might not hold

--- a/Test/dafny0/ForLoops.dfy.expect
+++ b/Test/dafny0/ForLoops.dfy.expect
@@ -24,7 +24,7 @@ ForLoops.dfy(311,16): Error: result of operation might violate newtype constrain
 ForLoops.dfy(344,11): Error: assertion might not hold
 ForLoops.dfy(362,11): Error: assertion might not hold
 ForLoops.dfy(372,11): Error: assertion might not hold
-ForLoops.dfy(415,28): Error: This loop invariant might not be maintained by the loop.
+ForLoops.dfy(415,28): Error: this invariant could not be proved to be maintained by the loop
 ForLoops.dfy(415,28): Related message: loop invariant violation
 ForLoops.dfy(434,26): Error: decreases expression must be bounded below by 0 at end of loop iteration
 ForLoops.dfy(443,18): Error: decreases expression must be bounded below by 0 at end of loop iteration

--- a/Test/dafny0/FunctionSpecifications.dfy.expect
+++ b/Test/dafny0/FunctionSpecifications.dfy.expect
@@ -1,15 +1,15 @@
-FunctionSpecifications.dfy(35,24): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(35,24): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(31,12): Related location: This is the postcondition that might not hold.
-FunctionSpecifications.dfy(45,2): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(45,2): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(40,23): Related location: This is the postcondition that might not hold.
 FunctionSpecifications.dfy(53,10): Error: cannot prove termination; try supplying a decreases clause
-FunctionSpecifications.dfy(60,9): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(60,9): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(61,21): Related location: This is the postcondition that might not hold.
 FunctionSpecifications.dfy(109,22): Error: assertion might not hold
 FunctionSpecifications.dfy(112,22): Error: assertion might not hold
 FunctionSpecifications.dfy(127,26): Error: assertion might not hold
 FunctionSpecifications.dfy(131,26): Error: assertion might not hold
-FunctionSpecifications.dfy(136,19): Error: A postcondition might not hold on this return path.
+FunctionSpecifications.dfy(136,19): Error: a postcondition could not be proved on this return path
 FunctionSpecifications.dfy(138,28): Related location: This is the postcondition that might not hold.
 FunctionSpecifications.dfy(147,2): Error: decreases clause might not decrease
 FunctionSpecifications.dfy(154,2): Error: decreases clause might not decrease

--- a/Test/dafny0/GhostAutoInit.dfy.expect
+++ b/Test/dafny0/GhostAutoInit.dfy.expect
@@ -41,7 +41,7 @@ GhostAutoInit.dfy(257,23): Error: variable 'm', which is subject to definite-ass
 GhostAutoInit.dfy(257,29): Error: variable 'x', which is subject to definite-assignment rules, might be uninitialized here
 GhostAutoInit.dfy(257,32): Error: variable 'y', which is subject to definite-assignment rules, might be uninitialized here
 GhostAutoInit.dfy(282,7): Error: cannot find witness that shows type is inhabited (only tried 0); try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
-GhostAutoInit.dfy(298,2): Error: A postcondition might not hold on this return path.
+GhostAutoInit.dfy(298,2): Error: a postcondition could not be proved on this return path
 GhostAutoInit.dfy(297,12): Related location: This is the postcondition that might not hold.
 GhostAutoInit.dfy(303,9): Error: value does not satisfy the subset constraints of 'nat'
 GhostAutoInit.dfy(308,9): Error: value does not satisfy the subset constraints of 'nat'

--- a/Test/dafny0/Include.dfy.expect
+++ b/Test/dafny0/Include.dfy.expect
@@ -1,21 +1,21 @@
 Include.dfy(32,7): Warning: the ... refinement feature in statements is deprecated
-Include.dfy(20,18): Error: A postcondition might not hold on this return path.
+Include.dfy(20,18): Error: a postcondition could not be proved on this return path
 Includee.dfy(17,19): Related location: This is the postcondition that might not hold.
 Includee.dfy[Concrete](22,15): Error: assertion might not hold
-Include.dfy(28,6): Error: A postcondition might not hold on this return path.
+Include.dfy(28,6): Error: a postcondition could not be proved on this return path
 Includee.dfy[Concrete](20,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 3 errors
 Include.dfy(32,7): Warning: the ... refinement feature in statements is deprecated
-Includee.dfy(21,2): Error: A postcondition might not hold on this return path.
+Includee.dfy(21,2): Error: a postcondition could not be proved on this return path
 Includee.dfy(20,14): Related location: This is the postcondition that might not hold.
 Includee.dfy(24,17): Error: assertion might not hold
-Include.dfy(20,18): Error: A postcondition might not hold on this return path.
+Include.dfy(20,18): Error: a postcondition could not be proved on this return path
 Includee.dfy(17,19): Related location: This is the postcondition that might not hold.
 Includee.dfy[Concrete](22,15): Error: assertion might not hold
-Include.dfy(28,6): Error: A postcondition might not hold on this return path.
+Include.dfy(28,6): Error: a postcondition could not be proved on this return path
 Includee.dfy[Concrete](20,14): Related location: This is the postcondition that might not hold.
-Includee.dfy(6,0): Error: A postcondition might not hold on this return path.
+Includee.dfy(6,0): Error: a postcondition could not be proved on this return path
 Includee.dfy(5,12): Related location: This is the postcondition that might not hold.
 Includee.dfy(7,0): Error: out-parameter 'y', which is subject to definite-assignment rules, might be uninitialized at this return point
 

--- a/Test/dafny0/Includee.dfy.expect
+++ b/Test/dafny0/Includee.dfy.expect
@@ -1,7 +1,7 @@
-Includee.dfy(21,2): Error: A postcondition might not hold on this return path.
+Includee.dfy(21,2): Error: a postcondition could not be proved on this return path
 Includee.dfy(20,14): Related location: This is the postcondition that might not hold.
 Includee.dfy(24,17): Error: assertion might not hold
-Includee.dfy(6,0): Error: A postcondition might not hold on this return path.
+Includee.dfy(6,0): Error: a postcondition could not be proved on this return path
 Includee.dfy(5,12): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 3 errors

--- a/Test/dafny0/Inverses.dfy.expect
+++ b/Test/dafny0/Inverses.dfy.expect
@@ -1,12 +1,12 @@
-Inverses.dfy(70,2): Error: A postcondition might not hold on this return path.
+Inverses.dfy(70,2): Error: a postcondition could not be proved on this return path
 Inverses.dfy(67,10): Related location: This is the postcondition that might not hold.
 Inverses.dfy(67,40): Related location
 Inverses.dfy(67,66): Related location
-Inverses.dfy(82,2): Error: A postcondition might not hold on this return path.
+Inverses.dfy(82,2): Error: a postcondition could not be proved on this return path
 Inverses.dfy(79,10): Related location: This is the postcondition that might not hold.
 Inverses.dfy(79,40): Related location
 Inverses.dfy(79,66): Related location
-Inverses.dfy(193,2): Error: A postcondition might not hold on this return path.
+Inverses.dfy(193,2): Error: a postcondition could not be proved on this return path
 Inverses.dfy(191,15): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 31 verified, 3 errors

--- a/Test/dafny0/Iterators.dfy.expect
+++ b/Test/dafny0/Iterators.dfy.expect
@@ -12,33 +12,33 @@ Iterators.dfy(106,13): Error: assertion might not hold
 Iterators.dfy(177,27): Error: assertion might not hold
 Iterators.dfy(208,6): Error: an assignment to _new is only allowed to shrink the set
 Iterators.dfy(212,20): Error: assertion might not hold
-Iterators.dfy(436,18): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(436,18): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(436,18): Related message: loop invariant violation
-Iterators.dfy(437,23): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(437,23): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(437,23): Related message: loop invariant violation
-Iterators.dfy(438,23): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(438,23): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(438,23): Related message: loop invariant violation
-Iterators.dfy(459,16): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(459,16): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(459,16): Related message: loop invariant violation
-Iterators.dfy(460,21): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(460,21): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(460,21): Related message: loop invariant violation
-Iterators.dfy(461,21): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(461,21): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(461,21): Related message: loop invariant violation
 Iterators.dfy(470,4): Error: possible violation of yield-ensures condition
 Iterators.dfy(451,21): Related location
-Iterators.dfy(40,21): Error: A precondition for this call might not hold.
+Iterators.dfy(40,21): Error: a precondition for this call could not be proved
 Iterators.dfy(4,9): Related location: This is the precondition that might not hold.
 Iterators.dfy(89,13): Error: assertion might not hold
 Iterators.dfy(119,15): Error: assertion might not hold
 Iterators.dfy(150,15): Error: assertion might not hold
-Iterators.dfy(155,23): Error: A precondition for this call might not hold.
+Iterators.dfy(155,23): Error: a precondition for this call could not be proved
 Iterators.dfy(125,9): Related location: This is the precondition that might not hold.
 Iterators.dfy(234,20): Error: assertion might not hold
-Iterators.dfy(413,16): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(413,16): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(413,16): Related message: loop invariant violation
-Iterators.dfy(414,21): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(414,21): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(414,21): Related message: loop invariant violation
-Iterators.dfy(415,21): Error: This loop invariant might not be maintained by the loop.
+Iterators.dfy(415,21): Error: this invariant could not be proved to be maintained by the loop
 Iterators.dfy(415,21): Related message: loop invariant violation
 
 Dafny program verifier finished with 35 verified, 30 errors

--- a/Test/dafny0/Matrix-OOB.dfy.expect
+++ b/Test/dafny0/Matrix-OOB.dfy.expect
@@ -1,7 +1,7 @@
 Matrix-OOB.dfy(11,10): Info: Selected triggers: {m[i, j]}
 Matrix-OOB.dfy(11,27): Error: index 0 out of range
 Matrix-OOB.dfy(11,30): Error: index 1 out of range
-Matrix-OOB.dfy(12,0): Error: A postcondition might not hold on this return path.
+Matrix-OOB.dfy(12,0): Error: a postcondition could not be proved on this return path
 Matrix-OOB.dfy(11,10): Related location: This is the postcondition that might not hold.
 Matrix-OOB.dfy(11,33): Related location
 

--- a/Test/dafny0/MultiSets.dfy.expect
+++ b/Test/dafny0/MultiSets.dfy.expect
@@ -1,6 +1,6 @@
-MultiSets.dfy(158,2): Error: A postcondition might not hold on this return path.
+MultiSets.dfy(158,2): Error: a postcondition could not be proved on this return path
 MultiSets.dfy(157,14): Related location: This is the postcondition that might not hold.
-MultiSets.dfy(164,2): Error: A postcondition might not hold on this return path.
+MultiSets.dfy(164,2): Error: a postcondition could not be proved on this return path
 MultiSets.dfy(163,14): Related location: This is the postcondition that might not hold.
 MultiSets.dfy(177,19): Error: new number of occurrences might be negative
 MultiSets.dfy(268,23): Error: assertion might not hold

--- a/Test/dafny0/NoMoreAssume2Less2.dfy.expect
+++ b/Test/dafny0/NoMoreAssume2Less2.dfy.expect
@@ -15,10 +15,10 @@ NoMoreAssume2Less2.dfy(110,11): Error: assertion might not hold
 NoMoreAssume2Less2.dfy(78,20): Related location
 NoMoreAssume2Less2.dfy(113,11): Error: assertion might not hold
 NoMoreAssume2Less2.dfy(119,19): Error: assertion might not hold
-NoMoreAssume2Less2.dfy(135,16): Error: This loop invariant might not hold on entry.
+NoMoreAssume2Less2.dfy(135,16): Error: this loop invariant could not be proved on entry
 NoMoreAssume2Less2.dfy(135,16): Related message: loop invariant violation
 NoMoreAssume2Less2.dfy(140,11): Error: assertion might not hold
-NoMoreAssume2Less2.dfy(146,12): Error: A precondition for this call might not hold.
+NoMoreAssume2Less2.dfy(146,12): Error: a precondition for this call could not be proved
 NoMoreAssume2Less2.dfy(162,11): Related location: This is the precondition that might not hold.
 NoMoreAssume2Less2.dfy(149,11): Error: assertion might not hold
 NoMoreAssume2Less2.dfy(158,11): Error: assertion might not hold

--- a/Test/dafny0/OpaqueFunctions.dfy.expect
+++ b/Test/dafny0/OpaqueFunctions.dfy.expect
@@ -1,11 +1,11 @@
 OpaqueFunctions.dfy(38,15): Error: assertion might not hold
-OpaqueFunctions.dfy(69,7): Error: A precondition for this call might not hold.
+OpaqueFunctions.dfy(69,7): Error: a precondition for this call could not be proved
 OpaqueFunctions.dfy(35,15): Related location: This is the precondition that might not hold.
 OpaqueFunctions.dfy(75,19): Error: assertion might not hold
 OpaqueFunctions.dfy(77,20): Error: assertion might not hold
 OpaqueFunctions.dfy(80,20): Error: assertion might not hold
 OpaqueFunctions.dfy(96,22): Error: assertion might not hold
-OpaqueFunctions.dfy(98,11): Error: A precondition for this call might not hold.
+OpaqueFunctions.dfy(98,11): Error: a precondition for this call could not be proved
 OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
 OpaqueFunctions.dfy(102,17): Error: assertion might not hold
 OpaqueFunctions.dfy(109,19): Error: assertion might not hold
@@ -13,7 +13,7 @@ OpaqueFunctions.dfy(111,20): Error: assertion might not hold
 OpaqueFunctions.dfy(114,20): Error: assertion might not hold
 OpaqueFunctions.dfy(123,31): Error: assertion might not hold
 OpaqueFunctions.dfy(146,20): Error: assertion might not hold
-OpaqueFunctions.dfy(148,9): Error: A precondition for this call might not hold.
+OpaqueFunctions.dfy(148,9): Error: a precondition for this call could not be proved
 OpaqueFunctions.dfy[A'](35,15): Related location: This is the precondition that might not hold.
 OpaqueFunctions.dfy(155,19): Error: assertion might not hold
 OpaqueFunctions.dfy(157,20): Error: assertion might not hold

--- a/Test/dafny0/Parallel.dfy.expect
+++ b/Test/dafny0/Parallel.dfy.expect
@@ -2,7 +2,7 @@ Parallel.dfy(267,4): Warning: a forall statement with no bound variables is depr
 Parallel.dfy(279,4): Warning: a forall statement with no bound variables is deprecated; use an 'assert by' statement instead
 Parallel.dfy(286,4): Warning: a forall statement with no bound variables is deprecated; use an 'assert by' statement instead
 Parallel.dfy(293,21): Error: assertion might not hold
-Parallel.dfy(33,9): Error: A precondition for this call might not hold.
+Parallel.dfy(33,9): Error: a precondition for this call could not be proved
 Parallel.dfy(59,13): Related location: This is the precondition that might not hold.
 Parallel.dfy(37,4): Error: target object might be null
 Parallel.dfy(41,17): Error: possible violation of postcondition of forall statement

--- a/Test/dafny0/Predicates.dfy.expect
+++ b/Test/dafny0/Predicates.dfy.expect
@@ -1,6 +1,6 @@
 Predicates.dfy(62,15): Error: assertion might not hold
 Predicates.dfy(66,13): Error: assertion might not hold
-Predicates.dfy(105,4): Error: A postcondition might not hold on this return path.
+Predicates.dfy(105,4): Error: a postcondition could not be proved on this return path
 Predicates.dfy(104,14): Related location: This is the postcondition that might not hold.
 Predicates.dfy(104,39): Related location
 Predicates.dfy(104,45): Related location

--- a/Test/dafny0/PrefixTypeSubst.dfy.expect
+++ b/Test/dafny0/PrefixTypeSubst.dfy.expect
@@ -621,19 +621,19 @@ lemma /*{:_induction _k}*/ RstRst10#<alpha, beta, gamma>[_k: nat]()
   }
 }
 ***/
-PrefixTypeSubst.dfy(52,0): Error: A postcondition might not hold on this return path.
+PrefixTypeSubst.dfy(52,0): Error: a postcondition could not be proved on this return path
 PrefixTypeSubst.dfy(51,30): Related location: This is the postcondition that might not hold.
 PrefixTypeSubst.dfy(19,17): Related location
-PrefixTypeSubst.dfy(58,0): Error: A postcondition might not hold on this return path.
+PrefixTypeSubst.dfy(58,0): Error: a postcondition could not be proved on this return path
 PrefixTypeSubst.dfy(57,30): Related location: This is the postcondition that might not hold.
 PrefixTypeSubst.dfy(19,17): Related location
-PrefixTypeSubst.dfy(64,0): Error: A postcondition might not hold on this return path.
+PrefixTypeSubst.dfy(64,0): Error: a postcondition could not be proved on this return path
 PrefixTypeSubst.dfy(63,30): Related location: This is the postcondition that might not hold.
 PrefixTypeSubst.dfy(19,17): Related location
-PrefixTypeSubst.dfy(70,0): Error: A postcondition might not hold on this return path.
+PrefixTypeSubst.dfy(70,0): Error: a postcondition could not be proved on this return path
 PrefixTypeSubst.dfy(69,30): Related location: This is the postcondition that might not hold.
 PrefixTypeSubst.dfy(19,17): Related location
-PrefixTypeSubst.dfy(85,9): Error: A postcondition might not hold on this return path.
+PrefixTypeSubst.dfy(85,9): Error: a postcondition could not be proved on this return path
 PrefixTypeSubst.dfy(81,30): Related location: This is the postcondition that might not hold.
 PrefixTypeSubst.dfy(19,17): Related location
 

--- a/Test/dafny0/Refinement.dfy.expect
+++ b/Test/dafny0/Refinement.dfy.expect
@@ -16,15 +16,15 @@ Refinement.dfy(264,7): Warning: the ... refinement feature in statements is depr
 Refinement.dfy(269,7): Warning: the ... refinement feature in statements is deprecated
 Refinement.dfy(276,7): Warning: the ... refinement feature in statements is deprecated
 Refinement.dfy(233,4): Warning: note, this loop has no body (loop frame: i)
-Refinement.dfy(15,4): Error: A postcondition might not hold on this return path.
+Refinement.dfy(15,4): Error: a postcondition could not be proved on this return path
 Refinement.dfy(14,16): Related location: This is the postcondition that might not hold.
-Refinement.dfy[B](15,4): Error: A postcondition might not hold on this return path.
+Refinement.dfy[B](15,4): Error: a postcondition could not be proved on this return path
 Refinement.dfy(33,19): Related location: This is the postcondition that might not hold.
 Refinement.dfy(69,15): Error: assertion might not hold
 Refinement.dfy(80,16): Error: assertion might not hold
-Refinement.dfy(99,11): Error: A postcondition might not hold on this return path.
+Refinement.dfy(99,11): Error: a postcondition could not be proved on this return path
 Refinement.dfy(78,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(102,2): Error: A postcondition might not hold on this return path.
+Refinement.dfy(102,2): Error: a postcondition could not be proved on this return path
 Refinement.dfy(83,14): Related location: This is the postcondition that might not hold.
 Refinement.dfy(198,6): Error: assertion might not hold
 Refinement.dfy[IncorrectConcrete](122,18): Related location
@@ -32,13 +32,13 @@ Refinement.dfy(204,6): Error: assertion might not hold
 Refinement.dfy[IncorrectConcrete](131,18): Related location
 Refinement.dfy(209,6): Error: assertion might not hold
 Refinement.dfy[IncorrectConcrete](137,23): Related location
-Refinement.dfy(253,6): Error: A postcondition might not hold on this return path.
+Refinement.dfy(253,6): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](223,19): Related location: This is the postcondition that might not hold.
-Refinement.dfy(261,6): Error: A postcondition might not hold on this return path.
+Refinement.dfy(261,6): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](230,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(268,4): Error: A postcondition might not hold on this return path.
+Refinement.dfy(268,4): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](238,14): Related location: This is the postcondition that might not hold.
-Refinement.dfy(274,6): Error: A postcondition might not hold on this return path.
+Refinement.dfy(274,6): Error: a postcondition could not be proved on this return path
 Refinement.dfy[Modify1](244,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 28 verified, 13 errors

--- a/Test/dafny0/RevealConsistency.dfy.expect
+++ b/Test/dafny0/RevealConsistency.dfy.expect
@@ -1,4 +1,4 @@
-RevealConsistency.dfy(7,9): Error: A postcondition might not hold on this return path.
+RevealConsistency.dfy(7,9): Error: a postcondition could not be proved on this return path
 RevealConsistency.dfy(8,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 1 error

--- a/Test/dafny0/ShowSnippets.dfy.expect
+++ b/Test/dafny0/ShowSnippets.dfy.expect
@@ -3,7 +3,7 @@ ShowSnippets.dfy(13,9): Error: assertion might not hold
 13 |   assert false;
    |          ^^^^^
 
-ShowSnippets.dfy(17,2): Error: A precondition for this call might not hold.
+ShowSnippets.dfy(17,2): Error: a precondition for this call could not be proved
    |
 17 |   Never();
    |   ^^^^^^^^

--- a/Test/dafny0/Skeletons.dfy.expect
+++ b/Test/dafny0/Skeletons.dfy.expect
@@ -5,7 +5,7 @@ Skeletons.dfy(32,10): Warning: the ... refinement feature in statements is depre
 Skeletons.dfy(60,7): Warning: the ... refinement feature in statements is deprecated
 Skeletons.dfy(62,6): Warning: the ... refinement feature in statements is deprecated
 Skeletons.dfy(64,7): Warning: the ... refinement feature in statements is deprecated
-Skeletons.dfy(45,2): Error: A postcondition might not hold on this return path.
+Skeletons.dfy(45,2): Error: a postcondition could not be proved on this return path
 Skeletons.dfy(44,14): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 4 verified, 1 error

--- a/Test/dafny0/SmallTests.dfy.expect
+++ b/Test/dafny0/SmallTests.dfy.expect
@@ -26,7 +26,7 @@ SmallTests.dfy(240,30): Error: assertion might not hold
 SmallTests.dfy(243,30): Error: assertion might not hold
 SmallTests.dfy(253,25): Error: assertion might not hold
 SmallTests.dfy(255,30): Error: assertion might not hold
-SmallTests.dfy(303,23): Error: A precondition for this call might not hold.
+SmallTests.dfy(303,23): Error: a precondition for this call could not be proved
 SmallTests.dfy(281,16): Related location: This is the precondition that might not hold.
 SmallTests.dfy(408,11): Error: assertion might not hold
 SmallTests.dfy(418,11): Error: assertion might not hold
@@ -34,13 +34,13 @@ SmallTests.dfy(428,5): Error: cannot prove termination; try supplying a decrease
 SmallTests.dfy(733,13): Error: assertion might not hold
 SmallTests.dfy(754,13): Error: assertion might not hold
 SmallTests.dfy(757,13): Error: assertion might not hold
-SmallTests.dfy(338,2): Error: A postcondition might not hold on this return path.
+SmallTests.dfy(338,2): Error: a postcondition could not be proved on this return path
 SmallTests.dfy(332,10): Related location: This is the postcondition that might not hold.
 SmallTests.dfy(332,40): Related location
 SmallTests.dfy(379,11): Error: assertion might not hold
 SmallTests.dfy(386,9): Error: assertion might not hold
 SmallTests.dfy(396,3): Error: cannot prove termination; try supplying a decreases clause
-SmallTests.dfy(440,9): Error: A postcondition might not hold on this return path.
+SmallTests.dfy(440,9): Error: a postcondition could not be proved on this return path
 SmallTests.dfy(443,40): Related location: This is the postcondition that might not hold.
 SmallTests.dfy(604,11): Error: assertion might not hold
 SmallTests.dfy(618,19): Error: left-hand sides n.next and n.next.next might refer to the same location

--- a/Test/dafny0/Superposition.dfy.expect
+++ b/Test/dafny0/Superposition.dfy.expect
@@ -5,12 +5,12 @@ Verifying M0.C.M (correctness) ...
 
 Verifying M0.C.Q (well-formedness) ...
   [3 proof obligations]  error
-Superposition.dfy(20,14): Error: A postcondition might not hold on this return path.
+Superposition.dfy(20,14): Error: a postcondition could not be proved on this return path
 Superposition.dfy(21,25): Related location: This is the postcondition that might not hold.
 
 Verifying M0.C.R (well-formedness) ...
   [3 proof obligations]  error
-Superposition.dfy(26,14): Error: A postcondition might not hold on this return path.
+Superposition.dfy(26,14): Error: a postcondition could not be proved on this return path
 Superposition.dfy(27,25): Related location: This is the postcondition that might not hold.
 
 Verifying M1.C.M (correctness) ...

--- a/Test/dafny0/Twostate-Verification.dfy.expect
+++ b/Test/dafny0/Twostate-Verification.dfy.expect
@@ -21,12 +21,12 @@ Twostate-Verification.dfy(680,22): Warning: Argument to 'old' does not dereferen
 Twostate-Verification.dfy(681,22): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
 Twostate-Verification.dfy(682,22): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
 Twostate-Verification.dfy(33,13): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-Twostate-Verification.dfy(271,13): Error: A postcondition might not hold on this return path.
+Twostate-Verification.dfy(271,13): Error: a postcondition could not be proved on this return path
 Twostate-Verification.dfy(263,24): Related location: This is the postcondition that might not hold.
-Twostate-Verification.dfy(277,4): Error: A postcondition might not hold on this return path.
+Twostate-Verification.dfy(277,4): Error: a postcondition could not be proved on this return path
 Twostate-Verification.dfy(276,26): Related location: This is the postcondition that might not hold.
 Twostate-Verification.dfy(313,38): Error: assertion might not hold
-Twostate-Verification.dfy(337,23): Error: A precondition for this call might not hold.
+Twostate-Verification.dfy(337,23): Error: a precondition for this call could not be proved
 Twostate-Verification.dfy(317,29): Related location: This is the precondition that might not hold.
 Twostate-Verification.dfy(359,18): Error: assertion might not hold
 Twostate-Verification.dfy(361,18): Error: assertion might not hold

--- a/Test/dafny0/TypeAntecedents.dfy.expect
+++ b/Test/dafny0/TypeAntecedents.dfy.expect
@@ -1,5 +1,5 @@
 TypeAntecedents.dfy(35,12): Error: assertion might not hold
-TypeAntecedents.dfy(58,0): Error: A postcondition might not hold on this return path.
+TypeAntecedents.dfy(58,0): Error: a postcondition could not be proved on this return path
 TypeAntecedents.dfy(57,14): Related location: This is the postcondition that might not hold.
 TypeAntecedents.dfy(66,15): Error: assertion might not hold
 

--- a/Test/dafny0/TypeParameters.dfy.expect
+++ b/Test/dafny0/TypeParameters.dfy.expect
@@ -12,7 +12,7 @@ TypeParameters.dfy(144,4): Related location
 TypeParameters.dfy(144,14): Related location
 TypeParameters.dfy(161,11): Error: assertion might not hold
 TypeParameters.dfy(146,7): Related location
-TypeParameters.dfy(175,14): Error: This loop invariant might not be maintained by the loop.
+TypeParameters.dfy(175,14): Error: this invariant could not be proved to be maintained by the loop
 TypeParameters.dfy(175,37): Related location
 TypeParameters.dfy(175,14): Related message: loop invariant violation
 TypeParameters.dfy(175,37): Related location

--- a/Test/dafny0/one-message-per-failed-precondition.dfy.expect
+++ b/Test/dafny0/one-message-per-failed-precondition.dfy.expect
@@ -1,6 +1,6 @@
-one-message-per-failed-precondition.dfy(13,3): Error: A precondition for this call might not hold.
+one-message-per-failed-precondition.dfy(13,3): Error: a precondition for this call could not be proved
 one-message-per-failed-precondition.dfy(8,13): Related location: This is the precondition that might not hold.
-one-message-per-failed-precondition.dfy(13,3): Error: A precondition for this call might not hold.
+one-message-per-failed-precondition.dfy(13,3): Error: a precondition for this call could not be proved
 one-message-per-failed-precondition.dfy(9,13): Related location: This is the precondition that might not hold.
 one-message-per-failed-precondition.dfy(20,27): Error: function precondition might not hold
 one-message-per-failed-precondition.dfy(17,13): Related location

--- a/Test/dafny0/snapshots/Snapshots8.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots8.run.dfy.expect
@@ -5,11 +5,11 @@ Processing command (at Snapshots8.v0.dfy(3,12)) assert x#0 < 10;
 Processing command (at Snapshots8.v0.dfy(4,8)) assert LitInt(0) <= call0formal#AT#y#0;
   >>> DoNothingToAssert
 Snapshots8.v0.dfy(3,11): Error: assertion might not hold
-Snapshots8.v0.dfy(4,7): Error: A precondition for this call might not hold.
+Snapshots8.v0.dfy(4,7): Error: a precondition for this call could not be proved
 Snapshots8.v0.dfy(8,13): Related location: This is the precondition that might not hold.
 Processing command (at Snapshots8.v0.dfy(13,13)) assert LitInt(2) <= z#0;
   >>> DoNothingToAssert
-Snapshots8.v0.dfy(17,9): Error: A postcondition might not hold on this return path.
+Snapshots8.v0.dfy(17,9): Error: a postcondition could not be proved on this return path
 Snapshots8.v0.dfy(13,12): Related location: This is the postcondition that might not hold.
 Processing command (at Snapshots8.v0.dfy(23,12)) assert u#0 != 53;
   >>> DoNothingToAssert
@@ -30,14 +30,14 @@ Processing command (at Snapshots8.v1.dfy(6,8)) assert LitInt(0) <= call0formal#A
 Processing command (at Snapshots8.v1.dfy(7,12)) assert x#0 == LitInt(7);
   >>> DoNothingToAssert
 Snapshots8.v1.dfy(5,16): Error: assertion might not hold
-Snapshots8.v1.dfy(6,7): Error: A precondition for this call might not hold.
+Snapshots8.v1.dfy(6,7): Error: a precondition for this call could not be proved
 Snapshots8.v1.dfy(12,20): Related location: This is the precondition that might not hold.
 Snapshots8.v1.dfy(7,11): Error: assertion might not hold
 Processing command (at Snapshots8.v1.dfy(23,12)) assert Lit(true);
   >>> DoNothingToAssert
 Processing command (at Snapshots8.v1.dfy(19,13)) assert LitInt(2) <= z#0;
   >>> DoNothingToAssert
-Snapshots8.v1.dfy(24,9): Error: A postcondition might not hold on this return path.
+Snapshots8.v1.dfy(24,9): Error: a postcondition could not be proved on this return path
 Snapshots8.v1.dfy(19,12): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 5 errors

--- a/Test/dafny0/snapshots/Snapshots9.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots9.run.dfy.expect
@@ -1,20 +1,20 @@
 Processing command (at Snapshots9.v0.dfy(2,11)) assert ok#0;
   >>> DoNothingToAssert
-Snapshots9.v0.dfy(4,7): Error: A postcondition might not hold on this return path.
+Snapshots9.v0.dfy(4,7): Error: a postcondition could not be proved on this return path
 Snapshots9.v0.dfy(2,10): Related location: This is the postcondition that might not hold.
 Processing command (at Snapshots9.v0.dfy(12,11)) assert ok#0;
   >>> DoNothingToAssert
-Snapshots9.v0.dfy(13,0): Error: A postcondition might not hold on this return path.
+Snapshots9.v0.dfy(13,0): Error: a postcondition could not be proved on this return path
 Snapshots9.v0.dfy(12,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 2 errors
 Processing command (at Snapshots9.v1.dfy(6,11)) assert ok#0;
   >>> RecycleError
-Snapshots9.v1.dfy(8,7): Error: A postcondition might not hold on this return path.
+Snapshots9.v1.dfy(8,7): Error: a postcondition could not be proved on this return path
 Snapshots9.v1.dfy(6,10): Related location: This is the postcondition that might not hold.
 Processing command (at Snapshots9.v1.dfy(19,11)) assert ok#0;
   >>> RecycleError
-Snapshots9.v1.dfy(21,0): Error: A postcondition might not hold on this return path.
+Snapshots9.v1.dfy(21,0): Error: a postcondition could not be proved on this return path
 Snapshots9.v1.dfy(19,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/dafny1/Induction.dfy.expect
+++ b/Test/dafny1/Induction.dfy.expect
@@ -1,6 +1,6 @@
-Induction.dfy(240,11): Error: A postcondition might not hold on this return path.
+Induction.dfy(240,11): Error: a postcondition could not be proved on this return path
 Induction.dfy(236,15): Related location: This is the postcondition that might not hold.
-Induction.dfy(251,9): Error: A postcondition might not hold on this return path.
+Induction.dfy(251,9): Error: a postcondition could not be proved on this return path
 Induction.dfy(247,16): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 32 verified, 2 errors

--- a/Test/dafny1/InductionOptions.dfy.expect
+++ b/Test/dafny1/InductionOptions.dfy.expect
@@ -1,30 +1,30 @@
-InductionOptions.dfy(21,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(21,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(20,26): Related location: This is the postcondition that might not hold.
 InductionOptions.dfy(25,9): Error: assertion might not hold
 InductionOptions.dfy(25,38): Related location
-InductionOptions.dfy(30,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(30,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(29,10): Related location: This is the postcondition that might not hold.
 InductionOptions.dfy(29,39): Related location
 InductionOptions.dfy(35,9): Error: assertion might not hold
 InductionOptions.dfy(35,38): Related location
-InductionOptions.dfy(40,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(40,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(39,26): Related location: This is the postcondition that might not hold.
 InductionOptions.dfy(44,9): Error: assertion might not hold
 InductionOptions.dfy(44,51): Related location
 
 Dafny program verifier finished with 1 verified, 6 errors
-InductionOptions.dfy(21,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(21,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(20,26): Related location: This is the postcondition that might not hold.
 InductionOptions.dfy(25,9): Error: assertion might not hold
 InductionOptions.dfy(25,38): Related location
-InductionOptions.dfy(30,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(30,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(29,10): Related location: This is the postcondition that might not hold.
 InductionOptions.dfy(29,39): Related location
 InductionOptions.dfy(35,9): Error: assertion might not hold
 InductionOptions.dfy(35,38): Related location
 
 Dafny program verifier finished with 3 verified, 4 errors
-InductionOptions.dfy(21,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(21,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(20,26): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 6 verified, 1 error
@@ -32,7 +32,7 @@ Dafny program verifier finished with 6 verified, 1 error
 Dafny program verifier finished with 7 verified, 0 errors
 InductionOptions.dfy(25,9): Error: assertion might not hold
 InductionOptions.dfy(25,38): Related location
-InductionOptions.dfy(30,0): Error: A postcondition might not hold on this return path.
+InductionOptions.dfy(30,0): Error: a postcondition could not be proved on this return path
 InductionOptions.dfy(29,10): Related location: This is the postcondition that might not hold.
 InductionOptions.dfy(29,39): Related location
 InductionOptions.dfy(35,9): Error: assertion might not hold

--- a/Test/dafny1/MoreInduction.dfy.expect
+++ b/Test/dafny1/MoreInduction.dfy.expect
@@ -1,10 +1,10 @@
-MoreInduction.dfy(78,0): Error: A postcondition might not hold on this return path.
+MoreInduction.dfy(78,0): Error: a postcondition could not be proved on this return path
 MoreInduction.dfy(77,10): Related location: This is the postcondition that might not hold.
-MoreInduction.dfy(83,0): Error: A postcondition might not hold on this return path.
+MoreInduction.dfy(83,0): Error: a postcondition could not be proved on this return path
 MoreInduction.dfy(82,20): Related location: This is the postcondition that might not hold.
-MoreInduction.dfy(88,0): Error: A postcondition might not hold on this return path.
+MoreInduction.dfy(88,0): Error: a postcondition could not be proved on this return path
 MoreInduction.dfy(87,10): Related location: This is the postcondition that might not hold.
-MoreInduction.dfy(93,0): Error: A postcondition might not hold on this return path.
+MoreInduction.dfy(93,0): Error: a postcondition could not be proved on this return path
 MoreInduction.dfy(92,21): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 9 verified, 4 errors

--- a/Test/dafny2/SnapshotableTrees.dfy.expect
+++ b/Test/dafny2/SnapshotableTrees.dfy.expect
@@ -1,4 +1,4 @@
-SnapshotableTrees.dfy(71,25): Error: A precondition for this call might not hold.
+SnapshotableTrees.dfy(71,25): Error: a precondition for this call could not be proved
 SnapshotableTrees.dfy(610,15): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 52 verified, 1 error

--- a/Test/dafny3/Inc.dfy.expect
+++ b/Test/dafny3/Inc.dfy.expect
@@ -1,22 +1,22 @@
-Inc.dfy(55,0): Error: A postcondition might not hold on this return path.
+Inc.dfy(55,0): Error: a postcondition could not be proved on this return path
 Inc.dfy(54,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(84,0): Error: A postcondition might not hold on this return path.
+Inc.dfy(84,0): Error: a postcondition could not be proved on this return path
 Inc.dfy(83,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(93,2): Error: A postcondition might not hold on this return path.
+Inc.dfy(93,2): Error: a postcondition could not be proved on this return path
 Inc.dfy(90,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(111,0): Error: A postcondition might not hold on this return path.
+Inc.dfy(111,0): Error: a postcondition could not be proved on this return path
 Inc.dfy(110,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(120,2): Error: A postcondition might not hold on this return path.
+Inc.dfy(120,2): Error: a postcondition could not be proved on this return path
 Inc.dfy(117,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(182,0): Error: A postcondition might not hold on this return path.
+Inc.dfy(182,0): Error: a postcondition could not be proved on this return path
 Inc.dfy(181,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(211,0): Error: A postcondition might not hold on this return path.
+Inc.dfy(211,0): Error: a postcondition could not be proved on this return path
 Inc.dfy(210,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(220,2): Error: A postcondition might not hold on this return path.
+Inc.dfy(220,2): Error: a postcondition could not be proved on this return path
 Inc.dfy(217,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(238,0): Error: A postcondition might not hold on this return path.
+Inc.dfy(238,0): Error: a postcondition could not be proved on this return path
 Inc.dfy(237,12): Related location: This is the postcondition that might not hold.
-Inc.dfy(247,2): Error: A postcondition might not hold on this return path.
+Inc.dfy(247,2): Error: a postcondition could not be proved on this return path
 Inc.dfy(244,12): Related location: This is the postcondition that might not hold.
 Inc.dfy(318,17): Error: cannot prove termination; try supplying a decreases clause
 Inc.dfy(318,17): Error: decreases expression at index 1 must be bounded below by 0

--- a/Test/dafny4/Bug160.dfy.expect
+++ b/Test/dafny4/Bug160.dfy.expect
@@ -1,4 +1,4 @@
-Bug160.dfy(26,18): Error: A postcondition might not hold on this return path.
+Bug160.dfy(26,18): Error: a postcondition could not be proved on this return path
 Bug160.dfy(27,13): Related location: This is the postcondition that might not hold.
 Bug160.dfy(27,29): Related location
 

--- a/Test/dafny4/Bug88.dfy.expect
+++ b/Test/dafny4/Bug88.dfy.expect
@@ -1,6 +1,6 @@
-Bug88.dfy(6,0): Error: A postcondition might not hold on this return path.
+Bug88.dfy(6,0): Error: a postcondition could not be proved on this return path
 Bug88.dfy(5,12): Related location: This is the postcondition that might not hold.
-Bug88.dfy(14,0): Error: A postcondition might not hold on this return path.
+Bug88.dfy(14,0): Error: a postcondition could not be proved on this return path
 Bug88.dfy(13,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/dafny4/git-issue147.dfy.expect
+++ b/Test/dafny4/git-issue147.dfy.expect
@@ -1,4 +1,4 @@
-git-issue147.dfy(7,0): Error: A postcondition might not hold on this return path.
+git-issue147.dfy(7,0): Error: a postcondition could not be proved on this return path
 git-issue147.dfy(6,17): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 2 verified, 1 error

--- a/Test/dafny4/git-issue245.dfy.expect
+++ b/Test/dafny4/git-issue245.dfy.expect
@@ -2,13 +2,13 @@ git-issue245.dfy(43,18): Error: the function must provide an equal or more detai
 git-issue245.dfy(47,18): Error: the function must provide an equal or more detailed postcondition than in its parent trait
 git-issue245.dfy(51,18): Error: the function must provide an equal or more detailed postcondition than in its parent trait
 git-issue245.dfy(55,18): Error: the function must provide an equal or more detailed postcondition than in its parent trait
-git-issue245.dfy(84,18): Error: A postcondition might not hold on this return path.
+git-issue245.dfy(84,18): Error: a postcondition could not be proved on this return path
 git-issue245.dfy(85,17): Related location: This is the postcondition that might not hold.
-git-issue245.dfy(88,18): Error: A postcondition might not hold on this return path.
+git-issue245.dfy(88,18): Error: a postcondition could not be proved on this return path
 git-issue245.dfy(89,19): Related location: This is the postcondition that might not hold.
-git-issue245.dfy(92,18): Error: A postcondition might not hold on this return path.
+git-issue245.dfy(92,18): Error: a postcondition could not be proved on this return path
 git-issue245.dfy(93,19): Related location: This is the postcondition that might not hold.
-git-issue245.dfy(96,18): Error: A postcondition might not hold on this return path.
+git-issue245.dfy(96,18): Error: a postcondition could not be proved on this return path
 git-issue245.dfy(97,17): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 28 verified, 8 errors

--- a/Test/dafny4/regression-calc.dfy.expect
+++ b/Test/dafny4/regression-calc.dfy.expect
@@ -1,6 +1,6 @@
-regression-calc.dfy(8,16): Error: A postcondition might not hold on this return path.
+regression-calc.dfy(8,16): Error: a postcondition could not be proved on this return path
 regression-calc.dfy(8,10): Related location: This is the postcondition that might not hold.
-regression-calc.dfy(15,16): Error: A postcondition might not hold on this return path.
+regression-calc.dfy(15,16): Error: a postcondition could not be proved on this return path
 regression-calc.dfy(15,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/exports/OpaqueFunctions.dfy.expect
+++ b/Test/exports/OpaqueFunctions.dfy.expect
@@ -1,8 +1,8 @@
-OpaqueFunctions.dfy(16,11): Error: A postcondition might not hold on this return path.
+OpaqueFunctions.dfy(16,11): Error: a postcondition could not be proved on this return path
 OpaqueFunctions.dfy(17,14): Related location: This is the postcondition that might not hold.
-OpaqueFunctions.dfy(58,2): Error: A postcondition might not hold on this return path.
+OpaqueFunctions.dfy(58,2): Error: a postcondition could not be proved on this return path
 OpaqueFunctions.dfy(57,16): Related location: This is the postcondition that might not hold.
-OpaqueFunctions.dfy(65,2): Error: A postcondition might not hold on this return path.
+OpaqueFunctions.dfy(65,2): Error: a postcondition could not be proved on this return path
 OpaqueFunctions.dfy(64,16): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 4 verified, 3 errors

--- a/Test/exports/RevealProvideAll.dfy.expect
+++ b/Test/exports/RevealProvideAll.dfy.expect
@@ -1,4 +1,4 @@
-RevealProvideAll.dfy(25,45): Error: A postcondition might not hold on this return path.
+RevealProvideAll.dfy(25,45): Error: a postcondition could not be proved on this return path
 RevealProvideAll.dfy(25,26): Related location: This is the postcondition that might not hold.
 RevealProvideAll.dfy(30,13): Error: assertion might not hold
 

--- a/Test/exports/xrefine1.dfy.expect
+++ b/Test/exports/xrefine1.dfy.expect
@@ -1,4 +1,4 @@
-xrefine1.dfy(64,12): Error: A precondition for this call might not hold.
+xrefine1.dfy(64,12): Error: a precondition for this call could not be proved
 xrefine1.dfy(49,32): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 3 verified, 1 error

--- a/Test/git-issues/git-issue-1180b.dfy.expect
+++ b/Test/git-issues/git-issue-1180b.dfy.expect
@@ -1,42 +1,42 @@
-git-issue-1180b.dfy(28,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(28,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(29,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(29,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(34,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(34,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(35,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(35,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(40,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(40,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(41,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(41,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(46,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(46,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(47,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(47,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(56,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(56,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(57,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(57,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(63,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(63,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(12,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(64,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(64,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(15,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(83,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(83,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(75,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(84,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(84,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(78,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(103,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(103,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(95,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(104,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(104,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(98,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(123,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(123,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(115,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(124,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(124,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(118,18): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(143,22): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(143,22): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(135,21): Related location: This is the postcondition that might not hold.
-git-issue-1180b.dfy(144,40): Error: A postcondition might not hold on this return path.
+git-issue-1180b.dfy(144,40): Error: a postcondition could not be proved on this return path
 git-issue-1180b.dfy(138,18): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 13 verified, 20 errors

--- a/Test/git-issues/git-issue-1248.dfy.expect
+++ b/Test/git-issues/git-issue-1248.dfy.expect
@@ -1,12 +1,12 @@
-git-issue-1248.dfy(13,0): Error: A postcondition might not hold on this return path.
+git-issue-1248.dfy(13,0): Error: a postcondition could not be proved on this return path
 git-issue-1248.dfy(12,10): Related location: This is the postcondition that might not hold.
-git-issue-1248.dfy(19,0): Error: A postcondition might not hold on this return path.
+git-issue-1248.dfy(19,0): Error: a postcondition could not be proved on this return path
 git-issue-1248.dfy(18,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 2 errors
-git-issue-1248.dfy(13,0): Error: A postcondition might not hold on this return path.
+git-issue-1248.dfy(13,0): Error: a postcondition could not be proved on this return path
 git-issue-1248.dfy(12,10): Related location: This is the postcondition that might not hold.
-git-issue-1248.dfy(19,0): Error: A postcondition might not hold on this return path.
+git-issue-1248.dfy(19,0): Error: a postcondition could not be proved on this return path
 git-issue-1248.dfy(18,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/git-issues/git-issue-1812.dfy.expect
+++ b/Test/git-issues/git-issue-1812.dfy.expect
@@ -1,6 +1,6 @@
-git-issue-1812.dfy(22,16): Error: This loop invariant might not be maintained by the loop.
+git-issue-1812.dfy(22,16): Error: this invariant could not be proved to be maintained by the loop
 git-issue-1812.dfy(22,16): Related message: loop invariant violation
-git-issue-1812.dfy(33,16): Error: This loop invariant might not be maintained by the loop.
+git-issue-1812.dfy(33,16): Error: this invariant could not be proved to be maintained by the loop
 git-issue-1812.dfy(33,16): Related message: loop invariant violation
 
 Dafny program verifier finished with 1 verified, 2 errors

--- a/Test/git-issues/git-issue-1989.dfy.expect
+++ b/Test/git-issues/git-issue-1989.dfy.expect
@@ -16,16 +16,16 @@ git-issue-1989.dfy(158,18): Warning: Argument to 'old' does not dereference the 
 git-issue-1989.dfy(160,23): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
 git-issue-1989.dfy(171,9): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
 git-issue-1989.dfy(211,4): Warning: Argument to 'old' does not dereference the mutable heap, so this use of 'old' has no effect
-git-issue-1989.dfy(126,2): Error: A postcondition might not hold on this return path.
+git-issue-1989.dfy(126,2): Error: a postcondition could not be proved on this return path
 git-issue-1989.dfy(122,22): Related location: This is the postcondition that might not hold.
 git-issue-1989.dfy(150,23): Error: assertion might not hold
-git-issue-1989.dfy(156,20): Error: A precondition for this call might not hold.
+git-issue-1989.dfy(156,20): Error: a precondition for this call could not be proved
 git-issue-1989.dfy(130,18): Related location: This is the precondition that might not hold.
 git-issue-1989.dfy(181,24): Error: assertion might not hold
-git-issue-1989.dfy(199,17): Error: A precondition for this call might not hold.
+git-issue-1989.dfy(199,17): Error: a precondition for this call could not be proved
 git-issue-1989.dfy(130,18): Related location: This is the precondition that might not hold.
 git-issue-1989.dfy(221,24): Error: assertion might not hold
-git-issue-1989.dfy(233,17): Error: A precondition for this call might not hold.
+git-issue-1989.dfy(233,17): Error: a precondition for this call could not be proved
 git-issue-1989.dfy(130,18): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 17 verified, 7 errors

--- a/Test/git-issues/git-issue-19b.dfy.expect
+++ b/Test/git-issues/git-issue-19b.dfy.expect
@@ -5,10 +5,10 @@ git-issue-19b.dfy(57,11): Error: assertion might not hold
 git-issue-19b.dfy(64,11): Error: assertion might not hold
 git-issue-19b.dfy(71,11): Error: assertion might not hold
 git-issue-19b.dfy(102,11): Error: assertion might not hold
-git-issue-19b.dfy(115,4): Error: A postcondition might not hold on this return path.
+git-issue-19b.dfy(115,4): Error: a postcondition could not be proved on this return path
 git-issue-19b.dfy(113,14): Related location: This is the postcondition that might not hold.
 git-issue-19b.dfy(113,36): Related location
-git-issue-19b.dfy(131,36): Error: A precondition for this call might not hold.
+git-issue-19b.dfy(131,36): Error: a precondition for this call could not be proved
 git-issue-19b.dfy(124,17): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 19 verified, 9 errors

--- a/Test/git-issues/git-issue-2026.dfy.expect
+++ b/Test/git-issues/git-issue-2026.dfy.expect
@@ -1,6 +1,6 @@
-git-issue-2026.dfy(11,18): Error: This loop invariant might not be maintained by the loop.
+git-issue-2026.dfy(11,18): Error: this invariant could not be proved to be maintained by the loop
 git-issue-2026.dfy(11,18): Related message: loop invariant violation
-git-issue-2026.dfy(12,18): Error: This loop invariant might not be maintained by the loop.
+git-issue-2026.dfy(12,18): Error: this invariant could not be proved to be maintained by the loop
 git-issue-2026.dfy(12,18): Related message: loop invariant violation
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/git-issues/git-issue-2197.dfy.expect
+++ b/Test/git-issues/git-issue-2197.dfy.expect
@@ -1,4 +1,4 @@
-git-issue-2197.dfy(11,0): Error: A postcondition might not hold on this return path.
+git-issue-2197.dfy(11,0): Error: a postcondition could not be proved on this return path
    |
 11 | {
    | ^
@@ -13,7 +13,7 @@ git-issue-2197.dfy(6,2): Related location
 6 |   y >= 1
   |   ^^^^^^
 
-git-issue-2197.dfy(17,0): Error: A postcondition might not hold on this return path.
+git-issue-2197.dfy(17,0): Error: a postcondition could not be proved on this return path
    |
 17 | {
    | ^
@@ -23,7 +23,7 @@ git-issue-2197.dfy(16,30): Related location: This is the postcondition that migh
 16 |   ensures 0 <= y < |test| ==> test[y]
    |                               ^^^^^^^
 
-git-issue-2197.dfy(22,2): Error: A precondition for this call might not hold.
+git-issue-2197.dfy(22,2): Error: a precondition for this call could not be proved
    |
 22 |   Never();
    |   ^^^^^^^^

--- a/Test/git-issues/git-issue-2266.dfy.expect
+++ b/Test/git-issues/git-issue-2266.dfy.expect
@@ -1,2 +1,1 @@
-
-Boogie program verifier finished with 1 verified, 0 errors
+Fatal Error: ProverException: Cannot find specified prover: /Users/aarotomb/Repositories/dafny/../unzippedRelease/dafny/z3/bin/z3-4.8.5

--- a/Test/git-issues/git-issue-2657.dfy.expect
+++ b/Test/git-issues/git-issue-2657.dfy.expect
@@ -1,4 +1,4 @@
-git-issue-2657.dfy(9,7): Error: A precondition for this call might not hold.
+git-issue-2657.dfy(9,7): Error: a precondition for this call could not be proved
 git-issue-2657.dfy(5,13): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/git-issues/git-issue-267.dfy.expect
+++ b/Test/git-issues/git-issue-267.dfy.expect
@@ -2,13 +2,3 @@
 Dafny program verifier finished with 0 verified, 0 errors
 
 Dafny program verifier did not attempt verification
-210
-
-Dafny program verifier did not attempt verification
-210
-
-Dafny program verifier did not attempt verification
-210
-
-Dafny program verifier did not attempt verification
-210

--- a/Test/git-issues/git-issue-2693.dfy.expect
+++ b/Test/git-issues/git-issue-2693.dfy.expect
@@ -1,6 +1,6 @@
 git-issue-2693.dfy(10,10): Warning: Support for member 'PropagateFailure' in type 'EvenGood_OddBad?' (used indirectly via a :- statement) being a method is deprecated; declare it to be a function instead
 git-issue-2693.dfy(10,10): Warning: Support for member 'Extract' in type 'EvenGood_OddBad?' (used indirectly via a :- statement) being a method is deprecated; declare it to be a function instead
-git-issue-2693.dfy(10,10): Error: A postcondition might not hold on this return path.
+git-issue-2693.dfy(10,10): Error: a postcondition could not be proved on this return path
 git-issue-2693.dfy(6,37): Related location: This is the postcondition that might not hold.
 git-issue-2693.dfy(21,12): Related location
 git-issue-2693.dfy(11,11): Error: assertion might not hold

--- a/Test/git-issues/git-issue-2703.dfy.expect
+++ b/Test/git-issues/git-issue-2703.dfy.expect
@@ -1,5 +1,5 @@
 git-issue-2703.dfy(10,14): Error: possible division by zero
-git-issue-2703.dfy(10,23): Error: A postcondition might not hold on this return path.
+git-issue-2703.dfy(10,23): Error: a postcondition could not be proved on this return path
 git-issue-2703.dfy(10,18): Related location: This is the postcondition that might not hold.
 git-issue-2703.dfy(16,24): Error: possible division by zero
 git-issue-2703.dfy(23,24): Error: possible division by zero

--- a/Test/git-issues/git-issue-3243.dfy.expect
+++ b/Test/git-issues/git-issue-3243.dfy.expect
@@ -1,7 +1,7 @@
 git-issue-3243.dfy(19,2): Warning: note, this loop has no body (loop frame: i)
-git-issue-3243.dfy(10,16): Error: This loop invariant might not hold on entry.
+git-issue-3243.dfy(10,16): Error: this loop invariant could not be proved on entry
 git-issue-3243.dfy(10,16): Related message: loop invariant violation
-git-issue-3243.dfy(21,16): Error: This loop invariant might not hold on entry.
+git-issue-3243.dfy(21,16): Error: this loop invariant could not be proved on entry
 git-issue-3243.dfy(21,16): Related message: loop invariant violation
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Test/git-issues/git-issue-3571.dfy
+++ b/Test/git-issues/git-issue-3571.dfy
@@ -8,7 +8,6 @@
 // RUN: %verify --resource-limit 100 --resource-limit 200  "%s" >> "%t"
 // RUN: %verify --solver-path x --solver-path y  "%s" >> "%t"
 // RUN: %verify --verification-time-limit 300 --verification-time-limit 500  "%s" >> "%t"
-// RUN: %resolve --error-limit:10 --error-limit:5  "%s" >> "%t"
 // RUN: %translate cs --output x --output y  "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 // Crashes size x is nothing real

--- a/Test/git-issues/git-issue-3571.dfy.expect
+++ b/Test/git-issues/git-issue-3571.dfy.expect
@@ -19,6 +19,4 @@ Dafny program verifier finished with 0 verified, 0 errors
 
 Dafny program verifier finished with 0 verified, 0 errors
 
-Dafny program verifier did not attempt verification
-
 Dafny program verifier finished with 0 verified, 0 errors

--- a/Test/git-issues/git-issue-370.dfy.expect
+++ b/Test/git-issues/git-issue-370.dfy.expect
@@ -1,16 +1,16 @@
-git-issue-370.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370.dfy(43,7): Related location: This is the postcondition that might not hold.
 git-issue-370.dfy(19,5): Related location
-git-issue-370.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370.dfy(29,9): Related location
-git-issue-370.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370.dfy(30,9): Related location
-git-issue-370.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370.dfy(31,9): Related location
-git-issue-370.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370.dfy(32,9): Related location
 

--- a/Test/git-issues/git-issue-370b.dfy.expect
+++ b/Test/git-issues/git-issue-370b.dfy.expect
@@ -1,16 +1,16 @@
-git-issue-370b.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370b.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370b.dfy(43,7): Related location: This is the postcondition that might not hold.
 git-issue-370b.dfy(19,5): Related location
-git-issue-370b.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370b.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370b.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370b.dfy(29,9): Related location
-git-issue-370b.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370b.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370b.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370b.dfy(30,9): Related location
-git-issue-370b.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370b.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370b.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370b.dfy(31,9): Related location
-git-issue-370b.dfy(45,0): Error: A postcondition might not hold on this return path.
+git-issue-370b.dfy(45,0): Error: a postcondition could not be proved on this return path
 git-issue-370b.dfy(44,7): Related location: This is the postcondition that might not hold.
 git-issue-370b.dfy(32,9): Related location
 

--- a/Test/git-issues/git-issue-384.dfy.expect
+++ b/Test/git-issues/git-issue-384.dfy.expect
@@ -1,4 +1,4 @@
-git-issue-384.dfy(13,2): Error: A postcondition might not hold on this return path.
+git-issue-384.dfy(13,2): Error: a postcondition could not be proved on this return path
 git-issue-384.dfy(12,12): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 2 verified, 1 error

--- a/Test/git-issues/git-issue-600.dfy.expect
+++ b/Test/git-issues/git-issue-600.dfy.expect
@@ -1,4 +1,4 @@
-git-issue-600.dfy(20,0): Error: A postcondition might not hold on this return path.
+git-issue-600.dfy(20,0): Error: a postcondition could not be proved on this return path
 git-issue-600.dfy(19,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 2 verified, 1 error

--- a/Test/irondafny0/inheritreqs0.dfy.expect
+++ b/Test/irondafny0/inheritreqs0.dfy.expect
@@ -1,4 +1,4 @@
-inheritreqs0.dfy(19,13): Error: A precondition for this call might not hold.
+inheritreqs0.dfy(19,13): Error: a precondition for this call could not be proved
 inheritreqs0.dfy[Impl](6,17): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/irondafny0/inheritreqs1.dfy.expect
+++ b/Test/irondafny0/inheritreqs1.dfy.expect
@@ -1,4 +1,4 @@
-inheritreqs1.dfy(20,13): Error: A precondition for this call might not hold.
+inheritreqs1.dfy(20,13): Error: a precondition for this call could not be proved
 inheritreqs1.dfy(15,17): Related location: This is the precondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Test/patterns/PatternMatchingErrors.dfy.expect
+++ b/Test/patterns/PatternMatchingErrors.dfy.expect
@@ -5,9 +5,9 @@ PatternMatchingErrors.dfy(40,2): Error: missing case in match statement: Leaf
 PatternMatchingErrors.dfy(40,2): Error: missing case in match statement: Branch(Branch(_, c: bool, _), _, _) (not all possibilities for constant 'c' have been covered)
 PatternMatchingErrors.dfy(40,2): Error: missing case in match statement: Branch(Leaf, _, Branch(_, _, _))
 PatternMatchingErrors.dfy(53,18): Error: value does not satisfy the subset constraints of 'nat'
-PatternMatchingErrors.dfy(78,2): Error: A postcondition might not hold on this return path.
+PatternMatchingErrors.dfy(78,2): Error: a postcondition could not be proved on this return path
 PatternMatchingErrors.dfy(75,12): Related location: This is the postcondition that might not hold.
-PatternMatchingErrors.dfy(99,33): Error: A postcondition might not hold on this return path.
+PatternMatchingErrors.dfy(99,33): Error: a postcondition could not be proved on this return path
 PatternMatchingErrors.dfy(96,12): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 0 verified, 9 errors

--- a/Test/server/counterexample.transcript.expect
+++ b/Test/server/counterexample.transcript.expect
@@ -2,7 +2,7 @@
 
 Verifying Abs (correctness) ...
   [1 proof obligation]  error
-c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return path.
+c:\DEV\Dafny\abs.dfy(4,4): Error: a postcondition could not be proved on this return path
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"},{"CanonicalName":"-1","Name":"y","RealName":null,"Value":"-1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!

--- a/Test/server/counterexample_commandline.dfy.expect
+++ b/Test/server/counterexample_commandline.dfy.expect
@@ -1,4 +1,4 @@
-counterexample_commandline.dfy(30,20): Error: A postcondition might not hold on this return path.
+counterexample_commandline.dfy(30,20): Error: a postcondition could not be proved on this return path
 counterexample_commandline.dfy(18,22): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 1 error

--- a/Test/server/git-issue223.transcript.expect
+++ b/Test/server/git-issue223.transcript.expect
@@ -2,7 +2,7 @@
 
 Verifying Abs (correctness) ...
   [1 proof obligation]  error
-c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return path.
+c:\DEV\Dafny\abs.dfy(4,4): Error: a postcondition could not be proved on this return path
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"},{"CanonicalName":"-1","Name":"y","RealName":null,"Value":"-1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
@@ -10,7 +10,7 @@ Verification completed successfully!
 
 Verifying Abs (correctness) ...
   [0 proof obligations]  error
-c:\DEV\Dafny\abs.dfy(4,4): Error: A postcondition might not hold on this return path.
+c:\DEV\Dafny\abs.dfy(4,4): Error: a postcondition could not be proved on this return path
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"-1","Name":"x","RealName":null,"Value":"-1"},{"CanonicalName":"-1","Name":"y","RealName":null,"Value":"-1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!

--- a/Test/traits/TraitOverride1.dfy.expect
+++ b/Test/traits/TraitOverride1.dfy.expect
@@ -1,5 +1,5 @@
 TraitOverride1.dfy(200,9): Error: the method must provide an equal or more detailed postcondition than in its parent trait
-TraitOverride1.dfy(205,2): Error: A postcondition might not hold on this return path.
+TraitOverride1.dfy(205,2): Error: a postcondition could not be proved on this return path
 TraitOverride1.dfy(204,40): Related location: This is the postcondition that might not hold.
 TraitOverride1.dfy(188,26): Related location
 

--- a/Test/triggers/splitting-picks-the-right-tokens.dfy.expect
+++ b/Test/triggers/splitting-picks-the-right-tokens.dfy.expect
@@ -1,10 +1,10 @@
 splitting-picks-the-right-tokens.dfy(9,11): Info: Selected triggers: {Id(x)}
 splitting-picks-the-right-tokens.dfy(16,11): Info: Selected triggers: {Id(x)}
-splitting-picks-the-right-tokens.dfy(20,12): Error: A precondition for this call might not hold.
+splitting-picks-the-right-tokens.dfy(20,12): Error: a precondition for this call could not be proved
 splitting-picks-the-right-tokens.dfy(16,11): Related location: This is the precondition that might not hold.
 splitting-picks-the-right-tokens.dfy(16,29): Related location
 splitting-picks-the-right-tokens.dfy(16,39): Related location
-splitting-picks-the-right-tokens.dfy(22,13): Error: A precondition for this call might not hold.
+splitting-picks-the-right-tokens.dfy(22,13): Error: a precondition for this call could not be proved
 splitting-picks-the-right-tokens.dfy(9,11): Related location: This is the precondition that might not hold.
 splitting-picks-the-right-tokens.dfy(9,37): Related location
 

--- a/Test/triggers/splitting-triggers-recovers-expressivity.dfy.expect
+++ b/Test/triggers/splitting-triggers-recovers-expressivity.dfy.expect
@@ -20,9 +20,9 @@ splitting-triggers-recovers-expressivity.dfy(49,11): Info: For expression "j >= 
    Rejected triggers: {P(j)} (may loop with "P(j + 1)") in subexpression at splitting-triggers-recovers-expressivity.dfy(49,59) [Related location] splitting-triggers-recovers-expressivity.dfy(49,78)
 splitting-triggers-recovers-expressivity.dfy(58,11): Info: Selected triggers:
    {P(i)}, {Q(i)}
-splitting-triggers-recovers-expressivity.dfy(12,63): Error: A postcondition might not hold on this return path.
+splitting-triggers-recovers-expressivity.dfy(12,63): Error: a postcondition could not be proved on this return path
 splitting-triggers-recovers-expressivity.dfy(12,10): Related location: This is the postcondition that might not hold.
-splitting-triggers-recovers-expressivity.dfy(19,15): Error: A postcondition might not hold on this return path.
+splitting-triggers-recovers-expressivity.dfy(19,15): Error: a postcondition could not be proved on this return path
 splitting-triggers-recovers-expressivity.dfy(19,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 5 verified, 2 errors

--- a/Test/triggers/splitting-triggers-yields-better-precondition-related-errors.dfy.expect
+++ b/Test/triggers/splitting-triggers-yields-better-precondition-related-errors.dfy.expect
@@ -1,6 +1,6 @@
 splitting-triggers-yields-better-precondition-related-errors.dfy(7,11): Warning: /!\ No terms found to trigger on.
 splitting-triggers-yields-better-precondition-related-errors.dfy(15,11): Warning: /!\ No terms found to trigger on.
-splitting-triggers-yields-better-precondition-related-errors.dfy(11,3): Error: A precondition for this call might not hold.
+splitting-triggers-yields-better-precondition-related-errors.dfy(11,3): Error: a precondition for this call could not be proved
 splitting-triggers-yields-better-precondition-related-errors.dfy(7,11): Related location: This is the precondition that might not hold.
 splitting-triggers-yields-better-precondition-related-errors.dfy(7,25): Related location
 splitting-triggers-yields-better-precondition-related-errors.dfy(20,2): Error: function precondition might not hold

--- a/Test/verification/filter.dfy.expect
+++ b/Test/verification/filter.dfy.expect
@@ -1,6 +1,6 @@
 
 Dafny program verifier finished with 1 verified, 0 errors
-filter.dfy(10,16): Error: A postcondition might not hold on this return path.
+filter.dfy(10,16): Error: a postcondition could not be proved on this return path
 filter.dfy(10,10): Related location: This is the postcondition that might not hold.
 
 Dafny program verifier finished with 1 verified, 1 error

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -61,7 +61,7 @@ index 0f17aa923..6b937ebcb 100644
        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
        <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
--      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.1" />
+-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.2" />
 +      <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
    </ItemGroup>
  

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -61,7 +61,7 @@ index 0f17aa923..6b937ebcb 100644
        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
        <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
--      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.0" />
+-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.1" />
 +      <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
    </ItemGroup>
  

--- a/docs/DafnyRef/Options.txt
+++ b/docs/DafnyRef/Options.txt
@@ -508,7 +508,9 @@ Usage: dafny [ option ... ] [ filename ... ]
   Multiple .bpl files supplied on the command line are concatenated into one
   Boogie program.
 
-  /lib           : Include library definitions
+  /lib:<name>    : Include definitions in library <name>. The file <name>.bpl
+                   must be an included resource in Core.dll. Currently, the
+                   following libraries are supported---base, node.
   /proc:<p>      : Only check procedures matched by pattern <p>. This option
                    may be specified multiple times to match multiple patterns.
                    The pattern <p> matches the whole procedure name and may
@@ -603,6 +605,8 @@ Usage: dafny [ option ... ] [ filename ... ]
 
   ---- Debugging and general tracing options ---------------------------------
 
+  /silent       print nothing at all
+  /quiet        print nothing but warnings and errors
   /trace        blurt out various debug trace information
   /traceTimes   output timing information at certain points in the pipeline
   /tracePOs     output information about the number of proof obligations
@@ -710,25 +714,23 @@ Usage: dafny [ option ... ] [ filename ... ]
                 a linear number of splits. The default way (top-down) is more
                 aggressive and it may create an exponential number of splits.
 
-  /randomSeed:<n>
-                Turn on randomization of the input that Boogie passes to the 
+  /randomSeed:<s>
+                Supply the random seed for /randomizeVcIterations option.
+
+  /randomizeVcIterations:<n>
+                Turn on randomization of the input that Boogie passes to the
                 SMT solver and turn on randomization in the SMT solver itself.
- 
+                Attempt to randomize and prove each VC n times using the random
+                seed s provided by the option /randomSeed:<s>. If /randomSeed option
+                is not provided, s is chosen to be zero.
+
                 Certain Boogie inputs are unstable in the sense that changes to 
                 the input that preserve its meaning may cause the output to change.
-                The /randomSeed option simulates meaning-preserving changes to 
-                the input without requiring the user to actually make those changes.
-
-                The /randomSeed option is implemented by renaming variables and 
-                reordering declarations in the input, and by setting 
-                solver options that have similar effects.
-
-  /randomSeedIterations:<n>
-                Attempt to prove each VC n times with n random seeds. If
-                /randomSeed has been provided, each proof attempt will use
-                a new random seed derived from this original seed. If not,
-                it will implicitly use /randomSeed:0 to ensure a difference
-                between iterations.
+                This option simulates meaning-preserving changes to the input
+                without requiring the user to actually make those changes.
+                This option is implemented by renaming variables and reordering
+                declarations in the input, and by setting solver options that have
+                similar effects.
 
   ---- Verification-condition splitting --------------------------------------
 


### PR DESCRIPTION
Addresses most of #3468. Additional help flags (for solver options, attributes), control of deprecation, extraction of counterexamples, and something like `/noCheating:0` could still potentially be valuable.

Bumps the Boogie dependency along the way.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
