### PR TITLE
Fix `allow_on_mac.sh` script

### DIFF
--- a/Scripts/allow_on_mac.sh
+++ b/Scripts/allow_on_mac.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-xattr -d com.apple.quarantine ./*.dylib dafny DafnyServer ./*.dll z3/bin/z3
+xattr -d com.apple.quarantine ./*.dylib dafny DafnyServer ./*.dll z3/bin/z3*


### PR DESCRIPTION
Update the `allow_on_mac.sh` script to reflect the new names for the Z3 binaries we distribute.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
