### PR TITLE
Turn off snippets for lit testing

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -156,7 +156,7 @@ def buildCmd(cmd, args):
 dafny = addParams(buildCmd(dafnyExecutable, dafnyArgs))
 boogie = buildCmd(boogieExecutable, boogieArgs)
 
-standardArguments = addParams(' '.join(["--use-basename-for-filename", "--show-snippets"]))
+standardArguments = addParams(' '.join(["--use-basename-for-filename", "--show-snippets:false"]))
 
 # Inform user what executable is being used
 lit_config.note(f'Using Dafny (%dafny): {dafny}\n')


### PR DESCRIPTION
A recent change (#4087) explicitly turned on snippets in `lit`-based testing. The change causes many tests to fail, when run using `lit`. This PR turns them back off.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
