### PR TITLE
Feat: Documenting Dafny Entities (Adding Docstring)

### DIFF
--- a/Source/DafnyCore/AST/Function.cs
+++ b/Source/DafnyCore/AST/Function.cs
@@ -437,4 +437,23 @@ experimentalPredicateAlwaysGhost - Compiled functions are written `function`. Gh
 
     resolver.Options.WarnShadowing = warnShadowingOption; // restore the original warnShadowing value
   }
+
+  protected override (IToken token, bool leadingTrivia) GetDocStringToken(DafnyOptions options) {
+    if (Body == null) {
+      if (EndToken.TrailingTrivia.Trim() != "") {
+        return (EndToken, false);
+      }
+
+      if (StartToken.LeadingTrivia.Trim() != "") {
+        return (StartToken, true);
+      }
+    } else if (Body.StartToken.Prev.Prev is var tokenWhereTrailingIsDocstring &&
+              tokenWhereTrailingIsDocstring.TrailingTrivia.Trim() != "") {
+      return (tokenWhereTrailingIsDocstring, false);
+    } else if (StartToken is var tokenWhereLeadingIsDocstring &&
+        tokenWhereLeadingIsDocstring.LeadingTrivia.Trim() != "") {
+      return (tokenWhereLeadingIsDocstring, true);
+    }
+    return (Token.NoToken, false);
+  }
 }

