### PR TITLE
Chore: Remove static from static methods in generation tests

### DIFF
--- a/Source/DafnyTestGeneration.Test/BasicTypes.cs
+++ b/Source/DafnyTestGeneration.Test/BasicTypes.cs
@@ -12,7 +12,7 @@ namespace DafnyTestGeneration.Test {
     public async Task Ints() {
       var source = @"
 module SimpleTest {
-  static method compareToZero(i: int) returns (ret: int) {
+  method compareToZero(i: int) returns (ret: int) {
     if (i == 0) {
         return 0;
     } else if (i > 0) {
@@ -43,7 +43,7 @@ module SimpleTest {
     public async Task Bools() {
       var source = @"
 module SimpleTest {
-  static method checkIfTrue(b: bool) returns (ret: bool) {
+  method checkIfTrue(b: bool) returns (ret: bool) {
     if (b) {
         return true;
     }
@@ -67,7 +67,7 @@ module SimpleTest {
     public async Task Reals() {
       var source = @"
 module SimpleTest {
-  static method compareToZero(r: real) returns (ret: int) {
+  method compareToZero(r: real) returns (ret: int) {
     if (r == 0.0) {
         return 0;
     } else if ((r > 0.0) && (r < 1.0)) {
@@ -107,7 +107,7 @@ module SimpleTest {
     public async Task BitVectors() {
       var source = @"
 module SimpleTest {
-  static method compareToBase(r: bv10) returns (ret: int) {
+  method compareToBase(r: bv10) returns (ret: int) {
     if (r == (10 as bv10)) {
         return 0;
     } else if (r > (10 as bv10)) {
@@ -138,7 +138,7 @@ module SimpleTest {
     public async Task Chars() {
       var source = @"
 module SimpleTest {
-  static method compareToB(c: char) returns (ret: int) {
+  method compareToB(c: char) returns (ret: int) {
     if (c == 'B') {
         return 0;
     } else if (c > 'B') {
@@ -171,7 +171,7 @@ module SimpleTest {
       // c != 'B"
       var source = @"
 module SimpleTest {
-  static method compareToB(c: char) returns (b:bool) {
+  method compareToB(c: char) returns (b:bool) {
     if (c == 'B') {
       return false;
     } else {

--- a/Source/DafnyTestGeneration.Test/Collections.cs
+++ b/Source/DafnyTestGeneration.Test/Collections.cs
@@ -11,7 +11,7 @@ namespace DafnyTestGeneration.Test {
     public async Task StringLength() {
       var source = @"
 module C {
-  static method compareStringLengthToOne(s: string) returns (ret: int) {
+  method compareStringLengthToOne(s: string) returns (ret: int) {
       if (|s| == 1) {
           return 0;
       } else if (|s| > 1) {
@@ -48,7 +48,7 @@ module SimpleTest {
      var value:char;
   }
 
-  static method compareStringToSeqOfChars(s: string, c:seq<CharObject>)
+  method compareStringToSeqOfChars(s: string, c:seq<CharObject>)
       returns (ret: bool)
   {
       if ((|s| != |c|) || (|s| < 2)) {

--- a/Source/DafnyTestGeneration.Test/Various.cs
+++ b/Source/DafnyTestGeneration.Test/Various.cs
@@ -79,7 +79,7 @@ module M {
     public async Task PathBasedTests() {
       var source = @"
 module Paths {
-  static method eightPaths (i:int)
+  method eightPaths (i:int)
     returns (divBy2:bool, divBy3:bool, divBy5:bool)
   {
     if (i % 2 == 0) {
@@ -128,7 +128,7 @@ module Paths {
     public async Task BlockBasedTests() {
       var source = @"
 module Paths {
-  static method eightPaths (i:int) returns (divBy2:bool, divBy3:bool, divBy5:bool) {
+  method eightPaths (i:int) returns (divBy2:bool, divBy3:bool, divBy5:bool) {
     if (i % 2 == 0) {
       divBy2 := true;
     } else {


### PR DESCRIPTION
I just saw some warnings in the CI and fixed them while I was fixing the deep tests. I'm pushing this warning fix.
Basically, methods don't need to be declared static if they are outside of a class.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
