### PR TITLE
Include runtime for java - revert of a revert

### DIFF
--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -79,7 +79,11 @@ namespace Microsoft.Dafny.Compilers {
         CsharpSynthesizer.EmitImports(wr);
       }
       EmitDafnySourceAttribute(program, wr);
-      ReadRuntimeSystem(program, "DafnyRuntime.cs", wr);
+
+      if (DafnyOptions.O.IncludeRuntime) {
+        ReadRuntimeSystem(program, "DafnyRuntime.cs", wr);
+      }
+
     }
 
     /// <summary>

--- a/Source/DafnyCore/Compilers/CSharp/CsharpBackend.cs
+++ b/Source/DafnyCore/Compilers/CSharp/CsharpBackend.cs
@@ -48,8 +48,8 @@ public class CsharpBackend : ExecutableBackend {
     compilation = compilation.WithOptions(compilation.Options.WithOutputKind(callToMain != null ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary));
 
     var tempCompilationResult = new CSharpCompilationResult();
-    var libPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-    if (DafnyOptions.O.UseRuntimeLib) {
+    if (!DafnyOptions.O.IncludeRuntime) {
+      var libPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
       compilation = compilation.AddReferences(MetadataReference.CreateFromFile(Path.Join(libPath, "DafnyRuntime.dll")));
       compilation = compilation.AddReferences(MetadataReference.CreateFromFile(Assembly.Load("netstandard").Location));
     }

--- a/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
+++ b/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
@@ -117,7 +117,11 @@ namespace Microsoft.Dafny.Compilers {
       this.hashWr = headerFileWr.Fork();
 
       var rt = wr.NewFile("DafnyRuntime.h");
-      ReadRuntimeSystem(program, "DafnyRuntime.h", rt);
+
+      if (DafnyOptions.O.IncludeRuntime) {
+        ReadRuntimeSystem(program, "DafnyRuntime.h", rt);
+      }
+
     }
     protected override void EmitFooter(Program program, ConcreteSyntaxTree wr) {
       // Define default values for each datatype

--- a/Source/DafnyCore/Compilers/ExecutableBackend.cs
+++ b/Source/DafnyCore/Compilers/ExecutableBackend.cs
@@ -77,7 +77,8 @@ public abstract class ExecutableBackend : Plugins.IExecutableBackend {
     return null;
   }
 
-  public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string/*?*/ callToMain, string/*?*/ targetFilename, ReadOnlyCollection<string> otherFileNames,
+  public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string/*?*/ callToMain, string/*?*/ targetFilename,
+    ReadOnlyCollection<string> otherFileNames,
     bool runAfterCompile, TextWriter outputWriter, out object compilationResult) {
     Contract.Requires(dafnyProgramName != null);
     Contract.Requires(targetProgramText != null);

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -63,13 +63,12 @@ namespace Microsoft.Dafny.Compilers {
       // Keep the import writers so that we can import subsequent modules into the main one
       EmitImports(wr, out RootImportWriter, out RootImportDummyWriter);
 
-      if (DafnyOptions.O.UseRuntimeLib) {
-        return;
+      if (DafnyOptions.O.IncludeRuntime) {
+        var rt = wr.NewFile("dafny/dafny.go");
+        ReadRuntimeSystem(program, "DafnyRuntime.go", rt);
+        rt = wr.NewFile("dafny/dafnyFromDafny.go");
+        ReadRuntimeSystem(program, "DafnyRuntimeFromDafny.go", rt);
       }
-      var rt = wr.NewFile("dafny/dafny.go");
-      ReadRuntimeSystem(program, "DafnyRuntime.go", rt);
-      rt = wr.NewFile("dafny/dafnyFromDafny.go");
-      ReadRuntimeSystem(program, "DafnyRuntimeFromDafny.go", rt);
     }
 
     protected override void EmitBuiltInDecls(BuiltIns builtIns, ConcreteSyntaxTree wr) {

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -298,12 +298,28 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitHeader(Program program, ConcreteSyntaxTree wr) {
+      if (DafnyOptions.O.IncludeRuntime) {
+        EmitRuntimeSource(program, wr);
+      }
       wr.WriteLine($"// Dafny program {program.Name} compiled into Java");
       ModuleName = program.MainMethod != null ? "main" : Path.GetFileNameWithoutExtension(program.Name);
       wr.WriteLine();
       // Keep the import writers so that we can import subsequent modules into the main one
       EmitImports(wr, out RootImportWriter);
       wr.WriteLine();
+    }
+
+    private void EmitRuntimeSource(Program program, ConcreteSyntaxTree wr) {
+      var assembly = System.Reflection.Assembly.Load("DafnyPipeline");
+      var files = assembly.GetManifestResourceNames();
+      const string header = "DafnyPipeline.java";
+      // Files in 'files' have the form 'DafnyPipeline.java.dafny.Array.java'
+      foreach (var file in files.Where(f => f.StartsWith(header))) {
+        var parts = file.Split('.');
+        var realName = string.Join('/', parts.SkipLast(1).Skip(2)) + "." + parts.Last();
+        var fileNode = wr.NewFile(realName);
+        ReadRuntimeSystem(program, file, fileNode);
+      }
     }
 
     // Only exists to make sure method is overriden
@@ -2852,7 +2868,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override void EmitFooter(Program program, ConcreteSyntaxTree wr) {
       // Emit tuples
       foreach (int i in tuples) {
-        if (i == 2 || i == 3) {
+        if (i <= 20) {
           continue; // Tuple2 and Tuple3 already exist in DafnyRuntime.jar, so don't remake these files.
         }
         CreateTuple(i, wr);

--- a/Source/DafnyCore/Compilers/Java/JavaBackend.cs
+++ b/Source/DafnyCore/Compilers/Java/JavaBackend.cs
@@ -64,9 +64,6 @@ public class JavaBackend : ExecutableBackend {
     }
 
     var targetDirectory = Path.GetDirectoryName(targetFilename);
-    if (!DafnyOptions.O.UseRuntimeLib) {
-      EmitRuntimeJar(targetDirectory);
-    }
 
     var files = new List<string>();
     foreach (string file in Directory.EnumerateFiles(targetDirectory, "*.java", SearchOption.AllDirectories)) {
@@ -81,18 +78,8 @@ public class JavaBackend : ExecutableBackend {
       return false;
     }
 
-    if (!DafnyOptions.O.UseRuntimeLib) {
-      // If the built-in runtime library is used, unpack it so it can be repacked into the final jar
-      var libUnpackProcess = PrepareProcessStartInfo("jar", new List<String> { "xf", "DafnyRuntime.jar" });
-      libUnpackProcess.WorkingDirectory = Path.GetFullPath(Path.GetDirectoryName(targetFilename));
-      if (0 != RunProcess(libUnpackProcess, outputWriter, "Error while creating jar file (unzipping runtime library).")) {
-        return false;
-      }
-    }
-
     var classFiles = Directory.EnumerateFiles(targetDirectory, "*.class", SearchOption.AllDirectories)
         .Select(file => Path.GetRelativePath(targetDirectory, file)).ToList();
-
 
     var simpleProgramName = Path.GetFileNameWithoutExtension(targetFilename);
     var jarPath = Path.GetFullPath(Path.ChangeExtension(dafnyProgramName, ".jar"));
@@ -145,15 +132,20 @@ public class JavaBackend : ExecutableBackend {
     return 0 == RunProcess(psi, outputWriter);
   }
 
-  protected string GetClassPath(string targetFilename) {
+  private string GetClassPath(string targetFilename) {
     var classpath = Environment.GetEnvironmentVariable("CLASSPATH"); // String.join converts null to ""
     // Note that the items in the CLASSPATH must have absolute paths because the compilation is performed in a subfolder of where the command-line is executed
     if (targetFilename != null) {
       var targetDirectory = Path.GetFullPath(Path.GetDirectoryName(targetFilename));
-      return string.Join(Path.PathSeparator, ".", targetDirectory, Path.Combine(targetDirectory, "DafnyRuntime.jar"), classpath);
-    } else {
-      return classpath;
+      var parts = new List<string> { ".", targetDirectory, classpath };
+      if (!DafnyOptions.O.IncludeRuntime) {
+        EmitRuntimeJar(targetDirectory);
+        parts.Add(Path.Combine(targetDirectory, "DafnyRuntime.jar"));
+      }
+      return string.Join(Path.PathSeparator, parts);
     }
+
+    return classpath;
   }
 
   static bool CopyExternLibraryIntoPlace(string externFilename, string mainProgram, TextWriter outputWriter) {

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override void EmitHeader(Program program, ConcreteSyntaxTree wr) {
       wr.WriteLine("// Dafny program {0} compiled into JavaScript", program.Name);
-      ReadRuntimeSystem(program, "DafnyRuntime.js", wr);
+      if (DafnyOptions.O.IncludeRuntime) {
+        ReadRuntimeSystem(program, "DafnyRuntime.js", wr);
+      }
     }
 
     public override void EmitCallToMain(Method mainMethod, string baseName, ConcreteSyntaxTree wr) {

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -57,7 +57,10 @@ namespace Microsoft.Dafny.Compilers {
     protected override string Conj { get => "and"; }
     protected override void EmitHeader(Program program, ConcreteSyntaxTree wr) {
       wr.WriteLine($"# Dafny program {program.Name} compiled into Python");
-      ReadRuntimeSystem(program, "DafnyRuntime.py", wr.NewFile($"{DafnyRuntimeModule}.py"));
+      if (DafnyOptions.O.IncludeRuntime) {
+        ReadRuntimeSystem(program, "DafnyRuntime.py", wr.NewFile($"{DafnyRuntimeModule}.py"));
+      }
+
       Imports.Add(DafnyRuntimeModule);
       EmitImports(null, wr);
       wr.WriteLine();

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -1526,11 +1526,6 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Requires(filename != null);
       Contract.Requires(wr != null);
 
-      if (DafnyOptions.O.UseRuntimeLib) {
-        return;
-      }
-
-
       var assembly = System.Reflection.Assembly.Load("DafnyPipeline");
       var stream = assembly.GetManifestResourceStream(filename);
       if (stream is null) {

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -313,7 +313,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
 
     public IncludesModes PrintIncludesMode = IncludesModes.None;
     public int OptimizeResolution = 2;
-    public bool UseRuntimeLib = false;
+    public bool IncludeRuntime = true;
     public bool DisableScopes = false;
     public int Allocated = 3;
     public bool UseStdin = false;
@@ -723,7 +723,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
           }
 
         case "useRuntimeLib": {
-            UseRuntimeLib = true;
+            IncludeRuntime = false;
             return true;
           }
 

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -151,7 +151,7 @@ true - The char type represents any Unicode scalar value.".TrimStart()) {
   public static readonly Option<bool> WarnShadowing = new("--warn-shadowing",
     "Emits a warning if the name of a declared variable caused another variable to be shadowed.");
 
-  public static readonly Option<bool> IncludeRuntime = new("--include-runtime",
+  public static readonly Option<bool> IncludeRuntimeOption = new("--include-runtime",
     "Include the Dafny runtime as source in the target language.");
 
   public enum TestAssumptionsMode {
@@ -180,7 +180,7 @@ Functionality is still being expanded. Currently only checks contracts on every 
         options.Induction = 1;
       }
     });
-    DafnyOptions.RegisterLegacyBinding(IncludeRuntime, (options, value) => { options.UseRuntimeLib = !value; });
+    DafnyOptions.RegisterLegacyBinding(IncludeRuntimeOption, (options, value) => { options.IncludeRuntime = value; });
     DafnyOptions.RegisterLegacyBinding(WarnShadowing, (options, value) => { options.WarnShadowing = value; });
     DafnyOptions.RegisterLegacyBinding(WarnMissingConstructorParenthesis,
       (options, value) => { options.DisallowConstructorCaseWithoutParentheses = value; });

--- a/Source/DafnyDriver/Commands/TranslateCommand.cs
+++ b/Source/DafnyDriver/Commands/TranslateCommand.cs
@@ -10,7 +10,7 @@ class TranslateCommand : ICommandSpec {
     new Option[] {
       CommonOptionBag.Output,
       CommonOptionBag.Verbose,
-      CommonOptionBag.IncludeRuntime,
+      CommonOptionBag.IncludeRuntimeOption,
     }.Concat(ICommandSpec.TranslationOptions).
       Concat(ICommandSpec.ConsoleOutputOptions).
       Concat(ICommandSpec.ResolverOptions);

--- a/Source/DafnyPipeline/DafnyPipeline.csproj
+++ b/Source/DafnyPipeline/DafnyPipeline.csproj
@@ -42,6 +42,9 @@
   we may be able to get away with only embedding these files inside this assembly.
   -->
   <ItemGroup>
+    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimeJava\src\main\**\*.java">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntime.cs">
       <LogicalName>DafnyRuntime.cs</LogicalName>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,52 +11,56 @@ using Xunit.Abstractions;
 namespace XUnitExtensions.Lit {
   public class LitCommandWithRedirection : ILitCommand {
 
-    public static LitCommandWithRedirection Parse(string[] tokens, LitTestConfiguration config) {
-      var commandSymbol = tokens[0];
-      var argumentsList = tokens[1..].ToList();
+    public static LitCommandWithRedirection Parse(Token[] tokens, LitTestConfiguration config) {
+      var commandSymbol = tokens[0].Value;
+      var argumentList = tokens[1..].ToList();
       string? inputFile = null;
       string? outputFile = null;
       var appendOutput = false;
       string? errorFile = null;
-      var redirectInIndex = argumentsList.IndexOf("<");
+      var redirectInIndex = argumentList.FindIndex(t => t.Value == "<");
       if (redirectInIndex >= 0) {
-        inputFile = config.ApplySubstitutions(argumentsList[redirectInIndex + 1]).Single();
-        argumentsList.RemoveRange(redirectInIndex, 2);
+        inputFile = config.ApplySubstitutions(argumentList[redirectInIndex + 1].Value).Single();
+        argumentList.RemoveRange(redirectInIndex, 2);
       }
-      var redirectOutIndex = argumentsList.IndexOf(">");
+      var redirectOutIndex = argumentList.FindIndex(t => t.Value == ">");
       if (redirectOutIndex >= 0) {
-        outputFile = config.ApplySubstitutions(argumentsList[redirectOutIndex + 1]).Single();
-        argumentsList.RemoveRange(redirectOutIndex, 2);
+        outputFile = config.ApplySubstitutions(argumentList[redirectOutIndex + 1].Value).Single();
+        argumentList.RemoveRange(redirectOutIndex, 2);
       }
-      var redirectAppendIndex = argumentsList.IndexOf(">>");
+      var redirectAppendIndex = argumentList.FindIndex(t => t.Value == ">>");
       if (redirectAppendIndex >= 0) {
-        outputFile = config.ApplySubstitutions(argumentsList[redirectAppendIndex + 1]).Single();
+        outputFile = config.ApplySubstitutions(argumentList[redirectAppendIndex + 1].Value).Single();
         appendOutput = true;
-        argumentsList.RemoveRange(redirectAppendIndex, 2);
+        argumentList.RemoveRange(redirectAppendIndex, 2);
       }
-      var redirectErrorIndex = argumentsList.IndexOf("2>");
+      var redirectErrorIndex = argumentList.FindIndex(t => t.Value == "2>");
       if (redirectErrorIndex >= 0) {
-        errorFile = config.ApplySubstitutions(argumentsList[redirectErrorIndex + 1]).Single();
-        argumentsList.RemoveRange(redirectErrorIndex, 2);
+        errorFile = config.ApplySubstitutions(argumentList[redirectErrorIndex + 1].Value).Single();
+        argumentList.RemoveRange(redirectErrorIndex, 2);
       }
-      var redirectErrorAppendIndex = argumentsList.IndexOf("2>>");
+      var redirectErrorAppendIndex = argumentList.FindIndex(t => t.Value == "2>>");
       if (redirectErrorAppendIndex >= 0) {
-        errorFile = config.ApplySubstitutions(argumentsList[redirectErrorAppendIndex + 1]).Single();
+        errorFile = config.ApplySubstitutions(argumentList[redirectErrorAppendIndex + 1].Value).Single();
         appendOutput = true;
-        argumentsList.RemoveRange(redirectErrorAppendIndex, 2);
+        argumentList.RemoveRange(redirectErrorAppendIndex, 2);
       }
 
-      var arguments = argumentsList.SelectMany(config.ApplySubstitutions);
+      ILitCommand CreateCommand() {
+        var arguments = argumentList.SelectMany(a => config.ApplySubstitutions(a.Value).Select(v => a with { Value = v }))
+          .ToList()
+          .SelectMany(a => a.Kind == Kind.MustGlob ? ExpandGlobs(a.Value) : new[] { a.Value })
+          .ToList();
+        if (config.Commands.TryGetValue(commandSymbol, out var command)) {
+          return command(arguments, config);
+        }
 
-      if (config.Commands.TryGetValue(commandSymbol, out var command)) {
-        return new LitCommandWithRedirection(command(arguments, config), inputFile, outputFile, appendOutput, errorFile);
+        commandSymbol = config.ApplySubstitutions(commandSymbol).Single();
+        return new ShellLitCommand(commandSymbol, arguments, config.PassthroughEnvironmentVariables);
       }
 
-      commandSymbol = config.ApplySubstitutions(commandSymbol).Single();
-
-      return new LitCommandWithRedirection(
-        new ShellLitCommand(commandSymbol, arguments, config.PassthroughEnvironmentVariables),
-        inputFile, outputFile, appendOutput, errorFile);
+      // Use a DelayedLitCommand so the glob expansion is done only after previous commands have executed
+      return new LitCommandWithRedirection(new DelayedLitCommand(CreateCommand), inputFile, outputFile, appendOutput, errorFile);
     }
 
     private readonly ILitCommand command;
@@ -81,6 +86,14 @@ namespace XUnitExtensions.Lit {
       outputWriter?.Close();
       errorWriter?.Close();
       return result;
+    }
+
+    protected static IEnumerable<string> ExpandGlobs(string chunk) {
+      var matcher = new Matcher();
+      matcher.AddInclude(chunk);
+      var root = Directory.GetDirectoryRoot(Directory.GetCurrentDirectory());
+      var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
+      return result.Files.Select(f => root + f.Path);
     }
 
     public override string ToString() {

--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -90,7 +90,7 @@ namespace XUnitExtensions.Lit {
 
     protected static IEnumerable<string> ExpandGlobs(string chunk) {
       var matcher = new Matcher();
-      var root = Path.GetPathRoot(chunk);
+      var root = Path.GetPathRoot(chunk)!;
       var rest = Path.GetRelativePath(root, chunk);
       matcher.AddInclude(rest);
       var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));

--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -90,10 +90,11 @@ namespace XUnitExtensions.Lit {
 
     protected static IEnumerable<string> ExpandGlobs(string chunk) {
       var matcher = new Matcher();
-      matcher.AddInclude(chunk);
-      var root = Directory.GetDirectoryRoot(Directory.GetCurrentDirectory());
+      var root = Path.GetPathRoot(chunk);
+      var rest = Path.GetRelativePath(root, chunk);
+      matcher.AddInclude(rest);
       var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
-      return result.Files.Select(f => root + f.Path);
+      return result.Files.Select(f => Path.Combine(root, f.Path));
     }
 
     public override string ToString() {

--- a/Source/XUnitExtensions/Lit/RunCommand.cs
+++ b/Source/XUnitExtensions/Lit/RunCommand.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Xunit.Abstractions;
 
 namespace XUnitExtensions.Lit {
@@ -8,23 +12,24 @@ namespace XUnitExtensions.Lit {
       return ParseArguments(ILitCommand.Tokenize(line), config);
     }
 
-    private static ILitCommand ParseArguments(string[] tokens, LitTestConfiguration config) {
-      if (tokens[0] == "!") {
+    private static ILitCommand ParseArguments(Token[] tokens, LitTestConfiguration config) {
+      if (tokens[0].Value == "!") {
         var operand = ParseArguments(tokens[1..], config);
         return new NotCommand(operand);
       }
-      if (tokens[0] == "%exits-with") {
-        var ec = Int32.Parse(tokens[1]);
+      if (tokens[0].Value == "%exits-with") {
+        var ec = Int32.Parse(tokens[1].Value);
         var operand = ParseArguments(tokens[2..], config);
         return new ExitCommand(ec, operand);
       }
-      if (tokens[0] == "%stdin") {
+      if (tokens[0].Value == "%stdin") {
         var operand = ParseArguments(tokens[2..], config);
-        return new StdInCommand(tokens[1], operand);
+        return new StdInCommand(tokens[1].Value, operand);
       }
 
+
       // Just supporting || for now since it's a precise way to ignore an exit code
-      var seqOperatorIndex = Array.IndexOf(tokens, "||");
+      var seqOperatorIndex = Array.FindIndex(tokens, t => t.Value == "||");
       if (seqOperatorIndex >= 0) {
         var lhs = LitCommandWithRedirection.Parse(tokens[0..seqOperatorIndex], config);
         var rhs = ParseArguments(tokens[(seqOperatorIndex + 1)..], config);

--- a/Test/comp/compile1verbose/CompileAndThenRun.dfy.expect
+++ b/Test/comp/compile1verbose/CompileAndThenRun.dfy.expect
@@ -16,6 +16,39 @@ hello, Dafny
 
 Dafny program verifier finished with 0 verified, 0 errors
 Wrote textual form of target program to CompileAndThenRun-java/CompileAndThenRun.java
+Additional target code written to CompileAndThenRun-java/dafny/Array.java
+Additional target code written to CompileAndThenRun-java/dafny/BigOrdinal.java
+Additional target code written to CompileAndThenRun-java/dafny/BigRational.java
+Additional target code written to CompileAndThenRun-java/dafny/CodePoint.java
+Additional target code written to CompileAndThenRun-java/dafny/DafnyEuclidean.java
+Additional target code written to CompileAndThenRun-java/dafny/DafnyHaltException.java
+Additional target code written to CompileAndThenRun-java/dafny/DafnyMap.java
+Additional target code written to CompileAndThenRun-java/dafny/DafnyMultiset.java
+Additional target code written to CompileAndThenRun-java/dafny/DafnySequence.java
+Additional target code written to CompileAndThenRun-java/dafny/DafnySet.java
+Additional target code written to CompileAndThenRun-java/dafny/Helpers.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple0.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple1.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple10.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple11.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple12.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple13.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple14.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple15.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple16.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple17.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple18.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple19.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple2.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple20.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple3.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple4.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple5.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple6.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple7.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple8.java
+Additional target code written to CompileAndThenRun-java/dafny/Tuple9.java
+Additional target code written to CompileAndThenRun-java/dafny/TypeDescriptor.java
 Additional target code written to CompileAndThenRun-java/_System/nat.java
 Additional target code written to CompileAndThenRun-java/_System/__default.java
 Wrote executable jar CompileAndThenRun.jar

--- a/Test/comp/compile3/JustRun.dfy.expect
+++ b/Test/comp/compile3/JustRun.dfy.expect
@@ -20,6 +20,39 @@ hello, Dafny
 
 Dafny program verifier finished with 0 verified, 0 errors
 Wrote textual form of target program to JustRun-java/JustRun.java
+Additional target code written to JustRun-java/dafny/Array.java
+Additional target code written to JustRun-java/dafny/BigOrdinal.java
+Additional target code written to JustRun-java/dafny/BigRational.java
+Additional target code written to JustRun-java/dafny/CodePoint.java
+Additional target code written to JustRun-java/dafny/DafnyEuclidean.java
+Additional target code written to JustRun-java/dafny/DafnyHaltException.java
+Additional target code written to JustRun-java/dafny/DafnyMap.java
+Additional target code written to JustRun-java/dafny/DafnyMultiset.java
+Additional target code written to JustRun-java/dafny/DafnySequence.java
+Additional target code written to JustRun-java/dafny/DafnySet.java
+Additional target code written to JustRun-java/dafny/Helpers.java
+Additional target code written to JustRun-java/dafny/Tuple0.java
+Additional target code written to JustRun-java/dafny/Tuple1.java
+Additional target code written to JustRun-java/dafny/Tuple10.java
+Additional target code written to JustRun-java/dafny/Tuple11.java
+Additional target code written to JustRun-java/dafny/Tuple12.java
+Additional target code written to JustRun-java/dafny/Tuple13.java
+Additional target code written to JustRun-java/dafny/Tuple14.java
+Additional target code written to JustRun-java/dafny/Tuple15.java
+Additional target code written to JustRun-java/dafny/Tuple16.java
+Additional target code written to JustRun-java/dafny/Tuple17.java
+Additional target code written to JustRun-java/dafny/Tuple18.java
+Additional target code written to JustRun-java/dafny/Tuple19.java
+Additional target code written to JustRun-java/dafny/Tuple2.java
+Additional target code written to JustRun-java/dafny/Tuple20.java
+Additional target code written to JustRun-java/dafny/Tuple3.java
+Additional target code written to JustRun-java/dafny/Tuple4.java
+Additional target code written to JustRun-java/dafny/Tuple5.java
+Additional target code written to JustRun-java/dafny/Tuple6.java
+Additional target code written to JustRun-java/dafny/Tuple7.java
+Additional target code written to JustRun-java/dafny/Tuple8.java
+Additional target code written to JustRun-java/dafny/Tuple9.java
+Additional target code written to JustRun-java/dafny/TypeDescriptor.java
 Additional target code written to JustRun-java/_System/nat.java
 Additional target code written to JustRun-java/_System/__default.java
 Wrote executable jar JustRun.jar

--- a/Test/comp/manualcompile/ManualCompile.dfy
+++ b/Test/comp/manualcompile/ManualCompile.dfy
@@ -1,4 +1,4 @@
-// RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:cs "%s" > "%t"
+// RUN: %baredafny translate cs %args --verbose --include-runtime "%s" > "%t"
 // RUN: dotnet build %S/ManualCompile.csproj
 // RUN: dotnet %S/bin/Debug/net6.0/ManualCompile.dll >> "%t"
 
@@ -8,9 +8,9 @@
 // RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:go "%s" >> "%t"
 // RUN: env GO111MODULE=auto GOPATH=%S/ManualCompile-go go run %S/ManualCompile-go/src/ManualCompile.go >> "%t"
 
-// RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:java "%s" >> "%t"
-// RUN: javac -cp %binaryDir/DafnyRuntime.jar:%S/ManualCompile-java %S/ManualCompile-java/ManualCompile.java %S/ManualCompile-java/*/*.java
-// RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/ManualCompile-java ManualCompile >> "%t"
+// RUN: %baredafny translate java %args --verbose --include-runtime "%s" >> "%t"
+// RUN: javac %S/ManualCompile-java/ManualCompile.java %S/ManualCompile-java/**/*.java
+// RUN: java -cp %S/ManualCompile-java ManualCompile >> "%t"
 
 // RUN: %dafny /compileVerbose:1 /compile:0 /spillTargetCode:2 /compileTarget:cpp "%s" >> "%t"
 // RUN: g++ -g -Wall -Wextra -Wpedantic -Wno-unused-variable -std=c++17 -I %binaryDir -o %S/ManualCompile.exe %S/ManualCompile.cpp

--- a/Test/comp/manualcompile/ManualCompile.dfy.expect
+++ b/Test/comp/manualcompile/ManualCompile.dfy.expect
@@ -16,6 +16,39 @@ hello, Dafny
 
 Dafny program verifier finished with 0 verified, 0 errors
 Wrote textual form of target program to ManualCompile-java/ManualCompile.java
+Additional target code written to ManualCompile-java/dafny/Array.java
+Additional target code written to ManualCompile-java/dafny/BigOrdinal.java
+Additional target code written to ManualCompile-java/dafny/BigRational.java
+Additional target code written to ManualCompile-java/dafny/CodePoint.java
+Additional target code written to ManualCompile-java/dafny/DafnyEuclidean.java
+Additional target code written to ManualCompile-java/dafny/DafnyHaltException.java
+Additional target code written to ManualCompile-java/dafny/DafnyMap.java
+Additional target code written to ManualCompile-java/dafny/DafnyMultiset.java
+Additional target code written to ManualCompile-java/dafny/DafnySequence.java
+Additional target code written to ManualCompile-java/dafny/DafnySet.java
+Additional target code written to ManualCompile-java/dafny/Helpers.java
+Additional target code written to ManualCompile-java/dafny/Tuple0.java
+Additional target code written to ManualCompile-java/dafny/Tuple1.java
+Additional target code written to ManualCompile-java/dafny/Tuple10.java
+Additional target code written to ManualCompile-java/dafny/Tuple11.java
+Additional target code written to ManualCompile-java/dafny/Tuple12.java
+Additional target code written to ManualCompile-java/dafny/Tuple13.java
+Additional target code written to ManualCompile-java/dafny/Tuple14.java
+Additional target code written to ManualCompile-java/dafny/Tuple15.java
+Additional target code written to ManualCompile-java/dafny/Tuple16.java
+Additional target code written to ManualCompile-java/dafny/Tuple17.java
+Additional target code written to ManualCompile-java/dafny/Tuple18.java
+Additional target code written to ManualCompile-java/dafny/Tuple19.java
+Additional target code written to ManualCompile-java/dafny/Tuple2.java
+Additional target code written to ManualCompile-java/dafny/Tuple20.java
+Additional target code written to ManualCompile-java/dafny/Tuple3.java
+Additional target code written to ManualCompile-java/dafny/Tuple4.java
+Additional target code written to ManualCompile-java/dafny/Tuple5.java
+Additional target code written to ManualCompile-java/dafny/Tuple6.java
+Additional target code written to ManualCompile-java/dafny/Tuple7.java
+Additional target code written to ManualCompile-java/dafny/Tuple8.java
+Additional target code written to ManualCompile-java/dafny/Tuple9.java
+Additional target code written to ManualCompile-java/dafny/TypeDescriptor.java
 Additional target code written to ManualCompile-java/_System/nat.java
 Additional target code written to ManualCompile-java/_System/__default.java
 hello, Dafny

--- a/Test/dafny0/JavaUseRuntimeLib.dfy
+++ b/Test/dafny0/JavaUseRuntimeLib.dfy
@@ -1,0 +1,9 @@
+// RUN: %dafny "%s" /useRuntimeLib /out:%S/Output/DafnyConsole.jar /compileTarget:java > "%t"
+// RUN: java -cp %binaryDir/DafnyRuntime.jar:%S/Output/DafnyConsole.jar DafnyConsole >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module DafnyConsole {
+  method Main() {
+    print "bye\n";
+  }
+}

--- a/Test/dafny0/JavaUseRuntimeLib.dfy.expect
+++ b/Test/dafny0/JavaUseRuntimeLib.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+bye

--- a/Test/verification/relaxAssignmentEnforceDeterminism.dfy
+++ b/Test/verification/relaxAssignmentEnforceDeterminism.dfy
@@ -1,4 +1,4 @@
-// RUN: %baredafny build %args --relax-definite-assignment --enforce-determinism "%s" 2> "%t" || true
+// RUN: ! %baredafny build %args --relax-definite-assignment --enforce-determinism "%s" 2> "%t"
 // RUN: %OutputCheck --file-to-check "%t" "%s"
 // CHECK: The option relax-definite-assignment can not be used in conjunction with enforce-determinism.
 

--- a/docs/dev/news/3611.fix
+++ b/docs/dev/news/3611.fix
@@ -1,0 +1,1 @@
+While using `dafny translate --target=java`, the `--include-sources` option works as intended, while before it had no affect.


### PR DESCRIPTION
Revert of a revert of #3619, that includes a fix for Windows in [this commit](https://github.com/dafny-lang/dafny/commit/25959d7b637d68d3d78ab56033dd31cca3998f51)

Added the run-deep-tests and will inspect all Windows runs before merging.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
