### PR TITLE
Fix LitCommandWithRedirection.ExpandGlob for Windows

### DIFF
--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -91,8 +91,9 @@ namespace XUnitExtensions.Lit {
     protected static IEnumerable<string> ExpandGlobs(string chunk) {
       var matcher = new Matcher();
       matcher.AddInclude(chunk);
-      var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo("/")));
-      return result.Files.Select(f => "/" + f.Path);
+      var root = Directory.GetDirectoryRoot(Directory.GetCurrentDirectory());
+      var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
+      return result.Files.Select(f => root + f.Path);
     }
 
     public override string ToString() {

--- a/Source/XUnitExtensions/Lit/RunCommand.cs
+++ b/Source/XUnitExtensions/Lit/RunCommand.cs
@@ -37,12 +37,5 @@ namespace XUnitExtensions.Lit {
       }
       return LitCommandWithRedirection.Parse(tokens, config);
     }
-
-    protected static IEnumerable<string> ExpandGlobs(string chunk) {
-      var matcher = new Matcher();
-      matcher.AddInclude(chunk);
-      var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo("/")));
-      return result.Files.Select(f => "/" + f.Path);
-    }
   }
 }


### PR DESCRIPTION
Fix LitCommandWithRedirection.ExpandGlob for Windows

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
