### PR TITLE
feat: no-verify for language server

### DIFF
--- a/Source/DafnyLanguageServer/ServerCommand.cs
+++ b/Source/DafnyLanguageServer/ServerCommand.cs
@@ -42,6 +42,7 @@ Send notifications about the verification status of each line in the program.
   };
 
   public IEnumerable<Option> Options => new Option[] {
+    BoogieOptionBag.NoVerify,
     Verification,
     GhostIndicators,
     LineVerificationStatus,

--- a/Source/DafnyLanguageServer/Workspace/Compilation.cs
+++ b/Source/DafnyLanguageServer/Workspace/Compilation.cs
@@ -101,6 +101,9 @@ public class Compilation {
 
   private async Task<DocumentAfterTranslation> TranslateAsync() {
     var parsedCompilation = await ResolvedDocument;
+    if (!options.Verify) {
+      throw new OperationCanceledException();
+    }
     if (parsedCompilation is not DocumentAfterResolution resolvedCompilation) {
       throw new OperationCanceledException();
     }

--- a/docs/dev/news/no-verify-server.feat
+++ b/docs/dev/news/no-verify-server.feat
@@ -1,0 +1,1 @@
+Added option --no-verify for language server


### PR DESCRIPTION

Enable the --no-verify option that is already available for the command line for the language server, for research
and teaching purposes.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
