### PR TITLE
Retry running gradle wrapper five times on Windows

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeJava/gradlew.bat
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/gradlew.bat
@@ -70,9 +70,15 @@ goto fail
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
-
-@rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+@rem Execute Gradle, trying at least 5 times
+for %%i in (1 2 3 4 5) do (
+  "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+  if errorlevel 1 (
+    sleep 15
+  ) else (
+    goto end
+  )
+)
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
Adds back the gradle install retry logic that was removed here: https://github.com/dafny-lang/dafny/pull/4177#

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
