### PR TITLE
chore: Disable test that calls gradlew for windows

### DIFF
--- a/Test/benchmarks/sequence-race/SequenceRace.dfy
+++ b/Test/benchmarks/sequence-race/SequenceRace.dfy
@@ -1,4 +1,7 @@
 
+// Only because we're calling gradlew rather than gradlew.bat
+// UNSUPPORTED: windows
+
 // Ensure trying to use an unsupported compilation target results in a clean error message.
 // RUN: %exits-with 3 %baredafny translate cs %args "%s" --plugin:DafnyBenchmarkingPlugin.dll > "%t"
 // RUN: %diff "%s.expect" "%t"

--- a/Test/benchmarks/sequence-race/SequenceRace.dfy.expect
+++ b/Test/benchmarks/sequence-race/SequenceRace.dfy.expect
@@ -1,4 +1,4 @@
 
 Dafny program verifier finished with 2 verified, 0 errors
-SequenceRace.dfy(27,0): Error: The benchmarking plugin does not support this compilation target: Microsoft.Dafny.Compilers.CsharpCompiler (--target:cs)
+SequenceRace.dfy(30,0): Error: The benchmarking plugin does not support this compilation target: Microsoft.Dafny.Compilers.CsharpCompiler (--target:cs)
 Wrote textual form of partial target program to SequenceRace.cs


### PR DESCRIPTION
Fixes nightly build break.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
