### PR TITLE
[Counterexamples] Support constant fields

### DIFF
--- a/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CounterExampleTest.cs
@@ -184,6 +184,25 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
     }
 
     [Fact]
+    public async Task ConstantField() {
+      var source = @"
+      class Value {
+        const v:int;
+      }
+      method a(v:Value) {
+        assert v.v != 42;
+      }
+      ".TrimStart();
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var counterExamples = (await RequestCounterExamples(documentItem.Uri)).ToArray();
+      Assert.Single(counterExamples);
+      Assert.Equal(1, counterExamples[0].Variables.Count);
+      Assert.True(counterExamples[0].Variables.ContainsKey("v:_module.Value?"));
+      Assert.Equal("(v := 42)", counterExamples[0].Variables["v:_module.Value?"]);
+    }
+
+    [Fact]
     public async Task FractionFieldAsReal() {
       var source = @"
       class Value {


### PR DESCRIPTION
Counterexamples should now correctly report values assigned to constant fields (where previously these values would not be filled in). As a bonus, this PR removes the need for special processing of arrays because array lengths are constant fields under the hood.

This PR adds the following test case for counterexample generation:

```Dafny
class Value {
  const v:int;
}
method a(v:Value) {
  assert v.v != 42;
}
```

With the expected output being: `v:_module.Value? = (v := 42)`

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
