### PR TITLE
Consistently respect --use-basename-for-filename

### DIFF
--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -31,6 +31,7 @@ public class DafnyFile {
     CanonicalPath = contentOverride == null ? Canonicalize(filePath).LocalPath : "<stdin>";
     filePath = CanonicalPath;
 
+    var filePathForErrors = options.UseBaseNameForFileName ? Path.GetFileName(filePath) : filePath;
     if (contentOverride != null) {
       IsPreverified = false;
       IsPrecompiled = false;
@@ -46,7 +47,7 @@ public class DafnyFile {
           return;
         }
 
-        options.Printer.ErrorWriteLine(options.OutputWriter, $"*** Error: file {filePath} not found");
+        options.Printer.ErrorWriteLine(options.OutputWriter, $"*** Error: file {filePathForErrors} not found");
         throw new IllegalDafnyFile(true);
       } else {
         Content = new StreamReader(filePath);
@@ -55,7 +56,6 @@ public class DafnyFile {
       IsPreverified = true;
       IsPrecompiled = false;
 
-      var filePathForErrors = options.UseBaseNameForFileName ? Path.GetFileName(filePath) : filePath;
       if (!File.Exists(filePath)) {
         options.Printer.ErrorWriteLine(options.OutputWriter, $"*** Error: file {filePathForErrors} not found");
         throw new IllegalDafnyFile(true);

--- a/Source/DafnyDriver/Commands/CommandRegistry.cs
+++ b/Source/DafnyDriver/Commands/CommandRegistry.cs
@@ -244,14 +244,17 @@ public static class CommandRegistry {
   }
 
   private static bool ProcessFile(DafnyOptions dafnyOptions, FileInfo singleFile) {
+    var filePathForErrors = dafnyOptions.UseBaseNameForFileName
+      ? Path.GetFileName(singleFile.FullName)
+      : singleFile.FullName;
     if (Path.GetExtension(singleFile.FullName) == ".toml") {
       if (dafnyOptions.ProjectFile != null) {
-        dafnyOptions.ErrorWriter.WriteLine($"Only one project file can be used at a time. Both {dafnyOptions.ProjectFile.Uri.LocalPath} and {singleFile.FullName} were specified");
+        dafnyOptions.ErrorWriter.WriteLine($"Only one project file can be used at a time. Both {dafnyOptions.ProjectFile.Uri.LocalPath} and {filePathForErrors} were specified");
         return false;
       }
 
       if (!File.Exists(singleFile.FullName)) {
-        dafnyOptions.ErrorWriter.WriteLine($"Error: file {singleFile.FullName} not found");
+        dafnyOptions.ErrorWriter.WriteLine($"Error: file {filePathForErrors} not found");
         return false;
       }
       var projectFile = ProjectFile.Open(new Uri(singleFile.FullName), dafnyOptions.ErrorWriter);

--- a/Test/dafny0/formatting2.dfy.expect
+++ b/Test/dafny0/formatting2.dfy.expect
@@ -1,1 +1,1 @@
-*** Error: file /unexisting.dfy not found
+*** Error: file unexisting.dfy not found


### PR DESCRIPTION
Fixes Test/dafny0/formatting2.dfy on Windows

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
