### PR TITLE
Fix: Docstring for functions with ensures

### DIFF
--- a/Source/DafnyCore/AST/Function.cs
+++ b/Source/DafnyCore/AST/Function.cs
@@ -439,20 +439,16 @@ experimentalPredicateAlwaysGhost - Compiled functions are written `function`. Gh
   }
 
   protected override string GetTriviaContainingDocstring() {
-    if (Body == null) {
-      if (EndToken.TrailingTrivia.Trim() != "") {
-        return EndToken.TrailingTrivia;
-      }
 
-      if (StartToken.LeadingTrivia.Trim() != "") {
-        return StartToken.LeadingTrivia;
-      }
-    } else if (Body.StartToken.Prev.Prev is var tokenWhereTrailingIsDocstring &&
-              tokenWhereTrailingIsDocstring.TrailingTrivia.Trim() != "") {
-      return tokenWhereTrailingIsDocstring.TrailingTrivia;
-    } else if (StartToken is var tokenWhereLeadingIsDocstring &&
-        tokenWhereLeadingIsDocstring.LeadingTrivia.Trim() != "") {
-      return tokenWhereLeadingIsDocstring.LeadingTrivia;
+    var endTokenDefinition =
+      OwnedTokens.LastOrDefault(token => token.val == ")" || token.pos == ResultType.EndToken.pos)
+      ?? EndToken;
+    if (endTokenDefinition.TrailingTrivia.Trim() != "") {
+      return endTokenDefinition.TrailingTrivia;
+    }
+
+    if (StartToken.LeadingTrivia.Trim() != "") {
+      return StartToken.LeadingTrivia;
     }
     return null;
   }

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -28,6 +28,28 @@ namespace DafnyPipeline.Test {
     private Newlines currentNewlines;
 
     [Fact]
+    void DocstringWorksForPredicates() {
+      DocstringWorksFor(@"
+predicate p1()
+  // Always true. Every time.
+  ensures p1() == true
+{ true }
+
+predicate p2(): (y: bool)
+  // Always true.
+  ensures y == true
+{ true }
+
+predicate p3(): (y: bool)
+  // Always true every time.
+  ensures y == true
+", new List<(string nodeTokenValue, string? expectedDocstring)>(){
+          ("p1", "Always true. Every time."),
+          ("p2", "Always true."),
+          ("p3", "Always true every time."),
+      });
+    }
+    [Fact]
     public void DocstringWorksForFunctions() {
       DocstringWorksFor(@"
 function Test1(i: int): int

--- a/docs/dev/news/3840.fix
+++ b/docs/dev/news/3840.fix
@@ -1,0 +1,1 @@
+Docstring for functions with ensures


### PR DESCRIPTION
This PR fixes #3840
The detection of the token with docstring was wrong for functions and predicates. This PR fixes that and adds a test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>