### PR TITLE
fix: Crash related to the override check for generic functions

### DIFF
--- a/Source/DafnyCore/Verifier/FunctionCallSubstituter.cs
+++ b/Source/DafnyCore/Verifier/FunctionCallSubstituter.cs
@@ -19,17 +19,19 @@ namespace Microsoft.Dafny {
       if (expr is FunctionCallExpr e) {
         var receiver = Substitute(e.Receiver);
         var newArgs = SubstituteExprList(e.Args);
+        var typeApplicationAtEnclosingClass = SubstituteTypeList(e.TypeApplication_AtEnclosingClass);
         Function function;
         if ((e.Function.EnclosingClass == Tr || Tr.InheritedMembers.Contains(e.Function)) && e.Receiver is ThisExpr && receiver is ThisExpr && Cl.Members.Find(m => m.OverriddenMember == e.Function) is { } f) {
           receiver = new ThisExpr((TopLevelDeclWithMembers)f.EnclosingClass);
           function = (Function)f;
+          typeApplicationAtEnclosingClass = SubstituteTypeList(receiver.Type.AsParentType(Cl).TypeArgs.ToList());
         } else {
           function = e.Function;
         }
         return new FunctionCallExpr(e.tok, e.Name, receiver, e.OpenParen, e.CloseParen, newArgs, e.AtLabel) {
           Function = function,
           Type = e.Type, // TODO: this may not work with type parameters.
-          TypeApplication_AtEnclosingClass = SubstituteTypeList(e.TypeApplication_AtEnclosingClass), // resolve here
+          TypeApplication_AtEnclosingClass = typeApplicationAtEnclosingClass, // resolve here
           TypeApplication_JustFunction = SubstituteTypeList(e.TypeApplication_JustFunction), // resolve here
           IsByMethodCall = e.IsByMethodCall
         };

--- a/Source/DafnyCore/Verifier/FunctionCallSubstituter.cs
+++ b/Source/DafnyCore/Verifier/FunctionCallSubstituter.cs
@@ -19,19 +19,19 @@ namespace Microsoft.Dafny {
       if (expr is FunctionCallExpr e) {
         var receiver = Substitute(e.Receiver);
         var newArgs = SubstituteExprList(e.Args);
-        var typeApplicationAtEnclosingClass = SubstituteTypeList(e.TypeApplication_AtEnclosingClass);
+        var typeApplicationAtEnclosingClass = e.TypeApplication_AtEnclosingClass;
         Function function;
         if ((e.Function.EnclosingClass == Tr || Tr.InheritedMembers.Contains(e.Function)) && e.Receiver is ThisExpr && receiver is ThisExpr && Cl.Members.Find(m => m.OverriddenMember == e.Function) is { } f) {
           receiver = new ThisExpr((TopLevelDeclWithMembers)f.EnclosingClass);
           function = (Function)f;
-          typeApplicationAtEnclosingClass = SubstituteTypeList(receiver.Type.AsParentType(Cl).TypeArgs.ToList());
+          typeApplicationAtEnclosingClass = receiver.Type.AsParentType(Cl).TypeArgs.ToList();
         } else {
           function = e.Function;
         }
         return new FunctionCallExpr(e.tok, e.Name, receiver, e.OpenParen, e.CloseParen, newArgs, e.AtLabel) {
           Function = function,
           Type = e.Type, // TODO: this may not work with type parameters.
-          TypeApplication_AtEnclosingClass = typeApplicationAtEnclosingClass, // resolve here
+          TypeApplication_AtEnclosingClass = SubstituteTypeList(typeApplicationAtEnclosingClass), // resolve here
           TypeApplication_JustFunction = SubstituteTypeList(e.TypeApplication_JustFunction), // resolve here
           IsByMethodCall = e.IsByMethodCall
         };

--- a/Test/git-issues/git-issue-3691.dfy
+++ b/Test/git-issues/git-issue-3691.dfy
@@ -3,11 +3,10 @@
 
 trait A {
   predicate f()
-  method g() ensures f()     // Line 3
-}
-
-class B<T> extends A {       // Line 6
-  predicate f() { true }     // Line 7
   method g() ensures f()
 }
 
+class B<T> extends A {
+  predicate f() { true }
+  method g() ensures f()
+}

--- a/Test/git-issues/git-issue-3691.dfy
+++ b/Test/git-issues/git-issue-3691.dfy
@@ -1,0 +1,13 @@
+// RUN: %exits-with 0 %dafny /compile:0 /allocated:4 /functionSyntax:4 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+trait A {
+  predicate f()
+  method g() ensures f()     // Line 3
+}
+
+class B<T> extends A {       // Line 6
+  predicate f() { true }     // Line 7
+  method g() ensures f()
+}
+

--- a/Test/git-issues/git-issue-3691.dfy.expect
+++ b/Test/git-issues/git-issue-3691.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors

--- a/docs/dev/news/3692.fix
+++ b/docs/dev/news/3692.fix
@@ -1,0 +1,1 @@
+Crash related to the override check for generic functions


### PR DESCRIPTION
Fixes #3691.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
