### PR TITLE
Fix deep tests (Windows)

### DIFF
--- a/.github/workflows/release-brew.yml
+++ b/.github/workflows/release-brew.yml
@@ -21,7 +21,7 @@ jobs:
         brew install dafny
     - name: Make test program
       run: |
-        echo "method Main() { assert true; print 42, '\n'; }" > a.dfy
+        echo "method Main() { assert true; print 42, ['\n']; }" > a.dfy
         echo "method m() { assert false; }" > b.dfy
         echo "42" > expect.txt
     - name: Versions

--- a/Source/DafnyCore/Auditor/Auditor.cs
+++ b/Source/DafnyCore/Auditor/Auditor.cs
@@ -109,7 +109,7 @@ public class Auditor : IRewriter {
       return table;
     }
     var templateText = new StreamReader(templateStream).ReadToEnd();
-    return TableRegex.Replace(templateText, table.ToString());
+    return TableRegex.Replace(templateText, table);
   }
 
   internal override void PostResolve(Program program) {

--- a/Source/DafnyCore/Auditor/Auditor.cs
+++ b/Source/DafnyCore/Auditor/Auditor.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Dafny.Auditor;
 
@@ -97,6 +98,8 @@ public class Auditor : IRewriter {
     }
   }
 
+  private static Regex TableRegex = new Regex(@"\{\{TABLE\}\}\r?\n");
+
   private string GenerateHTMLReport(AuditReport report) {
     var table = report.RenderHTMLTable();
     var assembly = System.Reflection.Assembly.GetCallingAssembly();
@@ -106,7 +109,7 @@ public class Auditor : IRewriter {
       return table;
     }
     var templateText = new StreamReader(templateStream).ReadToEnd();
-    return templateText.Replace("{{TABLE}}\n", table.ToString());
+    return TableRegex.Replace(templateText, table.ToString());
   }
 
   internal override void PostResolve(Program program) {

--- a/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
@@ -161,8 +161,12 @@ public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase, IAsync
   }
 
   protected async Task AssertNoResolutionErrors(TextDocumentItem documentItem) {
-    var resolutionDiagnostics = (await Documents.GetResolvedDocumentAsync(documentItem))!.Diagnostics;
-    Assert.Equal(0, resolutionDiagnostics.Count(d => d.Severity == DiagnosticSeverity.Error));
+    var resolutionDiagnostics = (await Documents.GetResolvedDocumentAsync(documentItem))!.Diagnostics.ToList();
+    var resolutionErrors = resolutionDiagnostics.Count(d => d.Severity == DiagnosticSeverity.Error);
+    if (0 != resolutionErrors) {
+      await Console.Out.WriteAsync(string.Join("\n", resolutionDiagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => d.ToString())));
+      Assert.Equal(0, resolutionErrors);
+    }
   }
 
   public async Task<PublishedVerificationStatus> PopNextStatus() {


### PR DESCRIPTION
The auditor was using code that replaced Unix newlines to create tests, so it did not work on Windows.
This PR fixes that.

Moreover, the release brew seemed to be broken for quite some time (tested 10 commits behind master, still the same issue) The smoke script, in go, prints '\n' literally instead of a newline. I wrapped it to make it a string so that it's printed normally.
I'll file this issue later.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
