### PR TITLE
Fix: Formatter consistent between command-line and VSCode

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions/Expressions.cs
@@ -783,7 +783,7 @@ public abstract class Expression : TokenNode {
   /// </summary>
   public static Expression CreateIdentExpr(IVariable v) {
     Contract.Requires(v != null);
-    var e = new IdentifierExpr(v.RangeToken.StartToken, v.Name);
+    var e = new IdentifierExpr(v.Tok, v.Name);
     e.Var = v;  // resolve here
     e.type = v.Type;  // resolve here
     return e;

--- a/Source/DafnyCore/AST/Expressions/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions/Expressions.cs
@@ -3508,7 +3508,7 @@ public abstract class SuffixExpr : ConcreteSyntaxExpression {
   }
 }
 
-public class NameSegment : ConcreteSyntaxExpression, ICloneable<NameSegment> {
+public class NameSegment : ConcreteSyntaxExpression, ICloneable<NameSegment>, ICanFormat {
   public readonly string Name;
   public readonly List<Type> OptTypeArguments;
   public NameSegment(IToken tok, string name, List<Type> optTypeArguments)
@@ -3530,6 +3530,13 @@ public class NameSegment : ConcreteSyntaxExpression, ICloneable<NameSegment> {
   }
 
   public override IEnumerable<Node> PreResolveChildren => OptTypeArguments ?? new List<Type>();
+  public bool SetIndent(int indentBefore, TokenNewIndentCollector formatter) {
+    formatter.SetTypeLikeIndentation(indentBefore, OwnedTokens);
+    foreach (var subType in PreResolveChildren.OfType<Type>()) {
+      formatter.SetTypeIndentation(subType);
+    }
+    return false;
+  }
 }
 
 /// <summary>

--- a/Source/DafnyCore/AST/Grammar/TokenNewIndentCollector.cs
+++ b/Source/DafnyCore/AST/Grammar/TokenNewIndentCollector.cs
@@ -412,12 +412,14 @@ public class TokenNewIndentCollector : TopDownVisitor<int> {
       }
 
       var initialMemberIndent = declWithMembers.tok.line == 0 ? indent : indent2;
-      foreach (var member in declWithMembers.Members) {
-        if (member.tok is IncludeToken) {
+      foreach (var member in declWithMembers.PreResolveChildren) {
+        if (member.Tok is IncludeToken) {
           continue;
         }
 
-        SetMemberIndentation(member, initialMemberIndent);
+        if (member is MemberDecl memberDecl) {
+          SetMemberIndentation(memberDecl, initialMemberIndent);
+        }
       }
     } else if (topLevelDecl is SubsetTypeDecl subsetTypeDecl) {
       SetRedirectingTypeDeclDeclIndentation(indent, subsetTypeDecl);
@@ -660,7 +662,7 @@ public class TokenNewIndentCollector : TopDownVisitor<int> {
                   commaIndent = indent;
                 } else {
                   rightIndent = indent + SpaceTab;
-                  commaIndent = indent = SpaceTab;
+                  commaIndent = indent + SpaceTab;
                 }
 
                 SetIndentations(assignmentOperator, afterStartIndent, opIndentDefault, rightIndent);
@@ -690,6 +692,10 @@ public class TokenNewIndentCollector : TopDownVisitor<int> {
       foreach (var node in rhs.PreResolveSubExpressions) {
         Visit(node, rightIndent);
       }
+    }
+
+    if (stmt is AssignSuchThatStmt assignSuchThatStmt) {
+      Visit(assignSuchThatStmt.Expr, rightIndent);
     }
 
     return false;

--- a/Source/DafnyCore/AST/Statements/AssignSuchThatStmt.cs
+++ b/Source/DafnyCore/AST/Statements/AssignSuchThatStmt.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Microsoft.Dafny;
 public class AssignSuchThatStmt : ConcreteUpdateStatement, ICloneable<AssignSuchThatStmt>, ICanResolve {
   public readonly Expression Expr;
   public readonly AttributedToken AssumeToken;
+
+  public override IEnumerable<Node> PreResolveChildren =>
+  Lhss.Concat<Node>(new List<Node>() {
+  Expr });
 
   public override IToken Tok {
     get {

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1110,20 +1110,17 @@ public class ModuleDefinition : RangeNode, IDeclarationOrUsage, IAttributeBearin
       Enumerable.Empty<Node>()).Concat<Node>(TopLevelDecls).
     Concat(RefinementQId == null ? Enumerable.Empty<Node>() : new Node[] { RefinementQId });
 
-  // TODO: Add attributes, ensure we take TopLevelDecls BEFORE resolution
-  // and PrefixNamedModules BEFORE resolution (take snapshots)
-
-  public IEnumerable<Node> PreResolveTopLevelDecls = null;
-  public IEnumerable<Node> PreResolvePrefixNamedModules = null;
+  private IEnumerable<Node> preResolveTopLevelDecls;
+  private IEnumerable<Node> preResolvePrefixNamedModules;
   public override IEnumerable<Node> PreResolveChildren =>
     Includes.Concat<Node>(Attributes != null ?
       new List<Node> { Attributes } :
-      Enumerable.Empty<Node>()).Concat(PreResolveTopLevelDecls ?? TopLevelDecls).Concat(
-    (PreResolvePrefixNamedModules ?? PrefixNamedModules.Select(tuple => tuple.Item2)));
+      Enumerable.Empty<Node>()).Concat(preResolveTopLevelDecls ?? TopLevelDecls).Concat(
+    (preResolvePrefixNamedModules ?? PrefixNamedModules.Select(tuple => tuple.Item2)));
 
   public void PreResolveSnapshotForFormatter() {
-    PreResolveTopLevelDecls = TopLevelDecls.ToImmutableList();
-    PreResolvePrefixNamedModules = PrefixNamedModules.Select(tuple => tuple.Item2).ToImmutableList();
+    preResolveTopLevelDecls = TopLevelDecls.ToImmutableList();
+    preResolvePrefixNamedModules = PrefixNamedModules.Select(tuple => tuple.Item2).ToImmutableList();
   }
 }
 

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Linq;
@@ -1231,6 +1232,8 @@ public abstract class TopLevelDecl : Declaration, TypeParameter.ParentType {
 public abstract class TopLevelDeclWithMembers : TopLevelDecl {
   public readonly List<MemberDecl> Members;
 
+  public readonly ImmutableList<MemberDecl> MembersBeforeResolution;
+
   // The following fields keep track of parent traits
   public readonly List<MemberDecl> InheritedMembers = new List<MemberDecl>();  // these are instance members declared in parent traits
   public readonly List<Type> ParentTraits;  // these are the types that are parsed after the keyword 'extends'; note, for a successfully resolved program, these are UserDefinedType's where .ResolvedClass is NonNullTypeDecl
@@ -1300,6 +1303,7 @@ public abstract class TopLevelDeclWithMembers : TopLevelDecl {
     Contract.Requires(cce.NonNullElements(typeArgs));
     Contract.Requires(cce.NonNullElements(members));
     Members = members;
+    MembersBeforeResolution = members.ToImmutableList();
     ParentTraits = traits ?? new List<Type>();
   }
 
@@ -1320,7 +1324,7 @@ public abstract class TopLevelDeclWithMembers : TopLevelDecl {
 
   public override IEnumerable<Node> Children => ParentTraits.Concat<Node>(Members);
 
-  public override IEnumerable<Node> PreResolveChildren => Children;
+  public override IEnumerable<Node> PreResolveChildren => ParentTraits.Concat<Node>(MembersBeforeResolution);
 
   /// <summary>
   /// Returns the set of transitive parent traits (not including "this" itself).

--- a/Source/DafnyCore/AST/TopLevelDeclarations.cs
+++ b/Source/DafnyCore/AST/TopLevelDeclarations.cs
@@ -1600,6 +1600,8 @@ public abstract class DatatypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl
 
   public override IEnumerable<Node> Children => Ctors.Concat<Node>(base.Children);
 
+  public override IEnumerable<Node> PreResolveChildren => Ctors.Concat<Node>(base.PreResolveChildren);
+
   public DatatypeDecl(RangeToken rangeToken, Name name, ModuleDefinition module, List<TypeParameter> typeArgs,
     [Captured] List<DatatypeCtor> ctors, List<MemberDecl> members, Attributes attributes, bool isRefining)
     : base(rangeToken, name, module, typeArgs, members, attributes, isRefining) {

--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -2662,6 +2662,8 @@ public class UserDefinedType : NonProxyType {
 
   public IToken NameToken => tok;
   public override IEnumerable<Node> Children => base.Children.Concat(new[] { NamePath });
+
+  public override IEnumerable<Node> PreResolveChildren => new List<Node>() { NamePath };
 }
 
 public abstract class TypeProxy : Type {

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
@@ -336,7 +336,9 @@ namespace Microsoft.Dafny {
       if (expr is ParensExpression) {
         var e = (ParensExpression)expr;
         ResolveExpression(e.E, resolutionContext);
-        e.ResolvedExpression = e.E;
+        var innerRange = e.E.RangeToken;
+        e.ResolvedExpression = e.E; // Overwrites the range, which is not suitable for ParensExpressions
+        e.E.RangeToken = innerRange;
         e.Type = e.E.Type;
 
       } else if (expr is ChainingExpression) {

--- a/Source/DafnyCore/Resolver/Resolver.cs
+++ b/Source/DafnyCore/Resolver/Resolver.cs
@@ -397,6 +397,9 @@ namespace Microsoft.Dafny {
       Type.ResetScopes();
 
       Type.EnableScopes();
+      // For the formatter, we ensure we take snapshots of the PrefixNamedModules
+      // and topleveldecls
+      prog.DefaultModuleDef.PreResolveSnapshotForFormatter();
       var origErrorCount = reporter.ErrorCount; //TODO: This is used further below, but not in the >0 comparisons in the next few lines. Is that right?
       var bindings = new ModuleBindings(null);
       var b = BindModuleNames(prog.DefaultModuleDef, bindings);

--- a/Source/DafnyPipeline.Test/FormatterBaseTest.cs
+++ b/Source/DafnyPipeline.Test/FormatterBaseTest.cs
@@ -38,9 +38,9 @@ namespace DafnyPipeline.Test {
     protected void FormatterWorksFor(string testCase, string? expectedProgramString = null, bool expectNoToken = false,
       bool reduceBlockiness = true) {
       var options = DafnyOptions.Create();
-      BatchErrorReporter reporter = new BatchErrorReporter(options);
       var newlineTypes = Enum.GetValues(typeof(Newlines));
       foreach (Newlines newLinesType in newlineTypes) {
+        BatchErrorReporter reporter = new BatchErrorReporter(options);
         currentNewlines = newLinesType;
         // This formatting test will remove all the spaces at the beginning of the line
         // and then recompute it. The result should be the same string.
@@ -70,7 +70,22 @@ namespace DafnyPipeline.Test {
             IndentationFormatter.ForProgram(dafnyProgram, reduceBlockiness))
           : programString;
         EnsureEveryTokenIsOwned(programNotIndented, dafnyProgram);
-        Assert.Equal(expectedProgram, reprinted);
+        if (expectedProgram != reprinted) {
+          Console.Out.WriteLine("Formatting before resolution generates an error:");
+          Assert.Equal(expectedProgram, reprinted);
+        }
+
+        // Formatting should work after resolution as well.
+        Main.Resolve(dafnyProgram, reporter);
+        reprinted = firstToken != null && firstToken.line > 0
+          ? Formatting.__default.ReindentProgramFromFirstToken(firstToken,
+            IndentationFormatter.ForProgram(dafnyProgram, reduceBlockiness))
+          : programString;
+        if (expectedProgram != reprinted) {
+          Console.Error.WriteLine("Formatting after resolution generates an error:");
+          Assert.Equal(expectedProgram, reprinted);
+        }
+        var initErrorCount = reporter.ErrorCount;
 
         // Verify that the formatting is stable.
         module = new LiteralModuleDecl(new DefaultModuleDefinition(), null);
@@ -78,7 +93,7 @@ namespace DafnyPipeline.Test {
         builtIns = new BuiltIns(options);
         Parser.Parse(reprinted, "virtual", "virtual", module, builtIns, reporter);
         dafnyProgram = new Program("programName", module, builtIns, reporter);
-        Assert.Equal(0, reporter.ErrorCount);
+        Assert.Equal(initErrorCount, reporter.ErrorCount);
         firstToken = dafnyProgram.GetFirstTopLevelToken();
         var reprinted2 = firstToken != null && firstToken.line > 0
           ? Formatting.__default.ReindentProgramFromFirstToken(firstToken,

--- a/Source/DafnyPipeline.Test/FormatterIssues.cs
+++ b/Source/DafnyPipeline.Test/FormatterIssues.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+
+namespace DafnyPipeline.Test;
+
+[Collection("Singleton Test Collection - FormatterForTopLevelDeclarations")]
+public class FormatterIssues : FormatterBaseTest {
+  [Fact]
+  public void GitIssue3790DafnyFormatterProducesIncorrectIndentation() {
+    FormatterWorksFor(@"
+lemma Try(i: int)
+{
+  match i {
+    case i' =>
+      var x :| x == i';
+      assert x == i';
+  }
+}");
+  }
+
+  [Fact]
+  public void FormatterWorksForEmptyDocument() {
+    FormatterWorksFor(@"
+", null, true);
+  }
+}

--- a/docs/dev/news/3790.fix
+++ b/docs/dev/news/3790.fix
@@ -1,0 +1,1 @@
+Formatter consistent between command-line and VSCode


### PR DESCRIPTION
This PR fixes #3790

Besides that bug, it looks like there was discrepancies between the formatter on the command-line and the formatter in VSCode. So I took the chance to fix it all at once because that bug was concerned as well.
I also modified the tests so that they also test the formatting post-resolution. It enabled me to find 13 failing tests that I all fixed as well.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>