### PR TITLE
Fix: Better error message when incorrect number of out parameters

### DIFF
--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -3096,7 +3096,9 @@ namespace Microsoft.Dafny {
         if (isInitCall) {
           reporter.Error(MessageSource.Resolver, s, "a method called as an initialization method must not have any result arguments");
         } else {
-          reporter.Error(MessageSource.Resolver, s, "wrong number of method result arguments (got {0}, expected {1})", s.Lhs.Count, callee.Outs.Count);
+          reporter.Error(MessageSource.Resolver, s,
+            "the method returns {1} value{3} but is assigned to {0} variable{2} (all return values must be assigned)",
+            s.Lhs.Count, callee.Outs.Count, s.Lhs.Count > 1 ? "s" : "", callee.Outs.Count > 1 ? "s" : "");
           tryToResolve = true;
         }
       } else {

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -95,7 +95,7 @@ ResolutionErrors.dfy(685,18): Error: second argument to "in" must be a set, mult
 ResolutionErrors.dfy(702,13): Error: lemmas are not allowed to have modifies clauses
 ResolutionErrors.dfy(729,22): Error: a possibly infinite loop is allowed only if the enclosing method is declared (with 'decreases *') to be possibly non-terminating
 ResolutionErrors.dfy(762,22): Error: a possibly infinite loop is allowed only if the enclosing method is declared (with 'decreases *') to be possibly non-terminating
-ResolutionErrors.dfy(795,17): Error: wrong number of method result arguments (got 0, expected 1)
+ResolutionErrors.dfy(795,17): Error: the method returns 1 value but is assigned to 0 variable (all return values must be assigned)
 ResolutionErrors.dfy(816,4): Error: ghost variables such as y are allowed only in specification contexts. y was inferred to be ghost based on its declaration or initialization.
 ResolutionErrors.dfy(827,40): Error: ghost variables such as y are allowed only in specification contexts. y was inferred to be ghost based on its declaration or initialization.
 ResolutionErrors.dfy(850,6): Error: RHS (of type B) not assignable to LHS (of type object)

--- a/docs/dev/news/3835.fix
+++ b/docs/dev/news/3835.fix
@@ -1,0 +1,1 @@
+Better error message when incorrect number of out parameters


### PR DESCRIPTION
This PR fixes #3835
I added the corresponding test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>