### PR TITLE
chore: Remove libraries submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Test/libraries"]
-	path = Test/libraries
-	url = https://github.com/dafny-lang/libraries.git


### PR DESCRIPTION
#3715 broken the nightly build because various tests in Test/libraries failed, but we already decided it made more sense to remove the submodule and rely on the libraries repo's own nightly build to catch issues instead.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
