### PR TITLE
Try using Boogie's "argument" type encoding scheme

### DIFF
--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -233,6 +233,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
       : base("dafny", "Dafny program verifier", new Bpl.ConsolePrinter()) {
       ErrorTrace = 0;
       Prune = true;
+      TypeEncodingMethod = Bpl.CoreOptions.TypeEncoding.Arguments;
       NormalizeNames = true;
       EmitDebugInformation = false;
       Backend = new CsharpBackend(this);


### PR DESCRIPTION
This seems to provide much better performance on the libraries code base, with no problems so far.

**Draft PR for testing, for the moment.**

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
