### PR TITLE
Update release process to work on non-master branches

### DIFF
--- a/Scripts/prepare_release.py
+++ b/Scripts/prepare_release.py
@@ -219,8 +219,8 @@ class Release:
         self.version = version
         self.source_branch_name = source_branch
         self.source_branch_path = f"refs/heads/{self.source_branch_name}"
-        self.branch_name = f"release-{version}"
-        self.branch_path = f"refs/heads/{self.branch_name}"
+        self.release_branch_name = f"release-{version}"
+        self.release_branch_path = f"refs/heads/{self.release_branch_name}"
         self.tag = f"v{version}"
         self.build_props_path = Path("Source/Directory.Build.props")
         self.release_notes_md_path = Path("RELEASE_NOTES.md")
@@ -276,7 +276,7 @@ class Release:
         return Version.from_string(self.version)
 
     def _is_release_branch(self) -> bool:
-        return self._get_branch(check=False) in (self.source_branch_path, self.branch_path)
+        return self._get_branch(check=False) in (self.source_branch_path, self.release_branch_path)
 
     @staticmethod
     def _is_repo_clean() -> bool:
@@ -303,7 +303,7 @@ class Release:
         return True
 
     def _no_release_branch(self) -> bool:
-        return git("rev-parse", "--quiet", "--verify", self.branch_path).returncode == 1
+        return git("rev-parse", "--quiet", "--verify", self.release_branch_path).returncode == 1
 
     def _no_release_tag(self) -> bool:
         return git("tag", "--verify", self.tag).returncode == 1
@@ -322,7 +322,7 @@ class Release:
         xml.write(self.build_props_path, encoding="utf-8")
 
     def _create_release_branch(self):
-        git("checkout", "-b", self.branch_name, check=True)
+        git("checkout", "-b", self.release_branch_name, check=True)
 
     def _consolidate_news_fragments(self):
         news = self.newsfragments.render()
@@ -344,7 +344,7 @@ class Release:
 
     def _push_release_branch(self):
         git("push", "--force-with-lease", "--set-upstream",
-            self.REMOTE, f"{self.branch_path}:{self.branch_path}",
+            self.REMOTE, f"{self.release_branch_path}:{self.release_branch_path}",
             check=True)
 
     # Still TODO:
@@ -369,7 +369,7 @@ class Release:
                    self._version_number_is_fresh)
         assert_one(f"Do we have news in {self.NEWSFRAGMENTS_PATH}?",
                    self._has_news)
-        assert_one(f"Is the current branch `{self.source_branch_name}` or `{self.branch_name}`?",
+        assert_one(f"Is the current branch `{self.source_branch_name}` or `{self.release_branch_name}`?",
                    self._is_release_branch)
         assert_one("Is repo clean (all changes committed)?",
                    self._is_repo_clean)
@@ -379,10 +379,10 @@ class Release:
                    self._no_release_blocking_issues)
         assert_one(f"Can we create release tag `{self.tag}`?",
                    self._no_release_tag)
