### PR TITLE
fix: Avoid race condition in Java runtime sequence concatenation optimization

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -99,9 +99,14 @@ jobs:
       with:
         path: dafny
         submodules: true # Until the libraries work again
-    - name: Install Java runtime locally
+    - name: Install Java runtime locally (non-Windows)
+      if: runner.os != 'Windows'
       working-directory: dafny/Source/DafnyRuntime/DafnyRuntimeJava
       run: ./gradlew publishToMavenLocal
+    - name: Install Java runtime locally (Windows)
+      if: runner.os == 'Windows'
+      working-directory: dafny/Source/DafnyRuntime/DafnyRuntimeJava
+      run: ./gradlew.bat publishToMavenLocal
 #    - name: Clean up libraries for testing
 #      run: |
 #        rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -99,6 +99,9 @@ jobs:
       with:
         path: dafny
         submodules: true # Until the libraries work again
+    - name: Install Java runtime locally
+      working-directory: dafny/Source/DafnyRuntime/DafnyRuntimeJava
+      run: ./gradlew publishToMavenLocal
 #    - name: Clean up libraries for testing
 #      run: |
 #        rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override

--- a/Source/DafnyBenchmarkingPlugin/JavaBenchmarkCompilationInstrumenter.cs
+++ b/Source/DafnyBenchmarkingPlugin/JavaBenchmarkCompilationInstrumenter.cs
@@ -32,6 +32,12 @@ public class JavaBenchmarkCompilationInstrumenter : GenericCompilationInstrument
         // so the better solution in the future is probably to maintain the benchmark object
         // as a separate object that Setup instantiates every time.
         wr.WriteLine("@org.openjdk.jmh.annotations.Setup(org.openjdk.jmh.annotations.Level.Iteration)");
+      } else if (Attributes.Contains(m.Attributes, "benchmarkTearDown")) {
+        if (m.Ins.Any()) {
+          Reporter.Error(MessageSource.Compiler, ResolutionErrors.ErrorId.none, m.tok,
+            $"Methods with {{:benchmarkTearDown}} can not accept parameters");
+        }
+        wr.WriteLine("@org.openjdk.jmh.annotations.TearDown(org.openjdk.jmh.annotations.Level.Iteration)");
       } else {
         wr.WriteLine("@org.openjdk.jmh.annotations.Benchmark");
       }

--- a/Source/DafnyPipeline/DafnyPipeline.csproj
+++ b/Source/DafnyPipeline/DafnyPipeline.csproj
@@ -61,7 +61,7 @@
       <LogicalName>DafnyRuntime.h</LogicalName>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimeJava\build\libs\DafnyRuntime.jar">
+    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimeJava\build\libs\DafnyRuntime-4.2.0.jar">
       <LogicalName>DafnyRuntime.jar</LogicalName>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/Source/DafnyPipeline/DafnyPipeline.csproj
+++ b/Source/DafnyPipeline/DafnyPipeline.csproj
@@ -63,6 +63,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimeJava\build\libs\DafnyRuntime-4.2.0.jar">
       <LogicalName>DafnyRuntime.jar</LogicalName>
+      <Link>DafnyRuntime.jar</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntime.js">

--- a/Source/DafnyRuntime/DafnyRuntime.csproj
+++ b/Source/DafnyRuntime/DafnyRuntime.csproj
@@ -26,7 +26,7 @@
     <Folder Include="DafnyRuntimeJava\build\libs" />
   </ItemGroup>
   <PropertyGroup>
-    <DafnyRuntimeJar>DafnyRuntimeJava/build/libs/DafnyRuntime.jar</DafnyRuntimeJar>
+    <DafnyRuntimeJar>DafnyRuntimeJava/build/libs/DafnyRuntime-4.2.0.jar</DafnyRuntimeJar>
   </PropertyGroup>
   <Target Name="BuildDafnyRuntimeJar" AfterTargets="ResolveReferences" BeforeTargets="CoreCompile" Inputs="$(MSBuildProjectFile);@(DafnyRuntimeJavaInputFile)" Outputs="$(DafnyRuntimeJar)">
     

--- a/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
@@ -80,8 +80,7 @@ publishing {
 signing {
     // Signing is required if building a release version and if we're going to publish it.
     // Otherwise, signing will only occur if signatory credentials are configured.
-    // TODO: Doesn't work in this version of Gradle
-//    required { isReleaseVersion && gradle.taskGraph.hasTask('publish') }
+    required { gradle.taskGraph.hasTask('publish') }
 
     sign publishing.publications.mavenJava
 }

--- a/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'signing'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
 
 repositories {
@@ -14,8 +16,14 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
 }
 
-group = 'dafny.lang'
+group = 'org.dafny'
+version = '4.2.0'
 sourceCompatibility = '1.8'
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -28,5 +36,62 @@ test {
 
 clean {
     delete '../../../Binaries/DafnyRuntime.jar'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'DafnyRuntime'
+            from components.java
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
+            pom {
+                name = 'DafnyRuntime'
+                description = 'Runtime for Dafny programs compiled to Java'
+                url = 'https://github.com/dafny-lang/dafny'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://spdx.org/licenses/MIT.html'
+                    }
+                }
+                developers {
+                    developer {
+                        name = 'The Dafny core team'
+                        email = 'core-team@dafny.org'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/dafny-lang/dafny.git'
+                    developerConnection = 'scm:git:git@github.com:dafny-lang/dafny.git'
+                    url = 'https://github.com/dafny-lang/dafny'
+                }
+            }
+        }
+    }
+}
+
+signing {
+    // Signing is required if building a release version and if we're going to publish it.
+    // Otherwise, signing will only occur if signatory credentials are configured.
+    // TODO: Doesn't work in this version of Gradle
+//    required { isReleaseVersion && gradle.taskGraph.hasTask('publish') }
+
+    sign publishing.publications.mavenJava
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
 }
 

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/Array.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/Array.java
@@ -12,9 +12,9 @@ import java.util.List;
  * to operate on possibly-primitive arrays.
  *
  * This isn't used by generated Dafny code, which directly uses values of type
