### PR TITLE
Fixes for tests among which CanLoadMultipleDocumentsConcurrently

### DIFF
--- a/Source/DafnyLanguageServer.Test/Extensions/LanguageClientExtensions.cs
+++ b/Source/DafnyLanguageServer.Test/Extensions/LanguageClientExtensions.cs
@@ -26,11 +26,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions {
       });
     }
 
-    public static Task CloseDocumentAndWaitAsync(this ILanguageClient client, TextDocumentItem documentItem, CancellationToken cancellationToken) {
-      client.CloseDocument(documentItem);
-      return client.WaitForNotificationCompletionAsync(documentItem.Uri, cancellationToken);
-    }
-
     public static Task OpenDocumentAndWaitAsync(this ILanguageClient client, TextDocumentItem documentItem, CancellationToken cancellationToken) {
       client.OpenDocument(documentItem);
       return client.WaitForNotificationCompletionAsync(documentItem.Uri, cancellationToken);

--- a/Source/DafnyLanguageServer.Test/MultipleFiles.cs
+++ b/Source/DafnyLanguageServer.Test/MultipleFiles.cs
@@ -41,7 +41,7 @@ method Bar() {
     var consumer2Diagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken, consumer2);
     Assert.True(consumer2Diagnostics.Length > 1);
 
-    await client.CloseDocumentAndWaitAsync(producerItem, CancellationToken);
+    client.CloseDocument(producerItem);
     var producerDiagnostics3 = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
     Assert.Empty(producerDiagnostics3); // File has no code
     var consumer3 = CreateTestDocument(consumerSource, Path.Combine(Directory.GetCurrentDirectory(), "consumer3.dfy"));

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/MultipleFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/MultipleFilesTest.cs
@@ -86,11 +86,11 @@ method Produces() {}
 
     Assert.NotEmpty(Projects.Managers);
 
-    await client.CloseDocumentAndWaitAsync(projectFile, CancellationToken);
+    client.CloseDocument(projectFile);
+    await client.WaitForNotificationCompletionAsync(codeFile.Uri, CancellationToken);
     Assert.NotEmpty(Projects.Managers);
 
-    await client.CloseDocumentAndWaitAsync(codeFile, CancellationToken);
-
+    client.CloseDocument(codeFile);
     var retryCount = 10;
     for (int i = 0; i < retryCount; i++) {
       if (!Projects.Managers.Any()) {
@@ -230,7 +230,7 @@ method Bar() {
     var consumer2Diagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken, consumer2);
     Assert.True(consumer2Diagnostics.Length > 1);
 
-    await client.CloseDocumentAndWaitAsync(producerItem, CancellationToken);
+    client.CloseDocument(producerItem);
     var producerDiagnostics3 = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken);
     Assert.Empty(producerDiagnostics3); // File has no code
     var consumer3 = await CreateAndOpenTestDocument(consumerSource, Path.Combine(Directory.GetCurrentDirectory(), "consumer3.dfy"));

--- a/Source/DafnyLanguageServer.Test/Synchronization/CloseDocumentTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/CloseDocumentTest.cs
@@ -19,13 +19,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
       return Task.CompletedTask;
     }
 
-    private Task CloseDocumentAndWaitAsync(TextDocumentItem documentItem) {
-      client.DidCloseTextDocument(new DidCloseTextDocumentParams {
-        TextDocument = documentItem
-      });
-      return client.WaitForNotificationCompletionAsync(documentItem.Uri, CancellationToken);
-    }
-
     [Fact]
     public async Task DocumentIsUnloadedWhenClosed() {
       var source = @"
@@ -34,7 +27,7 @@ function GetConstant(): int {
 }".Trim();
       var documentItem = CreateTestDocument(source);
       await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
-      await CloseDocumentAndWaitAsync(documentItem);
+      client.CloseDocument(documentItem);
       for (int attempt = 0; attempt < 50; attempt++) {
         if (!Projects.Managers.Any()) {
           return;
@@ -52,7 +45,7 @@ function GetConstant(): int {
   1
 }".Trim();
       var documentItem = CreateTestDocument(source);
-      await CloseDocumentAndWaitAsync(documentItem);
+      client.CloseDocument(documentItem);
       Assert.Null(await Projects.GetResolvedDocumentAsync(documentItem.Uri));
     }
 

--- a/Source/DafnyLanguageServer.Test/Synchronization/ProjectManagerDatabaseTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/ProjectManagerDatabaseTest.cs
@@ -26,9 +26,9 @@ public class ProjectManagerDatabaseTest : ClientBasedLanguageServerTest {
 
     List<Task> tasks = new();
     foreach (var loadingDocument in loadingDocuments) {
-      // Mix regular and close requests, both can be handled in parallel.
+      // Mix regular and close requests, both can be handled in parallel, although the hover might fail for a closed document.
       tasks.Add(client.RequestHover(new HoverParams { Position = (0, 0), TextDocument = loadingDocument.Uri }, CancellationToken));
-      tasks.Add(client.CloseDocumentAndWaitAsync(loadingDocument, CancellationToken));
+      client.CloseDocument(loadingDocument);
     }
 
     await Task.WhenAll(tasks);
@@ -78,7 +78,7 @@ public class ProjectManagerDatabaseTest : ClientBasedLanguageServerTest {
     List<Task> tasks = new();
     foreach (var loadingDocument in loadingDocuments) {
       tasks.Add(client.RequestHover(new HoverParams { Position = (0, 0), TextDocument = loadingDocument.Uri }, CancellationToken));
-      tasks.Add(client.CloseDocumentAndWaitAsync(loadingDocument, CancellationToken));
+      client.CloseDocument(loadingDocument);
     }
 
     await Task.WhenAll(tasks);

--- a/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
@@ -171,11 +171,12 @@ method Multiply(x: int, y: int) returns (product: int)
         loadingDocuments.Add(documentItem);
       }
       for (int i = 0; i < documentsToLoadConcurrently; i++) {
+        await client.WaitForNotificationCompletionAsync(loadingDocuments[i].Uri, CancellationTokenWithHighTimeout);
         await Projects.GetLastDocumentAsync(loadingDocuments[i]).WaitAsync(CancellationTokenWithHighTimeout);
       }
 
       foreach (var loadingDocument in loadingDocuments) {
-        await client.CloseDocumentAndWaitAsync(loadingDocument, CancellationTokenWithHighTimeout);
+        client.CloseDocument(loadingDocument);
       }
       await AssertNoDiagnosticsAreComing(CancellationTokenWithHighTimeout);
     }

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
 
       var beforeParsing = DateTime.Now;
       try {
-        var rootSourceUris = project.GetRootSourceUris(fileSystem, options).Concat(options.CliRootSourceUris);
+        var rootSourceUris = project.GetRootSourceUris(fileSystem, options).Concat(options.CliRootSourceUris).ToList();
         List<DafnyFile> dafnyFiles = new();
         foreach (var rootSourceUri in rootSourceUris) {
           try {

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerFilesystem.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerFilesystem.cs
@@ -68,7 +68,7 @@ public class LanguageServerFilesystem : IFileSystem {
   public void CloseDocument(TextDocumentIdentifier document) {
     var uri = document.Uri.ToUri();
 
-    logger.LogWarning($"Closing document {document.Uri}");
+    logger.LogInformation($"Closing document {document.Uri}");
     if (!openFiles.TryRemove(uri, out _)) {
       logger.LogError($"Could not close file {uri} because it was not open.");
     }

--- a/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     public async Task<IdeState?> GetResolvedDocumentAsync(TextDocumentIdentifier documentId) {
       var manager = await GetProjectManager(documentId, false);
       if (manager != null) {
-        return await manager.GetSnapshotAfterResolutionAsync()!;
+        var result = await manager.GetSnapshotAfterResolutionAsync()!;
+        return result;
       }
 
       return null;
@@ -102,7 +103,8 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       };
       var manager = await GetProjectManager(documentId, false);
       if (manager != null) {
-        return await manager.GetLastDocumentAsync()!;
+        var result = await manager.GetLastDocumentAsync()!;
+        return result;
       }
 
       return null;


### PR DESCRIPTION
### Changes

- Make CI more reliable by fixing the stability of `CanLoadMultipleDocumentsConcurrently`
- Get rid of `CloseDocumentAndWaitAsync` since it doesn't make sense to hover over a closed document, which is what it was doing.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
