### PR TITLE
Update automated formatter

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -53,7 +53,7 @@ jobs:
       run: dotnet build Source/Dafny.sln
     - name: Check whitespace and style
       working-directory: dafny
-      run: dotnet format whitespace Source/Dafny.sln --verify-no-changes --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs
+      run: dotnet format whitespace Source/Dafny.sln --verify-no-changes --exclude boogie/ --exclude Source/DafnyCore/Scanner.cs --exclude Source/DafnyCore/Parser.cs
     - name: Create NuGet package (just to make sure it works)
       run: dotnet pack --no-build dafny/Source/Dafny.sln
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -53,7 +53,7 @@ jobs:
       run: dotnet build Source/Dafny.sln
     - name: Check whitespace and style
       working-directory: dafny
-      run: dotnet tool run dotnet-format -w -s error --check Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs
+      run: dotnet format whitespace Source/Dafny.sln --verify-no-changes --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs
     - name: Create NuGet package (just to make sure it works)
       run: dotnet pack --no-build dafny/Source/Dafny.sln
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 -   repo: local
     hooks:
     -   id: dotnet-format
-        name: dotnet-format
+        name: dotnet format
         language: system
-        entry: dotnet tool run dotnet-format --folder -w --include
+        entry: dotnet format whitespace --folder --include
         types_or: ["c#"]

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ z3-ubuntu:
 	chmod +x ${DIR}/Binaries/z3/bin/z3-*
 
 format:
-	dotnet tool run dotnet-format -w -s error Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs
+	dotnet format whitespace Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs
 
 clean:
 	(cd ${DIR}; cd Source; rm -rf Dafny/bin Dafny/obj DafnyDriver/bin DafnyDriver/obj DafnyRuntime/obj DafnyRuntime/bin DafnyServer/bin DafnyServer/obj DafnyPipeline/obj DafnyPipeline/bin DafnyCore/obj DafnyCore/bin)

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ z3-ubuntu:
 	chmod +x ${DIR}/Binaries/z3/bin/z3-*
 
 format:
-	dotnet format whitespace Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs
+	dotnet format whitespace Source/Dafny.sln --exclude Source/DafnyCore/Scanner.cs --exclude Source/DafnyCore/Parser.cs
 
 clean:
 	(cd ${DIR}; cd Source; rm -rf Dafny/bin Dafny/obj DafnyDriver/bin DafnyDriver/obj DafnyRuntime/obj DafnyRuntime/bin DafnyServer/bin DafnyServer/obj DafnyPipeline/obj DafnyPipeline/bin DafnyCore/obj DafnyCore/bin)