--- a/Source/DafnyCore/AST/Function.cs
+++ b/Source/DafnyCore/AST/Function.cs
@@ -438,7 +438,7 @@ experimentalPredicateAlwaysGhost - Compiled functions are written `function`. Gh
     resolver.Options.WarnShadowing = warnShadowingOption; // restore the original warnShadowing value
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     if (Body == null) {
       if (EndToken.TrailingTrivia.Trim() != "") {
         return EndToken.TrailingTrivia;

--- a/Source/DafnyCore/AST/Function.cs
+++ b/Source/DafnyCore/AST/Function.cs
@@ -438,7 +438,7 @@ experimentalPredicateAlwaysGhost - Compiled functions are written `function`. Gh
     resolver.Options.WarnShadowing = warnShadowingOption; // restore the original warnShadowing value
   }
 
-  protected override (IToken token, bool leadingTrivia) GetDocStringToken(DafnyOptions options) {
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
     if (Body == null) {
       if (EndToken.TrailingTrivia.Trim() != "") {
         return (EndToken, false);

--- a/Source/DafnyCore/AST/Function.cs
+++ b/Source/DafnyCore/AST/Function.cs
@@ -438,7 +438,7 @@ experimentalPredicateAlwaysGhost - Compiled functions are written `function`. Gh
     resolver.Options.WarnShadowing = warnShadowingOption; // restore the original warnShadowing value
   }
 
-  protected override string GetDocstringToken() {
+  protected override string GetDocstringFromTokens() {
     if (Body == null) {
       if (EndToken.TrailingTrivia.Trim() != "") {
         return EndToken.TrailingTrivia;

--- a/Source/DafnyCore/AST/Function.cs
+++ b/Source/DafnyCore/AST/Function.cs
@@ -7,7 +7,7 @@ using Microsoft.Dafny.Auditor;
 
 namespace Microsoft.Dafny;
 
-public class Function : MemberDecl, TypeParameter.ParentType, ICallable, ICanFormat {
+public class Function : MemberDecl, TypeParameter.ParentType, ICallable, ICanFormat, IHasDocstring {
   public override string WhatKind => "function";
 
   public string GetFunctionDeclarationKeywords(DafnyOptions options) {
@@ -438,22 +438,22 @@ experimentalPredicateAlwaysGhost - Compiled functions are written `function`. Gh
     resolver.Options.WarnShadowing = warnShadowingOption; // restore the original warnShadowing value
   }
 
-  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+  protected override string GetDocstringToken() {
     if (Body == null) {
       if (EndToken.TrailingTrivia.Trim() != "") {
-        return (EndToken, false);
+        return EndToken.TrailingTrivia;
       }
 
       if (StartToken.LeadingTrivia.Trim() != "") {
-        return (StartToken, true);
+        return StartToken.LeadingTrivia;
       }
     } else if (Body.StartToken.Prev.Prev is var tokenWhereTrailingIsDocstring &&
               tokenWhereTrailingIsDocstring.TrailingTrivia.Trim() != "") {
-      return (tokenWhereTrailingIsDocstring, false);
+      return tokenWhereTrailingIsDocstring.TrailingTrivia;
     } else if (StartToken is var tokenWhereLeadingIsDocstring &&
         tokenWhereLeadingIsDocstring.LeadingTrivia.Trim() != "") {
-      return (tokenWhereLeadingIsDocstring, true);
+      return tokenWhereLeadingIsDocstring.LeadingTrivia;
     }
-    return (Token.NoToken, false);
+    return null;
   }
 }

--- a/Source/DafnyCore/AST/Grammar/TriviaFormatterHelper.cs
+++ b/Source/DafnyCore/AST/Grammar/TriviaFormatterHelper.cs
@@ -12,11 +12,11 @@ public static class TriviaFormatterHelper {
     return EndsWithNewlineRegex.IsMatch(s);
   }
 
-  private static readonly string AnyNewline = @"\r?\n|\r(?!\n)";
+  public static readonly string AnyNewline = @"\r?\n|\r(?!\n)";
 
   private static readonly string NoCommentDelimiter = @"(?:(?!/\*|\*/)[\s\S])*";
 
-  private static readonly string MultilineCommentContent =
+  public static readonly string MultilineCommentContent =
     $@"(?:{NoCommentDelimiter}(?:(?'Open'/\*)|(?'-Open'\*/)))*{NoCommentDelimiter}";
 
   public static readonly Regex NewlineRegex =

--- a/Source/DafnyCore/AST/IteratorDecl.cs
+++ b/Source/DafnyCore/AST/IteratorDecl.cs
@@ -482,7 +482,7 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext, IHasDocstring {
   }
 
 
-  protected override string GetDocstringToken() {
+  protected override string GetDocstringFromTokens() {
     IToken lastClosingParenthesis = null;
     foreach (var token in OwnedTokens) {
       if (token.val == ")") {

--- a/Source/DafnyCore/AST/IteratorDecl.cs
+++ b/Source/DafnyCore/AST/IteratorDecl.cs
@@ -480,4 +480,24 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext {
       Members.Add(moveNext);
     }
   }
+
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    IToken lastClosingParenthesis = null;
+    foreach (var token in OwnedTokens) {
+      if (token.val == ")") {
+        lastClosingParenthesis = token;
+      }
+    }
+
+    if (lastClosingParenthesis != null && lastClosingParenthesis.TrailingTrivia.Trim() != "") {
+      return (lastClosingParenthesis, false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, true);
+    }
+
+    return (Token.NoToken, false);
+  }
 }

--- a/Source/DafnyCore/AST/IteratorDecl.cs
+++ b/Source/DafnyCore/AST/IteratorDecl.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Dafny;
 
-public class IteratorDecl : ClassDecl, IMethodCodeContext {
+public class IteratorDecl : ClassDecl, IMethodCodeContext, IHasDocstring {
   public override string WhatKind { get { return "iterator"; } }
   public readonly List<Formal> Ins;
   public readonly List<Formal> Outs;
@@ -482,7 +482,7 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext {
   }
 
 
-  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+  protected override string GetDocstringToken() {
     IToken lastClosingParenthesis = null;
     foreach (var token in OwnedTokens) {
       if (token.val == ")") {
@@ -491,13 +491,9 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext {
     }
 
     if (lastClosingParenthesis != null && lastClosingParenthesis.TrailingTrivia.Trim() != "") {
-      return (lastClosingParenthesis, false);
+      return lastClosingParenthesis.TrailingTrivia;
     }
 
-    if (StartToken.LeadingTrivia.Trim() != "") {
-      return (StartToken, true);
-    }
-
-    return (Token.NoToken, false);
+    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
   }
 }

--- a/Source/DafnyCore/AST/IteratorDecl.cs
+++ b/Source/DafnyCore/AST/IteratorDecl.cs
@@ -482,7 +482,7 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext, IHasDocstring {
   }
 
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken lastClosingParenthesis = null;
     foreach (var token in OwnedTokens) {
       if (token.val == ")") {
@@ -494,6 +494,6 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext, IHasDocstring {
       return lastClosingParenthesis.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }

--- a/Source/DafnyCore/AST/MemberDecls.cs
+++ b/Source/DafnyCore/AST/MemberDecls.cs
@@ -173,6 +173,18 @@ public class Field : MemberDecl, ICanFormat {
 
     return true;
   }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    if (EndToken.TrailingTrivia.Trim() != "") {
+      return (EndToken, leadingTrivia: false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, leadingTrivia: true);
+    }
+
+    return (Token.NoToken, leadingTrivia: false);
+  }
 }
 
 public class SpecialFunction : Function, ICallable {

--- a/Source/DafnyCore/AST/MemberDecls.cs
+++ b/Source/DafnyCore/AST/MemberDecls.cs
@@ -174,12 +174,12 @@ public class Field : MemberDecl, ICanFormat, IHasDocstring {
     return true;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     if (EndToken.TrailingTrivia.Trim() != "") {
       return EndToken.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 

--- a/Source/DafnyCore/AST/MemberDecls.cs
+++ b/Source/DafnyCore/AST/MemberDecls.cs
@@ -93,7 +93,7 @@ public abstract class MemberDecl : Declaration {
   public virtual IEnumerable<Expression> SubExpressions => Enumerable.Empty<Expression>();
 }
 
-public class Field : MemberDecl, ICanFormat {
+public class Field : MemberDecl, ICanFormat, IHasDocstring {
   public override string WhatKind => "field";
   public readonly bool IsMutable;  // says whether or not the field can ever change values
   public readonly bool IsUserMutable;  // says whether or not code is allowed to assign to the field (IsUserMutable implies IsMutable)
@@ -174,16 +174,12 @@ public class Field : MemberDecl, ICanFormat {
     return true;
   }
 
-  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+  protected override string GetDocstringToken() {
     if (EndToken.TrailingTrivia.Trim() != "") {
-      return (EndToken, leadingTrivia: false);
+      return EndToken.TrailingTrivia;
     }
 
-    if (StartToken.LeadingTrivia.Trim() != "") {
-      return (StartToken, leadingTrivia: true);
-    }
-
-    return (Token.NoToken, leadingTrivia: false);
+    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
   }
 }
 

--- a/Source/DafnyCore/AST/MemberDecls.cs
+++ b/Source/DafnyCore/AST/MemberDecls.cs
@@ -174,7 +174,7 @@ public class Field : MemberDecl, ICanFormat, IHasDocstring {
     return true;
   }
 
-  protected override string GetDocstringToken() {
+  protected override string GetDocstringFromTokens() {
     if (EndToken.TrailingTrivia.Trim() != "") {
       return EndToken.TrailingTrivia;
     }

--- a/Source/DafnyCore/AST/Method.cs
+++ b/Source/DafnyCore/AST/Method.cs
@@ -337,7 +337,7 @@ public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, 
     }
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken lastClosingParenthesis = null;
     foreach (var token in OwnedTokens) {
       if (token.val == ")") {
@@ -349,6 +349,6 @@ public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, 
       return lastClosingParenthesis.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }

--- a/Source/DafnyCore/AST/Method.cs
+++ b/Source/DafnyCore/AST/Method.cs
@@ -5,7 +5,7 @@ using Microsoft.Dafny.Auditor;
 
 namespace Microsoft.Dafny;
 
-public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, ICanFormat {
+public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, ICanFormat, IHasDocstring {
   public override IEnumerable<Node> Children => new Node[] { Body, Decreases }.
     Where(x => x != null).Concat(Ins).Concat(Outs).Concat<Node>(TypeArgs).
     Concat(Req).Concat(Ens).Concat(Mod.Expressions);
@@ -337,7 +337,7 @@ public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, 
     }
   }
 
-  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+  protected override string GetDocstringToken() {
     IToken lastClosingParenthesis = null;
     foreach (var token in OwnedTokens) {
       if (token.val == ")") {
@@ -346,13 +346,9 @@ public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, 
     }
 
     if (lastClosingParenthesis != null && lastClosingParenthesis.TrailingTrivia.Trim() != "") {
-      return (lastClosingParenthesis, false);
+      return lastClosingParenthesis.TrailingTrivia;
     }
 
-    if (StartToken.LeadingTrivia.Trim() != "") {
-      return (StartToken, true);
-    }
-
-    return (Token.NoToken, false);
+    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
   }
 }

--- a/Source/DafnyCore/AST/Method.cs
+++ b/Source/DafnyCore/AST/Method.cs
@@ -336,4 +336,23 @@ public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, 
       resolver.currentMethod = null;
     }
   }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    IToken lastClosingParenthesis = null;
+    foreach (var token in OwnedTokens) {
+      if (token.val == ")") {
+        lastClosingParenthesis = token;
+      }
+    }
+
+    if (lastClosingParenthesis != null && lastClosingParenthesis.TrailingTrivia.Trim() != "") {
+      return (lastClosingParenthesis, false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, true);
+    }
+
+    return (Token.NoToken, false);
+  }
 }

--- a/Source/DafnyCore/AST/Method.cs
+++ b/Source/DafnyCore/AST/Method.cs
@@ -337,7 +337,7 @@ public class Method : MemberDecl, TypeParameter.ParentType, IMethodCodeContext, 
     }
   }
 
-  protected override string GetDocstringToken() {
+  protected override string GetDocstringFromTokens() {
     IToken lastClosingParenthesis = null;
     foreach (var token in OwnedTokens) {
       if (token.val == ")") {

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1729,6 +1729,20 @@ public abstract class DatatypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl
 
     return true;
   }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    foreach (var token in OwnedTokens) {
+      if (token.val == "=" && token.TrailingTrivia.Trim() != "") {
+        return (token, leadingTrivia: false);
+      }
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, leadingTrivia: true);
+    }
+
+    return (Token.NoToken, false);
+  }
 }
 
 public class IndDatatypeDecl : DatatypeDecl {
@@ -1854,6 +1868,22 @@ public class DatatypeCtor : Declaration, TypeParameter.ParentType {
 
       return "#" + EnclosingDatatype.FullName + "." + Name;
     }
+  }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    if (EndToken.TrailingTrivia.Trim() != "") {
+      return (EndToken, leadingTrivia: false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, leadingTrivia: true);
+    }
+
+    if (StartToken.Prev.val == "|" && StartToken.Prev.TrailingTrivia.Trim() != "") {
+      return (StartToken.Prev, leadingTrivia: false);
+    }
+
+    return (Token.NoToken, leadingTrivia: false);
   }
 }
 
@@ -2074,6 +2104,29 @@ public class OpaqueTypeDecl : TopLevelDeclWithMembers, TypeParameter.ParentType,
     }
 
     return true;
+  }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    IToken openingBlock = null;
+    foreach (var token in OwnedTokens) {
+      if (token.val == "{") {
+        openingBlock = token;
+      }
+    }
+
+    if (openingBlock != null && openingBlock.Prev.TrailingTrivia.Trim() != "") {
+      return (openingBlock.Prev, false);
+    }
+
+    if (openingBlock == null && EndToken.TrailingTrivia.Trim() != "") {
+      return (EndToken, false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, true);
+    }
+
+    return (Token.NoToken, false);
   }
 }
 
@@ -2327,6 +2380,31 @@ public abstract class TypeSynonymDeclBase : TopLevelDecl, RedirectingTypeDecl {
   public override bool IsEssentiallyEmpty() {
     // A synonym/subset type is not considered "essentially empty", because it always has a parent type to be resolved.
     return false;
+  }
+
+
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    IToken openingBlock = null;
+    foreach (var token in OwnedTokens) {
+      if (token.val == "{") {
+        openingBlock = token;
+      }
+    }
+
+    if (openingBlock != null && openingBlock.Prev.TrailingTrivia.Trim() != "") {
+      return (openingBlock.Prev, false);
+    }
+
+    if (openingBlock == null && EndToken.TrailingTrivia.Trim() != "") {
+      return (EndToken, false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, true);
+    }
+
+    return (Token.NoToken, false);
   }
 }
 

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -375,6 +375,31 @@ public abstract class ModuleDecl : TopLevelDecl {
     // A module or import is considered "essentially empty" to its parents, but the module is going to be resolved by itself.
     return true;
   }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    IToken candidate = null;
+    var tokens = OwnedTokens.Any() ?
+      OwnedTokens :
+      PreResolveChildren.Any() ? PreResolveChildren.First().OwnedTokens : Enumerable.Empty<IToken>();
+    foreach (var token in tokens) {
+      if (token.val == "{") {
+        candidate = token.Prev;
+        if (candidate.TrailingTrivia.Trim() != "") {
+          return (candidate, leadingTrivia: false);
+        }
+      }
+    }
+
+    if (candidate == null && EndToken.TrailingTrivia.Trim() != "") {
+      return (EndToken, leadingTrivia: false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, leadingTrivia: true);
+    }
+
+    return (Token.NoToken, leadingTrivia: false);
+  }
 }
 // Represents module X { ... }
 public class LiteralModuleDecl : ModuleDecl, ICanFormat {

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -376,7 +376,7 @@ public abstract class ModuleDecl : TopLevelDecl, IHasDocstring {
     return true;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken candidate = null;
     var tokens = OwnedTokens.Any() ?
       OwnedTokens :
@@ -394,7 +394,7 @@ public abstract class ModuleDecl : TopLevelDecl, IHasDocstring {
       return EndToken.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 // Represents module X { ... }
@@ -609,12 +609,12 @@ public class ModuleExportDecl : ModuleDecl, ICanFormat {
     return true;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     if (Tok.TrailingTrivia.Trim() != "") {
       return Tok.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 
@@ -1502,7 +1502,7 @@ public class ClassDecl : TopLevelDeclWithMembers, RevealableTypeDecl, ICanFormat
     return true;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken candidate = null;
     foreach (var token in OwnedTokens) {
       if (token.val == "{") {
@@ -1517,7 +1517,7 @@ public class ClassDecl : TopLevelDeclWithMembers, RevealableTypeDecl, ICanFormat
       return EndToken.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 
@@ -1730,14 +1730,14 @@ public abstract class DatatypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl
     return true;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     foreach (var token in OwnedTokens) {
       if (token.val == "=" && token.TrailingTrivia.Trim() != "") {
         return token.TrailingTrivia;
       }
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 
@@ -1866,20 +1866,12 @@ public class DatatypeCtor : Declaration, TypeParameter.ParentType, IHasDocstring
     }
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     if (EndToken.TrailingTrivia.Trim() != "") {
       return EndToken.TrailingTrivia;
     }
 
-    if (StartToken.LeadingTrivia.Trim() != "") {
-      return StartToken.LeadingTrivia;
-    }
-
-    if (StartToken.Prev.val == "|" && StartToken.Prev.TrailingTrivia.Trim() != "") {
-      return StartToken.Prev.TrailingTrivia;
-    }
-
-    return null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 
@@ -2099,7 +2091,7 @@ public class OpaqueTypeDecl : TopLevelDeclWithMembers, TypeParameter.ParentType,
     return true;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken openingBlock = null;
     foreach (var token in OwnedTokens) {
       if (token.val == "{") {
@@ -2115,7 +2107,7 @@ public class OpaqueTypeDecl : TopLevelDeclWithMembers, TypeParameter.ParentType,
       return EndToken.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 
@@ -2275,7 +2267,7 @@ public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, Redirect
     return false;
   }
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken candidate = null;
     foreach (var token in OwnedTokens) {
       if (token.val == "{") {
@@ -2290,7 +2282,7 @@ public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, Redirect
       return EndToken.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 
@@ -2391,7 +2383,7 @@ public abstract class TypeSynonymDeclBase : TopLevelDecl, RedirectingTypeDecl, I
 
 
 
-  protected override string GetDocstringFromTokens() {
+  protected override string GetTriviaContainingDocstring() {
     IToken openingBlock = null;
     foreach (var token in OwnedTokens) {
       if (token.val == "{") {
@@ -2407,7 +2399,7 @@ public abstract class TypeSynonymDeclBase : TopLevelDecl, RedirectingTypeDecl, I
       return EndToken.TrailingTrivia;
     }
 
-    return StartToken.LeadingTrivia.Trim() != "" ? StartToken.LeadingTrivia : null;
+    return GetTriviaContainingDocstringFromStartTokeOrNull();
   }
 }
 

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1880,6 +1880,10 @@ public class CallableWrapper : CodeContextWrapper, ICallable {
 
   protected ICallable cwInner => (ICallable)inner;
   public IToken Tok => cwInner.Tok;
+  public string GetDocString(DafnyOptions options) {
+    return ((ICallable)inner).GetDocString(options);
+  }
+
   public string WhatKind => cwInner.WhatKind;
   public string NameRelativeToModule => cwInner.NameRelativeToModule;
   public Specification<Expression> Decreases => cwInner.Decreases;
@@ -1903,6 +1907,10 @@ public class DontUseICallable : ICallable {
   public string FullSanitizedName { get { throw new cce.UnreachableException(); } }
   public bool AllowsNontermination { get { throw new cce.UnreachableException(); } }
   public IToken Tok { get { throw new cce.UnreachableException(); } }
+  public string GetDocString(DafnyOptions options) {
+    throw new cce.UnreachableException();
+  }
+
   public string NameRelativeToModule { get { throw new cce.UnreachableException(); } }
   public Specification<Expression> Decreases { get { throw new cce.UnreachableException(); } }
   public bool InferredDecreases {

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1497,6 +1497,28 @@ public class ClassDecl : TopLevelDeclWithMembers, RevealableTypeDecl, ICanFormat
 
     return true;
   }
+
+  protected override (IToken token, bool leadingTrivia) GetDocstringToken() {
+    IToken candidate = null;
+    foreach (var token in OwnedTokens) {
+      if (token.val == "{") {
+        candidate = token.Prev;
+        if (candidate.TrailingTrivia.Trim() != "") {
+          return (candidate, leadingTrivia: false);
+        }
+      }
+    }
+
+    if (candidate == null && EndToken.TrailingTrivia.Trim() != "") {
+      return (EndToken, leadingTrivia: false);
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return (StartToken, leadingTrivia: true);
+    }
+
+    return (Token.NoToken, leadingTrivia: false);
+  }
 }
 
 public class DefaultClassDecl : ClassDecl {

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -314,6 +314,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
     public IncludesModes PrintIncludesMode = IncludesModes.None;
     public int OptimizeResolution = 2;
     public bool IncludeRuntime = true;
+    public bool UseJavadocLikeDocstringRewriter = false;
     public bool DisableScopes = false;
     public int Allocated = 4;
     public bool UseStdin = false;
@@ -326,7 +327,8 @@ NoGhost - disable printing of functions, ghost methods, and proof
 
     public static string DefaultZ3Version = "4.12.1";
 
-    public static readonly ReadOnlyCollection<Plugin> DefaultPlugins = new(new[] { SinglePassCompiler.Plugin });
+    public static readonly ReadOnlyCollection<Plugin> DefaultPlugins =
+      new(new[] { SinglePassCompiler.Plugin, InternalDocstringRewritersPluginConfiguration.Plugin });
     private IList<Plugin> cliPluginCache;
     public IList<Plugin> Plugins => cliPluginCache ??= ComputePlugins();
     public List<Plugin> AdditionalPlugins = new();

--- a/Source/DafnyCore/Generic/Node.cs
+++ b/Source/DafnyCore/Generic/Node.cs
@@ -175,7 +175,7 @@ public abstract class Node : INode {
   // Applies plugin-defined docstring filters
   public string GetDocstring(DafnyOptions options) {
     var plugins = options.Plugins;
-    string trivia = GetDocstringToken();
+    string trivia = GetDocstringFromTokens();
     if (string.IsNullOrEmpty(trivia)) {
       return null;
     }
@@ -250,7 +250,7 @@ public abstract class Node : INode {
   }
 
   // Unfiltered version that only returns the trivia containing the docstring
-  protected virtual string GetDocstringToken() {
+  protected virtual string GetDocstringFromTokens() {
     return null;
   }
 }

--- a/Source/DafnyCore/Generic/Node.cs
+++ b/Source/DafnyCore/Generic/Node.cs
@@ -170,7 +170,7 @@ public abstract class Node : INode {
   // Applies plugin-defined docstring filters
   public string GetDocString(DafnyOptions options) {
     var plugins = options.Plugins;
-    var (token, leadingTrivia) = GetDocStringToken(options);
+    var (token, leadingTrivia) = GetDocstringToken();
     if (token == null || token == Token.NoToken || token.line == 0) {
       return null;
     }
@@ -247,7 +247,7 @@ public abstract class Node : INode {
   }
 
   // Unfiltered version that only returns the trivia containing the docstring
-  protected virtual (IToken token, bool leadingTrivia) GetDocStringToken(DafnyOptions options) {
+  protected virtual (IToken token, bool leadingTrivia) GetDocstringToken() {
     return (token: Token.NoToken, leadingTrivia: true);
   }
 }

--- a/Source/DafnyCore/Generic/Node.cs
+++ b/Source/DafnyCore/Generic/Node.cs
@@ -190,7 +190,7 @@ public abstract class Node : INode {
 
     var extraction = new Regex(
       $@"(?<multiline>(?<indentation>[ \t]*)/\*(?<multilinecontent>{TriviaFormatterHelper.MultilineCommentContent})\*/)" +
-      $@"|(?<singleline>// ?(?<singlelinecontent>[^\r\n]*)(?:{TriviaFormatterHelper.AnyNewline}|$))");
+      $@"|(?<singleline>// ?(?<singlelinecontent>[^\r\n]*?)[ \t]*(?:{TriviaFormatterHelper.AnyNewline}|$))");
     var rawDocstring = new List<string>() { };
     var matches = extraction.Matches(trivia);
     for (var i = 0; i < matches.Count; i++) {

--- a/Source/DafnyCore/Generic/Node.cs
+++ b/Source/DafnyCore/Generic/Node.cs
@@ -178,7 +178,7 @@ public abstract class Node : INode {
     var rawDocstring = ExtractDocstring(token, leadingTrivia);
     foreach (var plugin in plugins) {
       foreach (var docstringRewriter in plugin.GetDocstringRewriters(options)) {
-        rawDocstring = docstringRewriter.RewriteDocstring(rawDocstring);
+        rawDocstring = docstringRewriter.RewriteDocstring(rawDocstring) ?? rawDocstring;
       }
     }
 

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -164,6 +164,10 @@ true - Use an updated type-inference engine. Warning: This mode is under constru
   public static readonly Option<bool> IncludeRuntimeOption = new("--include-runtime",
     "Include the Dafny runtime as source in the target language.");
 
+  public static readonly Option<bool> UseJavadocLikeDocstringRewriterOption = new("--javadoclike-docstring-plugin",
+    "Rewrite docstrings using a simple Javadoc-to-markdown converter"
+  );
+
   public enum TestAssumptionsMode {
     None,
     Externs
@@ -197,6 +201,8 @@ Functionality is still being expanded. Currently only checks contracts on every 
       }
     });
     DafnyOptions.RegisterLegacyBinding(IncludeRuntimeOption, (options, value) => { options.IncludeRuntime = value; });
+    DafnyOptions.RegisterLegacyBinding(UseJavadocLikeDocstringRewriterOption,
+      (options, value) => { options.UseJavadocLikeDocstringRewriter = value; });
     DafnyOptions.RegisterLegacyBinding(WarnShadowing, (options, value) => { options.WarnShadowing = value; });
     DafnyOptions.RegisterLegacyBinding(WarnMissingConstructorParenthesis,
       (options, value) => { options.DisallowConstructorCaseWithoutParentheses = value; });

--- a/Source/DafnyCore/Plugin.cs
+++ b/Source/DafnyCore/Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -10,6 +11,7 @@ using Dafny.Plugins;
 public interface Plugin {
   public IEnumerable<IExecutableBackend> GetCompilers(DafnyOptions options);
   public IEnumerable<IRewriter> GetRewriters(ErrorReporter reporter);
+  public IEnumerable<DocstringRewriter> GetDocstringRewriters(DafnyOptions options);
 }
 
 record ErrorPlugin(string AssemblyAndArgument, Exception Exception) : Plugin {
@@ -19,6 +21,10 @@ record ErrorPlugin(string AssemblyAndArgument, Exception Exception) : Plugin {
 
   public IEnumerable<IRewriter> GetRewriters(ErrorReporter reporter) {
     return new[] { new ErrorRewriter(reporter, this) };
+  }
+
+  public IEnumerable<DocstringRewriter> GetDocstringRewriters(DafnyOptions options) {
+    return Enumerable.Empty<DocstringRewriter>();
   }
 
   class ErrorRewriter : IRewriter {
@@ -48,6 +54,10 @@ public class ConfiguredPlugin : Plugin {
 
   public IEnumerable<IRewriter> GetRewriters(ErrorReporter reporter) {
     return Configuration.GetRewriters(reporter).Select(rewriter => new PluginRewriter(reporter, rewriter));
+  }
+
+  public IEnumerable<DocstringRewriter> GetDocstringRewriters(DafnyOptions options) {
+    return Configuration.GetDocstringRewriters(options);
   }
 }
 

--- a/Source/DafnyCore/Plugins/DocstringRewriter.cs
+++ b/Source/DafnyCore/Plugins/DocstringRewriter.cs
@@ -1,0 +1,19 @@
+﻿namespace Microsoft.Dafny.Plugins;
+
+public abstract class DocstringRewriter {
+  /// Retrieves the content of what Dafny believes is the Docstring
+  /// and filters it. Note that the default rendering in VSCode is Markdown,
+  /// so since it's the major IDE that Dafny supports, you probably want to
+  /// have your docstring converter converts parts of the code to Markdown
+  /// As an example:
+  /// ```
+  /// function Test(i: int): int
+  /// // Returns the number of
+  /// // numbers smaller than i
+  /// { ... }
+  /// ```
+  /// The argument docstring will contain "Returns the number of\nnumbers smaller than i"
+  public virtual string RewriteDocstring(string extractedDocString) {
+    return extractedDocString;
+  }
+}

--- a/Source/DafnyCore/Plugins/PluginConfiguration.cs
+++ b/Source/DafnyCore/Plugins/PluginConfiguration.cs
@@ -39,4 +39,13 @@ public abstract class PluginConfiguration {
   public virtual IExecutableBackend[] GetCompilers(DafnyOptions options) {
     return Array.Empty<IExecutableBackend>();
   }
+
+  /// <summary>
+  /// Override this method to provide docstring converters
+  /// </summary>
+  /// <param name="options"></param>
+  /// <returns>A list of docstring converters implemented by this plugin, applied from left to right</returns>
+  public virtual DocstringRewriter[] GetDocstringRewriters(DafnyOptions options) {
+    return Array.Empty<DocstringRewriter>();
+  }
 }

--- a/Source/DafnyCore/Plugins/Rewriter.cs
+++ b/Source/DafnyCore/Plugins/Rewriter.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 using System.Diagnostics.Contracts;
 
 namespace Microsoft.Dafny.Plugins {

--- a/Source/DafnyCore/Rewriters/IRewriter.cs
+++ b/Source/DafnyCore/Rewriters/IRewriter.cs
@@ -5,11 +5,7 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Dafny {
   /// <summary>
-  /// A class that plugins should extend, in order to provide an extra Rewriter to the pipeline.
-  ///
-  /// If the plugin defines no PluginConfiguration, then Dafny will instantiate every sub-class
-  /// of Rewriter from the plugin, providing them with an ErrorReporter in the constructor
-  /// as the first and only argument.
+  /// Internal rewriters used in the resolution pipeline
   /// </summary>
   public abstract class IRewriter {
     /// <summary>
@@ -17,20 +13,6 @@ namespace Microsoft.Dafny {
     /// </summary>
     protected ErrorReporter Reporter;
 
-    /// <summary>
-    /// Constructor that accepts an ErrorReporter
-    /// You can obtain an ErrorReporter two following ways:
-    /// * Extend a PluginConfiguration class, and override the method GetRewriters(), whose first argument is an ErrorReporter
-    /// * Have no PluginConfiguration  class, and an ErrorReporter will be provided to your class's constructor.
-    /// 
-    /// Then you can use the protected field "reporter" like the following:
-    /// 
-    ///     reporter.Error(MessageSource.Compiler, token, "[Your plugin] Your error message here");
-    ///
-    /// The token is usually obtained on expressions and statements in the field `tok`
-    /// If you do not have access to them, use moduleDefinition.GetFirstTopLevelToken()
-    /// </summary>
-    /// <param name="reporter">The error reporter. Usually outputs automatically to IDE or command-line</param>
     protected internal IRewriter(ErrorReporter reporter) {
       Contract.Requires(reporter != null);
       this.Reporter = reporter;

--- a/Source/DafnyCore/Rewriters/InternalDocstringRewritersPluginConfiguration.cs
+++ b/Source/DafnyCore/Rewriters/InternalDocstringRewritersPluginConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Dafny.Compilers;
+using Microsoft.Dafny.Plugins;
+
+namespace Microsoft.Dafny; 
+
+public class InternalDocstringRewritersPluginConfiguration : Plugins.PluginConfiguration {
+  public static readonly InternalDocstringRewritersPluginConfiguration Singleton = new();
+  public static readonly Plugin Plugin = new ConfiguredPlugin(Singleton);
+
+  public override DocstringRewriter[] GetDocstringRewriters(DafnyOptions options) {
+    if (options.UseJavadocLikeDocstringRewriter) {
+      return new DocstringRewriter[] {
+        new JavadocLikeDocstringRewriter()
+      };
+    } else {
+      return new DocstringRewriter[] { };
+    }
+  }
+}

--- a/Source/DafnyCore/Rewriters/JavadocLikeDocstringRewriter.cs
+++ b/Source/DafnyCore/Rewriters/JavadocLikeDocstringRewriter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Dafny; 
+
+// To use it in CLI or Dafny language server, use the option
+// --javadoclike-docstring-plugin
+// You can also create your own 
+public class JavadocLikeDocstringRewriter : Plugins.DocstringRewriter {
+  private const string DocTableStart = "\n|  |  |\n| --- | --- |";
+
+  public override string RewriteDocstring(string extractedDocString) {
+    var detectJavadoc = new Regex(@"(\r?\n|^)\s*(@param|@return)");
+    if (!detectJavadoc.Match(extractedDocString).Success) {
+      return null;
+    }
+    var documentation = "";
+
+    var initialText = new Regex(@"^(?:(?!\r?\n\s*@)[\s\S])*").Match(extractedDocString).Value.Trim();
+    documentation += initialText;
+
+    var paramsRanges = new Regex(@"@param\s+(?<Name>\w+)\s+(?<Description>(?:(?!\n\s*@)[\s\S])*)");
+
+    var matches = paramsRanges.Matches(extractedDocString);
+    var tableRows = 0;
+    for (var i = 0; i < matches.Count; i++) {
+      var match = matches[i];
+      var name = match.Groups["Name"].Value;
+      var description = EscapeNewlines(match.Groups["Description"].Value);
+      if (i == 0) {
+        if (tableRows++ == 0) {
+          documentation += DocTableStart;
+        }
+        documentation += "\n| **Params** | ";
+      } else {
+        documentation += "\n| | ";
+      }
+      documentation += $"**{name}** - {description} |";
+    }
+    var returnsDoc = new Regex(@"@returns?\s+(?<Description>(?:(?!\n\s*@)[\s\S])*)");
+    if (returnsDoc.Match(extractedDocString) is { Success: true } matched) {
+      var description = EscapeNewlines(matched.Groups["Description"].Value);
+      if (tableRows == 0) {
+        documentation += DocTableStart;
+      }
+      documentation += $"\n| **Returns** | {description} |";
+    }
+
+    return documentation;
+  }
+
+  private static string EscapeNewlines(string content) {
+    var newlines = new Regex(@"\r?\n");
+    return newlines.Replace(content, "<br>");
+  }
+}

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
@@ -564,16 +564,16 @@ type T = x: D | x.value % 2 == 0 witness DD(0)
 /* Even numbers hidden in a newtype */
 newtype Even = x: int | x % 2 == 0
 
-// A useful lemma
+/** A useful lemma */
 lemma lem() {}
 
-// A useful greatest lemma
+/** A useful greatest lemma */
 greatest lemma greatestLemma() {}
 
-// A useful least lemma
+/** A useful least lemma */
 least lemma leastLemma() {}
 
-// A useful twostate lemma
+/** A useful twostate lemma */
 twostate lemma twostateLemma() {}
 
 method test(d: D, t: T, e: Even) {

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Xunit;
 using XunitAssertMessages;
@@ -37,11 +38,11 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
         Assert.Null(hover);
         return;
       }
-      AssertM.NotNull(hover, $"No hover message found at {hoverPosition}");
+      AssertM.NotNull(hover, $"No hover message found at {hoverPosition}, was supposed to display {expectedContent}");
       var markup = hover.Contents.MarkupContent;
       Assert.NotNull(markup);
       Assert.Equal(MarkupKind.Markdown, markup.Kind);
-      Assert.True(markup.Value.Contains(expectedContent), $"Could not find {expectedContent} in {markup.Value}");
+      Assert.True(markup.Value.Contains(expectedContent), $"Could not find '{expectedContent}'\n in \n'{markup.Value}'");
     }
 
     /// <summary>
@@ -52,11 +53,17 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
     /// at the place where a user would hover.
     /// </summary>
     /// <param name="sourceWithHovers"></param>
-    private async Task AssertHover(string sourceWithHovers) {
-      await SetUp(o => o.ProverOptions.Add("SOLVER=noop"));
+    /// <param name="modifyOptions"></param>
+    private async Task AssertHover(string sourceWithHovers, [CanBeNull] Action<DafnyOptions> modifyOptions = null) {
+      await SetUp(o => {
+        o.ProverOptions.Add("SOLVER=noop");
+        if (modifyOptions != null) {
+          modifyOptions(o);
+        }
+      });
       sourceWithHovers = sourceWithHovers.TrimStart().Replace("\r", ""); // Might not be necessary
       // Split the source from hovering tasks
-      var hoverRegex = new Regex(@"\n\s*(?<ColumnChar>\^)\[(?<ExpectedContent>.*)\](?=\n|$)");
+      var hoverRegex = new Regex(@"\n//\s*(?<ColumnChar>\^)\[(?<ExpectedContent>.*)\](?=\n|$)");
       var source = hoverRegex.Replace(sourceWithHovers, "");
       var hovers = hoverRegex.Matches(sourceWithHovers);
       var documentItem = CreateTestDocument(source);
@@ -81,7 +88,7 @@ method DoIt() returns (x: int) {
 
 method CallDoIt() returns () {
   var x := DoIt();
-              ^[```dafny\nmethod DoIt() returns (x: int)\n```]
+//            ^[```dafny\nmethod DoIt() returns (x: int)\n```]
 }");
     }
 
@@ -95,9 +102,9 @@ method M(dt: DT) {
   match dt {
     case C => 
     case A | B => var x := (y => y)(1); assert x == 1;
-                      ^[```dafny\nx: int\n```]
-                            ^[```dafny\ny: int\n```]
-                                 ^[```dafny\ny: int\n```]
+//                    ^[```dafny\nx: int\n```]
+//                          ^[```dafny\ny: int\n```]
+//                               ^[```dafny\ny: int\n```]
   }
 }
 
@@ -105,9 +112,9 @@ method M2(dt: DT) {
   match dt {
     case C => 
     case _ => var x := (y => y)(1); assert x == 1;
-                  ^[```dafny\nx: int\n```]
-                        ^[```dafny\ny: int\n```]
-                             ^[```dafny\ny: int\n```]
+//                ^[```dafny\nx: int\n```]
+//                      ^[```dafny\ny: int\n```]
+//                           ^[```dafny\ny: int\n```]
   }
 }
 
@@ -115,18 +122,18 @@ function F(dt: DT): int {
   match dt {
     case C => 0
     case A | B => var x := (y => y)(1); assert x == 1; 0
-                      ^[```dafny\nx: int\n```]
-                            ^[```dafny\ny: int\n```]
-                                 ^[```dafny\ny: int\n```]
+//                    ^[```dafny\nx: int\n```]
+//                          ^[```dafny\ny: int\n```]
+//                               ^[```dafny\ny: int\n```]
   }
 }
 function F2(dt: DT): int {
   match dt {
     case C => 0
     case _ => var x := (y => y)(1); assert x == 1; 0
-                  ^[```dafny\nx: int\n```]
-                        ^[```dafny\ny: int\n```]
-                             ^[```dafny\ny: int\n```]
+//                ^[```dafny\nx: int\n```]
+//                      ^[```dafny\ny: int\n```]
+//                           ^[```dafny\ny: int\n```]
   }
 }
 ");
@@ -150,7 +157,7 @@ function F2(dt: DT): int {
 method DoIt() {
   var x := new int[0];
   var y := x.Length;
-              ^[```dafny\nconst array.Length: int\n```]
+//            ^[```dafny\nconst array.Length: int\n```]
 }");
     }
 
@@ -174,7 +181,7 @@ method DoIt() returns (x: int) {
       await AssertHover(@"
 method DoIt() returns (x: int) {
   return GetX();
-            ^[null]
+//          ^[null]
 }");
     }
 
@@ -187,7 +194,7 @@ class Test {
   method DoIt() {
     var x := """";
     print x;
-          ^[```dafny\nx: string\n```]
+//        ^[```dafny\nx: string\n```]
   }
 }");
     }
@@ -201,7 +208,7 @@ class Test {
   method DoIt() {
     var x := 1;
     print this.x;
-               ^[```dafny\nvar Test.x: int\n```]
+//             ^[```dafny\nvar Test.x: int\n```]
   }
 }");
     }
@@ -217,7 +224,7 @@ class Test {
     {
       var x := ""2"";
       print x;
-            ^[```dafny\nx: string\n```]
+//          ^[```dafny\nx: string\n```]
     }
   }
 }");
@@ -235,7 +242,7 @@ class Test {
       var x := 2;
     }
     print x;
-          ^[```dafny\nx: string\n```]
+//        ^[```dafny\nx: string\n```]
   }
 }");
     }
@@ -249,7 +256,7 @@ class A {
 
 class B {
   var a: A;
-         ^[```dafny\nclass A\n```]
+//       ^[```dafny\nclass A\n```]
 
   constructor() {
     a := new A();
@@ -269,7 +276,7 @@ class B {
 
   constructor() {
     a := new A();
-             ^[```dafny\nclass A\n```]
+//           ^[```dafny\nclass A\n```]
   }
 }");
     }
@@ -282,7 +289,7 @@ class A {
 }
 
 method DoIt(a: A) {}
-               ^[```dafny\nclass A\n```]");
+//             ^[```dafny\nclass A\n```]");
     }
 
     [Fact]
@@ -290,7 +297,7 @@ method DoIt(a: A) {}
       await AssertHover(@"
 trait Base {}
 class Sub extends Base {}
-                   ^[```dafny\ntrait Base\n```]");
+//                 ^[```dafny\ntrait Base\n```]");
     }
 
     [Fact]
@@ -299,7 +306,7 @@ class Sub extends Base {}
 datatype SomeType = SomeType {
   method AssertEqual(x: int, y: int) {
     var j:=x == y;
-           ^[```dafny\nx: int\n```]
+//         ^[```dafny\nx: int\n```]
   }
 }");
     }
@@ -316,7 +323,7 @@ datatype SomeType = SomeType {
 method Main() {
   var instance: SomeType;
   instance.AssertEqual(1, 2);
-            ^[```dafny\nmethod SomeType.AssertEqual(x: int, y: int)\n```]
+//          ^[```dafny\nmethod SomeType.AssertEqual(x: int, y: int)\n```]
 }");
     }
 
@@ -325,7 +332,7 @@ method Main() {
       await AssertHover(@"
 method f(i: int) {
   var r := i;
-           ^[```dafny\ni: int\n```]
+//         ^[```dafny\ni: int\n```]
 }");
     }
 
@@ -334,7 +341,7 @@ method f(i: int) {
       await AssertHover(@"
 method f(i: int) {
   var r := i;
-      ^[```dafny\nr: int\n```]
+//    ^[```dafny\nr: int\n```]
 }");
     }
 
@@ -343,8 +350,8 @@ method f(i: int) {
       await AssertHover(@"
 method f(i: int) {
   var x:=forall j :: j + i == i + j;
-                ^[```dafny\nj: int\n```]
-                     ^[```dafny\nj: int\n```]
+//              ^[```dafny\nj: int\n```]
+//                   ^[```dafny\nj: int\n```]
 }");
     }
 
@@ -353,8 +360,8 @@ method f(i: int) {
       await AssertHover(@"
 method f(i: int) {
   var x:=exists j :: j + i == i;
-                ^[```dafny\nj: int\n```]
-                     ^[```dafny\nj: int\n```]
+//              ^[```dafny\nj: int\n```]
+//                   ^[```dafny\nj: int\n```]
 }");
     }
 
@@ -364,8 +371,8 @@ method f(i: int) {
 method f(i: int) {
   var x := {1, 2, 3};
   var y := set j | j in x && j < 3;
-               ^[```dafny\nj: int\n```]
-                   ^[```dafny\nj: int\n```]
+//             ^[```dafny\nj: int\n```]
+//                 ^[```dafny\nj: int\n```]
 }");
     }
 
@@ -374,8 +381,8 @@ method f(i: int) {
       await AssertHover(@"
 method f(i: int) {
   var m := map j : int | 0 <= j <= i :: j * j;
-               ^[```dafny\nj: int\n```]
-                              ^[```dafny\nj: int\n```]
+//             ^[```dafny\nj: int\n```]
+//                            ^[```dafny\nj: int\n```]
 }");
     }
 
@@ -384,8 +391,8 @@ method f(i: int) {
       await AssertHover(@"
 method f(i: int) {
   var m := j => j * i;
-           ^[```dafny\nj: int\n```]
-                ^[```dafny\nj: int\n```]
+//         ^[```dafny\nj: int\n```]
+//              ^[```dafny\nj: int\n```]
 }");
     }
 
@@ -394,8 +401,8 @@ method f(i: int) {
       await AssertHover(@"
 ghost predicate f(i: int) {
   forall j :: j + i == i + j
-         ^[```dafny\nj: int\n```]
-              ^[```dafny\nj: int\n```]
+//       ^[```dafny\nj: int\n```]
+//            ^[```dafny\nj: int\n```]
 }");
     }
 
@@ -408,8 +415,8 @@ predicate even(n: nat)
   if n < 2 then n == 0 else even(n - 2)
 } by method {
   var x := n % 2 == 0;
-      ^[```dafny\nx: bool\n```]
-           ^[```dafny\nn: nat\n```]
+//    ^[```dafny\nx: bool\n```]
+//         ^[```dafny\nn: nat\n```]
   return x;
 }");
     }
@@ -419,8 +426,8 @@ predicate even(n: nat)
       await AssertHover(@"
 function test(n: nat): nat {
   var i := n * 2;
-      ^[```dafny\ni: int\n```]
-           ^[```dafny\nn: nat\n```]
+//    ^[```dafny\ni: int\n```]
+//         ^[```dafny\nn: nat\n```]
   if i == 4 then 3 else 2
 }");
     }
@@ -430,8 +437,8 @@ function test(n: nat): nat {
       await AssertHover(@"
 method returnBiggerThan(n: nat) returns (y: int)
   requires var y := 100; forall i :: i < n ==> i < y 
-               ^[```dafny\ny: int\n```]
-                                ^[```dafny\ni: int\n```]
+//             ^[```dafny\ny: int\n```]
+//                              ^[```dafny\ni: int\n```]
   ensures forall i :: i > y ==> i > n 
  {
   return n + 2;
@@ -442,9 +449,9 @@ method returnBiggerThan(n: nat) returns (y: int)
     public async Task HoveringResultVarReturnsInferredType() {
       await AssertHover(@"
 function f(i: int): (r: int)
-                     ^[```dafny\nr: int\n```]
+//                   ^[```dafny\nr: int\n```]
   ensures r - i < 10
-          ^[```dafny\nr: int\n```]
+//        ^[```dafny\nr: int\n```]
 {
   i + 2
 }");
@@ -458,7 +465,7 @@ function f(i: int): Pos {
   if i <= 3 then Pos(i)
   else
    var r := f(i - 2);
-       ^[```dafny\nr: Pos\n```]
+//     ^[```dafny\nr: Pos\n```]
    Pos(r.line + 2)
 }");
     }
@@ -468,7 +475,7 @@ function f(i: int): Pos {
       await AssertHover(@"
 datatype Position = Position(Line: nat)
 function ToRelativeIndependent(): (p: Position)
-                                         ^[```dafny\ndatatype Position\n```]
+//                                       ^[```dafny\ndatatype Position\n```]
 {
    Position(12)
 }
@@ -481,16 +488,154 @@ function ToRelativeIndependent(): (p: Position)
 lemma dummy(e: int) {
   match e {
     case _ => var xx := 1;
-                   ^[```dafny\nghost xx: int\n```]
+//                 ^[```dafny\nghost xx: int\n```]
   }
 }
 method test(opt: int) {
   match(opt)
   case 1 =>
     var s := 1;
-        ^[```dafny\ns: int\n```]
+//      ^[```dafny\ns: int\n```]
 }
 ");
+    }
+
+    [Fact]
+    public async Task HoverShouldDisplayComments() {
+      await AssertHover(@"
+predicate pm()
+  // No comment for pm
+{ true }
+
+/** Rich comment
+  * @param k The input
+  *          that is ignored
+  * @param l The second input that is ignored
+  * @returns 1 no matter what*/
+function g(k: int, l: int): int { 1 }
+
+// No comment for pt
+twostate predicate pt() { true }
+
+least predicate pl()
+  // No comment for pl
+{ true }
+
+// A comment for pg
+// That spans two lines
+greatest predicate pg() { true }
+
+/** Returns an integer without guarantee
+  * @returns The integer
+  */
+method m() returns (i: int) { i := *; }
+
+/** The class C. Should be used like this:
+  * ```dafny
+  * new C();
+  * ```
+  */
+class C {
+  // Unformatted comment
+  static method m() {}
+
+  // This is the constructor
+  constructor() {}
+
+  /** Should be the number of x in C */
+  var x: int
+
+  const X: int
+  // The expected number of x
+}
+
+function f(): int
+  /** Rich comment
+    * @returns 1 no matter what
+    */
+{ 1 }
+
+/** Rich comment for D */
+datatype D = DD(value: int)
+
+/* D whose value is even */
+type T = x: D | x.value % 2 == 0 witness DD(0)
+
+/* Even numbers hidden in a newtype */
+newtype Even = x: int | x % 2 == 0
+
+// A useful lemma
+lemma lem() {}
+
+// A useful greatest lemma
+greatest lemma greatestLemma() {}
+
+// A useful least lemma
+least lemma leastLemma() {}
+
+// A useful twostate lemma
+twostate lemma twostateLemma() {}
+
+method test(d: D, t: T, e: Even) {
+//             ^[Rich comment for D]
+ //                   ^[D whose value is even] // Not working yet
+ //                         ^[Even numbers hidden in a newtype] // Not working yet
+  var x1 := pm();
+//          ^[No comment for pm]
+  var x2 := pg();
+//          ^[A comment for pg\nThat spans two lines]
+  var x3 := pl();
+//          ^[No comment for pl]
+  var x4 := pt();
+//          ^[No comment for pt]
+  var xg := g(0, 1);
+//          ^[Rich comment\n@param k The input\n         that is ignored\n@param l The second input that is ignored\n@returns 1 no matter what]
+  C.m(); // TODO
+ //  ^[Unformatted comment] // Does not work yet.
+  var c: C := new C();
+//                ^[The class C. Should be used like this:\n```dafny\nnew C();\n```]
+  var xc := c.x;
+//            ^[Should be the number of x in C]
+  var xx := c.X;
+//            ^[The expected number of x]
+  var xf := f();
+//          ^[Rich comment\n@returns 1 no matter what]
+  lem();
+//^[A useful lemma]
+  greatestLemma();
+//^[A useful greatest lemma]
+  leastLemma();
+//^[A useful least lemma]
+  twostateLemma();
+//^[A useful twostate lemma]
+}");
+      await AssertHover(@"
+/** Rich comment
+  * @param k The input
+  *          that is ignored
+  * @param l The second input that is ignored
+  * @returns 1 no matter what*/
+function g(k: int, l: int): int { 1 }
+
+/** Returns an integer without guarantee
+  * @returns The integer
+  */
+method m() returns (i: int) { i := *; }
+
+function f(): int
+  /** Rich comment
+    * @returns 1 no matter what
+    */
+{ 1 }
+
+method test() {
+  var xg := g(0, 1);
+//          ^[Rich comment\n|  |  |\n| --- | --- |\n| **Params** | **k** - The input<br>         that is ignored |\n| | **l** - The second input that is ignored |\n| **Returns** | 1 no matter what |]
+  var i := m();
+//         ^[Unformatted comment] // Does not work yet.
+  var xf := f();
+//          ^[Rich comment\n|  |  |\n| --- | --- |\n| **Returns** | 1 no matter what |]
+}", o => o.Set(CommonOptionBag.UseJavadocLikeDocstringRewriterOption, true));
     }
   }
 }

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
     }
 
     private string CreateSymbolMarkdown(ILocalizableSymbol symbol, CancellationToken cancellationToken) {
-      var docString = symbol.Node.GetDocString(options);
+      var docString = symbol.Node is IHasDocstring nodeWithDocstring ? nodeWithDocstring.GetDocstring(options) : "";
       return (docString + $"\n```dafny\n{symbol.GetDetailText(options, cancellationToken)}\n```").TrimStart();
     }
   }

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
 
     private string CreateSymbolMarkdown(ILocalizableSymbol symbol, CancellationToken cancellationToken) {
       var docString = symbol.Node.GetDocString(options);
-      return (docString + $"```\ndafny\n{symbol.GetDetailText(options, cancellationToken)}\n```").TrimStart();
+      return (docString + $"\n```dafny\n{symbol.GetDetailText(options, cancellationToken)}\n```").TrimStart();
     }
   }
 }

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -346,7 +346,8 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
     }
 
     private string CreateSymbolMarkdown(ILocalizableSymbol symbol, CancellationToken cancellationToken) {
-      return $"```dafny\n{symbol.GetDetailText(options, cancellationToken)}\n```";
+      var docString = symbol.Node.GetDocString(options);
+      return (docString + $"```\ndafny\n{symbol.GetDetailText(options, cancellationToken)}\n```").TrimStart();
     }
   }
 }

--- a/Source/DafnyLanguageServer/Language/Symbols/FieldSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/FieldSymbol.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class FieldSymbol : MemberSymbol, ILocalizableSymbol {
     public Field Declaration { get; }
-    public object Node => Declaration;
+    public INode Node => Declaration;
 
     public FieldSymbol(ISymbol? scope, Field field) : base(scope, field) {
       Declaration = field;

--- a/Source/DafnyLanguageServer/Language/Symbols/FunctionSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/FunctionSymbol.cs
@@ -5,7 +5,7 @@ using System.Threading;
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class FunctionSymbol : MemberSymbol, ILocalizableSymbol {
     public Function Declaration { get; }
-    public object Node => Declaration;
+    public INode Node => Declaration;
 
     public IList<VariableSymbol> Parameters { get; } = new List<VariableSymbol>();
 

--- a/Source/DafnyLanguageServer/Language/Symbols/ILocalizableSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/ILocalizableSymbol.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading;
-using AstNode = System.Object;
+using AstNode = Microsoft.Dafny.INode;
 
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   /// <summary>

--- a/Source/DafnyLanguageServer/Language/Symbols/MethodSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/MethodSymbol.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
     /// Gets the method node representing the declaration of this symbol.
     /// </summary>
     public Method Declaration { get; }
-    public object Node => Declaration;
+    public INode Node => Declaration;
 
     /// <summary>
     /// Gets the method parameters.

--- a/Source/DafnyLanguageServer/Language/Symbols/ModuleSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/ModuleSymbol.cs
@@ -4,7 +4,7 @@ using System.Threading;
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class ModuleSymbol : Symbol, ILocalizableSymbol {
     public ModuleDefinition Declaration { get; }
-    public object Node => Declaration;
+    public INode Node => Declaration;
 
     public ISet<ISymbol> Declarations { get; } = new HashSet<ISymbol>();
 

--- a/Source/DafnyLanguageServer/Language/Symbols/ScopeSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/ScopeSymbol.cs
@@ -4,7 +4,7 @@ using Microsoft.Boogie;
 
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class ScopeSymbol : Symbol, ILocalizableSymbol {
-    public object Node { get; }
+    public INode Node { get; }
     public readonly IToken BodyStartToken;
     public readonly IToken BodyEndToken;
     public List<ISymbol> Symbols { get; } = new();

--- a/Source/DafnyLanguageServer/Language/Symbols/TypeWithMembersSymbolBase.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/TypeWithMembersSymbolBase.cs
@@ -3,7 +3,7 @@ using System.Threading;
 
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public abstract class TypeWithMembersSymbolBase : Symbol, ILocalizableSymbol {
-    public abstract object Node { get; }
+    public abstract INode Node { get; }
 
     public IList<ISymbol> Members { get; } = new List<ISymbol>();
 
@@ -16,7 +16,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
 
   public abstract class TypeWithMembersSymbolBase<TNode> : TypeWithMembersSymbolBase where TNode : TopLevelDeclWithMembers {
     public TNode Declaration { get; }
-    public override object Node => Declaration;
+    public override Node Node => Declaration;
 
     protected TypeWithMembersSymbolBase(ISymbol? scope, TNode declaration) : base(scope, declaration.Name) {
       Declaration = declaration;

--- a/Source/DafnyLanguageServer/Language/Symbols/ValueTypeSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/ValueTypeSymbol.cs
@@ -4,7 +4,7 @@ using System.Threading;
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class ValueTypeSymbol : Symbol, ILocalizableSymbol {
     public ValuetypeDecl Declaration { get; }
-    public object Node => Declaration;
+    public INode Node => Declaration;
 
     public IList<ISymbol> Members { get; } = new List<ISymbol>();
 

--- a/Source/DafnyLanguageServer/Language/Symbols/VariableSymbol.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/VariableSymbol.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class VariableSymbol : Symbol, ILocalizableSymbol {
     public IVariable Declaration { get; }
-    public object Node => Declaration;
+    public INode Node => Declaration;
 
     public VariableSymbol(ISymbol? scope, IVariable variable) : base(scope, variable.Name) {
       Declaration = variable;

--- a/Source/DafnyLanguageServer/ServerCommand.cs
+++ b/Source/DafnyLanguageServer/ServerCommand.cs
@@ -48,6 +48,7 @@ Send notifications about the verification status of each line in the program.
     LineVerificationStatus,
     VerifySnapshots,
     CommonOptionBag.EnforceDeterminism,
+    CommonOptionBag.UseJavadocLikeDocstringRewriterOption
   }.Concat(ICommandSpec.VerificationOptions).
     Concat(ICommandSpec.ResolverOptions);
 

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -365,7 +365,7 @@ iterator Iter2(x: int) yields (y: int)
             Assert.NotNull(targetNode);
           }
 
-          var docString = targetNode.GetDocString(options);
+          var docString = targetNode.GetDocstring(options);
           Assert.Equal(expectedDocstring, docString);
         }
       }

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -47,10 +47,10 @@ function Test2(i: int): int
 
 // Test3 computes an int
 // It takes an int and adds 3 to it
-function Test3(i: int): int
+ghost function Test3(i: int): int
 { i + 3 }
 
-// TODO: MAke this function recursive and this is not a docstring
+// this is not a docstring but can be used as a TODO
 function Test4(i: int): int
   // Test4 computes an int
   // It takes an int and adds 4 to it
@@ -62,11 +62,10 @@ function Test5(i: int): int
 { i + 5 }
 
 function Test6(i: int): int
-  /** Test6 computes an int
-    * It takes an int and adds 6 to it */
-{ i + 6 }
+/** Test6 computes an int
+  * It takes an int and adds 6 to it */
 
-function Test7(i: int): int
+function Test7(i: int): (j: int)
   /* Test7 computes an int
   It takes an int and adds 7 to it */
 { i + 7 }
@@ -98,6 +97,202 @@ function Test11(i: int): int
           ($"Test11", $"Test11 computes an int\n It takes an int and adds 11 to it")
         }
         ).ToList());
+    }
+
+    [Fact]
+    public void DocstringWorksForPredicate() {
+      DocstringWorksFor(@"
+class X {
+  static predicate Test1(i: int)
+    // Test1 checks if an int
+    // is equal to 1
+  { i == 1 }
+  // Unrelated trailing comment
+  
+  // Test2 checks if an int
+  // is equal to 2
+  static predicate Test2(i: int)
+  { i == 2 }
+}
+", new List<(string nodeTokenValue, string expectedDocstring)>() {
+        ("Test1", "Test1 checks if an int\nis equal to 1"),
+        ("Test2", "Test2 checks if an int\nis equal to 2")});
+    }
+
+    [Fact]
+    public void DocstringWorksForMethodsAndLemmas() {
+      DocstringWorksFor(@"
+// ComputeThing prints something to the screen
+method ComputeThing(i: int) returns (j: int)
+{ print i; }
+// Unattached comment
+
+// Unattached comment
+method ComputeThing2(i: int) returns (j: int)
+  // ComputeThing2 prints something to the screen
+  requires i == 2
+{ print i; }
+
+// Unattached comment
+method ComputeThing3(i: int) returns (j: int)
+  // ComputeThing3 prints something to the screen
+
+// Unattached comment
+method ComputeThing4(i: int)
+  // ComputeThing4 prints something to the screen
+  requires i == 2
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("ComputeThing", "ComputeThing prints something to the screen"),
+        ("ComputeThing2", "ComputeThing2 prints something to the screen"),
+        ("ComputeThing3", "ComputeThing3 prints something to the screen"),
+        ("ComputeThing4", "ComputeThing4 prints something to the screen")
+      });
+    }
+    [Fact]
+    public void DocstringWorksForConst() {
+      DocstringWorksFor(@"
+class X {
+  const x2 := 29
+  // The biggest prime number less than 30 
+
+  // The biggest prime number less than 20 
+  const x1 := 19
+
+  // Unrelated todo 
+  const x3 := 37
+  // The biggest prime number less than 40
+}
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("x1", "The biggest prime number less than 20"),
+        ("x2", "The biggest prime number less than 30"),
+        ("x3", "The biggest prime number less than 40")});
+    }
+
+    [Fact]
+    public void DocstringWorksForSubsetType() {
+      DocstringWorksFor(@"
+class X {
+  type Odd := x: int | x % 2 == 1 witness 1
+  // Type of number that are not divisible by 2 
+
+  // Type of numbers divisible by 2
+  type Even := x: int | x % 2 == 1 witness 1
+
+  // Unrelated comment
+  type Weird := x: int | x % 2 == x % 3 witness 0
+  // Type of numbers whose remainder modulo 2 or 3 is the same
+}", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("Odd", "Type of number that are not divisible by 2"),
+        ("Even", "Type of numbers divisible by 2"),
+        ("Weird", "Type of numbers whose remainder modulo 2 or 3 is the same")});
+    }
+
+    [Fact]
+    public void DocstringWorksForDatatypes() {
+      DocstringWorksFor(@"
+// Unrelated comment
+datatype State =
+  // A typical log message from a process monitoring
+  | // Unrelated comment
+    Begin(time: int)
+    // The beginning of the process
+  | // Unrelated comment
+    End(time: int)
+    // The end of the process
+
+// Another typical log message from a process monitoring
+datatype State2 =
+  | // The start of the process
+    Start(time: int)
+  | // The finishing state of the process
+    Finish(time: int)
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("State", "A typical log message from a process monitoring"),
+        ("Begin", "The beginning of the process"),
+        ("End", "The end of the process"),
+        ("State2", "Another typical log message from a process monitoring"),
+        ("Start", "The start of the process"),
+        ("Finish", "The finishing state of the process"),
+      });
+    }
+
+
+    [Fact]
+    public void DocstringWorksForClassAndTraits() {
+      DocstringWorksFor(@"
+trait X
+// A typical base class
+{}
+
+// Unattached comment
+trait T1 extends X
+// A typical extending trait
+{}
+
+// A typical extending trait with an even number
+trait T2 extends X
+{}
+
+// Unrelated comment
+class A extends T
+  // A typical example of a class extending a trait
+{}
+
+// Another typical example of a class extending a trait
+class A2 extends T
+{}
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("X", "A typical base class"),
+        ("T1", "A typical extending trait"),
+        ("T2", "A typical extending trait with an even number"),
+        ("A", "A typical example of a class extending a trait"),
+        ("A2", "Another typical example of a class extending a trait")
+      });
+    }
+
+    [Fact]
+    public void DocstringWorksForModules() {
+      DocstringWorksFor(@"
+// Unattached comment
+module A
+  // A is the most interesting module
+{}
+
+// Unattached comment
+module B refines A
+  // But it can be refined
+{}
+// Unattached comment
+
+// Clearly, modules can be abstract as well
+abstract module C
+{}
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("A", "A is the most interesting module"),
+        ("B", "But it can be refined"),
+        ("C", "Clearly, modules can be abstract as well")
+      });
+    }
+
+    [Fact]
+    public void DocstringWorksForIterators() {
+      DocstringWorksFor(@"
+// Iter is interesting
+iterator Iter(x: int) yields (y: int)
+  requires A: 0 <= x
+{
+}
+
+// Unattached comment
+iterator Iter2(x: int) yields (y: int)
+  // Iter2 is interesting
+  requires A: 0 <= x
+{
+}
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("Iter", "Iter is interesting"),
+        ("Iter2", "Iter2 is interesting")
+      });
     }
 
     protected Node? FindNode(Node? node, Func<Node, bool> nodeFinder) {

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -171,20 +171,42 @@ class X {
     [Fact]
     public void DocstringWorksForSubsetType() {
       DocstringWorksFor(@"
-class X {
-  type Odd := x: int | x % 2 == 1 witness 1
-  // Type of number that are not divisible by 2 
+type Odd = x: int | x % 2 == 1 witness 1
+// Type of number that are not divisible by 2 
 
-  // Type of numbers divisible by 2
-  type Even := x: int | x % 2 == 1 witness 1
+// Type of numbers divisible by 2
+type Even = x: int | x % 2 == 1 witness 1
 
-  // Unrelated comment
-  type Weird := x: int | x % 2 == x % 3 witness 0
-  // Type of numbers whose remainder modulo 2 or 3 is the same
-}", new List<(string nodeTokenValue, string expectedDocstring)> {
+// Unrelated comment
+type Weird = x: int | x % 2 == x % 3 witness 0
+// Type of numbers whose remainder modulo 2 or 3 is the same
+
+// Unattached comment
+type ZeroOrMore = nat
+// ZeroOrMore is the same as nat
+
+// ZeroOrMore2 is the same as nat 
+type ZeroOrMore2 = nat
+
+// Unattached comment
+type OpaqueType
+// OpaqueType has opaque methods so you don't see them
+{
+}
+
+// OpaqueType2 has opaque methods so you don't see them
+type OpaqueType2
+{
+}
+", new List<(string nodeTokenValue, string expectedDocstring)> {
         ("Odd", "Type of number that are not divisible by 2"),
         ("Even", "Type of numbers divisible by 2"),
-        ("Weird", "Type of numbers whose remainder modulo 2 or 3 is the same")});
+        ("Weird", "Type of numbers whose remainder modulo 2 or 3 is the same"),
+        ("ZeroOrMore", "ZeroOrMore is the same as nat"),
+        ("ZeroOrMore2", "ZeroOrMore2 is the same as nat"),
+        ("OpaqueType", "OpaqueType has opaque methods so you don't see them"),
+        ("OpaqueType2", "OpaqueType2 has opaque methods so you don't see them")
+      });
     }
 
     [Fact]

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -1,0 +1,165 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using Bpl = Microsoft.Boogie;
+using BplParser = Microsoft.Boogie.Parser;
+using Microsoft.Dafny;
+using Xunit;
+
+namespace DafnyPipeline.Test {
+
+  // Simple test cases (FormatterWorksFor with only one argument)
+  // consist of removing all the indentation from the program,
+  // adding it through the formatter, and checking if we obtain the initial result
+  //
+  // Advanced test cases consist of passing the program and its expected result after indentation
+  //
+  // Every test is performed with all three newline styles
+  // Every formatted program is formatted again to verify that it stays the same.
+  public class DocstringTest {
+    enum Newlines {
+      LF,
+      CR,
+      CRLF
+    };
+
+    private Newlines currentNewlines;
+
+    [Fact]
+    public void DocstringWorksForFunctions() {
+      DocstringWorksFor(@"
+function Test1(i: int): int
+  // Test1 computes an int
+  // It takes an int and adds 1 to it
+{ i + 1 }
+
+function Test2(i: int): int
+  //Test2 computes an int
+  //It takes an int and adds 2 to it
+{ i + 2 }
+// Trailing comment
+
+// Test3 computes an int
+// It takes an int and adds 3 to it
+function Test3(i: int): int
+{ i + 3 }
+
+// TODO: MAke this function recursive and this is not a docstring
+function Test4(i: int): int
+  // Test4 computes an int
+  // It takes an int and adds 4 to it
+{ i + 4 }
+
+function Test5(i: int): int
+  /* Test5 computes an int
+   * It takes an int and adds 5 to it */
+{ i + 5 }
+
+function Test6(i: int): int
+  /** Test6 computes an int
+    * It takes an int and adds 6 to it */
+{ i + 6 }
+
+function Test7(i: int): int
+  /* Test7 computes an int
+  It takes an int and adds 7 to it */
+{ i + 7 }
+
+function Test8(i: int): int
+  /* Test8 computes an int
+     It takes an int and adds 8 to it */
+{ i + 8 }
+
+function Test9(i: int): int /*
+  Test9 computes an int
+  It takes an int and adds 9 to it */
+{ i + 9 }
+
+function Test10(i: int): int
+  /* Test10 computes an int
+      It takes an int and adds 10 to it */
+{ i + 1 }
+
+function Test11(i: int): int
+  /** Test11 computes an int
+    *  It takes an int and adds 11 to it */
+{ i + 1 }
+", Enumerable.Range(1, 9).Select(i =>
+        ($"Test{i}", $"Test{i} computes an int\nIt takes an int and adds {i} to it")
+        ).Concat(
+        new List<(string, string)>() {
+          ($"Test10", $"Test10 computes an int\n It takes an int and adds 10 to it"),
+          ($"Test11", $"Test11 computes an int\n It takes an int and adds 11 to it")
+        }
+        ).ToList());
+    }
+
+    protected Node? FindNode(Node? node, Func<Node, bool> nodeFinder) {
+      if (node == null) {
+        return node;
+      }
+      if (nodeFinder(node)) {
+        return node;
+      } else {
+        foreach (var childNode in node.PreResolveChildren) {
+          if (FindNode(childNode, nodeFinder) is { } found) {
+            return found;
+          }
+        }
+
+        return null;
+      }
+    }
+
+    protected void DocstringWorksFor(string source, string nodeTokenValue, string expectedDocstring) {
+      DocstringWorksFor(source, new List<(string nodeTokenValue, string expectedDocstring)>() {
+        (nodeTokenValue, expectedDocstring)
+      });
+    }
+
+    protected void DocstringWorksFor(string source, List<(string nodeTokenValue, string expectedDocstring)> tests) {
+      var options = DafnyOptions.Create();
+      BatchErrorReporter reporter = new BatchErrorReporter(options);
+      var newlineTypes = Enum.GetValues(typeof(Newlines));
+      foreach (Newlines newLinesType in newlineTypes) {
+        currentNewlines = newLinesType;
+        // This formatting test will remove all the spaces at the beginning of the line
+        // and then recompute it. The result should be the same string.
+        var programString = AdjustNewlines(source);
+        ModuleDecl module = new LiteralModuleDecl(new DefaultModuleDefinition(), null);
+        Microsoft.Dafny.Type.ResetScopes();
+        BuiltIns builtIns = new BuiltIns(options);
+        Parser.Parse(programString, "virtual", "virtual", module, builtIns, reporter);
+        var dafnyProgram = new Program("programName", module, builtIns, reporter);
+        if (reporter.ErrorCount > 0) {
+          var error = reporter.AllMessages[ErrorLevel.Error][0];
+          Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");
+        }
+
+        foreach (var (nodeTokenValue, expectedDocstring) in tests) {
+          var targetNode = FindNode(dafnyProgram, node => node.Tok.val == nodeTokenValue);
+          if (targetNode == null) {
+            Assert.NotNull(targetNode);
+          }
+
+          var docString = targetNode.GetDocString(options);
+          Assert.Equal(expectedDocstring, docString);
+        }
+      }
+    }
+
+    private string AdjustNewlines(string programString) {
+      return currentNewlines switch {
+        Newlines.LF => new Regex("\r?\n").Replace(programString, "\n"),
+        Newlines.CR => new Regex("\r?\n").Replace(programString, "\r"),
+        _ => new Regex("\r?\n").Replace(programString, "\r\n")
+      };
+    }
+  }
+}

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -153,9 +153,9 @@ method ComputeThing4(i: int)
       DocstringWorksFor(@"
 class X {
   const x2 := 29
-  // The biggest prime number less than 30 
+  // The biggest prime number less than 30
 
-  // The biggest prime number less than 20 
+  // The biggest prime number less than 20
   const x1 := 19
 
   // Unrelated todo 

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -128,7 +128,7 @@ method ComputeThing(i: int) returns (j: int)
 // Unattached comment
 
 // Unattached comment
-method ComputeThing2(i: int) returns (j: int)
+lemma ComputeThing2(i: int) returns (j: int)
   // ComputeThing2 prints something to the screen
   requires i == 2
 { print i; }
@@ -182,6 +182,26 @@ type Weird = x: int | x % 2 == x % 3 witness 0
 // Type of numbers whose remainder modulo 2 or 3 is the same
 
 // Unattached comment
+newtype Digit = x: int | 0 <= x < 10
+// A single digit
+
+// A hex digit
+newtype HexDigit = x: int | 0 <= x < 16
+
+newtype BinDigit = x: int | 0 <= x < 2 witness 1
+// A binary digit
+{
+  function flip(): BinDigit {
+    1 - this
+  }
+}
+
+// Unrelated comment
+type Weird = x: int | x % 2 == x % 3 witness 0
+// Type of numbers whose remainder modulo 2 or 3 is the same
+
+
+// Unattached comment
 type ZeroOrMore = nat
 // ZeroOrMore is the same as nat
 
@@ -202,6 +222,9 @@ type OpaqueType2
         ("Odd", "Type of number that are not divisible by 2"),
         ("Even", "Type of numbers divisible by 2"),
         ("Weird", "Type of numbers whose remainder modulo 2 or 3 is the same"),
+        ("Digit", "A single digit"),
+        ("HexDigit", "A hex digit"),
+        ("BinDigit", "A binary digit"),
         ("ZeroOrMore", "ZeroOrMore is the same as nat"),
         ("ZeroOrMore2", "ZeroOrMore2 is the same as nat"),
         ("OpaqueType", "OpaqueType has opaque methods so you don't see them"),
@@ -269,6 +292,40 @@ class A2 extends T
         ("T2", "A typical extending trait with an even number"),
         ("A", "A typical example of a class extending a trait"),
         ("A2", "Another typical example of a class extending a trait")
+      });
+    }
+
+
+    [Fact]
+    public void DocstringWorksForExport() {
+      DocstringWorksFor(@"
+module Test {
+
+  // You only get the signatures of f and g
+  export hidden provides f
+         provides g
+
+  // Unattached comment
+  export consistent
+    // You get the definition of g but not f
+    provides f
+    reveals g
+
+  // You get both the definition of f and g
+  export full provides f
+         reveals g
+
+  function g(): int {
+    f() + f()
+  }
+  function f(): int {
+    1
+  }
+}
+", new List<(string nodeTokenValue, string expectedDocstring)> {
+        ("hidden", "You only get the signatures of f and g"),
+        ("consistent", "You get the definition of g but not f"),
+        ("full", "You get both the definition of f and g")
       });
     }
 

--- a/docs/dev/news/docstring.feat
+++ b/docs/dev/news/docstring.feat
@@ -1,0 +1,4 @@
+* Added `.GetDocstring(DafnyOptions)` to every AST node
+* Plugin support for custom Docstring formatter, 
+* Activatable plugin to support a subset of Javadoc through `--javadoclike-docstring-plugin`
+* Support for displaying docstring in VSCode


### PR DESCRIPTION
We gathered as a team last July to discuss how to add first-class support for Docstring, which is the interpretation of a special comment used for documentation purposes, e.g. hovering a symbol and getting more information about it.

We asked the following questions:
* **What entities will have docstrings attached to them?**. We decided that, for now: fields, methods (also lemmas), functions (also predicates), datatypes, datatype constructors, opaque types, subset types, newtypes, classes, traits and export declarations would have a docstring associated to them.
  We did not consider attaching docstring to function parameters yet, nor docstring to requires/ensures clause (but the `{:error}` attribute can help) so I leave these out of scope for now.
* **What comment syntax to use for docstring?**. We considered `//`, `/* .. */`, `///` and ``/** ... */` and concluded that, in places where a comment would never be present except if it were a docstring (see below), all comments would count as docstrings and be concatenated together. In places a comment could be present and might or might not be a docstring (e.g. //TODO...), we would only support `/***/` kind of docstring.
* **From what comments would docstring be extracted?**.
Comments can be placed virtually between any two tokens in the code. There were essentially two ways to place comments so that they can be interpreted as doscstring: Either above the entity, or below the entity. It turns out that there was no consensus on which one would be preferred (50%-50% of voices for a quorum of 6). Placing the comment below looks more like a regular definition (here is the entity, here is the definition) and is taken by some languages (Python, Caml...), while placing it above is what some other languages like C# or Java do.
Our collective decision was to interpret comments placed below automatically as docstring first, because they are not ambiguous, and start to use it by default when writing Dafny ourselves. If not below, we would recognize comments above `/** ... */` as docstring.
You will find below two same source code with the two different versions.

* **What syntax do we support for converting docstring?**. 
By default, we only remove comment signs and properly re-indent the docstring, but we do not process it further.
Because Dafny's currently supported IDE has VSCode whicih displays hover messages in Markdown, we expect users to write their docstring in Markdown though.
We also decided that we would enable a plugin-based rewriting of the docstring so that users can format it the way they want, and that Javadoc could be an example of such a plugin that we would provide as an example but not provide support for it, as users should relatively easily be able to override it.

# Implementation

* This PR adds a new interface `IHasDocstring` with the method `.GetDocstring(DafnyOptions options)`
All nodes implement the method but only a specific subset implement the interface. The docstrings are tested with respect to our decision in `DafnyPipeline`
* The first "*" and space of every long comment is removed, except if there was a line after the first one which did not start with a star. If there is no star at all, multiline comments are left-trimmed to match the space before the `/*` + two spaces, assuming the `/*` is the first non-whitespace character of the line.
* This PR also adds a small Javadoc-like-to-markdown converter that can be activated with the flag `--javadoclike-docstring-plugin`, which I hope will be activated by default when using the language server from a future version of VSCode. The goal is to provide a helper for those who are used to this syntax, not support the entire javadoc language
* This PR also adds support for the hover handler to actually display docstring when hovering over existing symbols. I left out of scope to add support for more symbol lookup as I saw some were missing.

# Screenshots
![image](https://user-images.githubusercontent.com/3601079/225992523-9f7b1ce7-2a6c-4ff9-88be-0fbf39fc968c.png)

# Additional notes

I can split this PR on demand if necessary.

# Appendix

## Docstring after/below entities - preferred choice (example)
```dafny
/// file comments


module A
  // module comment
{
}


method read(x: string, y: string): returns (z: int)
  // reads file in this.buffer
  modifies this`buffer
  ensures z > 0
  ensures z == abs(x + y)
{ … }

var x := 7
// This is docstring about x

// This is just a comment and not a docstring
const C := 8 // This is docstring about C

const C := 8
// This is docstring about C
// On two lines

datatype T0 =  // Docstring for T
  | A(x: int,
      y: int) // Docstring for A
  | B()       /* Docstring for B */ |
    C()       // Docstring for C

datatype T1 =
  // Docstring for T
  | A(x: int,
      y: int)
    // Docstring for A
  /* Still a docstring for A */ | B() // This is for B
  | C() /* Docstring for C */


export
  // This is the eponymous export set intended for most clients
  provides A, B, C


export Friends extends M
  // This export set is for clients who need to know more of the
  // details of the module's definitions.
  reveals A
  provides D
```


## Docstring before/above entities, also supported (example)
```dafny
/// Not a docstring, can be used as the file comment or for literate programming

/** module comment */
module A {
}


/** reads file in this.buffer */
method read(x: string, y: string) returns (z: string)
  modifies this`buffer
  ensures z > 0
  ensures z == abs(x + y)
{ … }

/** This is docstring about x */
var x := 7
// This is docstring about x part 2


/** This is docstring about x */
var x := 7


/** Docstring for T0*/
datatype T0 =
  | // Docstring for A
    A(x: int,
      y: int)
  | // Docstring for B
    B()
  | // Docstring for C
    C()


/// This is the eponymous export set intended for most clients
export provides A, B, C

/// This export set is for clients who need to know more of the
/// details of the module's definitions.
export Friends extends M
  reveals A
  provides D

```



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
