### PR TITLE
Improve diagnostic when include directive cycles occur

### DIFF
--- a/Source/DafnyCore/AST/Grammar/ProgramParser.cs
+++ b/Source/DafnyCore/AST/Grammar/ProgramParser.cs
@@ -98,8 +98,26 @@ public class ProgramParser {
       DafnyMain.MaybePrintProgram(program, options.DafnyPrintFile, false);
     }
 
+    ShowWarningsForIncludeCycles(program);
+
 
     return program;
+  }
+
+  private void ShowWarningsForIncludeCycles(Program program) {
+    var graph = new Graph<Uri>();
+    foreach (var edgesForUri in program.Includes.GroupBy(i => i.IncluderFilename)) {
+      foreach (var edge in edgesForUri) {
+        graph.AddEdge(edge.IncluderFilename, edge.IncludedFilename);
+      }
+    }
+
+    var sortedSccRoots = graph.TopologicallySortedComponents();
+    var includeCycles = sortedSccRoots.Select(graph.GetSCC).Where(scc => scc.Count > 1);
+    foreach (var cycle in includeCycles) {
+      program.Reporter.Warning(MessageSource.Parser, (string)null, program.GetFirstTopLevelToken(), 
+        $"Program contains a cycle of includes, consisting of:\n{string.Join("\n", cycle.Select(c => c.LocalPath))}");
+    }
   }
 
   public static void AddParseResultToProgram(DfyParseResult parseResult, Program program) {

--- a/Source/DafnyCore/AST/Grammar/ProgramParser.cs
+++ b/Source/DafnyCore/AST/Grammar/ProgramParser.cs
@@ -115,7 +115,7 @@ public class ProgramParser {
     var sortedSccRoots = graph.TopologicallySortedComponents();
     var includeCycles = sortedSccRoots.Select(graph.GetSCC).Where(scc => scc.Count > 1);
     foreach (var cycle in includeCycles) {
-      program.Reporter.Warning(MessageSource.Parser, (string)null, program.GetFirstTopLevelToken(), 
+      program.Reporter.Warning(MessageSource.Parser, (string)null, program.GetFirstTopLevelToken(),
         $"Program contains a cycle of includes, consisting of:\n{string.Join("\n", cycle.Select(c => c.LocalPath))}");
     }
   }

--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServer.Test.csproj
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServer.Test.csproj
@@ -90,6 +90,12 @@
     <None Update="Synchronization\TestFiles\includesSemanticError.dfy">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Synchronization\TestFiles\cycleA.dfy">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Synchronization\TestFiles\cycleB.dfy">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyLanguageServer.Test/Synchronization/IncludeFileTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/IncludeFileTest.cs
@@ -46,9 +46,10 @@ include ""./cycleA.dfy""
     var documentItem = CreateTestDocument(source, Path.Combine(Directory.GetCurrentDirectory(), "Synchronization/TestFiles/test.dfy"));
     await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
     var diagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
-    Assert.Single(diagnostics);
-    Assert.Contains("the included file", diagnostics[0].Message);
-    Assert.Contains("cycleB.dfy", diagnostics[0].Message);
+    Assert.Equal(2, diagnostics.Length);
+    Assert.Contains("cycle of includes", diagnostics[0].Message);
+    Assert.Contains("the included file", diagnostics[1].Message);
+    Assert.Contains("cycleB.dfy", diagnostics[1].Message);
   }
 
   [Fact]

--- a/Source/DafnyLanguageServer.Test/Synchronization/IncludeFileTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/IncludeFileTest.cs
@@ -39,6 +39,19 @@ include ""./syntaxError.dfy""
   }
 
   [Fact]
+  public async Task IncludeCycle() {
+    var source = @"
+include ""./cycleA.dfy""
+".TrimStart();
+    var documentItem = CreateTestDocument(source, Path.Combine(Directory.GetCurrentDirectory(), "Synchronization/TestFiles/test.dfy"));
+    await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+    var diagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
+    Assert.Single(diagnostics);
+    Assert.Contains("the included file", diagnostics[0].Message);
+    Assert.Contains("cycleB.dfy", diagnostics[0].Message);
+  }
+
+  [Fact]
   public async Task IndirectlyIncludedFileFailsSemantic() {
     var source = @"
 include ""./includesSemanticError.dfy""

--- a/Source/DafnyLanguageServer.Test/Synchronization/TestFiles/cycleA.dfy
+++ b/Source/DafnyLanguageServer.Test/Synchronization/TestFiles/cycleA.dfy
@@ -1,0 +1,1 @@
+include "./cycleB.dfy"

--- a/Source/DafnyLanguageServer.Test/Synchronization/TestFiles/cycleB.dfy
+++ b/Source/DafnyLanguageServer.Test/Synchronization/TestFiles/cycleB.dfy
@@ -1,0 +1,3 @@
+include "./cycleA.dfy"
+
+const x: int := true

--- a/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
+++ b/Source/DafnyLanguageServer/Language/DiagnosticErrorReporter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     private const string RelatedLocationMessage = RelatedLocationCategory;
 
     private readonly DocumentUri entryDocumentUri;
-    private readonly Dictionary<DocumentUri, IList<DafnyDiagnostic>> diagnostics = new();
+    private readonly Dictionary<DocumentUri, List<DafnyDiagnostic>> diagnostics = new();
     private readonly Dictionary<ErrorLevel, int> counts = new();
     private readonly Dictionary<ErrorLevel, int> countsNotVerificationOrCompiler = new();
     private readonly ReaderWriterLockSlim rwLock = new();
@@ -33,7 +33,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       this.entryDocumentUri = entryDocumentUri;
     }
 
