### PR TITLE
chore: Enable all CI for main-* as well, disable push triggers

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -9,8 +9,7 @@ name: Test documentation
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ master ]
-  push:
+    branches: [ master, main-* ]
 
 jobs:
   check-deep-tests:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -3,8 +3,11 @@ name: Build and Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ master ]
-  push:
+    branches: [ master, main-* ]
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   dotnet-version: 6.0.x # SDK Version for building Dafny

--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -2,9 +2,8 @@ name: Build DafnyRef.pdf
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
-    branches: [ master ]
+    branches: [ master, main-* ]
 
 jobs:
   check-deep-tests:

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -3,8 +3,7 @@ name: Build and Test Dafny Runtimes
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ master ]
-  push:
+    branches: [ master, main-* ]
 
 jobs:
   check-deep-tests:

--- a/.github/workflows/xunit-tests.yml
+++ b/.github/workflows/xunit-tests.yml
@@ -3,8 +3,11 @@ name: Run XUnit tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ master ]
-  push:
+    branches: [ master, main-* ]
+
+concurrency:
+  group: unit-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 ## In the matrix:
 ##  os - name of the Github actions runner


### PR DESCRIPTION
Our model is to have branch protection for all important branches, and therefore there isn't any need to run CI on pushes (especially since we have a nightly build to test these branches directly anyway). This should save a fair bit of CI capacity.

Also adds concurrency control for unit tests too (since they are also getting expensive).

This does NOT yet enable the nightly build for `main-*` unfortunately, as scheduled builds only run on the default branch, so that will take some more thinking (plus ensuring that different branches produce distinct prerelease version identifiers).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
