### PR TITLE
Update to Boogie 2.16.4

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -30,7 +30,7 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.3" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -61,7 +61,7 @@ index 0f17aa923..6b937ebcb 100644
        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
        <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
--      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.3" />
+-      <PackageReference Include="Boogie.ExecutionEngine" Version="2.16.4" />
 +      <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
    </ItemGroup>
  


### PR DESCRIPTION
Update to Boogie 2.16.4, which contains this stack overflow fix: https://github.com/boogie-org/boogie/pull/710

Fixes #3819, fixes #3803

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
