### PR TITLE
Ensure that all code coverage class filters are applied

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -127,12 +127,7 @@ jobs:
           reportgenerator \
             -reports:"./**/coverage.cobertura.xml" \
             -reporttypes:Cobertura -targetdir:coverage-cobertura \
-            -classfilters:-Microsoft.Dafny.*PreType* \
-            -classfilters:-Microsoft.Dafny.ResolverPass \
-            -classfilters:-Microsoft.Dafny.*Underspecification* \
-            -classfilters:-Microsoft.Dafny.DetectUnderspecificationVisitor \
-            -classfilters:-Microsoft.Dafny.Microsoft.Dafny.UnderspecificationDetector \
-            -classfilters:-Microsoft.Dafny.ResolverPass
+            -classfilters:"-Microsoft.Dafny.*PreType*;-Microsoft.Dafny.ResolverPass;-Microsoft.Dafny.*Underspecification*;-Microsoft.Dafny.DetectUnderspecificationVisitor;-Microsoft.Dafny.Microsoft.Dafny.UnderspecificationDetector"
           # Generate HTML from combined report, leaving out XUnitExtensions
           reportgenerator \
             -reports:"coverage-cobertura/Cobertura.xml" \


### PR DESCRIPTION
Multiple class filters must be passed in as a [single argument](https://github.com/danielpalme/ReportGenerator#usage--command-line-parameters), but previously they were passed as multiple `-classfilters:` of which only the first was actually applied.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
