### PR TITLE
fix: Better cloning of variable declarations in match statements

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Expressions.cs
+++ b/Source/DafnyCore/AST/Expressions/Expressions.cs
@@ -2858,13 +2858,18 @@ public class CasePattern<VT> : TokenNode
       Var = cloner.CloneIVariable(original.Var, false);
     }
 
+    if (original.Arguments != null) {
+      Arguments = original.Arguments.Select(cloner.CloneCasePattern).ToList();
+    }
+    
+    // In this case, tt is important to resolve the resolved fields AFTER the Arguments above.
+    // If we resolve the expression first, the references to variables declared in the case pattern
+    // will be cloned as references instead of declarations,
+    // and when we clone the declarations the cache in Cloner.clones will incorrectly return
+    // the original variable instead.
     if (cloner.CloneResolvedFields) {
       Expr = cloner.CloneExpr(original.Expr);
       Ctor = original.Ctor;
-    }
-
-    if (original.Arguments != null) {
-      Arguments = original.Arguments.Select(cloner.CloneCasePattern).ToList();
     }
   }
 

--- a/Source/DafnyCore/AST/Expressions/NestedMatchCaseStmt.cs
+++ b/Source/DafnyCore/AST/Expressions/NestedMatchCaseStmt.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Microsoft.Dafny;
 
-public class NestedMatchCaseStmt : NestedMatchCase, IAttributeBearingDeclaration {
+public class NestedMatchCaseStmt : NestedMatchCase, IAttributeBearingDeclaration, ICloneable<NestedMatchCaseStmt> {
   public readonly List<Statement> Body;
   public Attributes Attributes;
   Attributes IAttributeBearingDeclaration.Attributes => Attributes;
@@ -21,6 +21,14 @@ public class NestedMatchCaseStmt : NestedMatchCase, IAttributeBearingDeclaration
     this.Attributes = attrs;
   }
 
+  private NestedMatchCaseStmt(Cloner cloner, NestedMatchCaseStmt original) : base(original.tok, original.Pat) {
+    this.Body = original.Body.Select(cloner.CloneStmt).ToList();
+    this.Attributes = cloner.CloneAttributes(original.Attributes);
+  }
+
+  public NestedMatchCaseStmt Clone(Cloner cloner) {
+    return new NestedMatchCaseStmt(cloner, this);
+  }
   public override IEnumerable<Node> Children => new[] { Pat }.Concat<Node>(Body).Concat(Attributes?.Args ?? Enumerable.Empty<Node>());
   public override IEnumerable<Node> PreResolveChildren => Children;
 

--- a/Source/DafnyCore/CompileNestedMatch/MatchFlattener.cs
+++ b/Source/DafnyCore/CompileNestedMatch/MatchFlattener.cs
@@ -123,7 +123,9 @@ public class MatchFlattener : IRewriter {
   }
 
   private Statement CompileNestedMatchStmt(NestedMatchStmt nestedMatchStmt) {
-    var cases = nestedMatchStmt.Cases.SelectMany(FlattenNestedMatchCaseStmt).ToList();
+    var cases = nestedMatchStmt.Cases.SelectMany(FlattenNestedMatchCaseStmt)
+      .Select(nms => nms.Clone(new Cloner(true)))
+      .ToList();
     var state = new MatchCompilationState(nestedMatchStmt, cases, resolutionContext.WithGhost(nestedMatchStmt.IsGhost), nestedMatchStmt.Attributes);
 
     var paths = cases.Select((@case, index) => (PatternPath)new StmtPatternPath(index, @case, @case.Attributes)).ToList();

--- a/Test/git-issues/github-issue-3658.dfy
+++ b/Test/git-issues/github-issue-3658.dfy
@@ -1,0 +1,27 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// This case used to cause duplicate Boogie variable declarations
+// because MatchFlattner was not cloning NestedMatchCaseStmts as it
+// created multiple copies for disjunctive patterns.
+
+method mmm() returns (i: int) {
+  match "abc"
+    case "def"|"ghi" => { var st := 0; return st; }
+    case _ => { return 1; }
+}
+
+// Whereas this case produced the same symptom but for a different reason:
+// incorrect cloning of CasePatterns that resulted in not cloning LocalVariable
+// declarations.  
+
+datatype Choice = A | B | C
+
+method Foo(x: Choice) returns (r: bool) {
+  match x {
+    case A => return true;
+    case _ => 
+      var (x, y) := (42, 43);
+      return false;
+  }
+}

--- a/Test/git-issues/github-issue-3658.dfy.expect
+++ b/Test/git-issues/github-issue-3658.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors


### PR DESCRIPTION
Fixes #3658 

I'm not that familiar with the idioms around cloning so we might be able to improve this slightly. In general, cloning feels pretty tricky to get right in the current design, and I'd prefer in the longer term to be more disciplined about how we use the caching in a `Cloner` to avoid these kinds of bugs.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