- * Object when the element type isn't known, relying on a {@link Type} passed
+ * Object when the element type isn't known, relying on a {@link TypeDescriptor} passed
  * in.  It's much more pleasant to use, and more type-safe, than the bare
- * {@link Type} operations, however, so extern implementors may be interested.
+ * {@link TypeDescriptor} operations, however, so extern implementors may be interested.
  * It is also used to implement {@link DafnySequence}.
  *
  * @param <T> The type of the elements in the array, or if that type is

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
@@ -882,10 +882,10 @@ final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
                 leftBuffer = cseq.left;
                 rightBuffer = cseq.right;
                 if (leftBuffer == null || rightBuffer == null) {
+                    copier.copyFrom(cseq.ans);
+                } else {
                     toVisit.push(rightBuffer);
                     toVisit.push(leftBuffer);
-                } else {
-                    copier.copyFrom(cseq.ans);
                 }
             } else {
                 copier.copyFrom(seq);

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
@@ -801,8 +801,8 @@ abstract class LazyDafnySequence<T> extends DafnySequence<T> {
 final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
     // INVARIANT: Either these are both non-null and ans is null or both are
     // null and ans is non-null.
-    private DafnySequence<T> left, right;
-    private volatile NonLazyDafnySequence<T> ans = null;
+    private volatile DafnySequence<T> left, right;
+    private NonLazyDafnySequence<T> ans = null;
     private final int length;
 
     ConcatDafnySequence(DafnySequence<T> left, DafnySequence<T> right) {

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
@@ -801,6 +801,13 @@ abstract class LazyDafnySequence<T> extends DafnySequence<T> {
 final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
     // INVARIANT: Either these are both non-null and ans is null or both are
     // null and ans is non-null.
+    // Under concurrent access this is more complicated though:
+    // the only safe pattern is to read left and right into temporary variables first
+    // and judge based on their values whether ans is populated or not.
+    // The opposite order is subject to race conditions:
+    // if you observe ans as null first and then attempt to read left or right,
+    // another thread could complete force() in-between and clear left and right
+    // before you get to them!
     private volatile DafnySequence<T> left, right;
     private NonLazyDafnySequence<T> ans = null;
     private final int length;
@@ -830,7 +837,7 @@ final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
 
     private NonLazyDafnySequence<T> computeElements() {
         // Somewhat arbitrarily, the copier will be created by the leftmost
-        // sequence.  This is fine unless native Java code is uncareful and has
+        // sequence.  This is fine unless native Java code is uncareful and
         // has created ArrayDafnySequences of boxed primitive types.
         Copier<T> copier;
 
@@ -843,16 +850,24 @@ final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
         Deque<DafnySequence<T>> toVisit = new ArrayDeque<>();
 
         // Another thread may have already completed force() at this point.
-        if (left == null || right == null) {
+        DafnySequence<T> leftBuffer = left;
+        DafnySequence<T> rightBuffer = right;
+        if (leftBuffer == null || rightBuffer == null) {
             return ans;
         }
 
-        toVisit.push(right);
-        DafnySequence<T> first = left;
-        while (first instanceof ConcatDafnySequence<?> &&
-                ((ConcatDafnySequence<T>) first).ans == null) {
-            toVisit.push(((ConcatDafnySequence<T>) first).right);
-            first = ((ConcatDafnySequence<T>) first).left;
+        toVisit.push(rightBuffer);
+        DafnySequence<T> first = leftBuffer;
+        while (first instanceof ConcatDafnySequence<?>) {
+            ConcatDafnySequence<T> cfirst = (ConcatDafnySequence<T>) first;
+            leftBuffer = cfirst.left;
+            rightBuffer = cfirst.right;
+            if (leftBuffer == null || rightBuffer == null) {
+                break;
+            } else {
+                toVisit.push(rightBuffer);
+                first = leftBuffer;
+            }
         }
         toVisit.push(first);
 
@@ -864,11 +879,13 @@ final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
             if (seq instanceof ConcatDafnySequence<?>) {
                 ConcatDafnySequence<T> cseq = (ConcatDafnySequence<T>) seq;
 
-                if (cseq.ans != null) {
-                    copier.copyFrom(cseq.ans);
+                leftBuffer = cseq.left;
+                rightBuffer = cseq.right;
+                if (leftBuffer == null || rightBuffer == null) {
+                    toVisit.push(rightBuffer);
+                    toVisit.push(leftBuffer);
                 } else {
-                    toVisit.push(cseq.right);
-                    toVisit.push(cseq.left);
+                    copier.copyFrom(cseq.ans);
                 }
             } else {
                 copier.copyFrom(seq);

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/DafnySequence.java
@@ -802,7 +802,7 @@ final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
     // INVARIANT: Either these are both non-null and ans is null or both are
     // null and ans is non-null.
     private DafnySequence<T> left, right;
-    private NonLazyDafnySequence<T> ans = null;
+    private volatile NonLazyDafnySequence<T> ans = null;
     private final int length;
 
     ConcatDafnySequence(DafnySequence<T> left, DafnySequence<T> right) {
@@ -841,6 +841,11 @@ final class ConcatDafnySequence<T> extends LazyDafnySequence<T> {
         // use recursion, but there could easily be enough sequences being
         // concatenated to exhaust the system stack.)
         Deque<DafnySequence<T>> toVisit = new ArrayDeque<>();
+
+        // Another thread may have already completed force() at this point.
+        if (left == null || right == null) {
+            return ans;
+        }
 
         toVisit.push(right);
         DafnySequence<T> first = left;

--- a/Test/benchmarks/sequence-race/SequenceRace.dfy
+++ b/Test/benchmarks/sequence-race/SequenceRace.dfy
@@ -17,6 +17,9 @@
 // Verify the benchmark actually ran and did not hit any exceptions.
 // CHECK: # Benchmark: _System.SequenceRace.LazyRace
 // CHECK-NOT: <failure>
+// Verify the teardown is only run once per iteration
+// CHECK: Iteration   1: That's all folks!
+// CHECK: Iteration   2: That's all folks!
 // CHECK: # Run complete.
 
 //
@@ -47,7 +50,7 @@ class {:benchmarks} SequenceRace {
     expect s[0] == 0;
   }
 
-  // method {:benchmarkTearDown} TearDown() {
-  //   print "Tear it down, boys\n";
-  // }
+  method {:benchmarkTearDown} TearDown() {
+    print "That's all folks!\n";
+  }
 }

--- a/Test/benchmarks/sequence-race/SequenceRace.dfy
+++ b/Test/benchmarks/sequence-race/SequenceRace.dfy
@@ -6,6 +6,7 @@
 // RUN: %diff "%s.expect" "%t"
 
 // RUN: %baredafny translate java %args "%s" --plugin:DafnyBenchmarkingPlugin.dll
+// RUN: rm -rf %S/java/src/jmh
 // RUN: mkdir -p %S/java/src/jmh
 // RUN: cp -r %S/SequenceRace-java %S/java/src/jmh/java
 
@@ -13,10 +14,9 @@
 // RUN: %S/java/gradlew jmh -p %S/java > "%t"
 // RUN: %OutputCheck --file-to-check "%t" "%s"
 
-// I'd like to verify that the benchmark always fails since the bug isn't fixed yet,
-// but that could easily lead to a flaky test since it's not guaranteed to fail every time.
-// For now we just verify that the benchmark code was actually picked up by JMH and ran to completion.
+// Verify the benchmark actually ran and did not hit any exceptions.
 // CHECK: # Benchmark: _System.SequenceRace.LazyRace
+// CHECK-NOT: <failure>
 // CHECK: # Run complete.
 
 //
@@ -47,4 +47,7 @@ class {:benchmarks} SequenceRace {
     expect s[0] == 0;
   }
 
+  // method {:benchmarkTearDown} TearDown() {
+  //   print "Tear it down, boys\n";
+  // }
 }

--- a/Test/benchmarks/sequence-race/SequenceRace.dfy.expect
+++ b/Test/benchmarks/sequence-race/SequenceRace.dfy.expect
@@ -1,4 +1,4 @@
 
 Dafny program verifier finished with 2 verified, 0 errors
-SequenceRace.dfy(32,0): Error: The benchmarking plugin does not support this compilation target: Microsoft.Dafny.Compilers.CsharpCompiler (--target:cs)
+SequenceRace.dfy(35,0): Error: The benchmarking plugin does not support this compilation target: Microsoft.Dafny.Compilers.CsharpCompiler (--target:cs)
 Wrote textual form of partial target program to SequenceRace.cs

--- a/Test/benchmarks/sequence-race/java/build.gradle.kts
+++ b/Test/benchmarks/sequence-race/java/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }


### PR DESCRIPTION
Fixes #1454.

Uses the same technique as the C# runtime, the only wrinkle being finding the left-most node in order to call `newCopied(length)` on it. This allows us to actually assert success in the multithreaded benchmark for this case.

This required being able to install the Java runtime to Maven local, so I've also applied the same changes @alex-chew had queued up for publishing this package.

Also added support for a `{:benchmarkTearDown}` attribute in the plugin, for once-per-benchmark cleanup, statistics reporting, etc.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