--- a/Source/AutoExtern/Program.cs
+++ b/Source/AutoExtern/Program.cs
@@ -89,8 +89,7 @@ internal class SemanticModel {
   public bool IsPublic(SyntaxNode syntax, bool fallback = true) {
     var symbol = GetSymbol(syntax);
     return symbol switch {
-      null => fallback,
-      { DeclaredAccessibility: Accessibility.Public } => true,
+      null => fallback, { DeclaredAccessibility: Accessibility.Public } => true,
       IPropertySymbol { ExplicitInterfaceImplementations: { IsEmpty: false } } => true,
       _ => false
     };

--- a/Source/DafnyCore/AST/Grammar/SourcePreprocessor.cs
+++ b/Source/DafnyCore/AST/Grammar/SourcePreprocessor.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Contracts;
 using System.IO;
 using System.Text;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 // Dafny files can use preprocessing directives, e.g.
 /// ```

--- a/Source/DafnyCore/CompileNestedMatch/MatchAst.cs
+++ b/Source/DafnyCore/CompileNestedMatch/MatchAst.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class MatchExpr : Expression, IMatch, ICloneable<MatchExpr> {  // a MatchExpr is an "extended expression" and is only allowed in certain places
   private Expression source;

--- a/Source/DafnyCore/CompileNestedMatch/MatchFlattener.cs
+++ b/Source/DafnyCore/CompileNestedMatch/MatchFlattener.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using static Microsoft.Dafny.ErrorRegistry;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 /// <summary>
 /// Removes nesting from matching patterns, such as case Cons(head1, Cons(head2, tail))

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -5328,21 +5328,18 @@ namespace Microsoft.Dafny.Compilers {
       IToken tok, ConcreteSyntaxTree wr, bool isReturning = false, bool elseReturnValue = false,
       bool isSubfiltering = false) {
       if (!boundVarType.Equals(collectionElementType, true) &&
-          boundVarType.NormalizeExpand(true) is UserDefinedType
-          {
+          boundVarType.NormalizeExpand(true) is UserDefinedType {
             TypeArgs: var typeArgs,
             ResolvedClass:
-            SubsetTypeDecl
-            {
+            SubsetTypeDecl {
               TypeArgs: var typeParametersArgs,
               Var: var variable,
               Constraint: var constraint
             }
           }) {
-        if (variable.Type.NormalizeExpandKeepConstraints() is UserDefinedType
-          {
-            ResolvedClass: SubsetTypeDecl
-          } normalizedVariableType) {
+        if (variable.Type.NormalizeExpandKeepConstraints() is UserDefinedType {
+          ResolvedClass: SubsetTypeDecl
+        } normalizedVariableType) {
           wr = MaybeInjectSubsetConstraint(boundVar, normalizedVariableType, collectionElementType,
               inLetExprBody, tok, wr, isReturning, elseReturnValue, true);
         }

--- a/Source/DafnyCore/DafnyConsolePrinter.cs
+++ b/Source/DafnyCore/DafnyConsolePrinter.cs
@@ -49,7 +49,7 @@ public class DafnyConsolePrinter : ConsolePrinter {
     var underlineLength = Math.Max(1, Math.Min(tokEndPos - tok.pos, lineEndPos - tok.pos));
     string underline = new string('^', underlineLength);
     tw.WriteLine($"{lineNumberSpaces} |");
-    tw.WriteLine($"{lineNumber      } | {line}");
+    tw.WriteLine($"{lineNumber} | {line}");
     tw.WriteLine($"{lineNumberSpaces} | {columnSpaces}{underline}");
     tw.WriteLine("");
   }

--- a/Source/DafnyCore/Feature.cs
+++ b/Source/DafnyCore/Feature.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.Boogie;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class FeatureDescriptionAttribute : Attribute {
   public readonly string Description;

--- a/Source/DafnyCore/Resolver/Abstemious.cs
+++ b/Source/DafnyCore/Resolver/Abstemious.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.Contracts;
 using Microsoft.Boogie;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class Abstemious {
   private readonly ErrorReporter reporter;

--- a/Source/DafnyCore/Resolver/InferDecreasesClause.cs
+++ b/Source/DafnyCore/Resolver/InferDecreasesClause.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class InferDecreasesClause {
   private readonly Resolver resolver;

--- a/Source/DafnyCore/Resolver/RunAllTestsMainMethod.cs
+++ b/Source/DafnyCore/Resolver/RunAllTestsMainMethod.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Microsoft.Boogie;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class RunAllTestsMainMethod : IRewriter {
 

--- a/Source/DafnyCore/Resolver/SubsetConstraintGhostChecker.cs
+++ b/Source/DafnyCore/Resolver/SubsetConstraintGhostChecker.cs
@@ -84,8 +84,7 @@ public class SubsetConstraintGhostChecker : ProgramTraverser {
 
     if (e is ForallExpr || e is ExistsExpr || e is SetComprehension || e is MapComprehension) {
       foreach (var boundVar in e.BoundVars) {
-        if (boundVar.Type.AsSubsetType is
-        {
+        if (boundVar.Type.AsSubsetType is {
           Constraint: var constraint,
           ConstraintIsCompilable: false and var constraintIsCompilable
         } and var subsetTypeDecl

--- a/Source/DafnyCore/Resolver/TailRecursion.cs
+++ b/Source/DafnyCore/Resolver/TailRecursion.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.Boogie;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 class TailRecursion {
 

--- a/Source/DafnyCore/Rewriters/InductionHeuristic.cs
+++ b/Source/DafnyCore/Rewriters/InductionHeuristic.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public static class InductionHeuristic {
 

--- a/Source/DafnyCore/Rewriters/InternalDocstringRewritersPluginConfiguration.cs
+++ b/Source/DafnyCore/Rewriters/InternalDocstringRewritersPluginConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Dafny.Compilers;
 using Microsoft.Dafny.Plugins;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class InternalDocstringRewritersPluginConfiguration : Plugins.PluginConfiguration {
   public static readonly InternalDocstringRewritersPluginConfiguration Singleton = new();

--- a/Source/DafnyCore/Rewriters/JavadocLikeDocstringRewriter.cs
+++ b/Source/DafnyCore/Rewriters/JavadocLikeDocstringRewriter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 // To use it in CLI or Dafny language server, use the option
 // --javadoclike-docstring-plugin

--- a/Source/DafnyDriver/Commands/TestCommand.cs
+++ b/Source/DafnyDriver/Commands/TestCommand.cs
@@ -3,7 +3,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class TestCommand : ICommandSpec {
   public IEnumerable<Option> Options =>

--- a/Source/DafnyLanguageServer.Test/Unit/DafnyLangSymbolResolverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/DafnyLangSymbolResolverTest.cs
@@ -3,7 +3,7 @@ using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit;
 
 public class DafnyLangSymbolResolverTest {
   private DafnyLangSymbolResolver dafnyLangSymbolResolver;

--- a/Source/DafnyLanguageServer.Test/Unit/GhostStateDiagnosticCollectorTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/GhostStateDiagnosticCollectorTest.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit;
 
 public class GhostStateDiagnosticCollectorTest {
   private GhostStateDiagnosticCollector ghostStateDiagnosticCollector;

--- a/Source/DafnyLanguageServer.Test/Util/Stringify.cs
+++ b/Source/DafnyLanguageServer.Test/Util/Stringify.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 
 public static class StringifyUtil {
 

--- a/Source/DafnyLanguageServer/Handlers/DafnyFormattingHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyFormattingHandler.cs
@@ -7,7 +7,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
-namespace Microsoft.Dafny.LanguageServer.Handlers; 
+namespace Microsoft.Dafny.LanguageServer.Handlers;
 
 public class DafnyFormattingHandler : DocumentFormattingHandlerBase {
   private readonly ILogger<DafnyCompletionHandler> logger;

--- a/Source/DafnyTestGeneration/DeadCodeCommand.cs
+++ b/Source/DafnyTestGeneration/DeadCodeCommand.cs
@@ -3,7 +3,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class DeadCodeCommand : ICommandSpec {
   public IEnumerable<Option> Options =>

--- a/Source/DafnyTestGeneration/GenerateTestsCommand.cs
+++ b/Source/DafnyTestGeneration/GenerateTestsCommand.cs
@@ -4,7 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class GenerateTestsCommand : ICommandSpec {
   public IEnumerable<Option> Options =>

--- a/Source/TestDafny/TestDafny.cs
+++ b/Source/TestDafny/TestDafny.cs
@@ -7,7 +7,7 @@ using Microsoft.Dafny.Plugins;
 using XUnitExtensions;
 using XUnitExtensions.Lit;
 
-namespace TestDafny; 
+namespace TestDafny;
 
 [Verb("for-each-compiler", HelpText = "Execute the given test file for every compiler, and assert the output matches the <test file>.expect file.")]
 public class ForEachCompilerOptions {

--- a/Source/XUnitExtensions/Lit/ExitCommand.cs
+++ b/Source/XUnitExtensions/Lit/ExitCommand.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Xunit.Abstractions;
 
-namespace XUnitExtensions.Lit; 
+namespace XUnitExtensions.Lit;
 
 public class ExitCommand : ILitCommand {
   private readonly int expectedExitCode;

--- a/Source/XUnitExtensions/Lit/NotCommand.cs
+++ b/Source/XUnitExtensions/Lit/NotCommand.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Xunit.Abstractions;
 
-namespace XUnitExtensions.Lit; 
+namespace XUnitExtensions.Lit;
 
 public class NotCommand : ILitCommand {
   private readonly ILitCommand operand;

--- a/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
+++ b/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
@@ -21,226 +21,226 @@ namespace XUnitExtensions.Lit {
 
     private abstract record CheckDirective(string File, int LineNumber) {
 
-    private static readonly Dictionary<string, Func<string, int, string, CheckDirective>> DirectiveParsers = new();
-    static CheckDirective() {
-      DirectiveParsers.Add("CHECK:", CheckRegexp.Parse);
-      DirectiveParsers.Add("CHECK-L:", CheckLiteral.Parse);
-      DirectiveParsers.Add("CHECK-NEXT:", CheckNextRegexp.Parse);
-      DirectiveParsers.Add("CHECK-NEXT-L:", CheckNextLiteral.Parse);
-      DirectiveParsers.Add("CHECK-NOT:", CheckNotRegexp.Parse);
-      DirectiveParsers.Add("CHECK-NOT-L:", CheckNotLiteral.Parse);
+      private static readonly Dictionary<string, Func<string, int, string, CheckDirective>> DirectiveParsers = new();
+      static CheckDirective() {
+        DirectiveParsers.Add("CHECK:", CheckRegexp.Parse);
+        DirectiveParsers.Add("CHECK-L:", CheckLiteral.Parse);
+        DirectiveParsers.Add("CHECK-NEXT:", CheckNextRegexp.Parse);
+        DirectiveParsers.Add("CHECK-NEXT-L:", CheckNextLiteral.Parse);
+        DirectiveParsers.Add("CHECK-NOT:", CheckNotRegexp.Parse);
+        DirectiveParsers.Add("CHECK-NOT-L:", CheckNotLiteral.Parse);
+      }
+
+      public static CheckDirective? Parse(string file, int lineNumber, string line) {
+        foreach (var (keyword, parser) in DirectiveParsers) {
+          var index = line.IndexOf(keyword);
+          if (index >= 0) {
+            var arguments = line[(index + keyword.Length)..].Trim();
+            return parser(file, lineNumber, arguments);
+          }
+        }
+        return null;
+      }
+
+      public abstract bool FindMatch(IEnumerator<string> lines);
     }
 
-    public static CheckDirective? Parse(string file, int lineNumber, string line) {
-      foreach (var (keyword, parser) in DirectiveParsers) {
-        var index = line.IndexOf(keyword);
-        if (index >= 0) {
-          var arguments = line[(index + keyword.Length)..].Trim();
-          return parser(file, lineNumber, arguments);
+    private record CheckRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckRegexp(file, lineNumber, new Regex(arguments));
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        while (lines.MoveNext()) {
+          if (Pattern.IsMatch(lines.Current)) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      public override string ToString() {
+        return $"Check Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
+      }
+    }
+
+    private record CheckNextRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNextRegexp(file, lineNumber, new Regex(arguments));
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        if (!lines.MoveNext()) {
+          throw new Exception("No more lines to match against");
+        }
+
+        return Pattern.IsMatch(lines.Current);
+      }
+
+      public override string ToString() {
+        return $"CheckNext Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
+      }
+    }
+
+    private record CheckLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckLiteral(file, lineNumber, arguments);
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        while (lines.MoveNext()) {
+          if (Literal == lines.Current.Trim()) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      public override string ToString() {
+        return $"CheckLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
+      }
+    }
+
+    private record CheckNextLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNextLiteral(file, lineNumber, arguments);
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        if (!lines.MoveNext()) {
+          throw new Exception("No more lines to match against");
+        }
+
+        return Literal == lines.Current.Trim();
+      }
+
+      public override string ToString() {
+        return $"CheckNextLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
+      }
+    }
+
+    private class CheckingEnumerator : IEnumerator<string> {
+      private readonly IEnumerator<string> Wrapped;
+      private readonly Action<string> Check;
+
+      public CheckingEnumerator(IEnumerator<string> wrapped, Action<string> check) {
+        Wrapped = wrapped;
+        Check = check;
+      }
+
+      public bool MoveNext() {
+        var result = Wrapped.MoveNext();
+        if (result) {
+          Check.Invoke(Wrapped.Current);
+        }
+        return result;
+      }
+
+      public void Reset() {
+        throw new NotImplementedException();
+      }
+
+      object IEnumerator.Current => Current;
+
+      public string Current => Wrapped.Current;
+
+      public void Dispose() => Wrapped.Dispose();
+    }
+
+    private record CheckNotRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNotRegexp(file, lineNumber, new Regex(arguments));
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        // This directive is tested using a CheckingEnumerator instead.
+        throw new NotImplementedException();
+      }
+
+      public override string ToString() {
+        return $"CheckNot Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
+      }
+    }
+
+    private record CheckNotLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNotLiteral(file, lineNumber, arguments);
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        // This directive is tested using a CheckingEnumerator instead.
+        throw new NotImplementedException();
+      }
+
+      public override string ToString() {
+        return $"CheckNotLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
+      }
+    }
+
+    public static ILitCommand Parse(IEnumerable<string> args, LitTestConfiguration config) {
+      ILitCommand? result = null;
+      Parser.Default.ParseArguments<OutputCheckOptions>(args).WithParsed(o => {
+        result = new OutputCheckCommand(o);
+      });
+      return result!;
+    }
+
+    public (int, string, string) Execute(ITestOutputHelper? outputHelper, TextReader? inputReader,
+                                         TextWriter? outputWriter, TextWriter? errorWriter) {
+      if (options.FileToCheck == null) {
+        return (0, "", "");
+      }
+
+      var linesToCheck = File.ReadAllLines(options.FileToCheck).ToList();
+      var fileName = options.CheckFile;
+      if (fileName == null) {
+        return (0, "", "");
+      }
+
+      var checkDirectives = File.ReadAllLines(options.CheckFile!)
+        .Select((line, index) => CheckDirective.Parse(fileName, index + 1, line))
+        .Where(e => e != null).Cast<CheckDirective>()
+        .Select(e => e!)
+        .ToList();
+      if (!checkDirectives.Any()) {
+        return (1, "", $"ERROR: '{fileName}' does not contain any CHECK directives");
+      }
+
+      IEnumerator<string> lineEnumerator = linesToCheck.GetEnumerator();
+      IEnumerator<string>? notCheckingEnumerator = null;
+      foreach (var directive in checkDirectives) {
+        // CHECK-NOT[-L] directives apply up until the next directive, so we handle
+        // them by wrapping the line enumerator for the next time through the loop.
+        if (directive is CheckNotRegexp(var _, var _, var pattern)) {
+          notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
+            if (pattern.IsMatch(line)) {
+              throw new Exception($"Match found for {directive}: {line}");
+            };
+          });
+        } else if (directive is CheckNotLiteral(var _, var _, var literal)) {
+          notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
+            if (literal == line.Trim()) {
+              throw new Exception($"Match found for {directive}: {line}");
+            };
+          });
+        } else {
+          var enumerator = notCheckingEnumerator ?? lineEnumerator;
+          if (!directive.FindMatch(enumerator)) {
+            return (1, "", $"ERROR: Could not find a match for {directive}");
+          }
+          notCheckingEnumerator = null;
         }
       }
-      return null;
-    }
-
-    public abstract bool FindMatch(IEnumerator<string> lines);
-  }
-
-  private record CheckRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckRegexp(file, lineNumber, new Regex(arguments));
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      while (lines.MoveNext()) {
-        if (Pattern.IsMatch(lines.Current)) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    public override string ToString() {
-      return $"Check Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
-    }
-  }
-
-  private record CheckNextRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNextRegexp(file, lineNumber, new Regex(arguments));
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      if (!lines.MoveNext()) {
-        throw new Exception("No more lines to match against");
+      if (notCheckingEnumerator != null) {
+        // Traverse the rest of the enumerator to make sure the CHECK-NOT[-L] directive is fully tested.
+        while (notCheckingEnumerator.MoveNext()) { }
       }
 
-      return Pattern.IsMatch(lines.Current);
-    }
-
-    public override string ToString() {
-      return $"CheckNext Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
-    }
-  }
-
-  private record CheckLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckLiteral(file, lineNumber, arguments);
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      while (lines.MoveNext()) {
-        if (Literal == lines.Current.Trim()) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    public override string ToString() {
-      return $"CheckLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
-    }
-  }
-
-  private record CheckNextLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNextLiteral(file, lineNumber, arguments);
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      if (!lines.MoveNext()) {
-        throw new Exception("No more lines to match against");
-      }
-
-      return Literal == lines.Current.Trim();
-    }
-
-    public override string ToString() {
-      return $"CheckNextLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
-    }
-  }
-
-  private class CheckingEnumerator : IEnumerator<string> {
-    private readonly IEnumerator<string> Wrapped;
-    private readonly Action<string> Check;
-
-    public CheckingEnumerator(IEnumerator<string> wrapped, Action<string> check) {
-      Wrapped = wrapped;
-      Check = check;
-    }
-
-    public bool MoveNext() {
-      var result = Wrapped.MoveNext();
-      if (result) {
-        Check.Invoke(Wrapped.Current);
-      }
-      return result;
-    }
-
-    public void Reset() {
-      throw new NotImplementedException();
-    }
-
-    object IEnumerator.Current => Current;
-
-    public string Current => Wrapped.Current;
-
-    public void Dispose() => Wrapped.Dispose();
-  }
-
-  private record CheckNotRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNotRegexp(file, lineNumber, new Regex(arguments));
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      // This directive is tested using a CheckingEnumerator instead.
-      throw new NotImplementedException();
-    }
-
-    public override string ToString() {
-      return $"CheckNot Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
-    }
-  }
-
-  private record CheckNotLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNotLiteral(file, lineNumber, arguments);
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      // This directive is tested using a CheckingEnumerator instead.
-      throw new NotImplementedException();
-    }
-
-    public override string ToString() {
-      return $"CheckNotLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
-    }
-  }
-
-  public static ILitCommand Parse(IEnumerable<string> args, LitTestConfiguration config) {
-    ILitCommand? result = null;
-    Parser.Default.ParseArguments<OutputCheckOptions>(args).WithParsed(o => {
-      result = new OutputCheckCommand(o);
-    });
-    return result!;
-  }
-
-  public (int, string, string) Execute(ITestOutputHelper? outputHelper, TextReader? inputReader,
-                                       TextWriter? outputWriter, TextWriter? errorWriter) {
-    if (options.FileToCheck == null) {
       return (0, "", "");
     }
 
-    var linesToCheck = File.ReadAllLines(options.FileToCheck).ToList();
-    var fileName = options.CheckFile;
-    if (fileName == null) {
-      return (0, "", "");
+    public override string ToString() {
+      return $"OutputCheck --file-to-check {options.FileToCheck} {options.CheckFile}";
     }
-
-    var checkDirectives = File.ReadAllLines(options.CheckFile!)
-      .Select((line, index) => CheckDirective.Parse(fileName, index + 1, line))
-      .Where(e => e != null).Cast<CheckDirective>()
-      .Select(e => e!)
-      .ToList();
-    if (!checkDirectives.Any()) {
-      return (1, "", $"ERROR: '{fileName}' does not contain any CHECK directives");
-    }
-
-    IEnumerator<string> lineEnumerator = linesToCheck.GetEnumerator();
-    IEnumerator<string>? notCheckingEnumerator = null;
-    foreach (var directive in checkDirectives) {
-      // CHECK-NOT[-L] directives apply up until the next directive, so we handle
-      // them by wrapping the line enumerator for the next time through the loop.
-      if (directive is CheckNotRegexp(var _, var _, var pattern)) {
-        notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
-          if (pattern.IsMatch(line)) {
-            throw new Exception($"Match found for {directive}: {line}");
-          };
-        });
-      } else if (directive is CheckNotLiteral(var _, var _, var literal)) {
-        notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
-          if (literal == line.Trim()) {
-            throw new Exception($"Match found for {directive}: {line}");
-          };
-        });
-      } else {
-        var enumerator = notCheckingEnumerator ?? lineEnumerator;
-        if (!directive.FindMatch(enumerator)) {
-          return (1, "", $"ERROR: Could not find a match for {directive}");
-        }
-        notCheckingEnumerator = null;
-      }
-    }
-    if (notCheckingEnumerator != null) {
-      // Traverse the rest of the enumerator to make sure the CHECK-NOT[-L] directive is fully tested.
-      while (notCheckingEnumerator.MoveNext()) { }
-    }
-
-    return (0, "", "");
   }
-
-  public override string ToString() {
-    return $"OutputCheck --file-to-check {options.FileToCheck} {options.CheckFile}";
-  }
-}
 }

--- a/Source/XUnitExtensions/Lit/StdInCommand.cs
+++ b/Source/XUnitExtensions/Lit/StdInCommand.cs
@@ -2,7 +2,7 @@ using System.IO;
 using System.Threading;
 using Xunit.Abstractions;
 
-namespace XUnitExtensions.Lit; 
+namespace XUnitExtensions.Lit;
 
 public class StdInCommand : ILitCommand {
   private readonly string stdin;

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,12 +8,6 @@
         "coco"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "boogie": {
       "version": "2.16.0",
       "commands": [


### PR DESCRIPTION
- Use the built-in dotnet format command instead of the dotnet-format tool
- Apply changes from a newer version of the formatter

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
