### PR TITLE
Disable ShowSnippets during Test Generation

### DIFF
--- a/Source/DafnyCore/DafnyConsolePrinter.cs
+++ b/Source/DafnyCore/DafnyConsolePrinter.cs
@@ -50,8 +50,8 @@ public class DafnyConsolePrinter : ConsolePrinter {
     return "<nonexistent line>";
   }
 
-  public void WriteSourceCodeSnippet(Boogie.IToken tok, TextWriter tw) {
-    string line = GetFileLine(((IToken)tok).Filepath, tok.line - 1);
+  public void WriteSourceCodeSnippet(IToken tok, TextWriter tw) {
+    string line = GetFileLine(tok.Filepath, tok.line - 1);
     string lineNumber = tok.line.ToString();
     string lineNumberSpaces = new string(' ', lineNumber.Length);
     string columnSpaces = new string(' ', tok.col - 1);
@@ -102,7 +102,11 @@ public class DafnyConsolePrinter : ConsolePrinter {
     }
 
     if (Options.Get(ShowSnippets)) {
-      WriteSourceCodeSnippet(tok, tw);
+      if(tok is IToken dafnyTok) {
+        WriteSourceCodeSnippet(dafnyTok, tw);
+      } else {
+        ErrorWriteLine(tw, "No Dafny location information, so snippet can't be generated."); 
+      }
     }
 
     if (tok is Dafny.NestedToken) {

--- a/Source/DafnyCore/DafnyConsolePrinter.cs
+++ b/Source/DafnyCore/DafnyConsolePrinter.cs
@@ -102,10 +102,10 @@ public class DafnyConsolePrinter : ConsolePrinter {
     }
 
     if (Options.Get(ShowSnippets)) {
-      if(tok is IToken dafnyTok) {
+      if (tok is IToken dafnyTok) {
         WriteSourceCodeSnippet(dafnyTok, tw);
       } else {
-        ErrorWriteLine(tw, "No Dafny location information, so snippet can't be generated."); 
+        ErrorWriteLine(tw, "No Dafny location information, so snippet can't be generated.");
       }
     }
 

--- a/Source/DafnyTestGeneration/DeadCodeCommand.cs
+++ b/Source/DafnyTestGeneration/DeadCodeCommand.cs
@@ -38,5 +38,6 @@ public class DeadCodeCommand : ICommandSpec {
 
     dafnyOptions.TestGenOptions.Mode = TestGenerationOptions.Modes.Block;
     dafnyOptions.TestGenOptions.WarnDeadCode = true;
+    dafnyOptions.Set(DafnyConsolePrinter.ShowSnippets, false);
   }
 }

--- a/Source/DafnyTestGeneration/GenerateTestsCommand.cs
+++ b/Source/DafnyTestGeneration/GenerateTestsCommand.cs
@@ -66,6 +66,7 @@ path - Prints path-coverage tests for the given program.");
     dafnyOptions.DeprecationNoise = 0;
     dafnyOptions.ForbidNondeterminism = true;
     dafnyOptions.DefiniteAssignmentLevel = 2;
+    dafnyOptions.Set(DafnyConsolePrinter.ShowSnippets, false);
 
     var mode = context.ParseResult.GetValueForArgument(modeArgument);
     dafnyOptions.TestGenOptions.Mode = mode switch {

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -563,12 +563,12 @@ The documentation for the root module is in `_.html`.
 
 #### 13.5.1.12. `dafny generate-tests` {#sec-dafny-generate-tests}
 
-This _experimental_ command (verifies the program and) then generates unit test code (as Dafny source code) that provides
-complete coverage of the method.
+This _experimental_ command generates unit test code (as Dafny source code) that provides
+complete coverage of a method indicated with the --target-method option.
 
-Such methods must be static and have no input parameters.
+This command enforces determinism by default and disables the functionality provided by the --snow-snippets option.
 
-_This command is under development and not yet functional._
+_This command is under development and not yet fully functional._
 
 #### 13.5.1.13. `dafny find-dead-code` {#sec-dafny-find-dead-code}
 

--- a/docs/dev/news/4216.fix
+++ b/docs/dev/news/4216.fix
@@ -1,0 +1,2 @@
+Disabled --show-snippets CLI option, which is otherwise on by default, during test generation
+Test generation modifies Boogie AST resulting from Dafny, and is, therefore, incompatible with --show-snippets


### PR DESCRIPTION
The `--show-snippets` breaks test generation because it relies on casting of `Boogie.IToken` to `Dafny.IToken` [here](https://github.com/dafny-lang/dafny/blob/d72dc7a85ae5d662dda78f927463d1e56b4a0696/Source/DafnyCore/DafnyConsolePrinter.cs#L54) and test generation makes changes to the Boogie AST that may introduce new tokens that cannot be cast. This PR disables the option, recently enabled by default, during test generation. An alternative would be to surround the cast with try-catch, but it seems that outside test generation purposes it is probably safe to assume that the cast succeeds. @atomb, @robin-aws would it be possible to merge this before the next release to make sure test generation stays stable? 

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
