### PR TITLE
Improve rules for nameonly/positional/nameless and required/optional …

### DIFF
--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
@@ -4681,12 +4681,12 @@ namespace Microsoft.Dafny {
       //   * required: a caller has to supply an argument
       //   * optional: the parameter has a default value that is used if a caller omits passing a specific argument
       //
-      // The syntax for giving a positional-only (i.e., nameless) parameter does not a default-value expression, so
+      // The syntax for giving a positional-only (i.e., nameless) parameter does not allow a default-value expression, so
       // a positional-only parameter is always required.
       //
       // At a call site, positional arguments are not allowed to follow named arguments. Therefore, if "x" is
       // a nameonly parameter, then there is no way to supply the parameters after "x" by position. Thus, any
-      // parameter that follows "x" must either by passed by name or have a default value. That is, if a later
+      // parameter that follows "x" must either be passed by name or have a default value. That is, if a later
       // parameter does not have a default value, it is _effectively_ nameonly. We impose the rule that
       //   * an effectively nameonly parameter must be declared as nameonly
       //
@@ -4716,7 +4716,7 @@ namespace Microsoft.Dafny {
           // "formal" is preceded by a nameonly parameter, but itself is neither nameonly nor has a default value
           reporter.Error(MessageSource.Resolver, formal.tok,
             $"this parameter is effectively nameonly (because of the earlier nameonly parameter '{nameOfMostRecentNameonlyParameter}'); " +
-            "declare it as nameonly or give it an default-value expression");
+            "declare it as nameonly or give it a default-value expression");
         }
         if (formal.IsNameOnly) {
           nameOfMostRecentNameonlyParameter = formal.Name;

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference.cs
@@ -4674,8 +4674,8 @@ namespace Microsoft.Dafny {
       Contract.Assume(AllTypeConstraints.Count == 0);
 
       // Formal parameters have three ways to indicate how they are to be passed in:
-      //   * nameonly: the only way to give a specific value is to name the parameter
-      //   * positional only: these are nameless arguments (which are allowed only for datatype constructor parameters)
+      //   * nameonly: the only way to give a specific argument value is to name the parameter
+      //   * positional only: these are nameless parameters (which are allowed only for datatype constructor parameters)
       //   * either positional or by name: this is the most common parameter
       // A parameter is either required or optional:
       //   * required: a caller has to supply an argument

--- a/Test/dafny0/ParameterResolution.dfy.expect
+++ b/Test/dafny0/ParameterResolution.dfy.expect
@@ -68,13 +68,13 @@ ParameterResolution.dfy(252,21): Error: Duplicate parameter name: x
 ParameterResolution.dfy(259,11): Error: default-value expressions for parameters contain a cycle: x -> x
 ParameterResolution.dfy(260,35): Error: unresolved identifier: _k
 ParameterResolution.dfy(261,26): Error: unresolved identifier: _k
-ParameterResolution.dfy(278,33): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'u'); declare it as nameonly or give it an default-value expression
-ParameterResolution.dfy(278,33): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'u'); declare it as nameonly or give it an default-value expression
-ParameterResolution.dfy(281,45): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter '1'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(278,33): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'u'); declare it as nameonly or give it a default-value expression
+ParameterResolution.dfy(278,33): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'u'); declare it as nameonly or give it a default-value expression
+ParameterResolution.dfy(281,45): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter '1'); declare it as nameonly or give it a default-value expression
 ParameterResolution.dfy(284,27): Error: because of a later nameless parameter, this default value is never used; remove it or name all subsequent parameters
-ParameterResolution.dfy(285,39): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'b'); declare it as nameonly or give it an default-value expression
-ParameterResolution.dfy(286,34): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'b'); declare it as nameonly or give it an default-value expression
-ParameterResolution.dfy(368,79): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(285,39): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'b'); declare it as nameonly or give it a default-value expression
+ParameterResolution.dfy(286,34): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'b'); declare it as nameonly or give it a default-value expression
+ParameterResolution.dfy(368,79): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it a default-value expression
 ParameterResolution.dfy(290,21): Error: nameonly parameter 'c' must be passed using a name binding; it cannot be passed positionally
 ParameterResolution.dfy(297,26): Error: nameonly parameter 'c' must be passed using a name binding; it cannot be passed positionally
 ParameterResolution.dfy(301,34): Error: a positional argument is not allowed to follow named arguments
@@ -97,7 +97,7 @@ ParameterResolution.dfy(351,15): Error: nameonly parameter '900' must be passed 
 ParameterResolution.dfy(355,15): Error: the binding named '0900' does not correspond to any formal parameter
 ParameterResolution.dfy(355,9): Error: datatype constructor parameter '900' at index 1 requires an argument of type int
 ParameterResolution.dfy(356,25): Error: the binding named '90_0' does not correspond to any formal parameter
-ParameterResolution.dfy(369,73): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it an default-value expression
-ParameterResolution.dfy(370,71): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(369,73): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it a default-value expression
+ParameterResolution.dfy(370,71): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it a default-value expression
 ParameterResolution.dfy(377,9): Error: wrong number of arguments (got 0, but datatype constructor 'Foo' expects at least 1: (bar: string, baz: string, qux: int))
 102 resolution/type errors detected in ParameterResolution.dfy

