### PR TITLE
fix: --stdin regressions

### DIFF
--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -941,7 +941,7 @@ Dafny
                                  Util.ValidateEscaping(theOptions, t, includedFile, isVerbatimString, errors);
                                  includedFile = Util.RemoveEscaping(theOptions, includedFile, isVerbatimString);
                                  if (!Path.IsPathRooted(includedFile)) {
-                                   string basePath = Path.GetDirectoryName(parsedFile.LocalPath);
+                                   string basePath = parsedFile.Scheme == "stdin" ? "" : Path.GetDirectoryName(parsedFile.LocalPath);
                                    includedFile = Path.Combine(basePath, includedFile);
                                  }
                                  var oneInclude = new Include(t, parsedFile, new Uri(Path.GetFullPath(includedFile)));

--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -9,7 +9,7 @@ using DafnyCore;
 namespace Microsoft.Dafny;
 
 public class DafnyFile {
-  public string FilePath => Uri.LocalPath;
+  public string FilePath { get; private set; }
   public string CanonicalPath { get; private set; }
   public string BaseName { get; private set; }
   public bool IsPreverified { get; set; }
@@ -36,7 +36,7 @@ public class DafnyFile {
     // So we will just use the absolute path, lowercased for all file systems.
     // cf. IncludeComparer.CompareTo
     CanonicalPath = contentOverride == null ? Canonicalize(filePath).LocalPath : "<stdin>";
-    filePath = CanonicalPath;
+    FilePath = CanonicalPath;
 
     var filePathForErrors = options.UseBaseNameForFileName ? Path.GetFileName(filePath) : filePath;
     if (contentOverride != null) {

--- a/Test/dafny0/Input/IncludesTuples.dfy
+++ b/Test/dafny0/Input/IncludesTuples.dfy
@@ -1,0 +1,6 @@
+// RUN: echo Input for Stdin.dfy
+// Note that the current directory for .NET tests is always the output directory
+// for the IntegrationTests project.
+// i.e. something like IntegrationTests/bin/Debug/net6.0
+
+include "TestFiles/LitTests/LitTest/dafny0/Tuples.dfy"

--- a/Test/dafny0/Stdin.dfy
+++ b/Test/dafny0/Stdin.dfy
@@ -1,4 +1,6 @@
 // RUN: %exits-with 0 %stdin "module A{}" %baredafny verify --show-snippets:false --stdin > "%t"
 // RUN: %exits-with 4 %stdin "method a() { assert false; }" %baredafny verify --show-snippets:false --stdin >> "%t"
+// RUN: %exits-with 0 %stdin "" %baredafny verify --show-snippets:false --stdin >> "%t"
+// RUN: %exits-with 0 %stdin "include \"Lib.dfy\"" %baredafny verify --show-snippets:false --stdin >> "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/Test/dafny0/Stdin.dfy
+++ b/Test/dafny0/Stdin.dfy
@@ -1,6 +1,5 @@
 // RUN: %exits-with 0 %stdin "module A{}" %baredafny verify --show-snippets:false --stdin > "%t"
 // RUN: %exits-with 4 %stdin "method a() { assert false; }" %baredafny verify --show-snippets:false --stdin >> "%t"
 // RUN: %exits-with 0 %stdin "" %baredafny verify --show-snippets:false --stdin >> "%t"
-// RUN: %exits-with 0 %stdin "include \"Lib.dfy\"" %baredafny verify --show-snippets:false --stdin >> "%t"
+// RUN: %exits-with 4 %baredafny verify --show-snippets:false --verify-included-files --stdin < %S/Input/IncludesTuples.dfy >> "%t"
 // RUN: %diff "%s.expect" "%t"
-

--- a/Test/dafny0/Stdin.dfy.expect
+++ b/Test/dafny0/Stdin.dfy.expect
@@ -3,3 +3,10 @@ Dafny program verifier finished with 0 verified, 0 errors
 <stdin>(1,20): Error: assertion might not hold
 
 Dafny program verifier finished with 0 verified, 1 error
+<stdin>(1,0): Warning: File contains no code
+
+Dafny program verifier finished with 0 verified, 0 errors
+TestFiles/LitTests/LitTest/dafny0/Tuples.dfy(22,18): Error: assertion might not hold
+TestFiles/LitTests/LitTest/dafny0/Tuples.dfy(24,20): Error: possible division by zero
+
+Dafny program verifier finished with 0 verified, 2 errors


### PR DESCRIPTION
Fixes #4045
Fixes #4135

Two different regressions both related to refactoring `DafnyFile` to identify the source using Uris. When the source is from standard in, we now use `stdin:///` as the URL. The `LocalPath` for that URL is `/`, but `Path.GetDirectoryName` of `/` is `null` and hence causes trouble without special handling.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
