### PR TITLE
Add associativity axioms for seq concatentation

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions/Expressions.cs
@@ -196,6 +196,16 @@ public abstract class Expression : TokenNode {
     return s;
   }
 
+  public static Expression CreateConcat(Expression e0, Expression e1) {
+    Contract.Requires(e0 != null);
+    Contract.Requires(e1 != null);
+    Contract.Ensures(Contract.Result<Expression>() != null);
+    var s = new BinaryExpr(e0.tok, BinaryExpr.Opcode.Add, e0, e1);
+    s.ResolvedOp = BinaryExpr.ResolvedOpcode.Concat;  // resolve here
+    s.Type = e0.Type.NormalizeExpand();  // resolve here
+    return s;
+  }
+
   /// <summary>
   /// Create a resolved expression of the form "e0 * e1"
   /// </summary>


### PR DESCRIPTION
Every instance of (a + b) + c or a + (b + c) now gets an additional axiom about its equality with the other form.

Fixes #3394

Still a draft until I do more performance evaluation.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
