### PR TITLE
Revert "Tested support for paths with spaces (#3684)"

### DIFF
--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Dafny {
       // supported in .Net APIs, because it is very difficult in general
       // So we will just use the absolute path, lowercased for all file systems.
       // cf. IncludeComparer.CompareTo
-      CanonicalPath = !useStdin ? Canonicalize(filePath).LocalPath : "<stdin>";
+      CanonicalPath = !useStdin ? Canonicalize(filePath).AbsolutePath : "<stdin>";
       filePath = CanonicalPath;
 
       if (extension == ".dfy" || extension == ".dfyi") {

--- a/Test/name with space/run.dfy
+++ b/Test/name with space/run.dfy
@@ -1,6 +1,0 @@
-// RUN: %exits-with 0 %dafny /compile:3 "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
-
-method Main() {
-  print "hello";
-}

--- a/Test/name with space/run.dfy.expect
+++ b/Test/name with space/run.dfy.expect
@@ -1,3 +1,0 @@
-
-Dafny program verifier finished with 0 verified, 0 errors
-hello

--- a/docs/dev/news/3683.fix
+++ b/docs/dev/news/3683.fix
@@ -1,1 +1,0 @@
-Tested support for paths with spaces in them


### PR DESCRIPTION
This reverts commit 3c8be1eb797c3969a55c8e3b31fbfddb2892086f.

Nightly fails on Windows with a path related error, so reverting this recent path related PR should fix nightly: https://github.com/dafny-lang/dafny/actions/runs/4340642872/jobs/7579382488

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