-        if self._get_branch(check=False) != self.branch_path:
-            assert_one(f"Can we create release branch `{self.branch_name}`?",
+        if self._get_branch(check=False) != self.release_branch_path:
+            assert_one(f"Can we create release branch `{self.release_branch_name}`?",
                        self._no_release_branch)
-            run_one(f"Creating release branch {self.branch_path}...",
+            run_one(f"Creating release branch {self.release_branch_path}...",
                     self._create_release_branch)
         else:
             progress("Note: Release branch already checked out, so not creating it.")
@@ -401,14 +401,14 @@ class Release:
         progress()
 
         DEEPTESTS_URL = "https://github.com/dafny-lang/dafny/actions/workflows/deep-tests.yml"
-        progress(f"Now, start a deep-tests workflow manually for branch {self.branch_name} at\n"
+        progress(f"Now, start a deep-tests workflow manually for branch {self.release_branch_name} at\n"
                  f"<{DEEPTESTS_URL}>.\n"
                  "Once it completes, re-run this script with argument `release`.")
         progress()
 
     def _tag_release(self):
         git("tag", "--annotate", f"--message=Dafny {self.tag}",
-            self.tag, self.branch_path, capture_output=False).check_returncode()
+            self.tag, self.release_branch_path, capture_output=False).check_returncode()
 
     def _push_release_tag(self):
         git("push", self.REMOTE, f"{self.tag}",
@@ -423,7 +423,7 @@ class Release:
         progress("Done!")
         progress()
 
-        PR_URL = f"https://github.com/dafny-lang/dafny/pull/new/{self.branch_name}"
+        PR_URL = f"https://github.com/dafny-lang/dafny/pull/new/{self.release_branch_name}"
         progress("You can merge this branch by opening a PR at\n"
                  f"<{PR_URL}>.")
 
@@ -451,7 +451,7 @@ def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Dafny release helper")
     parser.add_argument("--dry-run", help="Do not make any modifications (no file updates, no git commands).",
                         action="store_true")
-    parser.add_argument("--source-branch", help="Which branch to release", default="master")
+    parser.add_argument("--source-branch", help="Which branch to release from (optional, defaults to 'master')", default="master")
     parser.add_argument("version", help="Version number for this release (A.B.C-xyz)")
     parser.add_argument("action", help="Which part of the release process to run",
                         choices=["prepare", "release"])

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -13,8 +13,9 @@
    incremented since the last release, so they do not necessarily need
    to be updated. However, you may want to increment them further
    depending the types of changes that are in the release.
-1. Run `Scripts/prepare_release.py $VER prepare --source-branch <this branch>` from the root of the
-   repository. The script will check that the repository is in a good
+1. Run `Scripts/prepare_release.py $VER prepare --source-branch <this branch>`
+   (`--source-branch` is optional and defaults to 'master')
+   from the root of the repository. The script will check that the repository is in a good
    state, create and check out a new release branch, update
    `Source/Directory.Build.props` and `RELEASE_NOTES.md`, prepare a release commit,
    and push it.

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -5,14 +5,15 @@
 1. Ensure that you are in a repository that:
    * is clean and up-to-date with no uncommitted changes,
    * was cloned with SSH so that you can push to it, and
-   * has the `master` branch checked out.
+   * has the intended branch checked out (usually `master`,
+     but may be another mainline branch such as `main-3.x`).
 
 1. Select a version number `$VER` (e.g., "3.0.0" or "3.0.0-alpha"). 
    The `major`.`minor`.`patch` numbers may already have been
    incremented since the last release, so they do not necessarily need
    to be updated. However, you may want to increment them further
    depending the types of changes that are in the release.
-1. Run `Scripts/prepare_release.py $VER prepare` from the root of the
+1. Run `Scripts/prepare_release.py $VER prepare --source-branch <this branch>` from the root of the
    repository. The script will check that the repository is in a good
    state, create and check out a new release branch, update
    `Source/Directory.Build.props` and `RELEASE_NOTES.md`, prepare a release commit,
@@ -43,7 +44,7 @@
    on multiple platforms. Again you can watch for this workflow at
    <https://github.com/dafny-lang/dafny/actions>.
 
-1. Create a pull request to merge the newly created branch into `master` (the
+1. Create a pull request to merge the newly created branch into the source branch (the
    script will give you a link to do so).  Get it approved and merged.
 
 1. Clone <https://github.com/dafny-lang/ide-vscode> and run `publish_process.js`

--- a/docs/dev/news/3641.feat
+++ b/docs/dev/news/3641.feat
@@ -1,0 +1,1 @@
+Expose non-relaxed definite assignment (`/definiteAssignment:4`) in legacy CLI

--- a/docs/dev/news/3641.fix
+++ b/docs/dev/news/3641.fix
@@ -1,3 +1,3 @@
-fix: --enforce-determinism now forbids constructor-less classes
-fix: With non-relaxed definite assignment, allow auto-init fields to be uninitialized
-feat: Expose non-relaxed definite assignment (/definiteAssignment:4) in legacy CLI
+Fixes to definite assignment and determinism options:
+   - `--enforce-determinism` now forbids constructor-less classes
+   - With non-relaxed definite assignment, allow auto-init fields to be uninitialized


### PR DESCRIPTION
Also split up a compound release note file that the script wouldn’t understand.

Tested with `--dry-run`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