--- a/Test/dafny0/ParameterResolution.dfy.expect
+++ b/Test/dafny0/ParameterResolution.dfy.expect
@@ -52,11 +52,6 @@ ParameterResolution.dfy(198,37): Error: type parameter 'X' (inferred to be '?') 
 ParameterResolution.dfy(193,21): Error: type parameter 'X' (inferred to be '?') in the function call to 'F' could not be determined
 ParameterResolution.dfy(194,13): Error: type parameter 'X' (inferred to be '?') in the function call to 'F' could not be determined
 ParameterResolution.dfy(196,29): Error: type parameter 'X' (inferred to be '?') in the function call to 'F' could not be determined
-ParameterResolution.dfy(202,37): Error: a required parameter must precede all optional parameters
-ParameterResolution.dfy(203,29): Error: a required parameter must precede all optional parameters
-ParameterResolution.dfy(203,29): Error: a required parameter must precede all optional parameters
-ParameterResolution.dfy(204,27): Error: a required parameter must precede all optional parameters
-ParameterResolution.dfy(205,37): Error: a required parameter must precede all optional parameters
 ParameterResolution.dfy(211,23): Error: old expressions are not allowed in this context
 ParameterResolution.dfy(213,25): Error: old expressions are not allowed in this context
 ParameterResolution.dfy(216,32): Error: old expressions are not allowed in this context
@@ -73,9 +68,13 @@ ParameterResolution.dfy(252,21): Error: Duplicate parameter name: x
 ParameterResolution.dfy(259,11): Error: default-value expressions for parameters contain a cycle: x -> x
 ParameterResolution.dfy(260,35): Error: unresolved identifier: _k
 ParameterResolution.dfy(261,26): Error: unresolved identifier: _k
-ParameterResolution.dfy(284,30): Error: a required parameter must precede all optional parameters
-ParameterResolution.dfy(285,39): Error: a required parameter must precede all optional parameters
-ParameterResolution.dfy(286,34): Error: a nameless parameter must precede all nameonly parameters
+ParameterResolution.dfy(278,33): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'u'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(278,33): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'u'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(281,45): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter '1'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(284,27): Error: because of a later nameless parameter, this default value is never used; remove it or name all subsequent parameters
+ParameterResolution.dfy(285,39): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'b'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(286,34): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'b'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(368,79): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it an default-value expression
 ParameterResolution.dfy(290,21): Error: nameonly parameter 'c' must be passed using a name binding; it cannot be passed positionally
 ParameterResolution.dfy(297,26): Error: nameonly parameter 'c' must be passed using a name binding; it cannot be passed positionally
 ParameterResolution.dfy(301,34): Error: a positional argument is not allowed to follow named arguments
@@ -98,4 +97,7 @@ ParameterResolution.dfy(351,15): Error: nameonly parameter '900' must be passed 
 ParameterResolution.dfy(355,15): Error: the binding named '0900' does not correspond to any formal parameter
 ParameterResolution.dfy(355,9): Error: datatype constructor parameter '900' at index 1 requires an argument of type int
 ParameterResolution.dfy(356,25): Error: the binding named '90_0' does not correspond to any formal parameter
-100 resolution/type errors detected in ParameterResolution.dfy
+ParameterResolution.dfy(369,73): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(370,71): Error: this parameter is effectively nameonly (because of the earlier nameonly parameter 'baz'); declare it as nameonly or give it an default-value expression
+ParameterResolution.dfy(377,9): Error: wrong number of arguments (got 0, but datatype constructor 'Foo' expects at least 1: (bar: string, baz: string, qux: int))
+102 resolution/type errors detected in ParameterResolution.dfy

--- a/docs/dev/news/3864.fix
+++ b/docs/dev/news/3864.fix
@@ -1,0 +1,1 @@
+Improved rules for nameonly parameters and parameter default-value expressions


### PR DESCRIPTION
Fixes #3859

This PR allows more parameter declarations (for example, as suggested in #3859, a `nameonly` parameter with a default value can now be follow by other `nameonly` parameters), clarifies some error messages, and gives new errors for useless situations (for example, a parameter's default value can not be used if it is followed by a positional-only parameter).

## The new rules

Formal parameters have three ways to indicate how they are to be passed in:

* `nameonly`: the only way to give a specific argument value is to name the parameter
* positional only: these are nameless parameters (which are allowed only for datatype constructor parameters)
* either positional or by name: this is the most common parameter

A parameter is either required or optional:
* required: a caller has to supply an argument
* optional: the parameter has a default value that is used if a caller omits passing a specific argument

The syntax for giving a positional-only (i.e., nameless) parameter does not a default-value expression, so a positional-only parameter is always required.

At a call site, positional arguments are not allowed to follow named arguments. Therefore, if `x` is a nameonly parameter, then there is no way to supply the parameters after `x` by position. Thus, any parameter that follows `x` must either by passed by name or have a default value. That is, if a later parameter does not have a default value, it is _effectively_ nameonly. We impose the rule that

* an effectively nameonly parameter must be declared as nameonly

For a positional-only parameter `x`, every parameter preceding `x` is _effectively_ required. We impose the rule that

* an effectively required parameter must not have a default-value expression

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
