### PR TITLE
Dispose executionEngine where it is used, and don't use it when not needed

### DIFF
--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -30,9 +30,8 @@ using Microsoft.Dafny.Plugins;
 
 namespace Microsoft.Dafny {
 
-  public class DafnyDriver {
+  public class DafnyDriver : IDisposable {
     public DafnyOptions Options { get; }
-
 
     private readonly ExecutionEngine engine;
 
@@ -138,10 +137,11 @@ namespace Microsoft.Dafny {
             return 0;
           }
 
-          var driver = new DafnyDriver(dafnyOptions);
+          using (var driver = new DafnyDriver(dafnyOptions)) {
 #pragma warning disable VSTHRD002
-          exitValue = driver.ProcessFilesAsync(dafnyFiles, otherFiles.AsReadOnly(), dafnyOptions).Result;
+            exitValue = driver.ProcessFilesAsync(dafnyFiles, otherFiles.AsReadOnly(), dafnyOptions).Result;
 #pragma warning restore VSTHRD002
+          }
           break;
         case CommandLineArgumentsResult.PREPROCESSING_ERROR:
           return (int)ExitValue.PREPROCESSING_ERROR;
@@ -959,6 +959,9 @@ namespace Microsoft.Dafny {
 
     #endregion
 
+    public void Dispose() {
+      engine.Dispose();
+    }
   }
 
   class NoExecutableBackend : IExecutableBackend {

--- a/Source/DafnyPipeline.Test/ImplicitAssertionTest.cs
+++ b/Source/DafnyPipeline.Test/ImplicitAssertionTest.cs
@@ -161,8 +161,7 @@ method Test(m: map<int, int>, x: int) {
       Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");
     }
 
-    var engine = Bpl.ExecutionEngine.CreateWithoutSharedCache(options);
-    var boogiePrograms = DafnyDriver.Translate(engine.Options, dafnyProgram).ToList();
+    var boogiePrograms = DafnyDriver.Translate(options, dafnyProgram).ToList();
     Assert.Single(boogiePrograms);
     var boogieProgram = boogiePrograms[0].Item2;
     var encountered = new List<string>();

--- a/Source/DafnyServer/Server.cs
+++ b/Source/DafnyServer/Server.cs
@@ -8,7 +8,7 @@ using DafnyServer;
 using Microsoft.Boogie;
 
 namespace Microsoft.Dafny {
-  public class Server {
+  public class Server : IDisposable {
     private bool running;
     private readonly ExecutionEngine engine;
 
@@ -228,6 +228,11 @@ namespace Microsoft.Dafny {
 
     void Exit() {
       this.running = false;
+      Dispose();
+    }
+
+    public void Dispose() {
+      engine.Dispose();
     }
   }
 

--- a/Source/DafnyTestGeneration/ProgramModifier.cs
+++ b/Source/DafnyTestGeneration/ProgramModifier.cs
@@ -60,8 +60,7 @@ namespace DafnyTestGeneration {
       program = new FunctionToMethodCallRewriter(this, options).VisitProgram(program);
       program = new AddImplementationsForCalls(options).VisitProgram(program);
       program = new RemoveChecks(options).VisitProgram(program);
-      var engine = ExecutionEngine.CreateWithoutSharedCache(options);
-      engine.CoalesceBlocks(program); // removes redundant basic blocks
+      BlockCoalescer.CoalesceBlocks(program);
       var annotator = new AnnotationVisitor(this, options);
       program = annotator.VisitProgram(program);
       AddAxioms(options, program);


### PR DESCRIPTION
Reduces memory usage by closing more Z3 processes and creating fewer

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
