### PR TITLE
doc: fix a typo in a Dafny example

### DIFF
--- a/docs/DafnyRef/Statements.md
+++ b/docs/DafnyRef/Statements.md
@@ -204,7 +204,7 @@ It assigns an arbitrary but type-correct value to the corresponding left-hand-si
 It can be mixed with other assignments of computed values.
 <!-- %no-check -->
 ```dafny
-a := *'
+a := *;
 a, b, c := 4, *, 5;
 ```
 


### PR DESCRIPTION
Fixes a small typo where a statement ended with `'` rather than `;`.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
