### PR TITLE
chore: Restore publishing language server to nuget, fix allow_on_mac.sh for z3 paths

### DIFF
--- a/Scripts/allow_on_mac.sh
+++ b/Scripts/allow_on_mac.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-xattr -d com.apple.quarantine ./*.dylib dafny DafnyServer ./*.dll z3/bin/z3
+xattr -dr com.apple.quarantine .

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -6,6 +6,8 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Dafny.LanguageServer</RootNamespace>
+    <OutputPath>..\..\Binaries\</OutputPath>
+    <IsPackable>true</IsPackable>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Other nuget packages depend on the language server, so we have to break those dependencies before we can stop publishing it.

Also patched allow_on_mac.sh to account for the change in Z3 packaging (and be more robust/idempotent in general)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
