### PR TITLE
Add additional IDE status messages, so users aren't wondering what ha…

### DIFF
--- a/Source/DafnyLanguageServer/Workspace/Compilation.cs
+++ b/Source/DafnyLanguageServer/Workspace/Compilation.cs
@@ -110,6 +110,7 @@ public class Compilation {
     }
 
     try {
+      statusPublisher.SendStatusNotification(resolvedCompilation.TextDocumentItem, CompilationStatus.PreparingVerification);
       var translatedDocument = await PrepareVerificationTasksAsync(resolvedCompilation, cancellationSource.Token);
       documentUpdates.OnNext(translatedDocument);
       foreach (var task in translatedDocument.VerificationTasks!) {

--- a/Source/DafnyLanguageServer/Workspace/Notifications/CompilationStatus.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/CompilationStatus.cs
@@ -7,9 +7,11 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
   /// </summary>
   [JsonConverter(typeof(StringEnumConverter))]
   public enum CompilationStatus {
-    ResolutionStarted,
+    Parsing,
     ParsingFailed,
+    ResolutionStarted,
     ResolutionFailed,
+    PreparingVerification,
     CompilationSucceeded
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       CancellationToken cancellationToken) {
       var outerModule = new DefaultModuleDefinition(new List<Uri>() { textDocument.Uri.ToUri() });
       var errorReporter = new DiagnosticErrorReporter(options, outerModule, textDocument.Text, textDocument.Uri);
-      statusPublisher.SendStatusNotification(textDocument, CompilationStatus.ResolutionStarted);
+      statusPublisher.SendStatusNotification(textDocument, CompilationStatus.Parsing);
       var program = parser.Parse(textDocument, errorReporter, cancellationToken);
       var documentAfterParsing = new DocumentAfterParsing(textDocument, program, errorReporter.GetDiagnostics(textDocument.Uri));
       if (errorReporter.HasErrors) {
@@ -92,6 +92,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         return documentAfterParsing;
       }
 
+      statusPublisher.SendStatusNotification(textDocument, CompilationStatus.ResolutionStarted);
       var compilationUnit = symbolResolver.ResolveSymbols(textDocument, program, out _, cancellationToken);
       var symbolTable = symbolTableFactory.CreateFrom(compilationUnit, cancellationToken);
 


### PR DESCRIPTION
Add additional IDE status messages, so users aren't wondering what happens between resolution and verification

I've tested the behavior with the current IDE and it still behaves the same, and with an updated IDE it shows the new states.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
