### PR TITLE
feat: Compile general traits with type parameters

### DIFF
--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -303,6 +303,12 @@ public abstract class Type : TokenNode {
   }
 
   /// <summary>
+  /// Returns true if the type has two representations at run time, the ordinary representation and a
+  /// "fat pointer" representation (which is a boxing of the ordinary representation, plus a vtable pointer).
+  /// </summary>
+  public bool HasFatPointer => NormalizeExpand() is UserDefinedType { ResolvedClass: NewtypeDecl { ParentTraits: { Count: > 0 } } };
+
+  /// <summary>
   /// This property returns true if the type is known to be nonempty.
   /// This property should be used only after successful resolution. It is assumed that all type proxies have
   /// been resolved and that all recursion through types comes to an end.

--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -265,27 +265,57 @@ namespace Microsoft.Dafny.Compilers {
 
           var wCtorParams = new ConcreteSyntaxTree();
           wCtorBody = wBody.Format($"public {name}({wCtorParams})").NewBlock();
-
-          if (typeParameters != null) {
-            var sep = "";
-            foreach (var ta in TypeArgumentInstantiation.ListFromFormals(typeParameters)) {
-              if (NeedsTypeDescriptor(ta.Formal)) {
-                var fieldName = FormatTypeDescriptorVariable(ta.Formal.GetCompileName(Options));
-                var decl = $"{DafnyTypeDescriptor}<{TypeName(ta.Actual, wTypeFields, ta.Formal.tok)}> {fieldName}";
-                wTypeFields.WriteLine($"private {decl};");
-                if (ta.Formal.Parent == cls) {
-                  wCtorParams.Write($"{sep}{decl}");
-                }
-
-                wCtorBody.WriteLine($"this.{fieldName} = {TypeDescriptor(ta.Actual, wCtorBody, ta.Formal.tok)};");
-                sep = ", ";
-              }
-            }
-          }
+          EmitTypeDescriptorsForClass(typeParameters, cls, wTypeFields, wCtorParams, null, wCtorBody);
         }
       }
 
       return new ClassWriter(this, wBody, wCtorBody);
+    }
+
+    /// <summary>
+    /// For each type parameter X in "typeParametersForClass" that needs a type descriptor,
+    ///   * Write "protected TypeDescriptor<X> _td_X;" to wTypeFields
+    ///     -- each entry is terminated by a newline
+    ///   * Write "TypeDescriptor<X> _td_X" to wCtorParams
+    ///     -- entries are separated by a comma
+    ///   * Write "_td_X" to wCallArguments
+    ///     -- entries are separated by a comma
+    ///   * Write "this._td_X := _td_X;" to wCtorBody
+    ///     -- each entry is terminated by a newline
+    /// Any of the writer parameters may be null, so long as at least one is non-null.
+    /// The method returns the number type descriptors written.
+    /// </summary>
+    int EmitTypeDescriptorsForClass(List<TypeParameter> typeParametersForClass, TopLevelDecl cls,
+      [CanBeNull] ConcreteSyntaxTree wTypeFields, [CanBeNull] ConcreteSyntaxTree wCtorParams,
+      [CanBeNull] ConcreteSyntaxTree wCallArguments, [CanBeNull] ConcreteSyntaxTree wCtorBody,
+      List<TypeParameter> alternateTypeParameters = null) {
+
+      var wError = wTypeFields ?? wCtorParams ?? wCallArguments ?? wCtorBody;
+      int numberOfEmittedTypeDescriptors = 0;
+      if (typeParametersForClass != null) {
+        var sep = "";
+        var j = 0;
+        foreach (var ta in TypeArgumentInstantiation.ListFromFormals(typeParametersForClass)) {
+          if (NeedsTypeDescriptor(ta.Formal)) {
+            var fieldName = FormatTypeDescriptorVariable((alternateTypeParameters == null ? ta.Formal : alternateTypeParameters[j]).GetCompileName(Options));
+            var actualType = alternateTypeParameters == null ? ta.Actual : new UserDefinedType(ta.Formal.tok, alternateTypeParameters[j]);
+            var paramName = TypeDescriptor(actualType, wError, ta.Formal.tok);
+            var decl = $"{DafnyTypeDescriptor}<{TypeName(actualType, wError, ta.Formal.tok)}> {fieldName}";
+
+            wTypeFields?.WriteLine($"protected {decl};");
+            if (ta.Formal.Parent == cls) {
+              wCtorParams?.Write($"{sep}{decl}");
+            }
+            wCtorBody?.WriteLine($"this.{fieldName} = {paramName};");
+            wCallArguments?.Write($"{sep}{paramName}");
+
+            sep = ", ";
+            numberOfEmittedTypeDescriptors++;
+          }
+          j++;
+        }
+      }
+      return numberOfEmittedTypeDescriptors;
     }
 
     /// <summary>
