### PR TITLE
fix: Block .doo files as input in legacy CLI

### DIFF
--- a/Source/DafnyCore/Compilers/Dafny/DafnyBackend.cs
+++ b/Source/DafnyCore/Compilers/Dafny/DafnyBackend.cs
@@ -45,7 +45,7 @@ public class DafnyBackend : ExecutableBackend {
     string targetFilename, ReadOnlyCollection<string> otherFileNames, object compilationResult, TextWriter outputWriter) {
     Contract.Requires(targetFilename != null || otherFileNames.Count == 0);
 
-    return RunTargetDafnyProgram(targetFilename, outputWriter);
+    return RunTargetDafnyProgram(targetFilename, outputWriter, false);
   }
 
   public DafnyBackend(DafnyOptions options) : base(options) {

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.Dafny.Compilers {
                 typeDescriptorExpr = $"{DafnyTypeDescriptor}.referenceWithInitializer({StripTypeParameters(targetTypeName)}.class, () -> ({targetTypeName}){d})";
               } else {
                 var td = FormatTypeDescriptorVariable(tp.GetCompileName(Options));
-                typeDescriptorExpr = $"{DafnyTypeDescriptor}.referenceWithInitializerAndTypeDescriptor({td}, () -> {d})";
+                typeDescriptorExpr = $"{DafnyTypeDescriptor}.referenceWithInitializerAndTypeDescriptor({td}, () -> ({targetTypeName}){d})";
               }
             }
             break;

--- a/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
+++ b/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
@@ -83,6 +83,6 @@ public class LibraryBackend : ExecutableBackend {
     ReadOnlyCollection<string> otherFileNames, object compilationResult, TextWriter outputWriter) {
 
     var dooPath = DooFilePath(dafnyProgramName);
-    return RunTargetDafnyProgram(dooPath, outputWriter);
+    return RunTargetDafnyProgram(dooPath, outputWriter, true);
   }
 }

--- a/Source/DafnyCore/DooFile.cs
+++ b/Source/DafnyCore/DooFile.cs
@@ -113,6 +113,11 @@ public class DooFile {
   }
 
   public bool Validate(string filePath, DafnyOptions options, Command currentCommand) {
+    if (currentCommand == null) {
+      options.Printer.ErrorWriteLine(Console.Out, $"Cannot load {filePath}: .doo files cannot be used with the legacy CLI");
+      return false;
+    }
+    
     if (options.VersionNumber != Manifest.DafnyVersion) {
       options.Printer.ErrorWriteLine(Console.Out, $"Cannot load {filePath}: it was built with Dafny {Manifest.DafnyVersion}, which cannot be used by Dafny {options.VersionNumber}");
       return false;


### PR DESCRIPTION
Also use the new CLI when executing Dafny files for the library and Simple Dafny backends.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
