### PR TITLE
Do not run translation if there are resolution errors

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Dafny.LanguageServer.Workspace.ChangeProcessors;
+using Newtonsoft.Json;
 using Xunit.Abstractions;
 using Xunit;
 using XunitAssertMessages;
@@ -16,7 +17,25 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
   public class DiagnosticsTest : ClientBasedLanguageServerTest {
+    private readonly string testFilesDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Synchronization/TestFiles");
 
+    [Fact]
+    public async Task ResolutionErrorInDifferentFileBlocksVerification() {
+      var source = @"
+include ""./semanticError.dfy""
+method Foo() ensures false { 
+  var x := SemanticError.untypedExport; 
+}
+";
+      
+      var documentItem = CreateTestDocument(source, Path.Combine(testFilesDirectory, "test.dfy"));
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+
+      var diagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
+      Assert.Single(diagnostics);
+      Assert.Contains("semanticError.dfy", diagnostics[0].Message);
+      await AssertNoDiagnosticsAreComing(CancellationToken);
+    }
     [Fact]
     public async Task GitIssue3155ItemWithSameKeyAlreadyBeenAdded() {
       var source = @"
@@ -598,7 +617,7 @@ module ModC {
     [Fact]
     public async Task OpeningDocumentWithSemanticErrorsInIncludeReportsResolverErrorAtIncludeStatement() {
       var source = "include \"semanticError.dfy\"";
-      var documentItem = CreateTestDocument(source, Path.Combine(Directory.GetCurrentDirectory(), "Synchronization/TestFiles/test.dfy"));
+      var documentItem = CreateTestDocument(source, Path.Combine(testFilesDirectory, "test.dfy"));
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       var diagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
       Assert.Single(diagnostics);

--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -27,7 +27,7 @@ method Foo() ensures false {
   var x := SemanticError.untypedExport; 
 }
 ";
-      
+
       var documentItem = CreateTestDocument(source, Path.Combine(testFilesDirectory, "test.dfy"));
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
 

--- a/Source/DafnyLanguageServer.Test/Synchronization/TestFiles/semanticError.dfy
+++ b/Source/DafnyLanguageServer.Test/Synchronization/TestFiles/semanticError.dfy
@@ -1,4 +1,6 @@
 ﻿module SemanticError {
+  const untypedExport := 3 + "hello"
+   
   method WithSemanticError() {
     var x: int := "1";
   }

--- a/Source/DafnyLanguageServer/Workspace/Compilation.cs
+++ b/Source/DafnyLanguageServer/Workspace/Compilation.cs
@@ -126,7 +126,7 @@ public class Compilation {
   public async Task<DocumentAfterTranslation> PrepareVerificationTasksAsync(
     DocumentAfterResolution loaded,
     CancellationToken cancellationToken) {
-    if (loaded.AllFileDiagnostics.Any(d =>
+    if (loaded.ResolutionDiagnostics.Values.SelectMany(x => x).Any(d =>
           d.Level == ErrorLevel.Error &&
           d.Source != MessageSource.Compiler &&
           d.Source != MessageSource.Verifier)) {


### PR DESCRIPTION
### Changes
In the language server, do not run translation if there are resolution errors

### Testing
Add XUnit test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