@@ -308,7 +338,7 @@ namespace Microsoft.Dafny.Compilers {
 
       List<TypeParameter> typeDescriptorParams;
       if (enclosingTypeDecl is DatatypeDecl dtDecl) {
-        typeDescriptorParams = UsedTypeParameters(dtDecl);
+        typeDescriptorParams = UsedTypeParameters(dtDecl, true);
       } else {
         typeDescriptorParams = enclosingTypeDecl.TypeArgs;
       }
@@ -483,7 +513,7 @@ namespace Microsoft.Dafny.Compilers {
       var simplifiedType = DatatypeWrapperEraser.SimplifyType(Options, UserDefinedType.FromTopLevelDecl(dt.tok, dt));
       var simplifiedTypeName = TypeName(simplifiedType, wr, dt.tok);
 
-      // ContreteSyntaxTree for the interface
+      // ConcreteSyntaxTree for the interface
       wr.Write($"public interface _I{dt.GetCompileName(Options)}{TypeParameters(nonGhostTypeArgs, true)}");
       var superTraits = dt.ParentTypeInformation.UniqueParentTraits();
       if (superTraits.Any()) {
@@ -499,17 +529,27 @@ namespace Microsoft.Dafny.Compilers {
       if (dt.IsRecordType) {
         DatatypeFieldsAndConstructor(dt.Ctors[0], 0, wr);
       } else {
-        wr.WriteLine($"public {IdName(dt)}() {{ }}");
+        var wTypeFields = wr.Fork();
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wCtorBody = wr.Format($"public {IdName(dt)}({wCtorParams})").NewBlock();
+        EmitTypeDescriptorsForClass(dt.TypeArgs, dt, wTypeFields, wCtorParams, null, wCtorBody);
       }
 
       var wDefault = new ConcreteSyntaxTree();
+      var wDefaultTypeArguments = new ConcreteSyntaxTree();
+      var defaultMethodTypeDescriptorCount = 0;
       if (nonGhostTypeArgs.Count == 0) {
         wr.FormatLine($"private static readonly {simplifiedTypeName} theDefault = {wDefault};");
         var w = wr.NewBlock($"public static {simplifiedTypeName} Default()");
         w.WriteLine("return theDefault;");
       } else {
-        var parameters = UsedTypeParameters(dt).Comma(tp => $"{tp.GetCompileName(Options)} {FormatDefaultTypeParameterValue(tp)}");
-        wr.Write($"public static {simplifiedTypeName} Default({parameters})");
+        wr.Write($"public static {simplifiedTypeName} Default(");
+        var wDefaultParameters = new ConcreteSyntaxTree();
+        defaultMethodTypeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wDefaultParameters, wDefaultTypeArguments, null);
+        var usedTypeParameters = UsedTypeParameters(dt);
+        var parameters = usedTypeParameters.Comma(tp => $"{tp.GetCompileName(Options)} {FormatDefaultTypeParameterValue(tp)}");
+        var sep = defaultMethodTypeDescriptorCount != 0 && usedTypeParameters.Count != 0 ? ", " : "";
+        wr.Write($"{wDefaultParameters}{sep}{parameters})");
         var w = wr.NewBlock();
         w.FormatLine($"return {wDefault};");
       }
@@ -522,13 +562,20 @@ namespace Microsoft.Dafny.Compilers {
       } else {
         if (dt is CoDatatypeDecl) {
           var wCo = wDefault;
+          var lazyTypeDescriptorArguments = new ConcreteSyntaxTree();
+          var count = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, null, lazyTypeDescriptorArguments, null);
+          var sep = count > 0 ? ", " : "";
           wDefault = new ConcreteSyntaxTree();
-          wCo.Format($"new {dt.GetFullCompileName(Options)}__Lazy{DtT_TypeArgs}(() => {{ return {wDefault}; }})");
+          wCo.Format($"new {dt.GetFullCompileName(Options)}__Lazy{DtT_TypeArgs}({lazyTypeDescriptorArguments}{sep}() => {{ return {wDefault}; }})");
         }
 
-        wDefault.Write(DtCreateName(groundingCtor));
-        var nonGhostFormals = groundingCtor.Formals.Where(f => !f.IsGhost);
-        wDefault.Write($"({nonGhostFormals.Comma(f => DefaultValue(f.Type, wDefault, f.tok))})");
+        var wDefaultArguments = wDefault.Write(DtCreateName(groundingCtor)).ForkInParens();
+        wDefaultArguments.Append(wDefaultTypeArguments);
+        var nonGhostFormals = groundingCtor.Formals.Where(f => !f.IsGhost).ToList();
+        if (defaultMethodTypeDescriptorCount != 0 && nonGhostFormals.Count != 0) {
+          wDefaultArguments.Write(", ");
+        }
+        wDefaultArguments.Write(nonGhostFormals.Comma(f => DefaultValue(f.Type, wDefault, f.tok)));
       }
 
       EmitTypeDescriptorMethod(dt, wr);
@@ -540,10 +587,15 @@ namespace Microsoft.Dafny.Compilers {
 
       // create methods
       foreach (var ctor in dt.Ctors.Where(ctor => !ctor.IsGhost)) {
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wCallArguments, null);
         wr.Write($"public static {DtTypeName(dt)} {DtCreateName(ctor)}(");
-        WriteFormals("", ctor.Formals, wr);
+        wr.Append(wCtorParams);
+        var formalCount = WriteFormals(typeDescriptorCount > 0 ? ", " : "", ctor.Formals, wr);
+        var sep = typeDescriptorCount > 0 && formalCount > 0 ? ", " : "";
         wr.NewBlock(")")
-          .WriteLine($"return new {DtCtorDeclarationName(ctor)}{DtT_TypeArgs}({ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
+          .WriteLine($"return new {DtCtorDeclarationName(ctor)}{DtT_TypeArgs}({wCallArguments}{sep}{ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
       }
 
       if (dt.IsRecordType) {
@@ -551,10 +603,15 @@ namespace Microsoft.Dafny.Compilers {
         // to provide a more uniform interface.
 
         var ctor = dt.Ctors[0];
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wCallArguments, null);
         wr.Write($"public static {DtTypeName(dt)} create_{ctor.GetCompileName(Options)}(");
-        WriteFormals("", ctor.Formals, wr);
+        wr.Append(wCtorParams);
+        var formalCount = WriteFormals(typeDescriptorCount > 0 ? ", " : "", ctor.Formals, wr);
+        var sep = typeDescriptorCount > 0 && formalCount > 0 ? ", " : "";
         wr.NewBlock(")")
-          .WriteLine($"return create({ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
+          .WriteLine($"return create({wCallArguments}{sep}{ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
       }
 
       // query properties
@@ -623,9 +680,13 @@ namespace Microsoft.Dafny.Compilers {
       var customReceiver = DowncastCloneNeedsCustomReceiver(datatype);
       var uTypeArgs = TypeParameters(nonGhostTypeArgs, uniqueNames: true);
       var typeArgs = TypeParameters(nonGhostTypeArgs);
+      var typeParameterSubstMap = nonGhostTypeArgs.ToDictionary(
+        tp => tp,
+        tp => new TypeParameter(tp.RangeToken, tp.NameNode.Prepend("_"), tp.VarianceSyntax));
       var typeSubstMap = nonGhostTypeArgs.ToDictionary(
         tp => tp,
-        tp => (Type)new UserDefinedType(tp.tok, new TypeParameter(tp.RangeToken, tp.NameNode.Prepend("_"), tp.VarianceSyntax)));
+        tp => (Type)new UserDefinedType(tp.tok, typeParameterSubstMap[tp]));
+      var uTypeParameters = datatype.TypeArgs.ConvertAll(tp => typeParameterSubstMap[tp]);
 
       var resultType = DatatypeWrapperEraser.GetInnerTypeOfErasableDatatypeWrapper(Options, datatype, out var innerType)
         ? TypeName(innerType.Subst(typeSubstMap), wr, datatype.tok)
@@ -647,6 +708,10 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       if (!(toInterface && customReceiver)) {
+        var wTypeDescriptorDecls = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(datatype.TypeArgs, datatype,
+          null, wTypeDescriptorDecls, null, null, uTypeParameters);
+
         string receiver;
         if (customReceiver) {
           var simplifiedType = DatatypeWrapperEraser.SimplifyType(Options, UserDefinedType.FromTopLevelDecl(datatype.tok, datatype));
@@ -654,8 +719,10 @@ namespace Microsoft.Dafny.Compilers {
         } else {
           receiver = "";
         }
-        var comma = receiver.Length != 0 && nonGhostTypeArgs.Count != 0 ? ", " : "";
-        wr.Write($"{resultType} DowncastClone{uTypeArgs}({receiver}{comma}{nonGhostTypeArgs.Comma(PrintConverter)})");
+
+        var comma0 = typeDescriptorCount != 0 && receiver.Length != 0 ? ", " : "";
+        var comma1 = (typeDescriptorCount != 0 || receiver.Length != 0) && nonGhostTypeArgs.Count != 0 ? ", " : "";
+        wr.Write($"{resultType} DowncastClone{uTypeArgs}({wTypeDescriptorDecls}{comma0}{receiver}{comma1}{nonGhostTypeArgs.Comma(PrintConverter)})");
       }
 
       if (ctor == null && !lazy) {
@@ -667,8 +734,12 @@ namespace Microsoft.Dafny.Compilers {
           ConcreteSyntaxTree NextBlock(string comp) { return body.NewBlock($"if (_this{comp})"); }
 
           void WriteReturn(ConcreteSyntaxTree wr, string staticClass) {
-            var comma = converters.Length != 0 ? ", " : "";
-            wr.WriteLine($"return {staticClass}{typeArgs}.DowncastClone{uTypeArgs}(_this{comma}{converters});");
+            var wTypeDescriptorArguments = new ConcreteSyntaxTree();
+            var typeDescriptorCount = EmitTypeDescriptorsForClass(datatype.TypeArgs, datatype,
+              null, null, wTypeDescriptorArguments, null, uTypeParameters);
+            var sep0 = typeDescriptorCount != 0 ? ", " : "";
+            var sep1 = converters.Length != 0 ? ", " : "";
+            wr.WriteLine($"return {staticClass}{typeArgs}.DowncastClone{uTypeArgs}({wTypeDescriptorArguments}{sep0}_this{sep1}{converters});");
           }
 
           if (datatype is CoDatatypeDecl) {
@@ -724,14 +795,24 @@ namespace Microsoft.Dafny.Compilers {
         wBody.WriteLine($"return {PrintConvertedExpr("_this", innerType)};");
       } else {
         var wBody = wr.NewBlock("").WriteLine($"if ({(customReceiver ? "_" : "")}this is {resultType} dt) {{ return dt; }}");
-        var constructorArgs = lazy
-          ? customReceiver
-            ? $"() => {datatype.GetCompileName(Options)}{typeArgs}.DowncastClone{uTypeArgs}(_this._Get(), {converters})"
-            : $"() => _Get().DowncastClone{uTypeArgs}({converters})"
-          : ctor.Formals.Where(f => !f.IsGhost).Comma(PrintInvocation);
-
+        var wCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(datatype.TypeArgs, datatype, null, null, wCallArguments, null, uTypeParameters);
+        var typeDescriptorArgumentsStrings = wCallArguments.ToString();
+        string constructorArgs;
+        if (!lazy) {
+          constructorArgs = ctor.Formals.Where(f => !f.IsGhost).Comma(PrintInvocation);
+        } else if (customReceiver) {
+          var sep0 = typeDescriptorCount != 0 ? ", " : "";
+          var sep1 = converters.Length != 0 ? ", " : "";
+          constructorArgs =
+            $"() => {datatype.GetCompileName(Options)}{typeArgs}.DowncastClone{uTypeArgs}({typeDescriptorArgumentsStrings}{sep0}_this._Get(){sep1}{converters})";
+        } else {
+          var sep0 = typeDescriptorCount != 0 && converters.Length != 0 ? ", " : "";
+          constructorArgs = $"() => _Get().DowncastClone{uTypeArgs}({typeDescriptorArgumentsStrings}{sep0}{converters})";
+        }
+        var sep = typeDescriptorCount != 0 && (lazy || ctor.Formals.Any(f => !f.IsGhost)) ? ", " : "";
         var className = lazy ? lazyClass : DtCtorDeclarationName(ctor);
-        wBody.WriteLine($"return new {className}{uTypeArgs}({constructorArgs});");
+        wBody.WriteLine($"return new {className}{uTypeArgs}({typeDescriptorArgumentsStrings}{sep}{constructorArgs});");
       }
     }
 
@@ -836,13 +917,18 @@ namespace Microsoft.Dafny.Compilers {
             //Can only be in output
             case TypeParameter.TPVariance.Co:
               if ((member is Function f && f.Formals.Exists(InvalidFormal))
-                  || (member is Method m && m.Ins.Exists(InvalidFormal))) { return true; }
+                  || (member is Method m && m.Ins.Exists(InvalidFormal))
+                  || NeedsTypeDescriptor(tp)) {
+                return true;
+              }
               break;
             //Can only be in input
             case TypeParameter.TPVariance.Contra:
               if ((member is Function fn && InvalidType(fn.ResultType))
                   || (member is Method me && me.Outs.Exists(InvalidFormal))
-                  || (member is ConstantField c && InvalidType(c.Type))) { return true; }
+                  || (member is ConstantField c && InvalidType(c.Type))) {
+                return true;
+              }
               break;
           }
         }
@@ -873,7 +959,13 @@ namespace Microsoft.Dafny.Compilers {
         w.WriteLine($"public {NeedsNew(dt, "Computer")}delegate {DtTypeName(dt)} Computer();");
         w.WriteLine($"{NeedsNew(dt, "c")}Computer c;");
         w.WriteLine($"{NeedsNew(dt, "d")}{DtTypeName(dt)} d;");
-        w.WriteLine($"public {dt.GetCompileName(Options)}__Lazy(Computer c) {{ this.c = c; }}");
+
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wBaseCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wBaseCallArguments, null);
+        var sep = typeDescriptorCount > 0 ? ", " : "";
+        w.NewBlock($"public {dt.GetCompileName(Options)}__Lazy({wCtorParams}{sep}Computer c) : base({wBaseCallArguments})")
+          .WriteLine("this.c = c;");
         CompileDatatypeDowncastClone(dt, w, nonGhostTypeArgs, lazy: true);
         w.WriteLine($"public override {DtTypeName(dt)} _Get() {{ if (c != null) {{ d = c(); c = null; }} return d; }}");
         w.WriteLine("public override string ToString() { return _Get().ToString(); }");
@@ -932,10 +1024,20 @@ namespace Microsoft.Dafny.Compilers {
         }
       }
 
-      wr.Write($"public {DtCtorDeclarationName(ctor)}(");
-      WriteFormals("", ctor.Formals, wr);
+      var wTypeFields = wr.Fork();
+      var wCtorParams = new ConcreteSyntaxTree();
+      var wBaseCall = new ConcreteSyntaxTree();
+      var wCtorBody = wr.Format($"public {DtCtorDeclarationName(ctor)}({wCtorParams}){wBaseCall}").NewBlock();
+      int typeDescriptorCount;
+      if (ctor.EnclosingDatatype.IsRecordType) {
+        typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, wTypeFields, wCtorParams, null, wCtorBody);
+      } else {
+        var wBaseCallArguments = wBaseCall.Write(" : base").ForkInParens();
+        typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wBaseCallArguments, null);
+      }
+      WriteFormals(typeDescriptorCount > 0 ? ", " : "", ctor.Formals, wCtorParams);
       {
-        var w = wr.NewBlock(")");
+        var w = wCtorBody;
         i = 0;
         foreach (Formal arg in ctor.Formals) {
           if (!arg.IsGhost) {
@@ -1582,8 +1684,17 @@ namespace Microsoft.Dafny.Compilers {
         if (nonGhostTypeArgs.Count != 0) {
           s += "<" + TypeNames(nonGhostTypeArgs, wr, udt.tok) + ">";
         }
+
+
+        var wDefaultTypeArguments = new ConcreteSyntaxTree();
+        var sep = "";
+        WriteTypeDescriptors(dt, udt.TypeArgs, wDefaultTypeArguments, ref sep);
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return string.Format($"{s}.Default({relevantTypeArgs.Comma(ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})");
+        var arguments = relevantTypeArgs.Comma(ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors));
+        if (relevantTypeArgs.Count == 0) {
+          sep = "";
+        }
+        return string.Format($"{s}.Default({wDefaultTypeArguments}{sep}{arguments})");
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }
@@ -1673,7 +1784,7 @@ namespace Microsoft.Dafny.Compilers {
 
         List<Type> relevantTypeArgs;
         if (cl is DatatypeDecl dt) {
-          relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs).ConvertAll(ta => ta.Actual);
+          relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs, true).ConvertAll(ta => ta.Actual);
         } else {
           relevantTypeArgs = type.TypeArgs;
         }
@@ -2352,24 +2463,26 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(custom ? "_this" : "this");
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       var dt = dtv.Ctor.EnclosingDatatype;
       var dtName = dt.GetFullCompileName(Options);
 
       var nonGhostInferredTypeArgs = SelectNonGhost(dt, dtv.InferredTypeArgs);
       var typeParams = nonGhostInferredTypeArgs.Count == 0 ? "" : $"<{TypeNames(nonGhostInferredTypeArgs, wr, dtv.tok)}>";
+      var sep = typeDescriptorArguments.Length != 0 && arguments.Length != 0 ? ", " : "";
       if (!dtv.IsCoCall) {
         // For an ordinary constructor (that is, one that does not guard any co-recursive calls), generate:
         //   Dt.create_Cons<T>( args )
-        wr.Write($"{dtName}{typeParams}.{DtCreateName(dtv.Ctor)}({arguments})");
+        wr.Write($"{dtName}{typeParams}.{DtCreateName(dtv.Ctor)}({typeDescriptorArguments}{sep}{arguments})");
       } else {
+        var sep0 = typeDescriptorArguments.Length != 0 ? ", " : "";
         // In the case of a co-recursive call, generate:
         //     new Dt__Lazy<T>( LAMBDA )
         // where LAMBDA is:
         //     () => { return Dt_Cons<T>( ...args... ); }
-        wr.Write($"new {dtName}__Lazy{typeParams}(");
+        wr.Write($"new {dtName}__Lazy{typeParams}({typeDescriptorArguments}{sep0}");
         wr.Write("() => { return ");
-        wr.Write("new {0}({1})", DtCtorName(dtv.Ctor, dtv.InferredTypeArgs, wr), arguments);
+        wr.Write($"new {DtCtorName(dtv.Ctor, dtv.InferredTypeArgs, wr)}({typeDescriptorArguments}{sep}{arguments})");
         wr.Write("; })");
       }
     }
@@ -2687,21 +2800,23 @@ namespace Microsoft.Dafny.Compilers {
       TrExprList(arguments, wr, inLetExprBody, wStmts);
     }
 
-    protected override ConcreteSyntaxTree UnboxNewtypeValue(ConcreteSyntaxTree wr) {
-      var w = wr.ForkInParens();
-      wr.Write("._value");
-      return w;
+    protected override ConcreteSyntaxTree FromFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        var w = wr.ForkInParens();
+        wr.Write("._value");
+        return w;
+      } else {
+        return wr;
+      }
     }
 
-    protected override ConcreteSyntaxTree EmitCoercionIfNecessary(Type @from, Type to, IToken tok, ConcreteSyntaxTree wr) {
-      if (from != null && to != null && from.IsTraitType && to.AsNewtype != null) {
-        return UnboxNewtypeValue(wr);
-      }
-      if (from != null && to != null && from.AsNewtype != null && to.IsTraitType && (enclosingMethod != null || enclosingFunction != null)) {
-        wr.Write($"new {from.AsNewtype.GetFullCompileName(Options)}");
+    protected override ConcreteSyntaxTree ToFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        wr.Write($"new {type.AsNewtype.GetFullCompileName(Options)}");
         return wr.ForkInParens();
+      } else {
+        return wr;
       }
-      return base.EmitCoercionIfNecessary(@from, to, tok, wr);
     }
 
     protected override ConcreteSyntaxTree EmitDowncast(Type from, Type to, IToken tok, ConcreteSyntaxTree wr) {
@@ -2717,7 +2832,7 @@ namespace Microsoft.Dafny.Compilers {
       } else {
         Contract.Assert(Type.SameHead(from, to));
 
-        var typeArgs = from.IsArrowType ? from.TypeArgs.Concat(to.TypeArgs) : to.TypeArgs;
+        var typeArgs = from.IsArrowType ? from.TypeArgs.Concat(to.TypeArgs).ToList() : to.TypeArgs;
         var wTypeArgs = typeArgs.Comma(ta => TypeName(ta, wr, tok));
         var argPairs = Enumerable.Zip(from.TypeArgs, to.TypeArgs);
         if (from.IsArrowType) {
@@ -2725,10 +2840,15 @@ namespace Microsoft.Dafny.Compilers {
         }
         var wConverters = argPairs.Comma(t => DowncastConverter(t.Item1, t.Item2, wr, tok));
         DatatypeDecl dt = from.AsDatatype;
+        var sep = "";
+        var wTypeDescriptorArguments = new ConcreteSyntaxTree();
+        if (to is UserDefinedType udt) {
+          WriteTypeDescriptors(udt.ResolvedClass, typeArgs, wTypeDescriptorArguments, ref sep);
+        }
         if (dt != null && DowncastCloneNeedsCustomReceiver(dt)) {
-          wr.Format($"{TypeName_Companion(from, wr, tok, null)}.DowncastClone<{wTypeArgs}>({w}, {wConverters})");
+          wr.Format($"{TypeName_Companion(from, wr, tok, null)}.DowncastClone<{wTypeArgs}>({wTypeDescriptorArguments}{sep}{w}, {wConverters})");
         } else {
-          wr.Format($"({w}).DowncastClone<{wTypeArgs}>({wConverters})");
+          wr.Format($"({w}).DowncastClone<{wTypeArgs}>({wTypeDescriptorArguments}{sep}{wConverters})");
         }
         Contract.Assert(from.TypeArgs.Count == to.TypeArgs.Count);
       }

--- a/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
+++ b/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
@@ -1664,7 +1664,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("this");
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       EmitDatatypeValue(dtv, dtv.Ctor, dtv.IsCoCall, arguments, wr);
     }
 

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("this");
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       throw new UnsupportedFeatureException(Token.NoToken, Feature.RunAllTests);
     }
 

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Dafny.Compilers {
       // }
       //
       // // For uniformity with co-datatypes
-      // func (_this Dt) Get() Data_Dt_ {
+      // func (_this Dt) Get_() Data_Dt_ {
       //   return _this.Data_Dt_
       // }
       //
@@ -626,7 +626,7 @@ namespace Microsoft.Dafny.Compilers {
       // }
       //
       // type Iface_Dt_ interface {
-      //   Get() Data_Dt_
+      //   Get_() Data_Dt_
       // }
       //
       // type lazyDt struct {
@@ -634,9 +634,9 @@ namespace Microsoft.Dafny.Compilers {
       //   init func() Dt
       // }
       //
-      // func (_this * lazyDt) Get() *Iface_Dt {
+      // func (_this * lazyDt) Get_() *Iface_Dt {
       //   if _this.value == nil {
-      //      _this.value = _this.init().Get()
+      //      _this.value = _this.init().Get_()
       //      _this.init = nil // allow GC of values in closure
       //   }
       //   return _this.value
@@ -652,7 +652,7 @@ namespace Microsoft.Dafny.Compilers {
       //   return Dt{*Dt_Ctor0{type0, type1}}
       // }
       //
-      // func (_this * Dt_Ctor0) Get() Dt {
+      // func (_this * Dt_Ctor0) Get_() Dt {
       //   return _this
       // }
       if (dt is TupleTypeDecl) {
@@ -676,18 +676,20 @@ namespace Microsoft.Dafny.Compilers {
 
       if (dt is IndDatatypeDecl) {
         var wStruct = wr.NewNamedBlock("type {0} struct", name);
+        WriteRuntimeTypeDescriptorsFields(dt.TypeArgs, false, wStruct, null, null);
         wStruct.WriteLine(dataName);
 
         wr.WriteLine();
-        var wGet = wr.NewNamedBlock("func (_this {0}) Get() {1}", name, dataName);
+        var wGet = wr.NewNamedBlock("func (_this {0}) Get_() {1}", name, dataName);
         wGet.WriteLine("return _this.{0}", dataName);
       } else {
         var wDt = wr.NewNamedBlock("type {0} struct", name);
+        WriteRuntimeTypeDescriptorsFields(dt.TypeArgs, false, wDt, null, null);
         wDt.WriteLine(ifaceName);
 
         wr.WriteLine();
         var wIface = wr.NewNamedBlock("type {0} interface", ifaceName);
-        wIface.WriteLine("Get() {0}", dataName);
+        wIface.WriteLine("Get_() {0}", dataName);
 
         wr.WriteLine();
         var wLazy = wr.NewNamedBlock("type lazy_{0}_ struct", name);
@@ -695,16 +697,20 @@ namespace Microsoft.Dafny.Compilers {
         wLazy.WriteLine("init func() {0}", name);
 
         wr.WriteLine();
-        var wLazyGet = wr.NewNamedBlock("func (_this *lazy_{0}_) Get() {1}", name, dataName);
+        var wLazyGet = wr.NewNamedBlock("func (_this *lazy_{0}_) Get_() {1}", name, dataName);
         var wIf = wLazyGet.NewBlock("if _this.value == nil");
-        wIf.WriteLine("_this.value = _this.init().Get()");
+        wIf.WriteLine("_this.value = _this.init().Get_()");
         wIf.WriteLine("_this.init = nil"); // allow GC of values in closure
 
         wLazyGet.WriteLine("return _this.value");
 
         wr.WriteLine();
-        var wLazyCreate = wr.NewNamedBlock("func ({0}) {1}(f func () {2}) {2}", companionTypeName, FormatLazyConstructorName(name), name, name);
-        wLazyCreate.WriteLine("return {0}{{&lazy_{0}_{{nil, f}}}}", name);
+        var wrFormals = new ConcreteSyntaxTree();
+        var wrActuals = new ConcreteSyntaxTree();
+        var typeDescriptorCount = WriteRuntimeTypeDescriptorsFormals(dt.TypeArgs, false, wrFormals, wrActuals);
+        var sep = typeDescriptorCount > 0 ? ", " : "";
+        var wLazyCreate = wr.NewNamedBlock($"func ({companionTypeName}) {FormatLazyConstructorName(name)}({wrFormals}{sep}f func () {name}) {name}");
+        wLazyCreate.WriteLine($"return {name}{{{wrActuals}{sep}&lazy_{name}_{{nil, f}}}}");
       }
 
       {
@@ -716,6 +722,16 @@ namespace Microsoft.Dafny.Compilers {
       wr.WriteLine();
       var staticFieldWriter = wr.NewNamedBlock("type {0} struct", companionTypeName);
       var staticFieldInitWriter = wr.NewNamedBlock("var {0} = {1}", FormatCompanionName(name), companionTypeName);
+
+      string typeDescriptorDeclarations;
+      string typeDescriptorUses;
+      {
+        var wTypeDescriptorDeclarations = new ConcreteSyntaxTree();
+        var wTypeDescriptorUses = new ConcreteSyntaxTree();
+        WriteRuntimeTypeDescriptorsFormals(dt.TypeArgs, false, wTypeDescriptorDeclarations, wTypeDescriptorUses);
+        typeDescriptorDeclarations = wTypeDescriptorDeclarations.ToString();
+        typeDescriptorUses = wTypeDescriptorUses.ToString();
+      }
 
       foreach (var ctor in dt.Ctors.Where(ctor => !ctor.IsGhost)) {
         var ctorStructName = name + "_" + ctor.GetCompileName(Options);
@@ -733,30 +749,34 @@ namespace Microsoft.Dafny.Compilers {
         wr.WriteLine("func ({0}{1}) is{2}() {{}}", dt is CoDatatypeDecl ? "*" : "", ctorStructName, name);
         wr.WriteLine();
 
-        wr.Write("func ({0}) {1}(", companionTypeName, FormatDatatypeConstructorName(ctor.GetCompileName(Options)));
+        wr.Write($"func ({companionTypeName}) {FormatDatatypeConstructorName(ctor.GetCompileName(Options))}({typeDescriptorDeclarations}");
+        var sep = typeDescriptorDeclarations.Length != 0 ? ", " : "";
         var argNames = new List<string>();
         k = 0;
         foreach (var formal in ctor.Formals) {
           if (!formal.IsGhost) {
             var formalName = DatatypeFieldName(formal, k);
 
-            wr.Write("{0}{1} {2}", k > 0 ? ", " : "", formalName, TypeName(formal.Type, wr, formal.Tok));
+            wr.Write($"{sep}{formalName} {TypeName(formal.Type, wr, formal.Tok)}");
 
             argNames.Add(formalName);
+            sep = ", ";
             k++;
           }
         }
         var wCreateBody = wr.NewNamedBlock(") {0}", name);
-        wCreateBody.WriteLine("return {0}{{{1}{2}{{{3}}}}}", name, dt is CoDatatypeDecl ? "&" : "", ctorStructName, Util.Comma(argNames));
+        sep = typeDescriptorDeclarations.Length != 0 ? ", " : "";
+        var co = dt is CoDatatypeDecl ? "&" : "";
+        wCreateBody.WriteLine($"return {name}{{{typeDescriptorUses}{sep}{co}{ctorStructName}{{{Util.Comma(argNames)}}}}}");
 
         wr.WriteLine();
         var wCheck = wr.NewNamedBlock("func (_this {0}) {1}() bool", name, FormatDatatypeConstructorCheckName(ctor.GetCompileName(Options)));
-        wCheck.WriteLine("_, ok := _this.Get().({0})", StructOfCtor(ctor));
+        wCheck.WriteLine("_, ok := _this.Get_().({0})", StructOfCtor(ctor));
         wCheck.WriteLine("return ok");
 
         if (dt is CoDatatypeDecl) {
           wr.WriteLine();
-          var wGet = wr.NewNamedBlock("func (_this *{0}) Get() {1}", ctorStructName, dataName);
+          var wGet = wr.NewNamedBlock("func (_this *{0}) Get_() {1}", ctorStructName, dataName);
           wGet.WriteLine("return _this");
         }
       }
@@ -766,8 +786,12 @@ namespace Microsoft.Dafny.Compilers {
        * }
        */
       wr.WriteLine();
-      wr.Write($"func ({companionTypeName}) Default(");
-      wr.Write(Util.Comma(UsedTypeParameters(dt), tp => $"{FormatDefaultTypeParameterValue(tp)} interface{{}}"));
+      wr.Write($"func ({companionTypeName}) Default({typeDescriptorDeclarations}");
+      var usedParameters = UsedTypeParameters(dt);
+      if (typeDescriptorDeclarations.Length != 0 && usedParameters.Count != 0) {
+        wr.Write(", ");
+      }
+      wr.Write(usedParameters.Comma(tp => $"{FormatDefaultTypeParameterValue(tp)} interface{{}}"));
       {
         var wDefault = wr.NewBlock($") {simplifiedTypeName}");
         wDefault.Write("return ");
@@ -778,8 +802,8 @@ namespace Microsoft.Dafny.Compilers {
           wDefault.Write(DefaultValue(innerType, wDefault, dt.tok));
         } else {
           var nonGhostFormals = groundingCtor.Formals.Where(f => !f.IsGhost).ToList();
-          var arguments = Util.Comma(nonGhostFormals, f => DefaultValue(f.Type, wDefault, f.tok));
-          EmitDatatypeValue(dt, groundingCtor, dt is CoDatatypeDecl, arguments, wDefault);
+          var arguments = nonGhostFormals.Comma(f => DefaultValue(f.Type, wDefault, f.tok));
+          EmitDatatypeValue(dt, groundingCtor, dt is CoDatatypeDecl, typeDescriptorUses, arguments, wDefault);
         }
         wDefault.WriteLine();
       }
@@ -810,9 +834,9 @@ namespace Microsoft.Dafny.Compilers {
               var wDtor = wr.NewNamedBlock("func (_this {0}) {1}() {2}", name, FormatDatatypeDestructorName(arg.CompileName), TypeName(arg.Type, wr, arg.tok));
               var n = dtor.EnclosingCtors.Count;
               if (n == 1) {
-                wDtor.WriteLine("return _this.Get().({0}).{1}", StructOfCtor(dtor.EnclosingCtors[0]), DatatypeFieldName(arg));
+                wDtor.WriteLine("return _this.Get_().({0}).{1}", StructOfCtor(dtor.EnclosingCtors[0]), DatatypeFieldName(arg));
               } else {
-                wDtor = wDtor.NewBlock("switch data := _this.Get().(type)");
+                wDtor = wDtor.NewBlock("switch data := _this.Get_().(type)");
                 var compiledConstructorsProcessed = 0;
                 for (var i = 0; i < n; i++) {
                   var ctor_i = dtor.EnclosingCtors[i];
@@ -839,7 +863,7 @@ namespace Microsoft.Dafny.Compilers {
         var w = wr.NewNamedBlock("func (_this {0}) String() string", name);
         // TODO Avoid switch if only one branch
         var needData = dt is IndDatatypeDecl && dt.Ctors.Exists(ctor => !ctor.IsGhost && ctor.Formals.Exists(arg => !arg.IsGhost));
-        w = w.NewNamedBlock("switch {0}_this.Get().(type)", needData ? "data := " : "");
+        w = w.NewNamedBlock("switch {0}_this.Get_().(type)", needData ? "data := " : "");
         w.WriteLine("case nil: return \"null\"");
         foreach (var ctor in dt.Ctors.Where(ctor => !ctor.IsGhost)) {
           var wCase = w.NewNamedBlock("case {0}:", StructOfCtor(ctor));
@@ -885,13 +909,13 @@ namespace Microsoft.Dafny.Compilers {
         // TODO: Way to implement shortcut check for address equality?
         var needData1 = dt.Ctors.Exists(ctor => !ctor.IsGhost && ctor.Formals.Exists(arg => !arg.IsGhost));
 
-        wEquals = wEquals.NewNamedBlock("switch {0}_this.Get().(type)", needData1 ? "data1 := " : "");
+        wEquals = wEquals.NewNamedBlock("switch {0}_this.Get_().(type)", needData1 ? "data1 := " : "");
         foreach (var ctor in dt.Ctors.Where(ctor => !ctor.IsGhost)) {
           var wCase = wEquals.NewNamedBlock("case {0}:", StructOfCtor(ctor));
 
           var needData2 = ctor.Formals.Exists(arg => !arg.IsGhost);
 
-          wCase.WriteLine("{0}, ok := other.Get().({1})", needData2 ? "data2" : "_", StructOfCtor(ctor));
+          wCase.WriteLine("{0}, ok := other.Get_().({1})", needData2 ? "data2" : "_", StructOfCtor(ctor));
           wCase.Write("return ok");
           var k = 0;
           foreach (Formal arg in ctor.Formals) {
@@ -924,13 +948,15 @@ namespace Microsoft.Dafny.Compilers {
 
       // RTD
       {
+        var usedOrAutoInitTypeParams = UsedTypeParameters(dt, true);
+        CreateRTD(name, usedOrAutoInitTypeParams, out var wDefault, wr);
+
+        WriteRuntimeTypeDescriptorsLocals(usedOrAutoInitTypeParams, true, wDefault);
+
         var usedTypeParams = UsedTypeParameters(dt);
-        CreateRTD(name, usedTypeParams, out var wDefault, wr);
-
-        WriteRuntimeTypeDescriptorsLocals(usedTypeParams, true, wDefault);
-
-        var arguments = Util.Comma(UsedTypeParameters(dt), tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
-        wDefault.WriteLine($"return {TypeName_Companion(dt, wr, dt.tok)}.Default({arguments});");
+        var sep = typeDescriptorUses.Length != 0 && usedTypeParams.Count != 0 ? ", " : "";
+        var arguments = usedTypeParams.Comma(tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
+        wDefault.WriteLine($"return {TypeName_Companion(dt, wr, dt.tok)}.Default({typeDescriptorUses}{sep}{arguments});");
       }
 
       EmitParentTraits(dt.tok, name, false, dt.ParentTraits, wr);
@@ -1005,25 +1031,24 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Requires(wr != null);
       Contract.Ensures(Contract.ValueAtReturn(out wDefaultBody) != null);
 
-      if (usedParams == null) {
-        usedParams = new List<TypeParameter>();
-      }
-      wr.WriteLine();
-      wr.Write("func {0}(", FormatRTDName(typeName));
-      WriteRuntimeTypeDescriptorsFormals(usedParams, true, wr);
-      var wTypeMethod = wr.NewBlock($") {DafnyTypeDescriptor}");
-      wTypeMethod.WriteLine("return type_{0}_{{{1}}}", typeName, Util.Comma(usedParams, tp => FormatRTDName(tp.GetCompileName(Options))));
+      usedParams ??= new List<TypeParameter>();
 
       wr.WriteLine();
-      var wType = wr.NewNamedBlock("type type_{0}_ struct", typeName);
+      wr.Write($"func {FormatRTDName(typeName)}(");
+      WriteRuntimeTypeDescriptorsFormals(usedParams, true, wr, null);
+      var wTypeMethod = wr.NewBlock($") {DafnyTypeDescriptor}");
+      wTypeMethod.WriteLine($"return type_{typeName}_{{{usedParams.Comma(tp => FormatRTDName(tp.GetCompileName(Options)))}}}");
+
+      wr.WriteLine();
+      var wType = wr.NewNamedBlock($"type type_{typeName}_ struct");
       WriteRuntimeTypeDescriptorsFields(usedParams, true, wType, null, null);
 
       wr.WriteLine();
       wDefaultBody = wr.NewNamedBlock("func (_this type_{0}_) Default() interface{{}}", typeName);
 
       wr.WriteLine();
-      var wString = wr.NewNamedBlock("func (_this type_{0}_) String() string", typeName);
-      wString.WriteLine("return \"{0}.{1}\"", ModuleName, typeName);
+      var wString = wr.NewNamedBlock($"func (_this type_{typeName}_) String() string");
+      wString.WriteLine($"return \"{ModuleName}.{typeName}\"");
     }
 
     protected override void GetNativeInfo(NativeType.Selection sel, out string name, out string literalSuffix, out bool needsCastAfterArithmetic) {
@@ -1271,37 +1296,32 @@ namespace Microsoft.Dafny.Compilers {
       foreach (var tp in typeParams) {
         if (useAllTypeArgs || NeedsTypeDescriptor(tp)) {
           var name = FormatRTDName(tp.GetCompileName(Options));
-
-          if (wr != null) {
-            wr.WriteLine($"{name} {DafnyTypeDescriptor}");
-          }
-
-          if (wInit != null) {
-            wInit.WriteLine("_this.{0} = {0}", name);
-          }
-
-          if (wParams != null) {
-            wParams.Write($"{sep}{name} {DafnyTypeDescriptor}");
-            sep = ", ";
-          }
-
+          wr?.WriteLine($"{name} {DafnyTypeDescriptor}");
+          wInit?.WriteLine("_this.{0} = {0}", name);
+          wParams?.Write($"{sep}{name} {DafnyTypeDescriptor}");
+          sep = ", ";
           count++;
         }
       }
       return count;
     }
 
-    void WriteRuntimeTypeDescriptorsFormals(List<TypeParameter> typeParams, bool useAllTypeArgs, ConcreteSyntaxTree wr) {
+    int WriteRuntimeTypeDescriptorsFormals(List<TypeParameter> typeParams, bool useAllTypeArgs,
+      [CanBeNull] ConcreteSyntaxTree wrFormals, [CanBeNull] ConcreteSyntaxTree wrActuals) {
       Contract.Requires(typeParams != null);
-      Contract.Requires(wr != null);
 
+      var count = 0;
       var prefix = "";
       foreach (var tp in typeParams) {
         if (useAllTypeArgs || NeedsTypeDescriptor(tp)) {
-          wr.Write($"{prefix}{FormatRTDName(tp.GetCompileName(Options))} {DafnyTypeDescriptor}");
+          var parameterName = FormatRTDName(tp.GetCompileName(Options));
+          wrFormals?.Write($"{prefix}{parameterName} {DafnyTypeDescriptor}");
+          wrActuals?.Write($"{prefix}{parameterName}");
           prefix = ", ";
+          count++;
         }
       }
+      return count;
     }
 
     void WriteRuntimeTypeDescriptorsLocals(List<TypeParameter> typeParams, bool useAllTypeArgs, ConcreteSyntaxTree wr) {
@@ -1365,7 +1385,7 @@ namespace Microsoft.Dafny.Compilers {
         var tp = type.AsTypeParameter;
         Contract.Assert(tp != null);
         string th;
-        if (thisContext != null && tp.Parent is ClassDecl) {
+        if (thisContext != null && tp.Parent is TopLevelDeclWithMembers and not TraitDecl) {
           th = "_this.";
         } else if (thisContext == null && tp.Parent is SubsetTypeDecl) {
           th = "_this.";
@@ -1381,7 +1401,7 @@ namespace Microsoft.Dafny.Compilers {
 
         var w = new ConcreteSyntaxTree();
         w.Write("{0}(", cl is TupleTypeDecl ? "_dafny.TupleType" : TypeName_RTD(xType, w, tok));
-        var typeArgs = cl is DatatypeDecl dt ? UsedTypeParameters(dt, udt.TypeArgs) : TypeArgumentInstantiation.ListFromClass(cl, udt.TypeArgs);
+        var typeArgs = cl is DatatypeDecl dt ? UsedTypeParameters(dt, udt.TypeArgs, true) : TypeArgumentInstantiation.ListFromClass(cl, udt.TypeArgs);
         EmitTypeDescriptorsActuals(typeArgs, udt.tok, w, true);
         w.Write(")");
         return w.ToString();
@@ -1602,8 +1622,15 @@ namespace Microsoft.Dafny.Compilers {
           return string.Format("{0}{{}}", TypeName(udt, wr, tok));
         }
         var n = dt is TupleTypeDecl ? "_dafny.TupleOf" : $"{TypeName_Companion(dt, wr, tok)}.Default";
+        var wTypeDescriptorArguments = new ConcreteSyntaxTree();
+        var sep = "";
+        WriteTypeDescriptors(dt, udt.TypeArgs, wTypeDescriptorArguments, ref sep);
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return $"{n}({Util.Comma(relevantTypeArgs, ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})";
+        if (relevantTypeArgs.Count == 0) {
+          sep = "";
+        }
+        var arguments = relevantTypeArgs.Comma(ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors));
+        return $"{n}({wTypeDescriptorArguments}{sep}{arguments})";
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }
@@ -2509,27 +2536,28 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(" })() ");
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
-      var dt = dtv.Ctor.EnclosingDatatype;
-      EmitDatatypeValue(dt, dtv.Ctor, dtv.IsCoCall, arguments, wr);
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
+      EmitDatatypeValue(dtv.Ctor.EnclosingDatatype, dtv.Ctor, dtv.IsCoCall, typeDescriptorArguments, arguments, wr);
     }
 
-    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, bool isCoCall, string arguments, ConcreteSyntaxTree wr) {
+    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, bool isCoCall, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       var ctorName = ctor.GetCompileName(Options);
       var companionName = TypeName_Companion(dt, wr, dt.tok);
 
+      var sep = typeDescriptorArguments.Length != 0 && arguments.Length != 0 ? ", " : "";
       if (dt is TupleTypeDecl) {
         wr.Write("_dafny.TupleOf({0})", arguments);
       } else if (!isCoCall) {
         // Ordinary constructor (that is, one that does not guard any co-recursive calls)
         // Generate: Companion_Dt_.CreateCtor(args)
-        wr.Write("{0}.{1}({2})", companionName, FormatDatatypeConstructorName(ctorName), arguments);
+        wr.Write($"{companionName}.{FormatDatatypeConstructorName(ctorName)}({typeDescriptorArguments}{sep}{arguments})");
       } else {
         // Co-recursive call
         // Generate:  Companion_Dt_.LazyDt(func () Dt => Companion_Dt_.CreateCtor(args))
-        wr.Write("{0}.{1}(func () {2} ", companionName, FormatLazyConstructorName(dt.GetCompileName(Options)),
+        wr.Write("{0}.{1}({2}{3}func () {4} ", companionName, FormatLazyConstructorName(dt.GetCompileName(Options)),
+          typeDescriptorArguments, sep,
           TypeName(UserDefinedType.FromTopLevelDecl(dt.tok, dt), wr, dt.tok));
-        wr.Write("{{ return {0}.{1}({2}) }}", companionName, FormatDatatypeConstructorName(ctorName), arguments);
+        wr.Write("{{ return {0}.{1}({2}{3}{4}) }}", companionName, FormatDatatypeConstructorName(ctorName), typeDescriptorArguments, sep, arguments);
         wr.Write(')');
       }
     }
@@ -3048,7 +3076,7 @@ namespace Microsoft.Dafny.Compilers {
       } else {
         var dtorName = DatatypeFieldName(dtor, formalNonGhostIndex);
         wr = EmitCoercionIfNecessary(from: dtor.Type, to: bvType, tok: dtor.tok, wr: wr);
-        wr.Write("{0}.Get().({1}).{2}", source, TypeName_Constructor(ctor, wr), dtorName);
+        wr.Write("{0}.Get_().({1}).{2}", source, TypeName_Constructor(ctor, wr), dtorName);
       }
     }
 
@@ -3546,10 +3574,23 @@ namespace Microsoft.Dafny.Compilers {
       return Type.SameHead(type1, type2) || (type1.IsArrayType && type1.IsArrayType);
     }
 
-    protected override ConcreteSyntaxTree UnboxNewtypeValue(ConcreteSyntaxTree wr) {
-      var w = wr.ForkInParens();
-      wr.Write($"._value");
-      return w;
+    protected override ConcreteSyntaxTree FromFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        var w = wr.ForkInParens();
+        wr.Write("._value");
+        return w;
+      } else {
+        return wr;
+      }
+    }
+
+    protected override ConcreteSyntaxTree ToFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        wr.Write(TypeName_Initializer(type, wr, type.AsNewtype.tok));
+        return wr.ForkInParens();
+      } else {
+        return wr;
+      }
     }
 
     protected override ConcreteSyntaxTree EmitCoercionIfNecessary(Type/*?*/ from, Type/*?*/ to, IToken tok, ConcreteSyntaxTree wr) {
@@ -3558,14 +3599,13 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       if (from != null && from.IsTraitType && to.AsNewtype != null) {
-        wr = UnboxNewtypeValue(wr);
+        wr = FromFatPointer(to, wr);
         var w = wr.ForkInParens();
         wr.Write($".(*{UserDefinedTypeName(to.AsNewtype, true)})");
         return w;
       }
       if (from != null && from.AsNewtype != null && to.IsTraitType && (enclosingMethod != null || enclosingFunction != null)) {
-        wr.Write(TypeName_Initializer(from, wr, tok));
-        return wr.ForkInParens();
+        return ToFatPointer(from, wr);
       }
 
       from = from == null ? null : DatatypeWrapperEraser.SimplifyType(Options, from);

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -909,26 +909,14 @@ namespace Microsoft.Dafny.Compilers {
       var wCtorParams = wBody.Fork();
       var wCtorBody = wBody.NewBlock(")", "");
 
-      if (typeParameters != null) {
-        sep = "";
-        foreach (var ta in TypeArgumentInstantiation.ListFromFormals(typeParameters)) {
-          if (NeedsTypeDescriptor(ta.Formal)) {
-            var fieldName = FormatTypeDescriptorVariable(ta.Formal.GetCompileName(Options));
-            var decl = $"{DafnyTypeDescriptor}<{BoxedTypeName(ta.Actual, wTypeFields, ta.Formal.tok)}> {fieldName}";
-            wTypeFields.WriteLine($"private {decl};");
-            if (ta.Formal.Parent == cls) {
-              wCtorParams.Write($"{sep}{decl}");
-            }
-            wCtorBody.WriteLine($"this.{fieldName} = {TypeDescriptor(ta.Actual, wCtorBody, ta.Formal.tok)};");
-            sep = ", ";
-          }
-        }
-      }
+      EmitTypeDescriptorsForClass(typeParameters, cls, wTypeFields, wCtorParams, null, wCtorBody);
 
       // make sure the (static fields associated with the) type method come after the Witness static field
       var wTypeMethod = wBody;
       var wRestOfBody = wBody.Fork();
-      if (cls is not DefaultClassDecl) {
+      if (cls is DefaultClassDecl or (ClassLikeDecl and not ArrayClassDecl)) {
+        // don't emit a type-descriptor method
+      } else {
         EmitTypeDescriptorMethod(cls, typeParameters, null, null, wTypeMethod);
       }
 
@@ -938,6 +926,51 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       return new ClassWriter(this, wRestOfBody, wCtorBody);
+    }
+
+    /// <summary>
+    /// For each type parameter X in "typeParametersForClass" that needs a type descriptor,
+    ///   * Write "protected TypeDescriptor<X> _td_X;" to wTypeFields
+    ///     -- each entry is terminated by a newline
+    ///   * Write "TypeDescriptor<X> _td_X" to wCtorParams
+    ///     -- entries are separated by a comma
+    ///   * Write "_td_X" to wCallArguments
+    ///     -- entries are separated by a comma
+    ///   * Write "this._td_X := _td_X;" to wCtorBody
+    ///     -- each entry is terminated by a newline
+    /// Any of the writer parameters may be null, so long as at least one is non-null.
+    /// The method returns the number type descriptors written.
+    /// </summary>
+    int EmitTypeDescriptorsForClass(List<TypeParameter> typeParametersForClass, TopLevelDecl cls,
+      [CanBeNull] ConcreteSyntaxTree wTypeFields, [CanBeNull] ConcreteSyntaxTree wCtorParams,
+      [CanBeNull] ConcreteSyntaxTree wCallArguments, [CanBeNull] ConcreteSyntaxTree wCtorBody,
+      string namePrefix = null) {
+
+      namePrefix ??= "";
+
+      var wError = wTypeFields ?? wCtorParams ?? wCallArguments ?? wCtorBody;
+      int numberOfEmittedTypeDescriptors = 0;
+      if (typeParametersForClass != null) {
+        var sep = "";
+        foreach (var ta in TypeArgumentInstantiation.ListFromFormals(typeParametersForClass)) {
+          if (NeedsTypeDescriptor(ta.Formal)) {
+            var fieldName = FormatTypeDescriptorVariable(ta.Formal.GetCompileName(Options));
+            var paramName = TypeDescriptor(ta.Actual, wError, ta.Formal.tok);
+            var decl = $"{DafnyTypeDescriptor}<{namePrefix}{BoxedTypeName(ta.Actual, wError, ta.Formal.tok)}> {fieldName}";
+
+            wTypeFields?.WriteLine($"protected {decl};");
+            if (ta.Formal.Parent == cls) {
+              wCtorParams?.Write($"{sep}{decl}");
+            }
+            wCtorBody?.WriteLine($"this.{fieldName} = {paramName};");
+            wCallArguments?.Write($"{sep}{paramName}");
+
+            sep = ", ";
+            numberOfEmittedTypeDescriptors++;
+          }
+        }
+      }
+      return numberOfEmittedTypeDescriptors;
     }
 
     private void EmitToString(string fullPrintName, ConcreteSyntaxTree wr) {
@@ -1017,8 +1050,7 @@ namespace Microsoft.Dafny.Compilers {
         typeDescriptorExpr = "_TYPE";
       }
       wr.Write($"public static {TypeParameters(typeParams, " ")}{DafnyTypeDescriptor}<{targetTypeName}> {TypeMethodName}(");
-      var typeDescriptorParams = typeParams.Where(NeedsTypeDescriptor);
-      wr.Write(typeDescriptorParams.Comma(tp => $"{DafnyTypeDescriptor}<{tp.GetCompileName(Options)}> {FormatTypeDescriptorVariable(tp.GetCompileName(Options))}"));
+      EmitTypeDescriptorsForClass(typeParams, enclosingTypeDecl, null, wr, null, null);
       var wTypeMethodBody = wr.NewBlock(")", "");
       var typeDescriptorCast = $"({DafnyTypeDescriptor}<{targetTypeName}>) ({DafnyTypeDescriptor}<?>)";
       wTypeMethodBody.WriteLine($"return {typeDescriptorCast} {typeDescriptorExpr};");
@@ -1803,9 +1835,14 @@ namespace Microsoft.Dafny.Compilers {
       if (dt.IsRecordType) {
         DatatypeFieldsAndConstructor(dt.Ctors[0], 0, wr);
       } else {
-        wr.WriteLine($"public {IdName(dt)}() {{ }}");
+        var wTypeFields = wr.Fork();
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wCtorBody = wr.Format($"public {IdName(dt)}({wCtorParams})").NewBlock();
+        EmitTypeDescriptorsForClass(dt.TypeArgs, dt, wTypeFields, wCtorParams, null, wCtorBody);
       }
 
+      var wDefaultTypeArguments = new ConcreteSyntaxTree();
+      var defaultMethodTypeDescriptorCount = 0;
       var usedTypeArgs = UsedTypeParameters(dt);
       ConcreteSyntaxTree wDefault;
       wr.WriteLine();
@@ -1817,18 +1854,11 @@ namespace Microsoft.Dafny.Compilers {
         w.WriteLine("return theDefault;");
       } else {
         wr.Write($"public static{justTypeArgs} {simplifiedTypeName} Default(");
-        var typeParameters = Util.Comma(usedTypeArgs, tp => $"{tp.GetCompileName(Options)} {FormatDefaultTypeParameterValue(tp)}");
-        wr.Write(typeParameters);
+        defaultMethodTypeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wr, wDefaultTypeArguments, null);
+        var typeParameters = usedTypeArgs.Comma(tp => $"{tp.GetCompileName(Options)} {FormatDefaultTypeParameterValue(tp)}");
+        var sep = defaultMethodTypeDescriptorCount != 0 && typeParameters.Length != 0 ? ", " : "";
+        wr.Write($"{sep}{typeParameters}");
         var w = wr.NewBlock(")");
-        var sep = "";
-        var typeArguments = TypeArgumentInstantiation.ListFromFormals(dt.TypeArgs);
-        WriteRuntimeTypeDescriptorsFormals(ForTypeDescriptors(typeArguments, dt, null, false), w, ref sep,
-          tp => {
-            sep = "";
-            return
-              $"{DafnyTypeDescriptor}<{tp.GetCompileName(Options)}> {FormatTypeDescriptorVariable(tp)} = ({DafnyTypeDescriptor}<{tp.GetCompileName(Options)}>)dafny.TypeDescriptor.OBJECT;\n    ";
-          });
-
         w.Write("return ");
         wDefault = w.Fork();
         w.WriteLine(";");
@@ -1843,18 +1873,22 @@ namespace Microsoft.Dafny.Compilers {
         var args = nonGhostFormals.Comma(f => DefaultValue(f.Type, wDefault, f.tok));
         EmitDatatypeValue(dt, groundingCtor,
           dt.TypeArgs.ConvertAll(tp => (Type)new UserDefinedType(dt.tok, tp)),
-          dt is CoDatatypeDecl, args, wDefault);
+          dt is CoDatatypeDecl, $"{wDefaultTypeArguments}", args, wDefault);
       }
 
-      var arguments = usedTypeArgs.Comma(tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
-      EmitTypeDescriptorMethod(dt, dt.TypeArgs, null, $"Default({arguments})", wr);
+      EmitTypeDescriptorMethod(dt, dt.TypeArgs, null, null, wr);
 
       // create methods
       foreach (var ctor in dt.Ctors.Where(ctor => !ctor.IsGhost)) {
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wCallArguments, null);
         wr.Write($"public static{justTypeArgs} {DtT_protected} {DtCreateName(ctor)}(");
-        WriteFormals("", ctor.Formals, wr);
+        wr.Append(wCtorParams);
+        var formalCount = WriteFormals(typeDescriptorCount > 0 ? ", " : "", ctor.Formals, wr);
+        var sep = typeDescriptorCount > 0 && formalCount > 0 ? ", " : "";
         wr.NewBlock(")")
-          .WriteLine($"return new {DtCtorDeclarationName(ctor, dt.TypeArgs)}({ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
+          .WriteLine($"return new {DtCtorDeclarationName(ctor, dt.TypeArgs)}({wCallArguments}{sep}{ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
       }
 
       if (dt.IsRecordType) {
@@ -1862,10 +1896,15 @@ namespace Microsoft.Dafny.Compilers {
         // to provide a more uniform interface.
 
         var ctor = dt.Ctors[0];
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wCallArguments, null);
         wr.Write($"public static{justTypeArgs} {DtT_protected} create_{ctor.GetCompileName(Options)}(");
-        WriteFormals("", ctor.Formals, wr);
+        wr.Append(wCtorParams);
+        var formalCount = WriteFormals(typeDescriptorCount > 0 ? ", " : "", ctor.Formals, wr);
+        var sep = typeDescriptorCount > 0 && formalCount > 0 ? ", " : "";
         wr.NewBlock(")")
-          .WriteLine($"return create({ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
+          .WriteLine($"return create({wCallArguments}{sep}{ctor.Formals.Where(f => !f.IsGhost).Comma(FormalName)});");
       }
 
       // query properties
@@ -1971,7 +2010,14 @@ namespace Microsoft.Dafny.Compilers {
         w.WriteLine($"public interface Computer {{ {dt.GetCompileName(Options)} run(); }}");
         w.WriteLine("Computer c;");
         w.WriteLine($"{dt.GetCompileName(Options)}{typeParams} d;");
-        w.WriteLine($"public {dt.GetCompileName(Options)}__Lazy(Computer c) {{ this.c = c; }}");
+
+        var wCtorParams = new ConcreteSyntaxTree();
+        var wBaseCallArguments = new ConcreteSyntaxTree();
+        var typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wBaseCallArguments, null);
+        var sep = typeDescriptorCount > 0 ? ", " : "";
+        var wCtorBody = w.NewBlock($"public {dt.GetCompileName(Options)}__Lazy({wCtorParams}{sep}Computer c)");
+        wCtorBody.WriteLine($"super({wBaseCallArguments});");
+        wCtorBody.WriteLine("this.c = c;");
         w.WriteLine($"public {dt.GetCompileName(Options)}{typeParams} Get() {{ if (c != null) {{ d = c.run(); c = null; }} return d; }}");
         w.WriteLine("public String toString() { return Get().toString(); }");
       }
@@ -1989,10 +2035,21 @@ namespace Microsoft.Dafny.Compilers {
           i++;
         }
       }
-      wr.Write($"public {DtCtorDeclarationName(ctor)} (");
-      WriteFormals("", ctor.Formals, wr);
+
+      var wTypeFields = wr.Fork();
+      var wCtorParams = new ConcreteSyntaxTree();
+      var wCtorBody = wr.Format($"public {DtCtorDeclarationName(ctor)} ({wCtorParams})").NewBlock();
+      int typeDescriptorCount;
+      if (ctor.EnclosingDatatype.IsRecordType) {
+        typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, wTypeFields, wCtorParams, null, wCtorBody);
+      } else {
+        var wBaseCallArguments = wCtorBody.Write("super").ForkInParens();
+        wCtorBody.WriteLine(";");
+        typeDescriptorCount = EmitTypeDescriptorsForClass(dt.TypeArgs, dt, null, wCtorParams, wBaseCallArguments, null);
+      }
+      WriteFormals(typeDescriptorCount > 0 ? ", " : "", ctor.Formals, wCtorParams);
       {
-        var w = wr.NewBlock(")");
+        var w = wCtorBody;
         i = 0;
         foreach (Formal arg in ctor.Formals) {
           if (!arg.IsGhost) {
@@ -2175,6 +2232,7 @@ namespace Microsoft.Dafny.Compilers {
     private ConcreteSyntaxTree EmitToString(ConcreteSyntaxTree wr, Type type) {
       Contract.Requires(!type.IsArrayType);
       ConcreteSyntaxTree argumentWriter;
+      type = DatatypeWrapperEraser.SimplifyType(Options, type, true);
       if (AsNativeType(type) != null && AsNativeType(type).LowerBound >= 0) {
         var nativeName = GetNativeTypeName(AsNativeType(type));
         switch (AsNativeType(type).Sel) {
@@ -2361,7 +2419,7 @@ namespace Microsoft.Dafny.Compilers {
     /// corresponding type descriptor. :(  Thus, this method returns "true".
     /// </summary>
     protected override bool NeedsTypeDescriptor(TypeParameter tp) {
-      return true;
+      return tp.Parent is not TupleTypeDecl;
     }
 
     protected override void TypeArgDescriptorUse(bool isStatic, bool lookasideBody, TopLevelDeclWithMembers cl, out bool needsTypeParameter, out bool needsTypeDescriptor) {
@@ -2384,9 +2442,7 @@ namespace Microsoft.Dafny.Compilers {
         return $"{DafnyTypeDescriptor}.BOOLEAN";
       } else if (type is CharType) {
         return UnicodeCharEnabled ? $"{DafnyTypeDescriptor}.UNICODE_CHAR" : $"{DafnyTypeDescriptor}.CHAR";
-      } else if (type is IntType) {
-        return $"{DafnyTypeDescriptor}.BIG_INTEGER";
-      } else if (type is BigOrdinalType) {
+      } else if (type is IntType or BigOrdinalType) {
         return $"{DafnyTypeDescriptor}.BIG_INTEGER";
       } else if (type is RealType) {
         return $"{DafnyTypeDescriptor}.BIG_RATIONAL";
@@ -2397,8 +2453,14 @@ namespace Microsoft.Dafny.Compilers {
         } else {
           return $"{DafnyTypeDescriptor}.BIG_INTEGER";
         }
-      } else if (type.IsObjectQ || type.IsObject) {
-        return $"{DafnyTypeDescriptor}.OBJECT";
+      } else if (type is SetType setType) {
+        return AddTypeDescriptorArgs(DafnySetClass, setType.TypeArgs, setType.TypeArgs, wr, tok);
+      } else if (type is SeqType seqType) {
+        return AddTypeDescriptorArgs(DafnySeqClass, seqType.TypeArgs, seqType.TypeArgs, wr, tok);
+      } else if (type is MultiSetType multiSetType) {
+        return AddTypeDescriptorArgs(DafnyMultiSetClass, multiSetType.TypeArgs, multiSetType.TypeArgs, wr, tok);
+      } else if (type is MapType mapType) {
+        return AddTypeDescriptorArgs(DafnyMapClass, mapType.TypeArgs, mapType.TypeArgs, wr, tok);
       } else if (type.IsArrayType) {
         ArrayClassDecl at = type.AsArrayType;
         var elType = UserDefinedType.ArrayElementType(type);
@@ -2423,6 +2485,14 @@ namespace Microsoft.Dafny.Compilers {
         } else {
           return $"(({DafnyTypeDescriptor}<{BoxedTypeName(type, wr, tok)}>)({TypeDescriptor(elType, wr, tok)}).arrayType())";
         }
+      } else if (type.IsObjectQ || type.IsObject) {
+        return $"{DafnyTypeDescriptor}.OBJECT";
+      } else if (type.IsRefType || type.IsTraitType) {
+        var typeName = TypeName(type, wr, tok);
+        var typeNameSansTypeParameters = StripTypeParameters(typeName);
+        return $"(({DafnyTypeDescriptor}<{typeName}>)" +
+               "(java.lang.Object)" +
+               $"{DafnyTypeDescriptor}.reference({typeNameSansTypeParameters}.class))";
       } else if (type.IsTypeParameter) {
         var tp = type.AsTypeParameter;
         Contract.Assert(tp != null);
@@ -2462,14 +2532,6 @@ namespace Microsoft.Dafny.Compilers {
         }
 
         return AddTypeDescriptorArgs(s, udt.TypeArgs, relevantTypeArgs, wr, udt.tok);
-      } else if (type is SetType setType) {
-        return AddTypeDescriptorArgs(DafnySetClass, setType.TypeArgs, setType.TypeArgs, wr, tok);
-      } else if (type is SeqType seqType) {
-        return AddTypeDescriptorArgs(DafnySeqClass, seqType.TypeArgs, seqType.TypeArgs, wr, tok);
-      } else if (type is MultiSetType multiSetType) {
-        return AddTypeDescriptorArgs(DafnyMultiSetClass, multiSetType.TypeArgs, multiSetType.TypeArgs, wr, tok);
-      } else if (type is MapType mapType) {
-        return AddTypeDescriptorArgs(DafnyMapClass, mapType.TypeArgs, mapType.TypeArgs, wr, tok);
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();
       }
@@ -2531,23 +2593,26 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       var dt = dtv.Ctor.EnclosingDatatype;
       var typeArgs = SelectNonGhost(dt, dtv.InferredTypeArgs);
-      EmitDatatypeValue(dt, dtv.Ctor, typeArgs, dtv.IsCoCall, arguments, wr);
+      EmitDatatypeValue(dt, dtv.Ctor, typeArgs, dtv.IsCoCall, typeDescriptorArguments, arguments, wr);
     }
 
-    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, List<Type> typeArgs, bool isCoCall, string arguments, ConcreteSyntaxTree wr) {
+    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, List<Type> typeArgs, bool isCoCall,
+      string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       var dtName = dt is TupleTypeDecl tupleDecl ? DafnyTupleClass(tupleDecl.NonGhostDims) : dt.GetFullCompileName(Options);
       var typeParams = typeArgs.Count == 0 ? "" : $"<{BoxedTypeNames(typeArgs, wr, dt.tok)}>";
+      var sep = typeDescriptorArguments.Length != 0 && arguments.Length != 0 ? ", " : "";
       if (!isCoCall) {
         // For an ordinary constructor (that is, one that does not guard any co-recursive calls), generate:
         //   Dt.<T>create_Cons( args )
-        wr.Write($"{dtName}.{typeParams}{DtCreateName(ctor)}({arguments})");
+        wr.Write($"{dtName}.{typeParams}{DtCreateName(ctor)}({typeDescriptorArguments}{sep}{arguments})");
       } else {
-        wr.Write($"new {dt.GetCompileName(Options)}__Lazy(");
+        var sep0 = typeDescriptorArguments.Length != 0 ? ", " : "";
+        wr.Write($"new {dt.GetCompileName(Options)}__Lazy({typeDescriptorArguments}{sep0}");
         wr.Write("() -> { return ");
-        wr.Write($"new {DtCtorName(ctor)}{typeParams}({arguments})");
+        wr.Write($"new {DtCtorName(ctor)}{typeParams}({typeDescriptorArguments}{sep}{arguments})");
         wr.Write("; })");
       }
     }
@@ -3142,8 +3207,15 @@ namespace Microsoft.Dafny.Compilers {
         if (usePlaceboValue) {
           return $"({s}{typeargs})null";
         }
+        var wDefaultTypeArguments = new ConcreteSyntaxTree();
+        var sep = "";
+        WriteTypeDescriptors(dt, udt.TypeArgs, wDefaultTypeArguments, ref sep);
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs);
-        return $"{s}.{typeargs}Default({Util.Comma(relevantTypeArgs, ta => DefaultValueCoercedIfNecessary(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})";
+        var arguments = relevantTypeArgs.Comma(ta => DefaultValueCoercedIfNecessary(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors));
+        if (relevantTypeArgs.Count == 0) {
+          sep = "";
+        }
+        return $"{s}.{typeargs}Default({wDefaultTypeArguments}{sep}{arguments})";
       } else {
         Contract.Assert(false);
         throw new cce.UnreachableException(); // unexpected type
@@ -3200,7 +3272,6 @@ namespace Microsoft.Dafny.Compilers {
       var staticMemberWriter = w.NewBlock("");
       var ctorBodyWriter = staticMemberWriter.NewBlock($"public _Companion_{name}()");
 
-      EmitTypeDescriptorMethod(null, typeParameters, name + typeParamString, initializer: null, wr: staticMemberWriter);
       return new ClassWriter(this, instanceMemberWriter, ctorBodyWriter, staticMemberWriter);
     }
 
@@ -3780,19 +3851,31 @@ namespace Microsoft.Dafny.Compilers {
       return type == NativeObjectType || type.IsTypeParameter;
     }
 
-    protected override ConcreteSyntaxTree UnboxNewtypeValue(ConcreteSyntaxTree wr) {
-      var w = wr.ForkInParens();
-      wr.Write("._value");
-      return w;
+    protected override ConcreteSyntaxTree FromFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        var w = wr.ForkInParens();
+        wr.Write("._value");
+        return w;
+      } else {
+        return wr;
+      }
+    }
+
+    protected override ConcreteSyntaxTree ToFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        wr.Write($"new {type.AsNewtype.GetFullCompileName(Options)}");
+        return wr.ForkInParens();
+      } else {
+        return wr;
+      }
     }
 
     protected override ConcreteSyntaxTree EmitCoercionIfNecessary(Type/*?*/ from, Type/*?*/ to, IToken tok, ConcreteSyntaxTree wr) {
       if (from != null && to != null && from.IsTraitType && to.AsNewtype != null) {
-        return UnboxNewtypeValue(wr);
+        return FromFatPointer(to, wr);
       }
       if (from != null && to != null && from.AsNewtype != null && to.IsTraitType && (enclosingMethod != null || enclosingFunction != null)) {
-        wr.Write($"new {from.AsNewtype.GetFullCompileName(Options)}");
-        return wr.ForkInParens();
+        return ToFatPointer(from, wr);
       }
 
       from = from == null ? null : DatatypeWrapperEraser.SimplifyType(Options, from);

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -323,7 +323,15 @@ namespace Microsoft.Dafny.Compilers {
       var btw = wr.NewNamedBlock("$module.{0} = class {0}", DtT_protected);
       wr = btw;
 
-      wr.WriteLine("constructor(tag) { this.$tag = tag; }");
+      var wTypeDescriptors = new ConcreteSyntaxTree();
+      var typeDescriptorComma = WriteRuntimeTypeDescriptorsFormals(dt.TypeArgs, false, wTypeDescriptors) != 0 ? ", " : "";
+      var typeDescriptors = wTypeDescriptors.ToString();
+
+      var wBody = wr.NewBlock($"constructor(tag{typeDescriptorComma}{typeDescriptors})");
+      wBody.WriteLine("this.$tag = tag;");
+      foreach (var tp in dt.TypeArgs.Where(NeedsTypeDescriptor)) {
+        wBody.WriteLine("this.{0} = {0};", "rtd$_" + tp.GetCompileName(Options));
+      }
 
       if (dt is CoDatatypeDecl) {
         var w0 = wr.NewBlock("_D()");
@@ -350,25 +358,31 @@ namespace Microsoft.Dafny.Compilers {
         // codatatype:
         //   static create_Ctor0(params) { if ($dt === null) { $dt = new Dt(tag); $dt._d = $dt; } $dt.param0 = param0; ...; return $dt; }
         //   static lazy_Ctor0(initializer) { let dt = new Dt(tag); dt._initializer = initializer; return dt; }
-        wr.Write("static create_{0}(", ctor.GetCompileName(Options));
+        wr.Write($"static create_{ctor.GetCompileName(Options)}(");
+        wr.Write(typeDescriptors);
+        var sep = typeDescriptorComma;
         if (dt is CoDatatypeDecl) {
-          wr.Write("$dt{0}", argNames.Count == 0 ? "" : ",");
+          wr.Write($"{sep}$dt");
+          sep = ", ";
+        }
+        if (argNames.Count != 0) {
+          wr.Write(sep);
         }
         wr.Write(Util.Comma(argNames, nm => nm));
         var w = wr.NewBlock(")");
         if (dt is CoDatatypeDecl) {
           var wThen = EmitIf("$dt === null", false, w);
-          wThen.WriteLine("$dt = new {0}({1});", DtT_protected, i);
+          wThen.WriteLine($"$dt = new {DtT_protected}({i}{typeDescriptorComma}{typeDescriptors});");
           wThen.WriteLine("$dt._d = $dt;");
         } else {
-          w.WriteLine("let $dt = new {0}({1});", DtT_protected, i);
+          w.WriteLine($"let $dt = new {DtT_protected}({i}{typeDescriptorComma}{typeDescriptors});");
         }
         foreach (var arg in argNames) {
           w.WriteLine("$dt.{0} = {0};", arg);
         }
         w.WriteLine("return $dt;");
         if (dt is CoDatatypeDecl) {
-          var wBody = wr.NewNamedBlock("static lazy_{0}(initializer)", ctor.GetCompileName(Options));
+          wBody = wr.NewNamedBlock("static lazy_{0}(initializer)", ctor.GetCompileName(Options));
           wBody.WriteLine("let dt = new {0}({1});", DtT_protected, i);
           wBody.WriteLine("dt._initializer = initializer;");
           wBody.WriteLine("return dt;");
@@ -432,7 +446,7 @@ namespace Microsoft.Dafny.Compilers {
         var els = w.NewBlock("");
         els.WriteLine("return \"{0}.{1}.unexpected\";", dt.EnclosingModuleDefinition.GetCompileName(Options), DtT);
 
-      } else if (dt is IndDatatypeDecl && !(dt is TupleTypeDecl)) {
+      } else if (dt is IndDatatypeDecl) {
         // toString method
         var w = wr.NewBlock("toString()");
         i = 0;
@@ -503,8 +517,12 @@ namespace Microsoft.Dafny.Compilers {
       // static Default(defaultValues...) {  // where defaultValues are the parameters to the grounding constructor
       //   return Dt.create_GroundingCtor(defaultValues...);
       // }
-      wr.Write("static Default(");
-      wr.Write(UsedTypeParameters(dt).Comma(FormatDefaultTypeParameterValue));
+      wr.Write($"static Default(");
+      var usedTypeParameters = UsedTypeParameters(dt);
+      if (WriteRuntimeTypeDescriptorsFormals(dt.TypeArgs, false, wr) != 0 && usedTypeParameters.Count != 0) {
+        wr.Write(", ");
+      }
+      wr.Write(usedTypeParameters.Comma(FormatDefaultTypeParameterValue));
       {
         var wDefault = wr.NewBlock(")");
         wDefault.Write("return ");
@@ -515,8 +533,8 @@ namespace Microsoft.Dafny.Compilers {
           wDefault.Write(DefaultValue(innerType, wDefault, dt.tok));
         } else {
           var nonGhostFormals = groundingCtor.Formals.Where(f => !f.IsGhost).ToList();
-          var arguments = Util.Comma(nonGhostFormals, f => DefaultValue(f.Type, wDefault, f.tok));
-          EmitDatatypeValue(dt, groundingCtor, dt is CoDatatypeDecl, arguments, wDefault);
+          var arguments = nonGhostFormals.Comma(f => DefaultValue(f.Type, wDefault, f.tok));
+          EmitDatatypeValue(dt, groundingCtor, dt is CoDatatypeDecl, typeDescriptors, arguments, wDefault);
         }
         wDefault.WriteLine(";");
       }
@@ -532,14 +550,15 @@ namespace Microsoft.Dafny.Compilers {
       //   };
       // }
       wr.Write("static Rtd(");
-      WriteRuntimeTypeDescriptorsFormals(UsedTypeParameters(dt), true, wr);
+      WriteRuntimeTypeDescriptorsFormals(UsedTypeParameters(dt, true), true, wr);
       var wRtd = wr.NewBlock(")");
       var wClass = wRtd.NewBlock("return class", ";");
       {
         var wDefault = wClass.NewBlock("static get Default()");
-        var arguments = Util.Comma(UsedTypeParameters(dt),
+        var sep = typeDescriptors.Length != 0 && usedTypeParameters.Count != 0 ? ", " : "";
+        var arguments = usedTypeParameters.Comma(
           tp => DefaultValue(new UserDefinedType(tp), wDefault, dt.tok, true));
-        wDefault.WriteLine($"return {DtT_protected}.Default({arguments});");
+        wDefault.WriteLine($"return {DtT_protected}.Default({typeDescriptors}{typeDescriptorComma}{arguments});");
       }
 
       return new ClassWriter(this, btw, btw);
@@ -698,7 +717,8 @@ namespace Microsoft.Dafny.Compilers {
       var customReceiver = !forBodyInheritance && NeedsCustomReceiver(member);
       wr.Write("{0}{1}(", isStatic || customReceiver ? "static " : "", name);
       var sep = "";
-      var nTypes = WriteRuntimeTypeDescriptorsFormals(ForTypeDescriptors(typeArgs, member.EnclosingClass, member, lookasideBody), wr, ref sep, tp => $"rtd$_{tp.GetCompileName(Options)}");
+      WriteRuntimeTypeDescriptorsFormals(ForTypeDescriptors(typeArgs, member.EnclosingClass, member, lookasideBody), wr, ref sep,
+        tp => $"rtd$_{tp.GetCompileName(Options)}");
       if (customReceiver) {
         var nt = member.EnclosingClass;
         var receiverType = UserDefinedType.FromTopLevelDecl(tok, nt);
@@ -778,7 +798,8 @@ namespace Microsoft.Dafny.Compilers {
       } else if (xType is UserDefinedType) {
         var udt = (UserDefinedType)xType;
         if (udt.ResolvedClass is TypeParameter tp) {
-          return string.Format("{0}rtd$_{1}", thisContext != null && tp.Parent is ClassDecl ? "this." : "", tp.GetCompileName(Options));
+          var receiver = thisContext != null && tp.Parent is TopLevelDeclWithMembers and not TraitDecl ? "this." : "";
+          return string.Format($"{receiver}rtd$_{tp.GetCompileName(Options)}");
         }
         var cl = udt.ResolvedClass;
         Contract.Assert(cl != null);
@@ -788,7 +809,7 @@ namespace Microsoft.Dafny.Compilers {
           var dt = (DatatypeDecl)cl;
           var w = new ConcreteSyntaxTree();
           w.Write("{0}.Rtd(", dt is TupleTypeDecl ? "_dafny.Tuple" : FullTypeName(udt));
-          EmitTypeDescriptorsActuals(UsedTypeParameters(dt, udt.TypeArgs), udt.tok, w, true);
+          EmitTypeDescriptorsActuals(UsedTypeParameters(dt, udt.TypeArgs, true), udt.tok, w, true);
           w.Write(")");
           return w.ToString();
         } else if (xType.IsNonNullRefType) {
@@ -988,7 +1009,14 @@ namespace Microsoft.Dafny.Compilers {
         var dt = (DatatypeDecl)cl;
         var s = dt is TupleTypeDecl ? "_dafny.Tuple" : FullTypeName(udt);
         var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs).ConvertAll(ta => ta.Actual);
-        return string.Format($"{s}.Default({Util.Comma(relevantTypeArgs, arg => DefaultValue(arg, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))})");
+
+        var wTypeDescriptors = new ConcreteSyntaxTree();
+        EmitTypeDescriptorsActuals(TypeArgumentInstantiation.ListFromClass(dt, udt.TypeArgs), tok, wTypeDescriptors);
+        var typeDescriptors = wTypeDescriptors.ToString();
+
+        var sep = typeDescriptors.Length != 0 && relevantTypeArgs.Count != 0 ? ", " : "";
+        var arguments = relevantTypeArgs.Comma(arg => DefaultValue(arg, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors));
+        return string.Format($"{s}.Default({typeDescriptors}{sep}{arguments})");
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
       }
@@ -1553,29 +1581,30 @@ namespace Microsoft.Dafny.Compilers {
       return wr;
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       var dt = dtv.Ctor.EnclosingDatatype;
-      EmitDatatypeValue(dt, dtv.Ctor, dtv.IsCoCall, arguments, wr);
+      EmitDatatypeValue(dt, dtv.Ctor, dtv.IsCoCall, typeDescriptorArguments, arguments, wr);
     }
 
-    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, bool isCoCall, string arguments, ConcreteSyntaxTree wr) {
+    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, bool isCoCall, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
       var dtName = dt.GetFullCompileName(Options);
       var ctorName = ctor.GetCompileName(Options);
 
+      var sep = typeDescriptorArguments.Length != 0 && arguments.Length != 0 ? ", " : "";
       if (dt is TupleTypeDecl) {
-        wr.Write("_dafny.Tuple.of({0})", arguments);
+        Contract.Assert(typeDescriptorArguments.Length == 0);
+        wr.Write($"_dafny.Tuple.of({arguments})");
       } else if (!isCoCall) {
         // Ordinary constructor (that is, one that does not guard any co-recursive calls)
         // Generate: Dt.create_Ctor(arguments)
-        wr.Write("{0}.create_{1}({2}{3})",
-          dtName, ctorName,
-          dt is IndDatatypeDecl ? "" : arguments.Length == 0 ? "null" : "null, ",
-          arguments);
+        var lazyArgument = dt is IndDatatypeDecl ? "" : arguments.Length == 0 ? "null" : "null, ";
+        wr.Write($"{dtName}.create_{ctorName}({lazyArgument}{typeDescriptorArguments}{sep}{arguments})");
       } else {
+        var sep0 = typeDescriptorArguments.Length != 0 ? ", " : "";
         // Co-recursive call
         // Generate:  Dt.lazy_Ctor(($dt) => Dt.create_Ctor($dt, args))
-        wr.Write("{0}.lazy_{1}(($dt) => ", dtName, ctorName);
-        wr.Write("{0}.create_{1}($dt{2}{3})", dtName, ctorName, arguments.Length == 0 ? "" : ", ", arguments);
+        wr.Write($"{dtName}.lazy_{ctorName}(($dt{sep0}{typeDescriptorArguments}) => ");
+        wr.Write("{0}.create_{1}($dt{2}{3}{4}{5})", dtName, ctorName, arguments.Length == 0 ? "" : ", ", typeDescriptorArguments, sep, arguments);
         wr.Write(")");
       }
     }
@@ -1928,21 +1957,24 @@ namespace Microsoft.Dafny.Compilers {
       return w;
     }
 
-    protected override ConcreteSyntaxTree UnboxNewtypeValue(ConcreteSyntaxTree wr) {
-      var w = wr.ForkInParens();
-      wr.Write("._value");
-      return w;
+    protected override ConcreteSyntaxTree FromFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        var w = wr.ForkInParens();
+        wr.Write("._value");
+        return w;
+      } else {
+        return wr;
+      }
     }
 
-    protected override ConcreteSyntaxTree EmitCoercionIfNecessary(Type @from, Type to, IToken tok, ConcreteSyntaxTree wr) {
-      if (from != null && to != null && from.IsTraitType && to.AsNewtype != null) {
-        return UnboxNewtypeValue(wr);
-      }
-      if (from != null && to != null && from.AsNewtype != null && to.IsTraitType && (enclosingMethod != null || enclosingFunction != null)) {
-        wr.Write($"new {from.AsNewtype.GetFullCompileName(Options)}");
+    protected override ConcreteSyntaxTree ToFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        wr.Write($"new {type.AsNewtype.GetFullCompileName(Options)}");
         return wr.ForkInParens();
+      } else {
+        return wr;
       }
-      return base.EmitCoercionIfNecessary(@from, to, tok, wr);
+
     }
 
     protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -274,19 +274,24 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       btw.WriteLine($"@classmethod");
-      var wDefault = btw.NewBlockPy($"def default(cls, {UsedTypeParameters(dt).Comma(FormatDefaultTypeParameterValue)}):");
+      var wDefault = btw.NewBlockPy($"def default(cls, {UsedTypeParameters(dt, true).Comma(FormatDefaultTypeParameterValue)}):");
       var groundingCtor = dt.GetGroundingCtor();
       if (groundingCtor.IsGhost) {
         wDefault.WriteLine($"return lambda: {ForcePlaceboValue(UserDefinedType.FromTopLevelDecl(dt.tok, dt), wDefault, dt.tok)}");
       } else if (DatatypeWrapperEraser.GetInnerTypeOfErasableDatatypeWrapper(Options, dt, out var innerType)) {
         wDefault.WriteLine($"return lambda: {DefaultValue(innerType, wDefault, dt.tok)}");
       } else {
-        var arguments = groundingCtor.Formals.Where(f => !f.IsGhost).Comma(f => DefaultValue(f.Type, wDefault, f.tok));
-        var constructorCall = $"{DtCtorDeclarationName(groundingCtor, false)}({arguments})";
-        if (dt is CoDatatypeDecl) {
-          constructorCall = $"{dt.GetCompileName(Options)}__Lazy(lambda: {constructorCall})";
-        }
-        wDefault.WriteLine($"return lambda: {constructorCall}");
+        var wTypeDescriptors = new ConcreteSyntaxTree();
+        var typeDescriptorComma = "";
+        WriteRuntimeTypeDescriptorsFormals(TypeArgumentInstantiation.ListFromFormals(dt.TypeArgs),
+          wTypeDescriptors, ref typeDescriptorComma, FormatDefaultTypeParameterValue);
+        var typeDescriptorUses = wTypeDescriptors.ToString();
+
+        var nonGhostFormals = groundingCtor.Formals.Where(f => !f.IsGhost).ToList();
+        var arguments = nonGhostFormals.Comma(f => DefaultValue(f.Type, wDefault, f.tok));
+        wDefault.Write("return lambda: ");
+        EmitDatatypeValue(dt, groundingCtor, dt is CoDatatypeDecl, typeDescriptorUses, arguments, wDefault, false);
+        wDefault.WriteLine();
       }
 
       // Ensures the inequality is based on equality defined in the constructor
@@ -321,8 +326,11 @@ namespace Microsoft.Dafny.Compilers {
       foreach (var ctor in dt.Ctors.Where(ctor => !ctor.IsGhost)) {
         // Class-level fields don't work in all python version due to metaclasses.
         // Adding a more restrictive type would be desirable, but Python expects their definition to precede this.
-        var argList = ctor.Destructors.Where(d => !d.IsGhost)
-          .Select(d => $"('{IdProtect(d.GetCompileName(Options))}', Any)").Comma();
+        var argListX = dt.TypeArgs.Where(NeedsTypeDescriptor)
+          .Select(tp => $"('{IdProtect(tp.GetCompileName(Options))}', Any)");
+        var argListY = ctor.Destructors.Where(d => !d.IsGhost)
+          .Select(d => $"('{IdProtect(d.GetCompileName(Options))}', Any)");
+        var argList = argListX.Concat(argListY).Comma();
         var namedtuple = $"NamedTuple('{IdProtect(ctor.GetCompileName(Options))}', [{argList}])";
         var header = $"class {DtCtorDeclarationName(ctor, false)}({DtT}, {namedtuple}):";
         var constructor = wr.NewBlockPy(header, close: BlockStyle.Newline);
@@ -610,7 +618,7 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       string TypeParameterDescriptor(TypeParameter typeParameter) {
-        if ((thisContext != null && typeParameter.Parent is ClassDecl) || typeParameter.Parent is IteratorDecl) {
+        if ((thisContext != null && typeParameter.Parent is TopLevelDeclWithMembers and not TraitDecl) || typeParameter.Parent is IteratorDecl) {
           return $"self.{typeParameter.GetCompileName(Options)}";
         }
         if (thisContext != null && thisContext.ParentFormalTypeParametersToActuals.TryGetValue(typeParameter, out var instantiatedTypeParameter)) {
@@ -631,7 +639,7 @@ namespace Microsoft.Dafny.Compilers {
         } else {
           w.Write($"{TypeName_UDT(FullTypeName(udt), udt, wr, tok)}.default(");
         }
-        EmitTypeDescriptorsActuals(UsedTypeParameters(dt, typeArgs), tok, w, true);
+        EmitTypeDescriptorsActuals(UsedTypeParameters(dt, typeArgs, true), tok, w, true);
         w.Write(")");
         return w.ToString();
       }
@@ -659,6 +667,15 @@ namespace Microsoft.Dafny.Compilers {
 
       if (xType.IsObjectQ) {
         return "object";
+      }
+
+      if (xType.AsNewtype != null && member == null) {
+        // when member is given, use UserDefinedType case below
+        var nativeType = xType.AsNewtype.NativeType;
+        if (nativeType != null) {
+          return GetNativeTypeName(nativeType);
+        }
+        return TypeName(xType.AsNewtype.BaseType, wr, tok, member);
       }
 
       switch (xType) {
@@ -744,10 +761,10 @@ namespace Microsoft.Dafny.Compilers {
                 }
 
               case DatatypeDecl dt:
-                var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs).ConvertAll(ta => ta.Actual);
+                var relevantTypeArgs = UsedTypeParameters(dt, udt.TypeArgs, true).ConvertAll(ta => ta.Actual);
                 return dt is TupleTypeDecl
                   ? $"({relevantTypeArgs.Comma(arg => DefaultValue(arg, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors))}{(relevantTypeArgs.Count == 1 ? "," : "")})"
-                  : $"{DtCtorDeclarationName(dt.GetGroundingCtor())}.default({relevantTypeArgs.Comma(arg => TypeDescriptor(arg, wr, tok))})()";
+                  : $"{dt.GetFullCompileName(Options)}.default({relevantTypeArgs.Comma(arg => TypeDescriptor(arg, wr, tok))})()";
 
               case TypeParameter tp:
                 return constructTypeParameterDefaultsFromTypeDescriptors
@@ -1156,20 +1173,26 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("None");
     }
 
-    protected override void EmitDatatypeValue(DatatypeValue dtv, string arguments, ConcreteSyntaxTree wr) {
-      if (dtv.IsCoCall) {
-        wr.Write($"{dtv.Ctor.EnclosingDatatype.GetFullCompileName(Options)}__Lazy(lambda: ");
+    protected override void EmitDatatypeValue(DatatypeValue dtv, string typeDescriptorArguments, string arguments, ConcreteSyntaxTree wr) {
+      EmitDatatypeValue(dtv.Ctor.EnclosingDatatype, dtv.Ctor, dtv.IsCoCall, typeDescriptorArguments, arguments, wr);
+    }
+
+    void EmitDatatypeValue(DatatypeDecl dt, DatatypeCtor ctor, bool isCoCall, string typeDescriptorArguments, string arguments,
+      ConcreteSyntaxTree wr, bool qualifiedName = true) {
+      if (isCoCall) {
+        wr.Write($"{dt.GetFullCompileName(Options)}__Lazy(lambda: ");
         var end = wr.Fork();
         wr.Write(")");
         wr = end;
       }
-      if (dtv.Ctor.EnclosingDatatype is not TupleTypeDecl) {
-        wr.Write($"{DtCtorDeclarationName(dtv.Ctor)}");
-      } else if (dtv.Ctor.Destructors.Count(d => !d.IsGhost) == 1) {
+      if (dt is not TupleTypeDecl) {
+        wr.Write($"{DtCtorDeclarationName(ctor, qualifiedName)}");
+      } else if (ctor.Destructors.Count(d => !d.IsGhost) == 1) {
         // 1-tuples need this this for disambiguation
         arguments += ",";
       }
-      wr.Write($"({arguments})");
+      var sep = typeDescriptorArguments.Length != 0 && arguments.Length != 0 ? ", " : "";
+      wr.Write($"({typeDescriptorArguments}{sep}{arguments})");
     }
 
     protected override void GetSpecialFieldInfo(SpecialField.ID id, object idParam, Type receiverType,
@@ -1244,7 +1267,7 @@ namespace Microsoft.Dafny.Compilers {
             GetSpecialFieldInfo(sf.SpecialId, sf.IdParam, objType, out var compiledName, out _, out _);
             return SimpleLvalue(w => {
               var customReceiver = NeedsCustomReceiver(sf) && sf.EnclosingClass is not TraitDecl;
-              if (customReceiver) {
+              if (sf.IsStatic || customReceiver) {
                 w.Write(TypeName_Companion(objType, w, member.tok, member));
               } else {
                 obj(w);
@@ -1432,21 +1455,23 @@ namespace Microsoft.Dafny.Compilers {
       return wStmts.NewBlockPy($"def {functionName}({bvName}):");
     }
 
-    protected override ConcreteSyntaxTree UnboxNewtypeValue(ConcreteSyntaxTree wr) {
-      var w = wr.ForkInParens();
-      wr.Write("._value");
-      return w;
+    protected override ConcreteSyntaxTree FromFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        var w = wr.ForkInParens();
+        wr.Write("._value");
+        return w;
+      } else {
+        return wr;
+      }
     }
 
-    protected override ConcreteSyntaxTree EmitCoercionIfNecessary(Type @from, Type to, IToken tok, ConcreteSyntaxTree wr) {
-      if (from != null && to != null && from.IsTraitType && to.AsNewtype != null) {
-        return UnboxNewtypeValue(wr);
-      }
-      if (from != null && to != null && from.AsNewtype != null && to.IsTraitType && (enclosingMethod != null || enclosingFunction != null)) {
-        wr.Write(from.AsNewtype.GetFullCompileName(Options));
+    protected override ConcreteSyntaxTree ToFatPointer(Type type, ConcreteSyntaxTree wr) {
+      if (type.HasFatPointer) {
+        wr.Write(type.AsNewtype.GetFullCompileName(Options));
         return wr.ForkInParens();
+      } else {
+        return wr;
       }
-      return base.EmitCoercionIfNecessary(@from, to, tok, wr);
     }
 
     protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, bool inLetExprBody,

--- a/Source/DafnyCore/Resolver/InferDecreasesClause.cs
+++ b/Source/DafnyCore/Resolver/InferDecreasesClause.cs
@@ -79,15 +79,19 @@ public class InferDecreasesClause {
 
       if (clbl is Function || clbl is Method) {
         TopLevelDeclWithMembers enclosingType;
+        MemberDecl originalMember;
         if (clbl is Function fc && !fc.IsStatic) {
           enclosingType = (TopLevelDeclWithMembers)fc.EnclosingClass;
+          originalMember = fc.Original;
         } else if (clbl is Method mc && !mc.IsStatic) {
           enclosingType = (TopLevelDeclWithMembers)mc.EnclosingClass;
+          originalMember = mc.Original;
         } else {
           enclosingType = null;
+          originalMember = null;
         }
 
-        if (enclosingType != null) {
+        if (enclosingType != null && originalMember == clbl) {
           var receiverType = ModuleResolver.GetThisType(clbl.Tok, enclosingType);
           if (receiverType.IsOrdered && !receiverType.IsRefType) {
             var th = new ThisExpr(clbl.Tok) { Type = receiverType }; // resolve here

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1384,6 +1384,7 @@ namespace Microsoft.Dafny {
                 foreach (var p in f.Formals) {
                   CheckTypeCharacteristics_Type(p.tok, p.Type, f.IsGhost || p.IsGhost);
                 }
+                CheckTypeCharacteristics_Type(f.Result?.tok ?? f.tok, f.ResultType, f.IsGhost);
                 if (f.Body != null) {
                   CheckTypeCharacteristics_Expr(f.Body, f.IsGhost);
                 }
@@ -1487,6 +1488,12 @@ namespace Microsoft.Dafny {
             var dd = (DatatypeDecl)d;
             foreach (var ctor in dd.Ctors) {
               ctor.Formals.Iter(formal => CheckVariance(formal.Type, dd, TypeParameter.TPVariance.Co, false));
+            }
+          }
+
+          if (d is TopLevelDeclWithMembers topLevelDeclWithMembers) {
+            foreach (var parentTrait in topLevelDeclWithMembers.ParentTraits) {
+              CheckVariance(parentTrait, topLevelDeclWithMembers, TypeParameter.TPVariance.Co, false);
             }
           }
         }

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -5016,9 +5016,10 @@ namespace Microsoft.Dafny {
     /// "context == Non" says that "type" must not vary at all.
     /// * "lax" says that the context is not strict -- type parameters declared to be strict must not be used in a lax context
     /// </summary>
-    public void CheckVariance(Type type, ICallable enclosingTypeDefinition, TypeParameter.TPVariance context, bool lax) {
+    public void CheckVariance(Type type, TopLevelDecl enclosingTypeDefinition, TypeParameter.TPVariance context, bool lax) {
       Contract.Requires(type != null);
       Contract.Requires(enclosingTypeDefinition != null);
+      Contract.Requires(!lax || enclosingTypeDefinition is ICallable);
 
       type = type.Normalize();  // we keep constraints, since subset types have their own type-parameter variance specifications; we also keep synonys, since that gives rise to better error messages
       if (type is BasicType) {
@@ -5056,9 +5057,9 @@ namespace Microsoft.Dafny {
           Contract.Assert(resolvedClass.TypeArgs.Count == t.TypeArgs.Count);
           if (lax) {
             // we have to be careful about uses of the type being defined
-            var cg = enclosingTypeDefinition.EnclosingModule.CallGraph;
+            var cg = enclosingTypeDefinition.EnclosingModuleDefinition.CallGraph;
             var t0 = resolvedClass as ICallable;
-            if (t0 != null && cg.GetSCCRepresentative(t0) == cg.GetSCCRepresentative(enclosingTypeDefinition)) {
+            if (t0 != null && cg.GetSCCRepresentative(t0) == cg.GetSCCRepresentative((ICallable)enclosingTypeDefinition)) {
               reporter.Error(MessageSource.Resolver, t.tok, "using the type being defined ('{0}') here would cause a logical inconsistency by defining a type whose cardinality exceeds itself (like the Continuum Transfunctioner, you might say its power would then be exceeded only by its mystery)", resolvedClass.Name);
             }
           }

--- a/Test/comp/AllExtern.java
+++ b/Test/comp/AllExtern.java
@@ -7,9 +7,10 @@ public class AllExtern {
         System.out.println("AllExtern.P");
     }
     public static Wrappers.Option<BigInteger> MaybeInt() {
-        return Wrappers.Option.create_Some(BigInteger.valueOf(42));
+        return Wrappers.Option.create_Some(dafny.TypeDescriptor.BIG_INTEGER, BigInteger.valueOf(42));
     }
     public static Wrappers.Pair<BigInteger, BigInteger> IntPair() {
-        return Wrappers.Pair.create_Pair(BigInteger.valueOf(3), BigInteger.valueOf(7));
+        return Wrappers.Pair.create(dafny.TypeDescriptor.BIG_INTEGER, dafny.TypeDescriptor.BIG_INTEGER,
+                                            BigInteger.valueOf(3), BigInteger.valueOf(7));
     }
 }

--- a/Test/comp/AutoInit.dfy
+++ b/Test/comp/AutoInit.dfy
@@ -63,6 +63,8 @@ method Main() {
   DatatypeDefaultValues.Test();
   ImportedTypes.Test();
   GhostWitness.Test();
+  TypeDescriptorInDatatypeValue.Test();
+  DatatypeValues.Test();
 }
 
 datatype ThisOrThat<A,B> = This(A) | Or | That(B)
@@ -320,5 +322,67 @@ module GhostWitness {
     g := f;
     var x := g(4) + f(5);
     print x, "\n";
+  }
+}
+
+module TypeDescriptorInDatatypeValue {
+  // auto-init type parameters: A, C
+  // used type parameters: C, D
+  datatype Datatype<A(0), B, C(0), D> = Simple(C, D) | More(Datatype<A, B, C, D>)
+
+  datatype Wrapper<A(0), B, C(0), D> = Wrapper(C)
+
+  codatatype Stream<A(0), B, C(0), D> = End(C, D) | Next(tail: Stream<A, B, C, D>)
+
+  // with contravariant type parameter, needs customer receiver
+  codatatype ContraStream<A(0), -B, C(0), D> = End(C, D) | Next(tail: ContraStream<A, B, C, D>)
+
+  codatatype CoEnum = CoEnum(int)
+
+  method Test() {
+    var abcd: Datatype<bool, int, char, real> := *;
+    print abcd, "\n";
+    PrintOne<Datatype<bool, int, char, real>>();
+
+    var wrapper: Wrapper<bool, int, char, real> := *;
+    print wrapper, "\n";
+    PrintOne<Wrapper<bool, int, char, real>>();
+
+    var s: Stream<bool, int, char, real> := *;
+    print s, "\n";
+    PrintOne<Stream<bool, int, char, real>>();
+
+    var cs: ContraStream<bool, int, char, real> := *;
+    print cs, "\n";
+    PrintOne<ContraStream<bool, int, char, real>>();
+
+    var coenum: CoEnum := *;
+    print coenum, "\n";
+    PrintOne<CoEnum>();
+  }
+
+  method PrintOne<X(0)>() {
+    var x: X := *;
+    print x, "\n";
+  }
+}
+
+module DatatypeValues {
+  codatatype Stream<G> = Next(head: G, tail: Stream<G>)
+
+  method Test() {
+    var s := CoCalls(3);
+    var a := AutoCoCalls(4);
+    print s, " ", a, "\n"; // Next AutoNext
+  }
+
+  function CoCalls<G>(g: G): Stream<G> {
+    Next(g, CoCalls(g))
+  }
+
+  codatatype AutoStream<G(0)> = AutoNext(head: G, tail: AutoStream<G>)
+
+  function AutoCoCalls<G(0)>(g: G): AutoStream<G> {
+    AutoNext(g, AutoCoCalls(g))
   }
 }

--- a/Test/comp/AutoInit.dfy.expect
+++ b/Test/comp/AutoInit.dfy.expect
@@ -35,3 +35,14 @@ Library.CoColor.Yellow and Library.CoColor.Yellow
 Library.MoColor.MoYellow and Library.MoColor.MoYellow
 0.0 and 0.0
 13
+TypeDescriptorInDatatypeValue.Datatype.Simple('D', 0.0)
+TypeDescriptorInDatatypeValue.Datatype.Simple('D', 0.0)
+'D'
+'D'
+TypeDescriptorInDatatypeValue.Stream.End
+TypeDescriptorInDatatypeValue.Stream.End
+TypeDescriptorInDatatypeValue.ContraStream.End
+TypeDescriptorInDatatypeValue.ContraStream.End
+TypeDescriptorInDatatypeValue.CoEnum.CoEnum
+TypeDescriptorInDatatypeValue.CoEnum.CoEnum
+DatatypeValues.Stream.Next DatatypeValues.AutoStream.AutoNext

--- a/Test/comp/Datatype.dfy
+++ b/Test/comp/Datatype.dfy
@@ -37,6 +37,7 @@ method Main() {
   TestGhostDestructors();
 
   TestNumericDestructorNames();
+  TypeDescriptorsInCovariantPositions.Test();
 }
 
 function Up(m: nat, n: nat): List
@@ -187,4 +188,23 @@ method TestNumericDestructorNames() {
       print a, " ", b, " ", c, "\n"; // 800 801 802
   }
   print j.0, " ", j.0_3, " ", j.012, "\n"; // 800 801 802
+}
+
+module TypeDescriptorsInCovariantPositions {
+  // This module contains two regression tests. One is that the compiler to C# once didn't consider
+  // that type descriptors are in-parameters whose type may mention co-variant type parameters. The
+  // other is that the compiler to Go once used the name "Get()" as the name of one of its internal
+  // methods, which then could conflict with a user-defined method with that name.
+  datatype Unit<+X(0)> = Unit
+  {
+    method Get(x: X) returns (r: X) { }
+    method Het() returns (r: X) { }
+  }
+
+  method Test() {
+    var u: Unit<real>;
+    var r0 := u.Get(3.2);
+    var r1 := u.Het();
+    print u, " ", r0, " ", r1, "\n";
+  }
 }

--- a/Test/comp/Datatype.dfy.expect
+++ b/Test/comp/Datatype.dfy.expect
@@ -20,3 +20,4 @@ Record.Record(58, true)
 199
 800 801 802
 800 801 802
+TypeDescriptorsInCovariantPositions.Unit.Unit 0.0 0.0

--- a/Test/comp/Datatype.dfy.java.expect
+++ b/Test/comp/Datatype.dfy.java.expect
@@ -20,3 +20,4 @@ Record.Record(58, true)
 199
 800 801 802
 800 801 802
+TypeDescriptorsInCovariantPositions.Unit.Unit 0.0 0.0

--- a/Test/comp/Datatype.dfy.py.expect
+++ b/Test/comp/Datatype.dfy.py.expect
@@ -20,3 +20,4 @@ Record.Record(58, true)
 199
 800 801 802
 800 801 802
+TypeDescriptorsInCovariantPositions.Unit.Unit 0.0 0.0

--- a/Test/comp/ErasableTypeWrappers.dfy
+++ b/Test/comp/ErasableTypeWrappers.dfy
@@ -17,6 +17,7 @@ method Main() {
   TestTypeParameters(GenericCompiled("<gen>"), GenericCompiled(3.14), GenericCompiled(2.7));
   TestMembers();
   OptimizationChecks.Test();
+  PrintRegressionTests.Test();
 }
 
 method TestTargetTypesAndConstructors() {
@@ -387,4 +388,27 @@ module OptimizationChecks {
   datatype HA = HA(HB)
   datatype HB = HB0(HD<HA>) | ghost HB1
   datatype HD<X> = HD(X, HA)
+}
+
+// --------------------------------------------------------------------------------
+
+module PrintRegressionTests {
+  datatype Wrapper<C(0)> = Wrapper(C)
+
+  newtype Native = x | 2 <= x < 11 witness 5
+
+  method Test() {
+    var charWrapper: Wrapper<char> := *;
+    print charWrapper, " "; // 'D' (or just D with /unicodeChar:0)
+    PrintOne<Wrapper<char>>(); // 'D' (or just D with /unicodeChar:0)
+
+    var nativeWrapper: Wrapper<Native> := *;
+    print nativeWrapper, " "; // 5
+    PrintOne<Wrapper<Native>>(); // 5
+  }
+
+  method PrintOne<X(0)>() {
+    var x: X := *;
+    print x, "\n";
+  }
 }

--- a/Test/comp/ErasableTypeWrappers.dfy.expect
+++ b/Test/comp/ErasableTypeWrappers.dfy.expect
@@ -16,3 +16,5 @@ true false
 HasConst.MakeC(4) (4, 4)
 4 (4, 4)
 OptimizationChecks.Ints.Ints(5, 7) OptimizationChecks.Ints.Ints(5, 7) OptimizationChecks.Ints.AnotherIntsWrapper(OptimizationChecks.Ints.Ints(5, 7))
+D D
+5 5

--- a/Test/dafny0/ResolutionErrors.dfy
+++ b/Test/dafny0/ResolutionErrors.dfy
@@ -3906,3 +3906,13 @@ module UseOfThis {
     const K: int
   }
 }
+
+module AutoInitTypeCheckRegression {
+  codatatype AutoStream<G(0)> = AutoNext(head: G, tail: AutoStream<G>)
+
+  function In<G>(a: AutoStream<G>): int // error: the argument to AutoStream is supposed to be an auto-init type
+  function Out<G>(g: G): AutoStream<G> // error: the argument to AutoStream is supposed to be an auto-init type
+
+  method M<G>(a: AutoStream<G>) // error: the argument to AutoStream is supposed to be an auto-init type
+  method N<G>(g: G) returns (a: AutoStream<G>) // error: the argument to AutoStream is supposed to be an auto-init type
+}

--- a/Test/dafny0/ResolutionErrors.dfy.expect
+++ b/Test/dafny0/ResolutionErrors.dfy.expect
@@ -627,4 +627,8 @@ ResolutionErrors.dfy(3885,23): Error: 'this' is not allowed in a 'static' contex
 ResolutionErrors.dfy(3885,28): Error: type of the receiver is not fully determined at this program point
 ResolutionErrors.dfy(3904,21): Error: 'this' is not allowed in a 'static' context
 ResolutionErrors.dfy(3904,26): Error: type of the receiver is not fully determined at this program point
-625 resolution/type errors detected in ResolutionErrors.dfy
+ResolutionErrors.dfy(3913,20): Error: type parameter (G) passed to type AutoStream must support auto-initialization (got G) (perhaps try declaring type parameter 'G' on line 3913 as 'G(0)', which says it can only be instantiated with a type that supports auto-initialization)
+ResolutionErrors.dfy(3914,25): Error: type parameter (G) passed to type AutoStream must support auto-initialization (got G) (perhaps try declaring type parameter 'G' on line 3914 as 'G(0)', which says it can only be instantiated with a type that supports auto-initialization)
+ResolutionErrors.dfy(3916,17): Error: type parameter (G) passed to type AutoStream must support auto-initialization (got G) (perhaps try declaring type parameter 'G' on line 3916 as 'G(0)', which says it can only be instantiated with a type that supports auto-initialization)
+ResolutionErrors.dfy(3917,32): Error: type parameter (G) passed to type AutoStream must support auto-initialization (got G) (perhaps try declaring type parameter 'G' on line 3917 as 'G(0)', which says it can only be instantiated with a type that supports auto-initialization)
+629 resolution/type errors detected in ResolutionErrors.dfy

--- a/Test/traits/TraitVariance.dfy
+++ b/Test/traits/TraitVariance.dfy
@@ -1,0 +1,36 @@
+// RUN: %exits-with 2 %dafny /generalTraits:1 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module NoVariance {
+  trait Trait<Y> { }
+
+  type AbstractType extends Trait<int> { }
+
+  datatype Datatype extends Trait<int> = Value
+
+  newtype Newtype extends Trait<int> = real
+
+  class Class extends Trait<int> { }
+}
+
+module NonVariantTypeParameter {
+  trait Trait<Y> { }
+
+  type AbstractType<X, +Z> extends Trait<X> { }
+
+  datatype Datatype<X, +Z> extends Trait<X> = Value
+
+  // At this time, the parser does not allow newtype to have type parameters. This will change in the future.
+  // newtype Newtype<X, +Z> extends Trait<X> = real
+}
+
+module VariantTypeParameter {
+  trait Trait<Y> { }
+
+  type AbstractType<+X, Z> extends Trait<X> { } // error: X not used according to its specification
+
+  datatype Datatype<+X, Z> extends Trait<X> = Value // error: X not used according to its specification
+
+  // At this time, the parser does not allow newtype to have type parameters. This will change in the future.
+  // newtype Newtype<+X, Z> extends Trait<X> = real // error: X not used according to its specification
+}

--- a/Test/traits/TraitVariance.dfy.expect
+++ b/Test/traits/TraitVariance.dfy.expect
@@ -1,0 +1,3 @@
+TraitVariance.dfy(30,41): Error: formal type parameter 'X' is not used according to its variance specification
+TraitVariance.dfy(32,41): Error: formal type parameter 'X' is not used according to its variance specification
+2 resolution/type errors detected in TraitVariance.dfy

--- a/docs/Compilation/AutoInitialization.md
+++ b/docs/Compilation/AutoInitialization.md
@@ -10,8 +10,9 @@ enforce that each value assigned to a variable is indeed a value of that variabl
 type. Since the type of a variable never changes, this ensures type safety, provided
 a variable is assigned before it is used. But what about any uses before then?
 
-If a variable is used before it has been assigned, Dafny still arranges for the
-variable to be initialized with _some_ value of the variable's type.
+If a variable is used before it has been assigned, Dafny still--in certain situations,
+like for array elements or when a variable is explicitly assigned `*`--arranges for
+the variable to be initialized with _some_ value of the variable's type.
 To accomplish this, the compiler needs to have the ability to emit an expression that
 produces a value of a given type. This is possible for many, but not all, types.
 
@@ -122,13 +123,16 @@ Auto-init types
 ---------------
 
 A type is called an _auto-init type_ if it is legal for a program to use a variable of
-that type before the variable has been initialized.
+that type before the variable has been initialized (or, for local variables, if the
+variable has only been assigned `*`).
 
 For example, `char` is an auto-init type. Therefore, the following is a legal program
 snippet:
 
-    var ch: char;
-    print ch, "\n";  // this uses ch before ch has been explicitly assigned
+    var ch: char := *;
+    print ch, "\n";  // this uses ch at a time when ch has only been assigned *
+    var arr: array<char> := new char[100];
+    print arr[5], "\n";  // this uses arr[5] before ch has been explicitly assigned
 
 A compiler is permitted to assign _any_ value to `ch`, so long as that value is of
 type `char`. In fact, the compiler is free to emit code that chooses a different
@@ -154,14 +158,14 @@ type                                             | default-valued expression
 `int`                                            | `BigInteger.Zero`
 `real`                                           | `BigRational.ZERO`
 `bool`                                           | `false`
-`char`                                           | `D`
+`char`                                           | `D` (because `\0` is not visible when printed as part of a string, so `D` leads to fewer surprises)
 bitvectors                                       | `0` or `BigInteger.Zero`
 `ORDINAL`                                        | `BigInteger.Zero`
 integer-based `newtype` without `witness` clause | same as for base type, cast appropriately
 real-based `newtype` without `witness` clause    | same as for base type, cast appropriately
 `newtype` `NT` with `witness` clause             | `NT.Witness`
 possibly-null reference types                    | `null`
-non-null array types                             | empty array of the appropriate type
+non-null array types                             | array of the appropriate type with every dimension having length 0
 type parameter `T`                               | `td_T.Default()`
 collection type `C<TT>`                          | `C<TT>.Empty`
 datatype or co-datatype `D<TT>`                  | `D<TT>.Default(E, ...)`
@@ -218,7 +222,7 @@ public static readonly B Witness = W;
 Each datatype and co-datatype has a _grounding constructor_. For a `datatype`, the grounding
 constructor is selected when the resolver ascertains that the datatype is nonempty. For a
 `codatatype`, the selection of the grounding constructor lacks sophistication--it is just the
-first of the given constructors.
+first of the given constructors. (Note, the grounding constructor might be ghost.)
 
 If the datatype is not an auto-init type, then there's nothing more to say about its default
 value. If it is an auto-init type, then the following explanations apply.
@@ -238,7 +242,10 @@ public static DT<TT> Default(T e, ...) {
 ```
 
 The parameters to this `Default` method are the default values for each of the type parameters
-used by the grounding constructor.
+used by the grounding constructor. (If the datatype's type parameters include some auto-init
+type parameters, then type descriptors for them are also passed in to both `Default` and
+`create_GroundingCtor`, not illustrated in the example just shown. More about such type descriptors
+in a section below.)
 
 If the (co-)datatype has no type parameters (note: that is, no type parameters at all--the
 "used parameters" are not involved here), then the default value is pre-computed and reused:
@@ -372,8 +379,7 @@ public static Dafny.TypeDescriptor<D<TT>> _TypeDescriptor(Dafny.TypeDescriptor<T
 }
 ```
 
-where the list of type parameters denoted by `T, ...` are the auto-init type parameters from `TT`.
-
+where the list of type parameters denoted by `T, ...` are the "used" type parameters from `TT`.
 
 ## Subset types
 
@@ -445,6 +451,15 @@ class Cl<T> {
 }
 ```
 
+### Type parameter of a (co-)datatype
+
+If `T` is a type parameter of a (co-)datatype, then `td_T` is a field of the object
+representing each (co-)datatype value.
+
+### Type parameter of a `newtype`
+
+Newtypes don't take type parameters.
+
 ### Type parameters of a trait
 
 To obtain type descriptors in function and method implementations that are given
@@ -452,7 +467,7 @@ in a trait, the function or method definition compiled into the companion class
 takes additional parameters that represent type descriptors for the type parameters
 of the trait.
 
-### Type parameter of a class or trait used in a static method or function
+### Type parameter of a class, trait, (co-)datatype, or abstract type used in a static method or static function
 
 In C#, the type parameters of a class are available in static methods. However,
 any type descriptors of the class are stored in instance fields, since the target
@@ -476,12 +491,6 @@ class Class<A> {
   static method M(Dafny.TypeDescriptor<A> td_A, BigInteger x)
 }
 ```
-
-### Type parameter of a `newtype` or (co-)datatype
-
-If `T` is a type parameter of a (co-)datatype, then the target code for any function
-or method takes additional parameters that represent type descriptors for the type
-parameters of the enclosing type.
 
 Type parameters and type descriptors for each type
 --------------------------------------------------
@@ -511,7 +520,7 @@ TYPE                                | TP  | TD  | TP  | TD  | TP  | TD   | TP  |
   instance member `<B(0)>`          | B   | B   | B   | B   |     | B    |     | B   |
   static member `<B(0)>`            | B   | B   | B   | B   |     | B    |     | B   |
 `datatype<A(0)>`
-  instance member `<B(0)>`          | B   | A,B | B   | A,B |     | A,B  |     | A,B |
+  instance member `<B(0)>`          | B   | B   | B   | B   |     | B    |     | B   |
   static member `<B(0)>`            | B   | A,B | A,B | A,B |     | A,B  |     | A,B |
 `trait<A(0)>`
   instance member `<B(0)>`          | B   | B   | B   | B   |     | B    |     | B   |
@@ -524,7 +533,7 @@ TYPE                                | TP  | TD  | TP  | TD  | TP  | TD   | TP  |
 *) type descriptors for functions don't actually seem necessary (but if functions have them,
 then const's need them, too)
 
-If the type parameters `A` and `B` does not have the `(0)` characteristic, then it is dropped
+If a type parameter among `A` and `B` does not have the `(0)` characteristic, then it is dropped
 from the TD column.
 
 This table is implemented in the `TypeArgDescriptorUse` method in the compiler.


### PR DESCRIPTION
This PR implements support in all 5 compilers for type parameters in types that extend traits. In particular, the compilation support covers datatypes and codatatypes that extend traits. This functionality is available as part of the `/generalTraits:1` beta.

(After this PR, there will be one more PR to complete compilation support for general traits. It has to do with `newtype`s that extend traits.)

## More details

Here follows a description of what this PR implements and why.

Consider the following types, which are already supported by Dafny:

``` dafny
class Class<T(0)> { // note the auto-init type parameter
  method M() {
    var t: T; // the compiler auto-initializes "t", since "T" is an auto-init type
    print t;
  }
}

datatype Datatype<T(0)> = Datatype { // note the auto-init type parameter
  method M() {
    var t: T; // the compiler auto-initializes "t", since "T" is an auto-init type
    print t;
  }
}
```

The implementations of methods `Class.M()` and `Datatype.M()` need a type descriptor for `T`. Before this PR, where this type descriptor comes from is different from a class and a datatype.

For the class, the type descriptor is stored in each object. Let's call it "Design A". This design makes the type descriptor easily accessible from the implementation of `Class.M()` and saves the caller from having to create such a type descriptor with each call to `M()`. On the downside, it means that the type descriptor occupies space in each object.

For the datatype, the design is the opposite. Let's call it "Design B". Under this design, the type parameter is passed into `Datatype.M()` as a parameter at run time, which has the pros/cons of Design A's cons/pros.

To support traits and dynamic dispatch, Design B is no longer an option. Consider the following variation of the types above:

``` dafny
trait Parent {
  method M()
}

class Class<T(0)> extends Parent {
  method M() {
    var t: T;
    print t;
  }
}

datatype Datatype<T(0)> extends Parent = Datatype {
  method M() {
    var t: T;
    print t;
  }
}

method Main() {
  var c: Class<int> := new Class<int>;
  var d: Datatype<bool> := Datatype;
  var p: Parent;
  p := c;
  p.M();
  p := d;
  p.M();
}
```

Here, the calls to `Parent.M()` (which are dynamically dispatched to `Caller.M()` and `Datatype.M()`, respectively) do not take any type-descriptor parameters, because there are no type parameters involved in `Parent.M()`. Hence, the only way for an implementation of `M()` in a child type that extends `Parent` to get hold of the necessary type parameters (which are specific to the child type) is for the child-type value to contain the type descriptors. So, we must choose Design A for any type (class, datatype, ...) that can extend a trait.

So, this PR changes the run-time representation of (co)datatypes to include, in the (co)datatype values themselves, the necessary type descriptors. While there is a cost to this at run time, it is not common for a (co)datatype to have an auto-init type parameter, so the target code in most cases will be unchanged. _Except_ for Java, which clumsily adds type descriptors for _all_ type parameters (not just auto-init type parameters). For several reasons (for example, see https://github.com/dafny-lang/dafny/issues/3055), this would be good to change in the (hopefully near) future.

This change also affects the "downward clone" mechanism used by the C# target.

## Alternative

Rather than adding type descriptors as fields in the run-time representation of classes and datatypes, one could include such type descriptors in the vtable that each such class/datatype already has a pointer to at run time. However, there are two issues that make such a change difficult. One issue is that such vtables are controlled by the target language. Thus, for each required instantiation of the type descriptors, one would need to declare a separate leaf type in the target language. The other issue is that the required instantiations may be difficult to compute statically.

So, while this alternative may be considered in the future (especially for a native compiler for Dafny), it is out of scope for this PR.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
