### PR TITLE
Add the axiom stating that `Seq#Take(s, Seq#Length(s)) == s)` for all…

### DIFF
--- a/Source/DafnyCore/DafnyPrelude.bpl
+++ b/Source/DafnyCore/DafnyPrelude.bpl
@@ -1106,6 +1106,10 @@ axiom (forall<T> s, t: Seq T, n: int ::
   Seq#Take(Seq#Append(s, t), n) == s &&
   Seq#Drop(Seq#Append(s, t), n) == t);
 
+axiom (forall<T> s : Seq T ::
+  { Seq#Take(s, Seq#Length(s)) }
+  Seq#Take(s, Seq#Length(s)) == s);
+
 function Seq#FromArray(h: Heap, a: ref): Seq Box;
 axiom (forall h: Heap, a: ref ::
   { Seq#Length(Seq#FromArray(h,a)) }

--- a/Test/git-issues/git-issue-4184.dfy
+++ b/Test/git-issues/git-issue-4184.dfy
@@ -1,0 +1,7 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method main() {
+  var arr: array<int>;
+  assert(multiset(arr[..]) == multiset(arr[..arr.Length]));
+}

--- a/Test/git-issues/git-issue-4184.dfy.expect
+++ b/Test/git-issues/git-issue-4184.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
… sequence `s` (#4194)

A trivial axiom stating `Seq#Take(s, Seq#Length(s)) == s)` for all sequence `s`. This will help deducing automatically and without using any workaround that "multiset(arr[..]) == multiset(arr[..arr.Length])" for any array `arr`.

Fixes #4184

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT
license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>

Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