-    public IReadOnlyDictionary<DocumentUri, IList<DafnyDiagnostic>> AllDiagnosticsCopy => diagnostics.ToImmutableDictionary();
+    public IReadOnlyDictionary<DocumentUri, List<DafnyDiagnostic>> AllDiagnosticsCopy => diagnostics.ToImmutableDictionary();
 
     public IReadOnlyList<DafnyDiagnostic> GetDiagnostics(DocumentUri documentUri) {
       rwLock.EnterReadLock();

--- a/Source/DafnyLanguageServer/Workspace/Documents/DocumentAfterParsing.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/DocumentAfterParsing.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Dafny.LanguageServer.Language;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -8,11 +9,11 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 namespace Microsoft.Dafny.LanguageServer.Workspace;
 
 public class DocumentAfterParsing : Document {
-  public IReadOnlyDictionary<DocumentUri, IList<DafnyDiagnostic>> ResolutionDiagnostics { get; }
+  public IReadOnlyDictionary<DocumentUri, List<DafnyDiagnostic>> ResolutionDiagnostics { get; }
 
   public DocumentAfterParsing(DocumentTextBuffer textDocumentItem,
     Dafny.Program program,
-    IReadOnlyDictionary<DocumentUri, IList<DafnyDiagnostic>> diagnostics) : base(textDocumentItem) {
+    IReadOnlyDictionary<DocumentUri, List<DafnyDiagnostic>> diagnostics) : base(textDocumentItem) {
     this.ResolutionDiagnostics = diagnostics;
     Program = program;
   }
@@ -44,17 +45,23 @@ public class DocumentAfterParsing : Document {
       }
     }
 
-    var sortedUris = graph.TopologicallySortedComponents();
+    var sortedSccRoots = graph.TopologicallySortedComponents();
+    var sortedUris = sortedSccRoots.SelectMany(sccRoot => graph.GetSCC(sccRoot));
     var sortedUrisWithoutRoot = sortedUris.SkipLast(1);
     foreach (var include in sortedUrisWithoutRoot) {
       var messageForIncludedFile =
-        ResolutionDiagnostics.GetOrDefault(include, Enumerable.Empty<DafnyDiagnostic>);
-      if (messageForIncludedFile.Any(m => m.Level == ErrorLevel.Error)) {
-        var diagnostic = new DafnyDiagnostic(null, Program.GetFirstTopLevelToken(), "the included file " + include.LocalPath + " contains error(s)",
-          MessageSource.Parser, ErrorLevel.Error, new DafnyRelatedInformation[] { });
-        yield return diagnostic;
-        break;
+        ResolutionDiagnostics.GetOrDefault(include, () => (IReadOnlyList<DafnyDiagnostic>)ImmutableList<DafnyDiagnostic>.Empty);
+      var errorMessages = messageForIncludedFile;
+      if (errorMessages.All(m => m.Level != ErrorLevel.Error)) {
+        continue;
       }
+
+      var containsErrorSTheFirstOneIs = "the included file " + include.LocalPath + " contains error(s). The first one is:"
+                                        + messageForIncludedFile.First();
+      var diagnostic = new DafnyDiagnostic(null, Program.GetFirstTopLevelToken(), containsErrorSTheFirstOneIs,
+        MessageSource.Parser, ErrorLevel.Error, new DafnyRelatedInformation[] { });
+      yield return diagnostic;
+      break;
     }
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/Documents/DocumentAfterResolution.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/DocumentAfterResolution.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace;
 public class DocumentAfterResolution : DocumentAfterParsing {
   public DocumentAfterResolution(DocumentTextBuffer textDocumentItem,
     Dafny.Program program,
-    IReadOnlyDictionary<DocumentUri, IList<DafnyDiagnostic>> diagnostics,
+    IReadOnlyDictionary<DocumentUri, List<DafnyDiagnostic>> diagnostics,
     SymbolTable? symbolTable,
     SignatureAndCompletionTable signatureAndCompletionTable,
     IReadOnlyList<Diagnostic> ghostDiagnostics) :

--- a/Source/DafnyLanguageServer/Workspace/Documents/DocumentAfterTranslation.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/DocumentAfterTranslation.cs
@@ -17,7 +17,7 @@ public class DocumentAfterTranslation : DocumentAfterResolution {
     IServiceProvider services,
     DocumentTextBuffer textDocumentItem,
     Dafny.Program program,
-    IReadOnlyDictionary<DocumentUri, IList<DafnyDiagnostic>> diagnostics,
+    IReadOnlyDictionary<DocumentUri, List<DafnyDiagnostic>> diagnostics,
     SymbolTable? symbolTable,
     SignatureAndCompletionTable signatureAndCompletionTable,
     IReadOnlyList<Diagnostic> ghostDiagnostics,


### PR DESCRIPTION
### Changes
- Fix a bug that would prevent showing error in included files that were part of a cycle of include directives
- Show a warning when a program contains a cycle of include directives

### Testing
- Added XUnit tests for the above two change

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
