### PR TITLE
Fix: Highlight "inconclusive" as errors in the gutter icons

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/ConcurrentLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/ConcurrentLinearVerificationGutterStatusTester.cs
@@ -50,7 +50,7 @@ public class ConcurrentLinearVerificationGutterStatusTester : LinearVerification
  .  S [S][ ][I][S][ ]:method H()
  .  S [=][=][-][~][O]:  ensures F(1)
  .  S [=][=][-][~][=]:{//Next: { assert false;
- .  S [S][ ][I][S][ ]:}", $"testfile{i}.dfy", true, verificationStatusGutterReceivers[i]));
+ .  S [S][ ][I][S][ ]:}", $"testfile{i}.dfy", true, true, verificationStatusGutterReceivers[i]));
     }
 
     for (var i = 0; i < MaxSimultaneousVerificationTasks; i++) {

--- a/Source/DafnyLanguageServer.Test/GutterStatus/LinearRenderingTest.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/LinearRenderingTest.cs
@@ -42,12 +42,17 @@ public class LinearRenderingTest {
             : LineVerificationStatus.VerifiedVerifying,
         _ => throw new ArgumentOutOfRangeException()
       },
-      // We don't display inconclusive on the gutter (user should focus on errors),
-      // We display an error range instead
+      // we display inconclusive as an error, because Dafny's goal is to verify
       GutterVerificationStatus.Inconclusive => currentStatus switch {
-        CurrentStatus.Current => LineVerificationStatus.ErrorContext,
-        CurrentStatus.Obsolete => LineVerificationStatus.ErrorContextObsolete,
-        CurrentStatus.Verifying => LineVerificationStatus.ErrorContextVerifying,
+        CurrentStatus.Current => isSingleLine ?
+          LineVerificationStatus.AssertionFailed :
+          LineVerificationStatus.ErrorContext,
+        CurrentStatus.Obsolete => isSingleLine ?
+          LineVerificationStatus.AssertionFailedObsolete :
+          LineVerificationStatus.ErrorContextObsolete,
+        CurrentStatus.Verifying => isSingleLine ?
+          LineVerificationStatus.AssertionFailedVerifying :
+          LineVerificationStatus.ErrorContextVerifying,
         _ => throw new ArgumentOutOfRangeException()
       },
       GutterVerificationStatus.Error => currentStatus switch {

--- a/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
@@ -113,10 +113,8 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
   protected ConcurrentDictionary<TestNotificationReceiver<VerificationStatusGutter>, List<LineVerificationStatus[]>>
     previousTraces = new();
 
-  protected async Task<List<LineVerificationStatus[]>> GetAllLineVerificationStatuses(
-      TextDocumentItem documentItem,
-      TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver
-      ) {
+  protected async Task<List<LineVerificationStatus[]>> GetAllLineVerificationStatuses(TextDocumentItem documentItem,
+    TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver, bool intermediates) {
     var traces = new List<LineVerificationStatus[]>();
     var maximumNumberOfTraces = 5000;
     var attachedTraces = previousTraces.GetOrCreate(verificationStatusGutterReceiver,
@@ -134,8 +132,14 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
         continue;
       }
 
-      traces.Add(verificationStatusGutter.PerLineStatus);
+      if (intermediates) {
+        traces.Add(verificationStatusGutter.PerLineStatus);
+      }
+
       if (NoMoreNotificationsToAwaitFrom(verificationStatusGutter)) {
+        if (!intermediates) {
+          traces.Add(verificationStatusGutter.PerLineStatus);
+        }
         break;
       }
 
@@ -229,9 +233,8 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
   }
 
   // If testTrace is false, codeAndTree should not contain a trace to test.
-  public async Task VerifyTrace(string codeAndTrace, string fileName = null, bool testTrace = true,
-    TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver = null
-    ) {
+  public async Task VerifyTrace(string codeAndTrace, string fileName = null, bool testTrace = true, bool intermediates = true,
+    TestNotificationReceiver<VerificationStatusGutter> verificationStatusGutterReceiver = null) {
     if (verificationStatusGutterReceiver == null) {
       verificationStatusGutterReceiver = this.verificationStatusGutterReceiver;
     }
@@ -243,10 +246,10 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
     var documentItem = CreateTestDocument(code, fileName);
     client.OpenDocument(documentItem);
     var traces = new List<LineVerificationStatus[]>();
-    traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver));
+    traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver, intermediates: intermediates));
     foreach (var (range, inserted) in changes) {
       ApplyChange(ref documentItem, range, inserted);
-      traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver));
+      traces.AddRange(await GetAllLineVerificationStatuses(documentItem, verificationStatusGutterReceiver, intermediates: intermediates));
     }
 
     if (testTrace) {

--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -12,6 +12,19 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
   // Add '//Next<n>:' to edit a line multiple times
 
   [Fact]
+  public async Task GitIssue3821GutterIgnoredProblem() {
+    await VerifyTrace(@"
+ | :function fib(n: nat): nat {
+ | :  if n <= 1 then n else fib(n-1) + fib(n-2)
+ | :}
+ | :
+[ ]:method {:rlimit 1} Test(s: seq<nat>)
+[=]:  requires |s| >= 1 && s[0] >= 0 {
+[=]:  assert fib(10) == 1; assert {:split_here} s[0] >= 0;
+[ ]:}", intermediates: false);
+  }
+
+  [Fact]
   public async Task NoGutterNotificationsReceivedWhenTurnedOff() {
     var source = @"
 method Foo() ensures false { } ";

--- a/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
@@ -284,8 +284,9 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
               : LineVerificationStatus.Verified,
         // We don't display inconclusive on the gutter (user should focus on errors),
         // We display an error range instead
-        GutterVerificationStatus.Inconclusive =>
-          LineVerificationStatus.ErrorContext,
+        GutterVerificationStatus.Inconclusive => isFinalError
+          ? LineVerificationStatus.AssertionFailed
+          : LineVerificationStatus.ErrorContext,
         GutterVerificationStatus.Error => isFinalError
             ? LineVerificationStatus.AssertionFailed
             : LineVerificationStatus.ErrorContext,

--- a/docs/dev/news/3821.fix
+++ b/docs/dev/news/3821.fix
@@ -1,0 +1,1 @@
+Highlight "inconclusive" as errors in the gutter icons


### PR DESCRIPTION
This PR fixes #3821
Now, the screenshot is strictly better than before (assertions that are inconclusive are highlighted as errors in the gutter)
![image](https://user-images.githubusercontent.com/3601079/228885466-4edeaf6a-aa88-470e-8deb-a712f17ddbe7.png)
However, there is one problem remaining:
Indeed, inconclusiveness happens for an entire batch, and its token is determined by Boogie to be the method's name no matter what.  This is why in the screenshot "Test" is underlined in red (that's the diagnostic token), whereas the gutter icons are chosen based on the individual assertion's tokens.
We should change this at the boogie level, but for now this PR is an improvement over the existing state of the art.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>