### PR TITLE
[Test Generation] Allow users to specify methods used to construct objects

### DIFF
--- a/Source/DafnyCore/TestGenerationOptions.cs
+++ b/Source/DafnyCore/TestGenerationOptions.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Dafny {
     [CanBeNull] public string PrintBpl = null;
     [CanBeNull] public string PrintStats = null;
     public bool DisablePrune = false;
-    public static readonly uint DefaultTimeLimit = 10;
+    public const uint DefaultTimeLimit = 10;
+    public const string TestConstructorAttribute = "testConstructor";
 
     public bool ParseOption(string name, Bpl.CommandLineParseState ps) {
       var args = ps.args;

--- a/Source/DafnyTestGeneration/DafnyInfo.cs
+++ b/Source/DafnyTestGeneration/DafnyInfo.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Dafny;
 using Function = Microsoft.Dafny.Function;
 using IdentifierExpr = Microsoft.Dafny.IdentifierExpr;
@@ -24,6 +25,7 @@ namespace DafnyTestGeneration {
     public readonly Dictionary<string, string> ToImportAs = new();
     private readonly Dictionary<string, (List<TypeParameter> args, Type superset)> subsetToSuperset = new();
     private readonly Dictionary<string, Expression> witnessForType = new();
+    private readonly Dictionary<string, MemberDecl> userDefinedConstructorForType = new();
     private readonly Dictionary<string, (IVariable variable, Expression expr)> conditionForType = new();
     // list of top level scopes accessible from the testing module
     private readonly List<VisibilityScope> scopes;
@@ -152,6 +154,14 @@ namespace DafnyTestGeneration {
 
       return Printer.ExprToString(Options, new ClonerWithSubstitution(this, new Dictionary<IVariable, string>(),
         "").CloneExpr(witnessForType[userDefinedType.Name]));
+    }
+
+    public string/*?*/ GetUserDefinedConstrutor(Type type) {
+      if (type is not UserDefinedType userDefinedType ||
+          !userDefinedConstructorForType.ContainsKey(userDefinedType.ToString())) {
+        return null;
+      }
+      return userDefinedConstructorForType[userDefinedType.ToString()].FullDafnyName + "()";
     }
 
     public Type/*?*/ GetSupersetType(Type type) {
@@ -463,8 +473,41 @@ namespace DafnyTestGeneration {
         }
       }
 
+      private static bool HasAttribute(Declaration d, string attribute) {
+        var curr = d.Attributes;
+        while (curr != null) {
+          if (curr.Name == attribute) {
+            return true;
+          }
+          curr = curr.Prev;
+        }
+        return false;
+      }
+
       private new void Visit(Method m) {
         info.methods[m.FullDafnyName] = m;
+        if (!HasAttribute(m, TestGenerationOptions.TestConstructorAttribute)) {
+          return;
+        }
+        if (m.Ins.Count != 1 && m.Req.Count != 0 && m.IsStatic) {
+          info.SetNonZeroExitCode = true;
+          info.Options.Printer.ErrorWriteLine(Console.Error,
+            $"*** Error: Methods annotated with " +
+            $"{TestGenerationOptions.TestConstructorAttribute} must be " +
+            $"static, have no preconditions, and have a single return " +
+            $"parameter. Method {m.FullDafnyName} violates these conditions.");
+          return;
+        }
+        var returnType = Utils.UseFullName(m.Outs[0].Type).ToString();
+        if (info.userDefinedConstructorForType.ContainsKey(returnType)) {
+          info.SetNonZeroExitCode = true;
+          info.Options.Printer.ErrorWriteLine(Console.Error,
+            $"*** Error: Found two methods annotated with " +
+            $"{TestGenerationOptions.TestConstructorAttribute}. Will use " +
+            $"{info.userDefinedConstructorForType[returnType].FullDafnyName}.");
+          return;
+        }
+        info.userDefinedConstructorForType[returnType] = m;
       }
 
       private new void Visit(Function f) {


### PR DESCRIPTION
This PR allows the user to specify methods that test generation can use to construct objects. My understanding is that a feature like this would improve the test generation experience (@codyroux, @hmijail, @aleks-AWS) but I mark the PR as a draft as I would want to make sure the proposed approach is helpful before asking to review the code. 

The proposed approach involves the user annotating such methods (which must be static, have one return parameter and no preconditions) with `:testConstructor` attribute. The test generation will use the provided method to construct objects of the corresponding type whose value is not constrained by the counterexample.

For instance, given the following Dafny program:

```Dafny
module M {
  class String { 
    var s:string;
    var len:int;
    // this constructor has a precondition,
    // so test generation will not use it
    constructor(s:string, len:int)  
      requires |s| == len
    {
      this.s := s;
      this.len := len;
    }
    // test generation will use this method to construct a string
    // whenever this string is unconstrained
    static method {:testConstructor} getString() returns (s:String) {
      s := new String("example", 7);
    }
  }
  function IsNull(s:String?):bool { 
    if s == null then false else true
  }
}
```
The tests generated for the `isNull` function will look like this (this test is added as part of the PR):

```Dafny
method {:test} test0() {
  var r0 := M.IsNull(null);
}
method {:test} test1() {
  var string0 : M.String := M.String.getString();
  var r0 := M.IsNull(string0);
}
```

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
