### PR TITLE
Fix: Opaque functions with frame condition supported as follow-up of #3779

### DIFF
--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -4010,6 +4010,11 @@ namespace Microsoft.Dafny {
       // This is the general case
       Bpl.Expr prevH = null;
       Bpl.BoundVariable prevHVar = null;
+      Bpl.Expr reveal = null;
+      Bpl.BoundVariable revealVar = null;
+      if (f.IsOpaque) {
+        revealVar = BplBoundVar("$reveal", Bpl.Type.Bool, out reveal);
+      }
       if (f is TwoStateFunction) {
         // The previous-heap argument is the same for both function arguments.  That is,
         // the frame axiom says nothing about functions invoked with different previous heaps.
@@ -4048,6 +4053,11 @@ namespace Microsoft.Dafny {
         Bpl.Expr s; var sV = BplBoundVar("$ly", predef.LayerType, out s);
         bvars.Add(sV);
         f0args.Add(s); f1args.Add(s);  // but don't add to f0argsCanCall or f1argsCanCall
+      }
+
+      if (reveal != null) {
+        bvars.Add(revealVar);
+        f0args.Add(reveal); f1args.Add(reveal);
       }
 
       if (prevH != null) {

--- a/Test/git-issues/git-issue-3955.dfy
+++ b/Test/git-issues/git-issue-3955.dfy
@@ -1,0 +1,19 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+class A {
+  var x: int
+  predicate Valid() reads this {
+    x >= 0
+  }
+}
+
+datatype B = B(
+  a: A
+) {
+  opaque predicate Valid()
+    reads a
+  {
+    a.Valid()
+  }
+}

--- a/Test/git-issues/git-issue-3955.dfy
+++ b/Test/git-issues/git-issue-3955.dfy
@@ -17,3 +17,13 @@ datatype B = B(
     a.Valid()
   }
 }
+
+class C {
+  var a: A
+  constructor()
+  opaque twostate predicate Valid()
+    reads this`a, a
+  {
+    a.Valid() && old(a.Valid())
+  }
+}

--- a/Test/git-issues/git-issue-3955.dfy.expect
+++ b/Test/git-issues/git-issue-3955.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Test/git-issues/git-issue-3955.dfy.expect
+++ b/Test/git-issues/git-issue-3955.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with TODO verified, TODO errors
+Dafny program verifier finished with 3 verified, 0 errors

--- a/docs/dev/news/3955.fix
+++ b/docs/dev/news/3955.fix
@@ -1,0 +1,1 @@
+Opaque functions with frame condition supported as follow-up of #3779

--- a/docs/dev/news/3955.fix
+++ b/docs/dev/news/3955.fix
@@ -1,1 +1,0 @@
-Opaque functions with frame condition supported as follow-up of #3779


### PR DESCRIPTION
This PR fixes #3955
I added the corresponding test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>