### PR TITLE
Combine module resolution loops

### DIFF
--- a/Source/DafnyCore/AST/Cloner.cs
+++ b/Source/DafnyCore/AST/Cloner.cs
@@ -645,10 +645,8 @@ namespace Microsoft.Dafny {
   /// * To get the .RefinementBase, it redirects using the given mapping
   /// </summary>
   class CompilationCloner : DeepModuleSignatureCloner {
-    Dictionary<ModuleDefinition, ModuleDefinition> compilationModuleClones;
-    public CompilationCloner(Dictionary<ModuleDefinition, ModuleDefinition> compilationModuleClones)
+    public CompilationCloner()
       : base(false) {
-      this.compilationModuleClones = compilationModuleClones;
     }
 
     public override TopLevelDecl CloneDeclaration(TopLevelDecl d, ModuleDefinition m) {

--- a/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
+++ b/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
@@ -179,7 +179,6 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
 
     Type.PushScope(tempVis);
     resolver.ComputeIsRecursiveBit(module);
-    resolver.SolveAllTypeConstraints();
     resolver.FillInDecreasesClauses(module);
 
     foreach (var iter in module.TopLevelDecls.OfType<IteratorDecl>()) {

--- a/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
+++ b/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
@@ -80,7 +80,7 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
     return true;
   }
 
-  public void ResolveLiteralModuleDeclaration(Resolver resolver, Program prog, int beforeModuleResolutionErrorCount) {
+  public void Resolve(Resolver resolver, Program prog, int beforeModuleResolutionErrorCount) {
     // The declaration is a literal module, so it has members and such that we need
     // to resolve. First we do refinement transformation. Then we construct the signature
     // of the module. This is the public, externally visible signature. Then we add in
@@ -109,7 +109,7 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
     var preResolveErrorCount = resolver.reporter.ErrorCount;
 
     resolver.ResolveModuleExport(this, sig);
-    var good = module.ResolveModuleDefinition(sig, resolver);
+    var good = module.Resolve(sig, resolver);
 
     if (good && resolver.reporter.ErrorCount == preResolveErrorCount) {
       // Check that the module export gives a self-contained view of the module.
@@ -157,7 +157,7 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
       }
       // Now we're ready to resolve the cloned module definition, using the compile signature
 
-      nw.ResolveModuleDefinition(compileSig, resolver);
+      nw.Resolve(compileSig, resolver);
 
       foreach (var rewriter in resolver.rewriters) {
         rewriter.PostCompileCloneAndResolve(nw);

--- a/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
+++ b/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Microsoft.Dafny;
@@ -77,5 +78,128 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
     }
 
     return true;
+  }
+
+  public void ResolveLiteralModuleDeclaration(Resolver resolver, Program prog)
+  {
+    // The declaration is a literal module, so it has members and such that we need
+    // to resolve. First we do refinement transformation. Then we construct the signature
+    // of the module. This is the public, externally visible signature. Then we add in
+    // everything that the system defines, as well as any "import" (i.e. "opened" modules)
+    // directives (currently not supported, but this is where we would do it.) This signature,
+    // which is only used while resolving the members of the module is stored in the (basically)
+    // global variable moduleInfo. Then the signatures of the module members are resolved, followed
+    // by the bodies.
+    var module = ModuleDef;
+
+    var errorCount = resolver.reporter.ErrorCount;
+    if (module.RefinementQId != null)
+    {
+      ModuleDecl md = resolver.ResolveModuleQualifiedId(module.RefinementQId.Root, module.RefinementQId, resolver.reporter);
+      module.RefinementQId.Set(md); // If module is not found, md is null and an error message has been emitted
+    }
+
+    foreach (var rewriter in resolver.rewriters)
+    {
+      rewriter.PreResolve(module);
+    }
+
+    Signature = resolver.RegisterTopLevelDecls(module, true);
+    Signature.Refines = resolver.refinementTransformer.RefinedSig;
+
+    var sig = Signature;
+    // set up environment
+    var preResolveErrorCount = resolver.reporter.ErrorCount;
+
+    resolver.ResolveModuleExport(this, sig);
+    var good = module.ResolveModuleDefinition(sig, resolver);
+
+    if (good && resolver.reporter.ErrorCount == preResolveErrorCount)
+    {
+      // Check that the module export gives a self-contained view of the module.
+      resolver.CheckModuleExportConsistency(prog, module);
+    }
+
+    var tempVis = new VisibilityScope();
+    tempVis.Augment(sig.VisibilityScope);
+    tempVis.Augment(resolver.systemNameInfo.VisibilityScope);
+    Type.PushScope(tempVis);
+
+    prog.ModuleSigs[module] = sig;
+
+    foreach (var rewriter in resolver.rewriters)
+    {
+      if (!good || resolver.reporter.ErrorCount != preResolveErrorCount)
+      {
+        break;
+      }
+
+      rewriter.PostResolveIntermediate(module);
+    }
+
+    if (good && resolver.reporter.ErrorCount == errorCount)
+    {
+      module.SuccessfullyResolved = true;
+    }
+
+    Type.PopScope(tempVis);
+
+    if (resolver.reporter.ErrorCount == errorCount && !module.IsAbstract)
+    {
+      // compilation should only proceed if everything is good, including the signature (which preResolveErrorCount does not include);
+      CompilationCloner cloner = new CompilationCloner();
+      var compileName = new Name(module.NameNode.RangeToken, module.GetCompileName(resolver.Options) + "_Compile");
+      var nw = cloner.CloneModuleDefinition(module, module.EnclosingModule, compileName);
+      var oldErrorsOnly = resolver.reporter.ErrorsOnly;
+      resolver.reporter.ErrorsOnly = true; // turn off warning reporting for the clone
+      // Next, compute the compile signature
+      Contract.Assert(!resolver.useCompileSignatures);
+      resolver.useCompileSignatures =
+        true; // set Resolver-global flag to indicate that Signatures should be followed to their CompiledSignature
+      Type.DisableScopes();
+      var compileSig = resolver.RegisterTopLevelDecls(nw, true);
+      compileSig.Refines = resolver.refinementTransformer.RefinedSig;
+      sig.CompileSignature = compileSig;
+      foreach (var exportDecl in sig.ExportSets.Values)
+      {
+        exportDecl.Signature.CompileSignature = cloner.CloneModuleSignature(exportDecl.Signature, compileSig);
+      }
+      // Now we're ready to resolve the cloned module definition, using the compile signature
+
+      nw.ResolveModuleDefinition(compileSig, resolver);
+
+      foreach (var rewriter in resolver.rewriters)
+      {
+        rewriter.PostCompileCloneAndResolve(nw);
+      }
+
+      prog.CompileModules.Add(nw);
+      resolver.useCompileSignatures = false; // reset the flag
+      Type.EnableScopes();
+      resolver.reporter.ErrorsOnly = oldErrorsOnly;
+    }
+
+    if (resolver.reporter.ErrorCount != errorCount)
+    {
+      return;
+    }
+
+    Type.PushScope(tempVis);
+    resolver.ComputeIsRecursiveBit(module);
+    resolver.FillInDecreasesClauses(module);
+    foreach (var iter in module.TopLevelDecls.OfType<IteratorDecl>())
+    {
+      resolver.reporter.Info(MessageSource.Resolver, iter.tok, Printer.IteratorClassToString(resolver.Reporter.Options, iter));
+    }
+
+    foreach (var rewriter in resolver.rewriters)
+    {
+      rewriter.PostDecreasesResolve(module);
+    }
+
+    resolver.FillInAdditionalInformation(module);
+    resolver.CheckForFuelAdjustments(module);
+
+    Type.PopScope(tempVis);
   }
 }

--- a/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
+++ b/Source/DafnyCore/AST/Modules/LiteralModuleDecl.cs
@@ -80,7 +80,7 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
     return true;
   }
 
-  public void ResolveLiteralModuleDeclaration(Resolver resolver, Program prog)
+  public void ResolveLiteralModuleDeclaration(Resolver resolver, Program prog, int beforeModuleResolutionErrorCount)
   {
     // The declaration is a literal module, so it has members and such that we need
     // to resolve. First we do refinement transformation. Then we construct the signature
@@ -179,7 +179,11 @@ public class LiteralModuleDecl : ModuleDecl, ICanFormat {
       resolver.reporter.ErrorsOnly = oldErrorsOnly;
     }
 
-    if (resolver.reporter.ErrorCount != errorCount)
+    /* It's strange to stop here when _any_ module has had resolution errors.
+     * Either stop here when _this_ module has had errors,
+     * or completely stop module resolution after one of them has errors
+     */
+    if (resolver.reporter.ErrorCount != beforeModuleResolutionErrorCount)
     {
       return;
     }

--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -376,7 +376,7 @@ public class ModuleDefinition : RangeNode, IDeclarationOrUsage, IAttributeBearin
   /// resolved, a caller has to check for both a change in error count and a "false"
   /// return value.
   /// </summary>
-  public bool ResolveModuleDefinition(ModuleSignature sig, Resolver resolver, bool isAnExport = false) {
+  public bool Resolve(ModuleSignature sig, Resolver resolver, bool isAnExport = false) {
     Contract.Requires(resolver.AllTypeConstraints.Count == 0);
     Contract.Ensures(resolver.AllTypeConstraints.Count == 0);
 

--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -368,4 +368,77 @@ public class ModuleDefinition : RangeNode, IDeclarationOrUsage, IAttributeBearin
   public ModuleDefinition Clone(Cloner cloner) {
     return new ModuleDefinition(cloner, this);
   }
+
+  /// <summary>
+  /// Resolves the module definition.
+  /// A return code of "false" is an indication of an error that may or may not have
+  /// been reported in an error message. So, in order to figure out if m was successfully
+  /// resolved, a caller has to check for both a change in error count and a "false"
+  /// return value.
+  /// </summary>
+  public bool ResolveModuleDefinition(ModuleSignature sig, Resolver resolver, bool isAnExport = false) {
+    Contract.Requires(resolver.AllTypeConstraints.Count == 0);
+    Contract.Ensures(resolver.AllTypeConstraints.Count == 0);
+
+    sig.VisibilityScope.Augment(resolver.systemNameInfo.VisibilityScope);
+    // make sure all imported modules were successfully resolved
+    foreach (var d in TopLevelDecls) {
+      if (d is AliasModuleDecl || d is AbstractModuleDecl) {
+        ModuleSignature importSig;
+        if (d is AliasModuleDecl) {
+          var alias = (AliasModuleDecl)d;
+          importSig = alias.TargetQId.Root != null ? alias.TargetQId.Root.Signature : alias.Signature;
+        } else {
+          importSig = ((AbstractModuleDecl)d).OriginalSignature;
+        }
+
+        if (importSig.ModuleDef == null || !importSig.ModuleDef.SuccessfullyResolved) {
+          if (!IsEssentiallyEmptyModuleBody()) {
+            // say something only if this will cause any testing to be omitted
+            resolver.reporter.Error(MessageSource.Resolver, d,
+              "not resolving module '{0}' because there were errors in resolving its import '{1}'", Name, d.Name);
+          }
+
+          return false;
+        }
+      } else if (d is LiteralModuleDecl) {
+        var nested = (LiteralModuleDecl)d;
+        if (!nested.ModuleDef.SuccessfullyResolved) {
+          if (!IsEssentiallyEmptyModuleBody()) {
+            // say something only if this will cause any testing to be omitted
+            resolver.reporter.Error(MessageSource.Resolver, nested,
+              "not resolving module '{0}' because there were errors in resolving its nested module '{1}'", Name,
+              nested.Name);
+          }
+
+          return false;
+        }
+      }
+    }
+
+    // resolve
+    var oldModuleInfo = resolver.moduleInfo;
+    resolver.moduleInfo = Resolver.MergeSignature(sig, resolver.systemNameInfo);
+    Type.PushScope(resolver.moduleInfo.VisibilityScope);
+    Resolver.ResolveOpenedImports(resolver.moduleInfo, this, resolver.useCompileSignatures, resolver); // opened imports do not persist
+    var datatypeDependencies = new Graph<IndDatatypeDecl>();
+    var codatatypeDependencies = new Graph<CoDatatypeDecl>();
+    var allDeclarations = ModuleDefinition.AllDeclarationsAndNonNullTypeDecls(TopLevelDecls).ToList();
+    int prevErrorCount = resolver.reporter.Count(ErrorLevel.Error);
+    resolver.ResolveTopLevelDecls_Signatures(this, sig, allDeclarations, datatypeDependencies, codatatypeDependencies);
+    Contract.Assert(resolver.AllTypeConstraints.Count == 0); // signature resolution does not add any type constraints
+
+    resolver.scope.PushMarker();
+    resolver.scope.AllowInstance = false;
+    resolver.ResolveAttributes(this, new ResolutionContext(new NoContext(EnclosingModule), false), true); // Must follow ResolveTopLevelDecls_Signatures, in case attributes refer to members
+    resolver.scope.PopMarker();
+
+    if (resolver.reporter.Count(ErrorLevel.Error) == prevErrorCount) {
+      resolver.ResolveTopLevelDecls_Core(allDeclarations, datatypeDependencies, codatatypeDependencies, Name, isAnExport);
+    }
+
+    Type.PopScope(resolver.moduleInfo.VisibilityScope);
+    resolver.moduleInfo = oldModuleInfo;
+    return true;
+  }
 }

--- a/Source/DafnyCore/Auditor/Auditor.cs
+++ b/Source/DafnyCore/Auditor/Auditor.cs
@@ -157,6 +157,6 @@ public class Auditor : IRewriter {
     }
 
     var findingCount = report.AllAssumptions().SelectMany(d => d.Value).Count();
-    Console.WriteLine($"Dafny auditor completed with {findingCount} findings");
+    Options.OutputWriter.WriteLine($"Dafny auditor completed with {findingCount} findings");
   }
 }

--- a/Source/DafnyCore/Resolver/Resolver.cs
+++ b/Source/DafnyCore/Resolver/Resolver.cs
@@ -504,6 +504,11 @@ namespace Microsoft.Dafny {
         ResolveModuleDeclaration(prog, decl);
       }
 
+      if (reporter.ErrorCount != origErrorCount) {
+        // do nothing else
+        return;
+      }
+      
       Type.DisableScopes();
       CheckDupModuleNames(prog);
 

--- a/Source/DafnyCore/Resolver/Resolver.cs
+++ b/Source/DafnyCore/Resolver/Resolver.cs
@@ -504,10 +504,11 @@ namespace Microsoft.Dafny {
         ResolveModuleDeclaration(prog, decl, origErrorCount);
       }
 
+      DafnyMain.MaybePrintProgram(prog, prog.Options.DafnyPrintResolvedFile, true);
       if (reporter.ErrorCount != origErrorCount) {
         return;
       }
-      
+
       Type.DisableScopes();
       CheckDupModuleNames(prog);
 
@@ -989,7 +990,7 @@ namespace Microsoft.Dafny {
     public void CheckModuleExportConsistency(Program program, ModuleDefinition m) {
       //check for export consistency by resolving internal modules
       //this should be effect-free, as it only operates on clones
-      
+
       var oldModuleInfo = moduleInfo;
       foreach (var exportDecl in m.TopLevelDecls.OfType<ModuleExportDecl>()) {
 

--- a/Source/DafnyCore/Resolver/Resolver.cs
+++ b/Source/DafnyCore/Resolver/Resolver.cs
@@ -501,11 +501,10 @@ namespace Microsoft.Dafny {
       }
 
       foreach (var decl in sortedDecls) {
-        ResolveModuleDeclaration(prog, decl);
+        ResolveModuleDeclaration(prog, decl, origErrorCount);
       }
 
       if (reporter.ErrorCount != origErrorCount) {
-        // do nothing else
         return;
       }
       
@@ -624,9 +623,9 @@ namespace Microsoft.Dafny {
       }
     }
 
-    private void ResolveModuleDeclaration(Program prog, ModuleDecl decl) {
+    private void ResolveModuleDeclaration(Program prog, ModuleDecl decl, int beforeModuleResolutionErrorCount) {
       if (decl is LiteralModuleDecl literalModuleDecl) {
-        literalModuleDecl.ResolveLiteralModuleDeclaration(this, prog);
+        literalModuleDecl.ResolveLiteralModuleDeclaration(this, prog, beforeModuleResolutionErrorCount);
       } else if (decl is AliasModuleDecl alias) {
         // resolve the path
         ModuleSignature p;

--- a/Source/DafnyCore/Resolver/Resolver.cs
+++ b/Source/DafnyCore/Resolver/Resolver.cs
@@ -504,7 +504,6 @@ namespace Microsoft.Dafny {
         ResolveModuleDeclaration(prog, decl, origErrorCount);
       }
 
-      DafnyMain.MaybePrintProgram(prog, prog.Options.DafnyPrintResolvedFile, true);
       if (reporter.ErrorCount != origErrorCount) {
         return;
       }

--- a/Source/DafnyCore/Resolver/Resolver.cs
+++ b/Source/DafnyCore/Resolver/Resolver.cs
@@ -625,7 +625,7 @@ namespace Microsoft.Dafny {
 
     private void ResolveModuleDeclaration(Program prog, ModuleDecl decl, int beforeModuleResolutionErrorCount) {
       if (decl is LiteralModuleDecl literalModuleDecl) {
-        literalModuleDecl.ResolveLiteralModuleDeclaration(this, prog, beforeModuleResolutionErrorCount);
+        literalModuleDecl.Resolve(this, prog, beforeModuleResolutionErrorCount);
       } else if (decl is AliasModuleDecl alias) {
         // resolve the path
         ModuleSignature p;
@@ -1038,7 +1038,7 @@ namespace Microsoft.Dafny {
           String.Format("Raised while checking export set {0}: ", exportDecl.Name));
         var testSig = RegisterTopLevelDecls(exportView, true);
         //testSig.Refines = refinementTransformer.RefinedSig;
-        exportView.ResolveModuleDefinition(testSig, this, true);
+        exportView.Resolve(testSig, this, true);
         var wasError = reporter.Count(ErrorLevel.Error) > 0;
         reporter = ((ErrorReporterWrapper)reporter).WrappedReporter;
 
@@ -1872,7 +1872,7 @@ namespace Microsoft.Dafny {
       sig.CompileSignature = p;
       sig.IsAbstract = p.IsAbstract;
       mods.Add(mod, sig);
-      var good = mod.ResolveModuleDefinition(sig, this);
+      var good = mod.Resolve(sig, this);
       if (good && reporter.Count(ErrorLevel.Error) == errCount) {
         mod.SuccessfullyResolved = true;
       }

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -157,10 +157,10 @@ module N refines M
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       var diagnostics = await GetLastDiagnostics(documentItem, CancellationToken);
-      Assert.Single(diagnostics);
+      Assert.Equal(2, diagnostics.Length);
       Assert.Equal(
         "static non-ghost const field 't' of type 'T' (which does not have a default compiled value) must give a defining value",
-        diagnostics[0].Message);
+        diagnostics[1].Message);
       await AssertNoDiagnosticsAreComing(CancellationToken);
     }
 

--- a/Source/IntegrationTests/LitTests.cs
+++ b/Source/IntegrationTests/LitTests.cs
@@ -20,7 +20,7 @@ namespace IntegrationTests {
     // Change this to true in order to debug the execution of commands like %dafny.
     // This is false by default because the main dafny CLI implementation currently has shared static state, which
     // causes errors when invoking the CLI in the same process on multiple inputs in sequence, much less in parallel.
-    private const bool InvokeMainMethodsDirectly = false;
+    private const bool InvokeMainMethodsDirectly = true;
 
     private static readonly Assembly DafnyDriverAssembly = typeof(Dafny.Dafny).Assembly;
     private static readonly Assembly TestDafnyAssembly = typeof(TestDafny.MultiBackendTest).Assembly;

--- a/Source/IntegrationTests/LitTests.cs
+++ b/Source/IntegrationTests/LitTests.cs
@@ -20,7 +20,7 @@ namespace IntegrationTests {
     // Change this to true in order to debug the execution of commands like %dafny.
     // This is false by default because the main dafny CLI implementation currently has shared static state, which
     // causes errors when invoking the CLI in the same process on multiple inputs in sequence, much less in parallel.
-    private const bool InvokeMainMethodsDirectly = true;
+    private const bool InvokeMainMethodsDirectly = false;
 
     private static readonly Assembly DafnyDriverAssembly = typeof(Dafny.Dafny).Assembly;
     private static readonly Assembly TestDafnyAssembly = typeof(TestDafny.MultiBackendTest).Assembly;

--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -83,6 +83,7 @@ namespace XUnitExtensions.Lit {
       if (outputFile != null) {
         outputWriters.Add(new StreamWriter(outputFile, append));
       }
+      inputReader = inputFile != null ? new StreamReader(inputFile) : inputReader;
 
       var errorWriters = new List<TextWriter> { errWriter };
       if (errorFile != null) {

--- a/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
+++ b/Source/XUnitExtensions/Lit/LitCommandWithRedirection.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Xunit.Abstractions;
@@ -77,15 +78,23 @@ namespace XUnitExtensions.Lit {
       this.errorFile = errorFile;
     }
 
-    public (int, string, string) Execute(TextReader inReader, TextWriter outWriter,
-      TextWriter errWriter) {
-      var inputReader = inputFile != null ? new StreamReader(inputFile) : inReader;
-      var outputWriter = outputFile != null ? new StreamWriter(outputFile, append) : outWriter;
-      var errorWriter = errorFile != null ? new StreamWriter(errorFile, append) : errWriter;
-      var result = command.Execute(inputReader, outputWriter, errorWriter);
-      inputReader?.Close();
-      outputWriter?.Close();
-      errorWriter?.Close();
+    public (int, string, string) Execute(TextReader inputReader, TextWriter outWriter, TextWriter errWriter) {
+      var outputWriters = new List<TextWriter> { outWriter };
+      if (outputFile != null) {
+        outputWriters.Add(new StreamWriter(outputFile, append));
+      }
+
+      var errorWriters = new List<TextWriter> { errWriter };
+      if (errorFile != null) {
+        errorWriters.Add(new StreamWriter(errorFile, append));
+      }
+      var result = command.Execute(inputReader,
+        new CombinedWriter(outWriter.Encoding, outputWriters),
+        new CombinedWriter(errWriter.Encoding, errorWriters));
+      inputReader.Close();
+      foreach (var writer in outputWriters.Concat(errorWriters)) {
+        writer.Close();
+      }
       return result;
     }
 
@@ -118,24 +127,44 @@ namespace XUnitExtensions.Lit {
   }
 }
 
-public class WriterFromOutputHelper : TextWriter {
-  private readonly ITestOutputHelper output;
+class CombinedWriter : TextWriter {
+  private IEnumerable<TextWriter> writers;
 
-  public WriterFromOutputHelper(ITestOutputHelper output) {
-    this.output = output;
+  public CombinedWriter(Encoding encoding, IEnumerable<TextWriter> writers) {
+    this.Encoding = encoding;
+    this.writers = writers;
+  }
+
+  public override Encoding Encoding { get; }
+
+  public override void Flush() {
+    foreach (var writer in writers) {
+      writer.Flush();
+    }
+    base.Flush();
+  }
+
+  public override Task FlushAsync() {
+    return Task.WhenAll(writers.Select(w => w.FlushAsync()));
   }
 
   public override void Write(char value) {
-
+    foreach (var writer in writers) {
+      writer.Write(value);
+    }
   }
 
-  public override Encoding Encoding => Encoding.Default;
-
-  public override void WriteLine(string? value) {
-    output.WriteLine(value);
+  public override void Write(char[] buffer, int index, int count) {
+    foreach (var writer in writers) {
+      writer.Write(buffer, index, count);
+    }
   }
 
-  public override void WriteLine(string format, params object?[] arg) {
-    output.WriteLine(format, arg);
+  public override Task WriteAsync(char value) {
+    return Task.WhenAll(writers.Select(w => w.WriteAsync(value)));
+  }
+
+  public override Task WriteAsync(char[] buffer, int index, int count) {
+    return Task.WhenAll(writers.Select(w => w.WriteAsync(buffer, index, count)));
   }
 }

--- a/Test/dafny0/TypeConstraints.dfy.expect
+++ b/Test/dafny0/TypeConstraints.dfy.expect
@@ -173,6 +173,7 @@ module Tests {
     }
 
     method N(m: nat) returns (n: nat)
+      decreases m
   }
   /*-- non-null type
   type {:axiom} CC(==) = c: CC? | c != null /*special witness*/

--- a/Test/dafny4/Bug170.dfy.expect
+++ b/Test/dafny4/Bug170.dfy.expect
@@ -12,6 +12,10 @@ Bug170.dfy(29,7): Info: A#[_k - 1]
 Bug170.dfy(30,6): Info: AA#[_k - 1]
 Bug170.dfy(10,12): Info: B#[_k - 1]
 Bug170.dfy(15,12): Info: A#[_k - 1]
+Bug170.dfy(18,14): Info: AA# decreases _k, x
+Bug170.dfy(26,14): Info: BB# decreases _k, x
+Bug170.dfy(18,14): Info: AA# {:induction _k, x}
+Bug170.dfy(26,14): Info: BB# {:induction _k, x}
 Bug170.dfy(36,21): Info: _k: ORDINAL
 Bug170.dfy(41,21): Info: _k: ORDINAL
 Bug170.dfy(46,17): Info: _k: ORDINAL
@@ -26,6 +30,10 @@ Bug170.dfy(56,4): Info: AA#[_k - 1]
 Bug170.dfy(57,11): Info: A#[_k - 1]
 Bug170.dfy(38,4): Info: B#[_k - 1]
 Bug170.dfy(43,4): Info: A#[_k - 1]
+Bug170.dfy(46,17): Info: AA# decreases _k, x
+Bug170.dfy(53,17): Info: BB# decreases _k, x
+Bug170.dfy(46,17): Info: AA# {:induction _k, x}
+Bug170.dfy(53,17): Info: BB# {:induction _k, x}
 Bug170.dfy(64,18): Info: _k: ORDINAL
 Bug170.dfy(69,14): Info: _k: ORDINAL
 Bug170.dfy(70,14): Info: A#[_k]
@@ -33,15 +41,7 @@ Bug170.dfy(69,14): Info: AA# with focal predicate A
 Bug170.dfy(72,7): Info: A#[_k - 1]
 Bug170.dfy(73,6): Info: AA#[_k - 1]
 Bug170.dfy(66,12): Info: A#[_k - 1]
-Bug170.dfy(18,14): Info: AA# decreases _k, x
-Bug170.dfy(26,14): Info: BB# decreases _k, x
-Bug170.dfy(46,17): Info: AA# decreases _k, x
-Bug170.dfy(53,17): Info: BB# decreases _k, x
 Bug170.dfy(69,14): Info: AA# decreases _k, x
-Bug170.dfy(18,14): Info: AA# {:induction _k, x}
-Bug170.dfy(26,14): Info: BB# {:induction _k, x}
-Bug170.dfy(46,17): Info: AA# {:induction _k, x}
-Bug170.dfy(53,17): Info: BB# {:induction _k, x}
 Bug170.dfy(69,14): Info: AA# {:induction _k, x}
 Bug170.dfy(50,11): Info: Some instances of this call are not inlined.
 Bug170.dfy(57,11): Info: Some instances of this call are not inlined.

--- a/Test/dafny4/UnionFind.dfy
+++ b/Test/dafny4/UnionFind.dfy
@@ -63,7 +63,7 @@ abstract module M1 refines M0 {
     // This function returns a snapshot of the .c fields of the objects in the domain of M
     ghost function {:autocontracts false} Collect(): CMap
       requires forall f :: f in M && f.c.Link? ==> f.c.next in M
-      reads this, set a | a in M
+      reads this, set a: Element | a in M
       ensures GoodCMap(Collect())
     {
       map e | e in M :: e.c

--- a/Test/dafny4/set-compr.dfy.expect
+++ b/Test/dafny4/set-compr.dfy.expect
@@ -1,3 +1,9 @@
+set-compr.dfy(6,13): Warning: /!\ No terms found to trigger on.
+set-compr.dfy(12,20): Warning: /!\ No terms found to trigger on.
+set-compr.dfy(11,21): Warning: /!\ No terms found to trigger on.
+set-compr.dfy(13,14): Warning: /!\ No terms found to trigger on.
+set-compr.dfy(20,19): Warning: /!\ No terms found to trigger on.
+set-compr.dfy(21,9): Warning: /!\ No terms found to trigger on.
 set-compr.dfy(28,9): Error: set comprehensions in non-ghost contexts must be compilable, but Dafny's heuristics can't figure out how to produce or compile a bounded set of values for 'o'
 set-compr.dfy(39,34): Error: a function definition is not allowed to depend on the set of allocated references
 set-compr.dfy(41,26): Error: a function definition is not allowed to depend on the set of allocated references

--- a/Test/git-issues/git-issue-977.dfy.expect
+++ b/Test/git-issues/git-issue-977.dfy.expect
@@ -7,6 +7,9 @@ git-issue-977.dfy(237,36): Info: Theorem2# with focal predicate Pos
 git-issue-977.dfy(241,4): Info: Theorem2#[_k - 1]
 git-issue-977.dfy(229,13): Info: co-recursive call
 git-issue-977.dfy(234,18): Info: Pos#[_k - 1]
+git-issue-977.dfy(217,13): Info: Selected triggers: {AAA#[k](t)}
+git-issue-977.dfy(227,17): Info: decreases 1, n
+git-issue-977.dfy(237,36): Info: Theorem2# decreases _k, n
 git-issue-977.dfy(95,19): Info: _k: ORDINAL
 git-issue-977.dfy(113,19): Info: _k: nat
 git-issue-977.dfy(84,16): Info: tail recursive
@@ -15,13 +18,10 @@ git-issue-977.dfy(113,19): Info: tail recursive
 git-issue-977.dfy(146,16): Info: tail recursive
 git-issue-977.dfy(97,21): Info: GreatestPredOrd#[_k - 1]
 git-issue-977.dfy(115,21): Info: GreatestPredNat#[_k - 1]
-git-issue-977.dfy(217,13): Info: Selected triggers: {AAA#[k](t)}
 git-issue-977.dfy(71,4): Info: Selected triggers:
    {RicochetOrd(m, num)}, {GreatestManualOrd(m, num)}, {GreatestPredOrd#[m](num)}, {m < k}
 git-issue-977.dfy(138,4): Info: Selected triggers:
    {GreatestManualOrd(m, num)}, {m < k}
-git-issue-977.dfy(227,17): Info: decreases 1, n
-git-issue-977.dfy(237,36): Info: Theorem2# decreases _k, n
 git-issue-977.dfy(50,15): Info: decreases n
 git-issue-977.dfy(61,6): Info: decreases k, num
 git-issue-977.dfy(84,16): Info: decreases num


### PR DESCRIPTION
Combine the different loops over modules that occur in resolution. There is now a method `LiteralModuleDecl.Resolve` that can be used for basing caching module resolution on.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
