### PR TITLE
Use type antecedent in Type/Allocation axioms for const fields

### DIFF
--- a/Source/DafnyCore/Verifier/Translator.ClassMembers.cs
+++ b/Source/DafnyCore/Verifier/Translator.ClassMembers.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Dafny {
     ///     // so "h" and $IsHeap(h) are omitted.
     ///     axiom fh < FunctionContextHeight ==>
     ///       (forall o: ref, h: Heap, G : Ty ::
-    ///         { h[o, f], TClassA(G) }  // if "f" is a const, omit TClassA(G) from the trigger and just use { f(G,o) }
+    ///         { h[o, f], TClassA(G) }
     ///         $IsHeap(h) &&
     ///         o != null && $Is(o, TClassA(G))  // or dtype(o) = TClassA(G)
     ///         ==>
@@ -245,7 +245,7 @@ namespace Microsoft.Dafny {
     ///     // As above for "G" and "ii", but "h" is included no matter what.
     ///     axiom fh < FunctionContextHeight ==>
     ///       (forall o: ref, h: Heap, G : Ty ::
-    ///         { h[o, f], TClassA(G) }  // if "f" is a const, use the trigger { f(G,o), h[o, alloc] }; for other readonly fields, use { f(o), h[o, alloc], TClassA(G) }
+    ///         { h[o, f], TClassA(G) }
     ///         $IsHeap(h) &&
     ///         o != null && $Is(o, TClassA(G)) &&  // or dtype(o) = TClassA(G)
     ///         h[o, alloc]
@@ -339,12 +339,10 @@ namespace Microsoft.Dafny {
         // Note: for the allocation axiom, isGoodHeap is added back in for !f.IsMutable below
       }
 
-      if (!(f is ConstantField)) {
-        Bpl.Expr is_o = BplAnd(
-          ReceiverNotNull(o),
-          c is TraitDecl ? MkIs(o, o_ty) : DType(o, o_ty)); // $Is(o, ..)  or  dtype(o) == o_ty
-        ante = BplAnd(ante, is_o);
-      }
+      Bpl.Expr is_o = BplAnd(
+        ReceiverNotNull(o),
+        c is TraitDecl ? MkIs(o, o_ty) : DType(o, o_ty)); // $Is(o, ..)  or  dtype(o) == o_ty
+      ante = BplAnd(ante, is_o);
 
       ante = BplAnd(ante, indexBounds);
 

--- a/Test/git-issues/git-issue-4035.dfy
+++ b/Test/git-issues/git-issue-4035.dfy
@@ -1,0 +1,80 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module ConstInTrait {
+  type ReallyEmpty = x: int | false witness *
+
+  trait UnimplementableTrait {
+    const x: ReallyEmpty
+  }
+
+  method M(o: object)
+    ensures false // error
+  {
+    if o is UnimplementableTrait {
+      var u := o as UnimplementableTrait;
+      var r := u.x as ReallyEmpty; // this once allowed M to derive "false"
+    }
+  }
+}
+
+module VarInTrait {
+  type ReallyEmpty = x: int | false witness *
+
+  trait UnimplementableTrait extends object {
+    var x: ReallyEmpty
+  }
+
+  method M(o: object)
+    ensures false // error
+  {
+    if o is UnimplementableTrait {
+      var u := o as UnimplementableTrait;
+      var r := u.x as ReallyEmpty;
+    }
+  }
+}
+
+module ConstInClass {
+  type ReallyEmpty = x: int | false witness *
+
+  class UninstantiableClass {
+    const x: ReallyEmpty
+
+    constructor ()
+      requires false
+    {
+    }
+  }
+
+  method M(o: object)
+    ensures false // error
+  {
+    if o is UninstantiableClass {
+      var u := o as UninstantiableClass;
+      var r := u.x as ReallyEmpty; // this once allowed M to derive "false"
+    }
+  }
+}
+
+module VarInClass {
+  type ReallyEmpty = x: int | false witness *
+
+  class UninstantiableClass extends object {
+    var x: ReallyEmpty
+
+    constructor ()
+      requires false
+    {
+    }
+  }
+
+  method M(o: object)
+    ensures false // error
+  {
+    if o is UninstantiableClass {
+      var u := o as UninstantiableClass;
+      var r := u.x as ReallyEmpty;
+    }
+  }
+}

--- a/Test/git-issues/git-issue-4035.dfy.expect
+++ b/Test/git-issues/git-issue-4035.dfy.expect
@@ -1,0 +1,10 @@
+git-issue-4035.dfy(14,4): Error: a postcondition could not be proved on this return path
+git-issue-4035.dfy(12,12): Related location: this is the postcondition that could not be proved
+git-issue-4035.dfy(31,4): Error: a postcondition could not be proved on this return path
+git-issue-4035.dfy(29,12): Related location: this is the postcondition that could not be proved
+git-issue-4035.dfy(53,4): Error: a postcondition could not be proved on this return path
+git-issue-4035.dfy(51,12): Related location: this is the postcondition that could not be proved
+git-issue-4035.dfy(75,4): Error: a postcondition could not be proved on this return path
+git-issue-4035.dfy(73,12): Related location: this is the postcondition that could not be proved
+
+Dafny program verifier finished with 2 verified, 4 errors


### PR DESCRIPTION
Fixes #4035


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
