### PR TITLE
Prevent a race condition related to ProjectManagerDatabase.OpenDocument

### DIFF
--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
@@ -120,37 +120,6 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
       }
     }
 
-    // protected virtual ILanguageClient CreateClient(
-    //   Action<LanguageClientOptions> clientOptionsAction = null,
-    //   Action<LanguageServerOptions> serverOptionsAction = null) {
-    //   var client = LanguageClient.PreInit(
-    //     options => {
-    //       var (reader, writer) = SetupServer(serverOptionsAction);
-    //       options
-    //         .WithInput(reader)
-    //         .WithOutput(writer)
-    //         .WithLoggerFactory(TestOptions.ClientLoggerFactory)
-    //         .WithAssemblies(TestOptions.Assemblies)
-    //         .WithAssemblies(typeof(LanguageProtocolTestBase).Assembly, GetType().Assembly)
-    //         .ConfigureLogging(x => x.SetMinimumLevel(LogLevel.Trace))
-    //         .WithInputScheduler(options.InputScheduler)
-    //         .WithOutputScheduler(options.OutputScheduler)
-    //         .WithDefaultScheduler(options.DefaultScheduler)
-    //         .Services
-    //         .AddTransient(typeof(IPipelineBehavior<,>), typeof(SettlePipeline<,>))
-    //         .AddSingleton(Events as IRequestSettler);
-    //
-    //       clientOptionsAction?.Invoke(options);
-    //     }
-    //   );
-    //
-    //   Disposable.Add(client);
-    //   Disposable.Add(Server);
-    //   Disposable.Add((IDisposable)Server.Services); // Testing shows that the services are not disposed automatically when the server is disposed.
-    //
-    //   return client;
-    // }
-
     private static void SetupTestLogging(ILoggingBuilder builder) {
       builder
         .AddFilter("OmniSharp", LogLevel.Warning)

--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
@@ -13,17 +13,15 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
 using System.IO;
-using System.IO.Pipelines;
 using System.Linq;
 using System.Threading.Tasks;
-using MediatR;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Various;
 using Microsoft.Dafny.LanguageServer.Language;
 using OmniSharp.Extensions.LanguageServer.Client;
 using Xunit.Abstractions;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest {
-  public class DafnyLanguageServerTestBase : LanguageServerTestBase {
+  public class DafnyLanguageServerTestBase : LanguageProtocolTestBase {
 
     protected readonly string SlowToVerify = @"
 lemma {:timeLimit 3} SquareRoot2NotRational(p: nat, q: nat)
@@ -51,7 +49,7 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
     protected static int fileIndex;
     protected readonly TextWriter output;
 
-    public ILanguageServer Server { get; private set; }
+    public ILanguageServer Server { get; protected set; }
 
     public IProjectDatabase Projects => Server.GetRequiredService<IProjectDatabase>();
 
@@ -60,30 +58,27 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
       this.output = new WriterFromOutputHelper(output);
     }
 
-    protected virtual IServiceCollection ServerOptionsAction(LanguageServerOptions serverOptions) {
-      return serverOptions.Services.AddSingleton<IProgramVerifier>(serviceProvider => new SlowVerifier(
-        serviceProvider.GetRequiredService<ILogger<DafnyProgramVerifier>>()
-      ));
+    protected virtual void ServerOptionsAction(LanguageServerOptions serverOptions) {
     }
 
-    protected virtual async Task<ILanguageClient> InitializeClient(
-      Action<LanguageClientOptions> clientOptionsAction = null,
-      Action<DafnyOptions> modifyOptions = null) {
+    protected Task<(ILanguageClient client, ILanguageServer server)> Initialize(Action<LanguageClientOptions> clientOptionsAction, Action<DafnyOptions> serverOptionsAction) {
+      return base.Initialize(clientOptionsAction, GetServerOptionsAction(serverOptionsAction));
+    }
+
+    private Action<LanguageServerOptions> GetServerOptionsAction(Action<DafnyOptions> modifyOptions) {
       var dafnyOptions = DafnyOptions.Create(output);
       modifyOptions?.Invoke(dafnyOptions);
-
-      void NewServerOptionsAction(LanguageServerOptions options) {
-        ApplyDefaultOptionValues(dafnyOptions);
-
-        ServerCommand.ConfigureDafnyOptionsForServer(dafnyOptions);
+      ApplyDefaultOptionValues(dafnyOptions);
+      ServerCommand.ConfigureDafnyOptionsForServer(dafnyOptions);
+      return options => {
+        options.ConfigureLogging(SetupTestLogging);
+        options.WithDafnyLanguageServer(() => { });
         options.Services.AddSingleton(dafnyOptions);
+        options.Services.AddSingleton<IProgramVerifier>(serviceProvider => new SlowVerifier(
+          serviceProvider.GetRequiredService<ILogger<DafnyProgramVerifier>>()
+        ));
         ServerOptionsAction(options);
-      }
-
-      var client = CreateClient(clientOptionsAction, NewServerOptionsAction);
-      await client.Initialize(CancellationToken).ConfigureAwait(false);
-
-      return client;
+      };
     }
 
     private static void ApplyDefaultOptionValues(DafnyOptions dafnyOptions) {
@@ -104,58 +99,36 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
       }
     }
 
-    protected virtual ILanguageClient CreateClient(
-      Action<LanguageClientOptions> clientOptionsAction = null,
-      Action<LanguageServerOptions> serverOptionsAction = null) {
-      var client = LanguageClient.PreInit(
-        options => {
-          var (reader, writer) = SetupServer(serverOptionsAction);
-          options
-            .WithInput(reader)
-            .WithOutput(writer)
-            .WithLoggerFactory(TestOptions.ClientLoggerFactory)
-            .WithAssemblies(TestOptions.Assemblies)
-            .WithAssemblies(typeof(LanguageProtocolTestBase).Assembly, GetType().Assembly)
-            .ConfigureLogging(x => x.SetMinimumLevel(LogLevel.Trace))
-            .WithInputScheduler(options.InputScheduler)
-            .WithOutputScheduler(options.OutputScheduler)
-            .WithDefaultScheduler(options.DefaultScheduler)
-            .Services
-            .AddTransient(typeof(IPipelineBehavior<,>), typeof(SettlePipeline<,>))
-            .AddSingleton(Events as IRequestSettler);
-
-          clientOptionsAction?.Invoke(options);
-        }
-      );
-
-      Disposable.Add(client);
-      Disposable.Add(Server);
-      Disposable.Add((IDisposable)Server.Services); // Testing shows that the services are not disposed automatically when the server is disposed.
-
-      return client;
-    }
-
-    protected (Stream clientOutput, Stream serverInput) SetupServer(
-      Action<LanguageServerOptions> serverOptionsAction = null) {
-      var clientPipe = new Pipe(TestOptions.DefaultPipeOptions);
-      var serverPipe = new Pipe(TestOptions.DefaultPipeOptions);
-      Server = OmniSharp.Extensions.LanguageServer.Server.LanguageServer.PreInit(
-        options => {
-          options
-            .WithInput(serverPipe.Reader)
-            .WithOutput(clientPipe.Writer)
-            .ConfigureLogging(SetupTestLogging)
-            .WithDafnyLanguageServer(() => { });
-          serverOptionsAction?.Invoke(options);
-        });
-      // This is the style used in the LSP implementation itself:
-      // https://github.com/OmniSharp/csharp-language-server-protocol/blob/1b6788df2600083c28811913a221ccac7b1d72c9/test/Lsp.Tests/Testing/LanguageServerTestBaseTests.cs
-#pragma warning disable VSTHRD110 // Observe result of async calls
-      Server.Initialize(CancellationToken);
-#pragma warning restore VSTHRD110 // Observe result of async calls
-
-      return (clientPipe.Reader.AsStream(), serverPipe.Writer.AsStream());
-    }
+    // protected virtual ILanguageClient CreateClient(
+    //   Action<LanguageClientOptions> clientOptionsAction = null,
+    //   Action<LanguageServerOptions> serverOptionsAction = null) {
+    //   var client = LanguageClient.PreInit(
+    //     options => {
+    //       var (reader, writer) = SetupServer(serverOptionsAction);
+    //       options
+    //         .WithInput(reader)
+    //         .WithOutput(writer)
+    //         .WithLoggerFactory(TestOptions.ClientLoggerFactory)
+    //         .WithAssemblies(TestOptions.Assemblies)
+    //         .WithAssemblies(typeof(LanguageProtocolTestBase).Assembly, GetType().Assembly)
+    //         .ConfigureLogging(x => x.SetMinimumLevel(LogLevel.Trace))
+    //         .WithInputScheduler(options.InputScheduler)
+    //         .WithOutputScheduler(options.OutputScheduler)
+    //         .WithDefaultScheduler(options.DefaultScheduler)
+    //         .Services
+    //         .AddTransient(typeof(IPipelineBehavior<,>), typeof(SettlePipeline<,>))
+    //         .AddSingleton(Events as IRequestSettler);
+    //
+    //       clientOptionsAction?.Invoke(options);
+    //     }
+    //   );
+    //
+    //   Disposable.Add(client);
+    //   Disposable.Add(Server);
+    //   Disposable.Add((IDisposable)Server.Services); // Testing shows that the services are not disposed automatically when the server is disposed.
+    //
+    //   return client;
+    // }
 
     private static void SetupTestLogging(ILoggingBuilder builder) {
       builder
@@ -194,10 +167,6 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
 
     public static string PrintEnumerable(IEnumerable<object> items) {
       return "[" + string.Join(", ", items.Select(o => o.ToString())) + "]";
-    }
-
-    protected override (Stream clientOutput, Stream serverInput) SetupServer() {
-      throw new NotImplementedException();
     }
   }
 }

--- a/Source/DafnyLanguageServer.Test/GutterStatus/ConcurrentLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/ConcurrentLinearVerificationGutterStatusTester.cs
@@ -27,7 +27,7 @@ public class ConcurrentLinearVerificationGutterStatusTester : LinearVerification
       verificationStatusGutterReceivers[i] = new();
     }
     verificationStatusGutterReceiver = new();
-    client = await InitializeClient(options =>
+    (client, Server) = await Initialize(options =>
       options
         .AddHandler(DafnyRequestNames.VerificationStatusGutter,
           NotificationHandler.For<VerificationStatusGutter>(NotifyAllVerificationGutterStatusReceivers))

--- a/Source/DafnyLanguageServer.Test/Synchronization/CachingTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/CachingTest.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 public class CachingTest : ClientBasedLanguageServerTest {
   private InMemorySink sink;
 
-  protected override IServiceCollection ServerOptionsAction(LanguageServerOptions serverOptions) {
+  protected override void ServerOptionsAction(LanguageServerOptions serverOptions) {
     sink = InMemorySink.Instance;
     var logger = new LoggerConfiguration().MinimumLevel.Debug()
       .WriteTo.InMemory().CreateLogger();
     var factory = LoggerFactory.Create(b => b.AddSerilog(logger));
-    return base.ServerOptionsAction(serverOptions.WithServices(c => c.Replace(new ServiceDescriptor(typeof(ILoggerFactory), factory))));
+    serverOptions.Services.Replace(new ServiceDescriptor(typeof(ILoggerFactory), factory));
   }
 
   [Fact]

--- a/Source/DafnyLanguageServer.Test/Synchronization/CloseDocumentTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/CloseDocumentTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
     private ILanguageClient client;
 
     public async Task InitializeAsync() {
-      client = await InitializeClient();
+      (client, Server) = await Initialize(_ => { }, _ => { });
     }
 
     public Task DisposeAsync() {

--- a/Source/DafnyLanguageServer.Test/Synchronization/OpenDocumentTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/OpenDocumentTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
     }
 
     private async Task SetUp(Action<DafnyOptions> modifyOptions) {
-      client = await InitializeClient(options => { }, modifyOptions);
+      (client, Server) = await Initialize(options => { }, modifyOptions);
     }
 
     [Fact]

--- a/Source/DafnyLanguageServer.Test/Synchronization/SynchronizationTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/SynchronizationTestBase.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
     protected ILanguageClient Client { get; set; }
 
     public virtual async Task InitializeAsync() {
-      Client = await InitializeClient();
+      (Client, Server) = await Initialize(_ => { }, _ => { });
     }
 
     public Task DisposeAsync() {

--- a/Source/DafnyLanguageServer.Test/Unit/CompilationManagerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/CompilationManagerTest.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Dafny.LanguageServer.Language;
+using Microsoft.Dafny.LanguageServer.Workspace;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit; 
+
+public class CompilationManagerTest {
+  [Fact]
+  public async Task CancelUnstartedCompilationLeadsToCancelledTasks() {
+    var dafnyOptions = DafnyOptions.Create(TextWriter.Null, TextReader.Null);
+    var compilationManager = new CompilationManager(new Mock<ILogger<CompilationManager>>().Object,
+      new Mock<ITextDocumentLoader>().Object,
+      new Mock<INotificationPublisher>().Object,
+      new Mock<IProgramVerifier>().Object,
+      new Mock<ICompilationStatusNotificationPublisher>().Object,
+      new Mock<IVerificationProgressReporter>().Object,
+      dafnyOptions,
+      null, new Compilation(0, new DafnyProject()), null);
+    compilationManager.CancelPendingUpdates();
+    await Assert.ThrowsAsync<TaskCanceledException>(() => compilationManager.ResolvedCompilation);
+  }
+}

--- a/Source/DafnyLanguageServer.Test/Unit/DafnyLangSymbolResolverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/DafnyLangSymbolResolverTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Dafny.LanguageServer.Language;
 using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Dafny.LanguageServer.Workspace;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,8 @@ public class DafnyLangSymbolResolverTest {
   public DafnyLangSymbolResolverTest() {
     var loggerFactory = new Mock<ILoggerFactory>();
     dafnyLangSymbolResolver = new DafnyLangSymbolResolver(
-      loggerFactory.Object,
+      new Mock<ILogger<DafnyLangSymbolResolver>>().Object,
+      new Mock<ILogger<CachingResolver>>().Object,
       new Mock<ITelemetryPublisher>().Object
     );
   }

--- a/Source/DafnyLanguageServer.Test/Unit/TextDocumentLoaderTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/TextDocumentLoaderTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
     private Mock<IGhostStateDiagnosticCollector> ghostStateDiagnosticCollector;
     private Mock<ICompilationStatusNotificationPublisher> notificationPublisher;
     private TextDocumentLoader textDocumentLoader;
-    private Mock<ILoggerFactory> logger;
+    private Mock<ILogger<ITextDocumentLoader>> logger;
     private Mock<INotificationPublisher> diagnosticPublisher;
 
     public TextDocumentLoaderTest(ITestOutputHelper output) {
@@ -34,7 +34,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit {
       ghostStateDiagnosticCollector = new();
       notificationPublisher = new();
       fileSystem = new();
-      logger = new Mock<ILoggerFactory>();
+      logger = new Mock<ILogger<ITextDocumentLoader>>();
       diagnosticPublisher = new Mock<INotificationPublisher>();
       textDocumentLoader = TextDocumentLoader.Create(
         parser.Object,

--- a/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
@@ -24,6 +24,7 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 
 public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase, IAsyncLifetime {
+
   protected ILanguageClient client;
   protected TestNotificationReceiver<FileVerificationStatus> verificationStatusReceiver;
   private TestNotificationReceiver<CompilationStatusParams> compilationStatusReceiver;
@@ -168,7 +169,7 @@ public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase, IAsync
     compilationStatusReceiver = new();
     verificationStatusReceiver = new();
     ghostnessReceiver = new();
-    client = await InitializeClient(InitialiseClientHandler, modifyOptions);
+    (client, Server) = await Initialize(InitialiseClientHandler, modifyOptions);
   }
 
   protected virtual void InitialiseClientHandler(LanguageClientOptions options) {

--- a/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
@@ -29,9 +29,8 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
 
     protected async Task SetUp(Action<DafnyOptions> modifyOptions) {
       notificationReceiver = new();
-      client = await InitializeClient(options => {
-        options
-          .AddHandler(DafnyRequestNames.CompilationStatus, NotificationHandler.For<CompilationStatusParams>(notificationReceiver.NotificationReceived));
+      (client, Server) = await Initialize(clientOptions => {
+        clientOptions.AddHandler(DafnyRequestNames.CompilationStatus, NotificationHandler.For<CompilationStatusParams>(notificationReceiver.NotificationReceived));
       }, modifyOptions);
     }
 

--- a/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
@@ -25,12 +25,19 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
 
     [Fact]
     public async Task UpdateDuringARequestWillCancelTheRequest() {
-      var programThatResolvesSlowlyEnough = @"method Foo() {}";
+      var programThatResolvesSlowlyEnough = RepeatStrBuilder(@"method Foo() {}", 1000);
       var documentItem = CreateTestDocument(programThatResolvesSlowlyEnough);
       client.OpenDocument(documentItem);
       var hoverTask = client.RequestHover(new HoverParams { Position = (0, 0), TextDocument = documentItem }, CancellationToken);
       ApplyChange(ref documentItem, new Range(0, 0, 0, 0), "//comment\n");
       await Assert.ThrowsAsync<ContentModifiedException>(() => hoverTask);
+    }
+
+    private static string RepeatStrBuilder(string text, uint n)
+    {
+      return new StringBuilder(text.Length * (int)n)
+        .Insert(0, text, (int)n)
+        .ToString();
     }
 
     [Fact(Timeout = MaxTestExecutionTimeMs)]

--- a/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
@@ -30,11 +30,12 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
       client.OpenDocument(documentItem);
       var hoverTask = client.RequestHover(new HoverParams { Position = (0, 0), TextDocument = documentItem }, CancellationToken);
       ApplyChange(ref documentItem, new Range(0, 0, 0, 0), "//comment\n");
+#pragma warning disable VSTHRD003
       await Assert.ThrowsAsync<ContentModifiedException>(() => hoverTask);
+#pragma warning restore VSTHRD003
     }
 
-    private static string RepeatStrBuilder(string text, uint n)
-    {
+    private static string RepeatStrBuilder(string text, uint n) {
       return new StringBuilder(text.Length * (int)n)
         .Insert(0, text, (int)n)
         .ToString();

--- a/Source/DafnyLanguageServer.Test/Various/ExceptionTests.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ExceptionTests.cs
@@ -23,8 +23,8 @@ public class ExceptionTests : ClientBasedLanguageServerTest {
   public bool CrashOnPrepareVerification { get; set; }
   public bool CrashOnLoad { get; set; }
 
-  protected override IServiceCollection ServerOptionsAction(LanguageServerOptions serverOptions) {
-    return serverOptions.Services
+  protected override void ServerOptionsAction(LanguageServerOptions serverOptions) {
+    serverOptions.Services
       .AddSingleton<ITextDocumentLoader>(serviceProvider => new CrashingLoader(this,
         LanguageServerExtensions.CreateTextDocumentLoader(serviceProvider)))
       .AddSingleton<IProgramVerifier>(serviceProvider => new CrashingVerifier(this,

--- a/Source/DafnyLanguageServer.Test/Various/StabilityTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/StabilityTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
     }
 
     public async Task InitializeAsync() {
-      client = await InitializeClient();
+      (client, Server) = await Initialize(_ => { }, _ => { });
     }
 
     public Task DisposeAsync() {

--- a/Source/DafnyLanguageServer/Handlers/DafnyTextDocumentHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyTextDocumentHandler.cs
@@ -59,14 +59,15 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       return new TextDocumentAttributes(uri, LanguageId);
     }
 
-    public override Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken cancellationToken) {
+    public override async Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken cancellationToken) {
       logger.LogTrace("received open notification {DocumentUri}", notification.TextDocument.Uri);
       try {
-        projects.OpenDocument(new DocumentTextBuffer(notification.TextDocument));
+        await projects.OpenDocument(new DocumentTextBuffer(notification.TextDocument));
       } catch (Exception e) {
         telemetryPublisher.PublishUnhandledException(e);
       }
-      return Unit.Task;
+
+      return Unit.Value;
     }
 
     /// <summary>

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         foreach (var rootSourceUri in rootSourceUris) {
           try {
             dafnyFiles.Add(new DafnyFile(reporter.Options, rootSourceUri, fileSystem.ReadFile(rootSourceUri)));
-          } catch (IOException e) {
+          } catch (IOException) {
             logger.LogError($"Tried to parse file {rootSourceUri} that could not be found");
           }
         }

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -19,25 +19,17 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     private readonly DafnyOptions options;
     private readonly IFileSystem fileSystem;
     private readonly ITelemetryPublisher telemetryPublisher;
-    private readonly ILogger logger;
+    private readonly ILogger<DafnyLangParser> logger;
     private readonly SemaphoreSlim mutex = new(1);
     private readonly CachingParser cachingParser;
 
-    private DafnyLangParser(DafnyOptions options, IFileSystem fileSystem, ITelemetryPublisher telemetryPublisher, ILoggerFactory loggerFactory) {
+    public DafnyLangParser(DafnyOptions options, IFileSystem fileSystem, ITelemetryPublisher telemetryPublisher,
+      ILogger<DafnyLangParser> logger, ILogger<CachingParser> innerParserLogger) {
       this.options = options;
       this.fileSystem = fileSystem;
       this.telemetryPublisher = telemetryPublisher;
-      logger = loggerFactory.CreateLogger<DafnyLangParser>();
-      cachingParser = new CachingParser(loggerFactory.CreateLogger<CachingParser>(), fileSystem);
-    }
-
-    /// <summary>
-    /// Factory method to safely create a new instance of the parser.
-    /// </summary>
-    /// <param name="logger">A logger instance that may be used by this parser instance.</param>
-    /// <returns>A safely created dafny parser instance.</returns>
-    public static DafnyLangParser Create(DafnyOptions options, IFileSystem fileSystem, ITelemetryPublisher telemetryPublisher, ILoggerFactory loggerFactory) {
-      return new DafnyLangParser(options, fileSystem, telemetryPublisher, loggerFactory);
+      this.logger = logger;
+      cachingParser = new CachingParser(innerParserLogger, fileSystem);
     }
 
     public Program Parse(DafnyProject project, ErrorReporter reporter, CancellationToken cancellationToken) {

--- a/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Language/LanguageServerExtensions.cs
@@ -26,11 +26,12 @@ namespace Microsoft.Dafny.LanguageServer.Language {
 
     private static IServiceCollection WithDafnyLanguage(this IServiceCollection services) {
       return services
-        .AddSingleton<IDafnyParser>(serviceProvider => DafnyLangParser.Create(
+        .AddSingleton<IDafnyParser>(serviceProvider => new DafnyLangParser(
           serviceProvider.GetRequiredService<DafnyOptions>(),
           serviceProvider.GetRequiredService<IFileSystem>(),
           serviceProvider.GetRequiredService<ITelemetryPublisher>(),
-          serviceProvider.GetRequiredService<LoggerFactory>()))
+          serviceProvider.GetRequiredService<ILogger<DafnyLangParser>>(),
+          serviceProvider.GetRequiredService<ILogger<CachingParser>>()))
         .AddSingleton<ISymbolResolver, DafnyLangSymbolResolver>()
         .AddSingleton<CreateIdeStateObserver>(serviceProvider => documentIdentifier =>
           new IdeStateObserver(serviceProvider.GetRequiredService<ILogger<IdeStateObserver>>(),

--- a/Source/DafnyLanguageServer/Language/Symbols/DafnyLangSymbolResolver.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/DafnyLangSymbolResolver.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   /// this resolver serializes all invocations.
   /// </remarks>
   public class DafnyLangSymbolResolver : ISymbolResolver {
-    private readonly ILoggerFactory loggerFactory;
     private readonly ILogger logger;
+    private readonly ILogger<CachingResolver> innerLogger;
     private readonly SemaphoreSlim resolverMutex = new(1);
     private readonly ITelemetryPublisher telemetryPublisher;
 
-    public DafnyLangSymbolResolver(ILoggerFactory loggerFactory, ITelemetryPublisher telemetryPublisher) {
-      this.loggerFactory = loggerFactory;
-      logger = loggerFactory.CreateLogger<DafnyLangSymbolResolver>();
+    public DafnyLangSymbolResolver(ILogger<DafnyLangSymbolResolver> logger, ILogger<CachingResolver> innerLogger, ITelemetryPublisher telemetryPublisher) {
+      this.logger = logger;
+      this.innerLogger = innerLogger;
       this.telemetryPublisher = telemetryPublisher;
     }
 
@@ -55,7 +55,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
     private void RunDafnyResolver(DafnyProject project, Program program, CancellationToken cancellationToken) {
       var beforeResolution = DateTime.Now;
       try {
-        var resolver = new CachingResolver(program, loggerFactory.CreateLogger<CachingResolver>(), resolutionCache);
+        var resolver = new CachingResolver(program, innerLogger, resolutionCache);
         resolver.Resolve(cancellationToken);
         resolutionCache.Prune();
         int resolverErrors = resolver.Reporter.ErrorCountUntilResolver;

--- a/Source/DafnyLanguageServer/Workspace/CompilationManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/CompilationManager.cs
@@ -82,6 +82,7 @@ public class CompilationManager {
     this.statusPublisher = statusPublisher;
     this.verificationProgressReporter = verificationProgressReporter;
     cancellationSource = new();
+    cancellationSource.Token.Register(() => started.TrySetCanceled(cancellationSource.Token));
 
     MarkVerificationFinished();
 

--- a/Source/DafnyLanguageServer/Workspace/IProjectDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/IProjectDatabase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// <summary>
   /// Stores and manages the provided documents.
   /// </summary>
-  public interface IProjectDatabase {
+  public interface IProjectDatabase : IDisposable {
     /// <summary>
     /// Closes the document with the specified ID.
     /// </summary>

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
@@ -37,10 +37,11 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         .AddSingleton<IFileSystem, LanguageServerFilesystem>()
         .AddSingleton<IDafnyParser>(serviceProvider => {
           var options = serviceProvider.GetRequiredService<DafnyOptions>();
-          return DafnyLangParser.Create(options,
+          return new DafnyLangParser(options,
             serviceProvider.GetRequiredService<IFileSystem>(),
             serviceProvider.GetRequiredService<ITelemetryPublisher>(),
-            serviceProvider.GetRequiredService<ILoggerFactory>());
+            serviceProvider.GetRequiredService<ILogger<DafnyLangParser>>(),
+            serviceProvider.GetRequiredService<ILogger<CachingParser>>());
         })
         .AddSingleton<ITextDocumentLoader>(CreateTextDocumentLoader)
         .AddSingleton<INotificationPublisher, NotificationPublisher>()

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         services.GetRequiredService<ISymbolTableFactory>(),
         services.GetRequiredService<IGhostStateDiagnosticCollector>(),
         services.GetRequiredService<ICompilationStatusNotificationPublisher>(),
-        services.GetRequiredService<ILoggerFactory>()
+        services.GetRequiredService<ILogger<ITextDocumentLoader>>()
       );
     }
   }

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -23,27 +23,26 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// The increased stack size is necessary to solve the issue https://github.com/dafny-lang/dafny/issues/1447.
   /// </remarks>
   public class TextDocumentLoader : ITextDocumentLoader {
-
+    private readonly ILogger<ITextDocumentLoader> documentLoader;
     private readonly IDafnyParser parser;
     private readonly ISymbolResolver symbolResolver;
     private readonly ISymbolTableFactory symbolTableFactory;
     private readonly IGhostStateDiagnosticCollector ghostStateDiagnosticCollector;
     protected readonly ICompilationStatusNotificationPublisher statusPublisher;
-    protected readonly ILoggerFactory loggerFactory;
 
     protected TextDocumentLoader(
-      ILoggerFactory loggerFactory,
+      ILogger<ITextDocumentLoader> documentLoader,
       IDafnyParser parser,
       ISymbolResolver symbolResolver,
       ISymbolTableFactory symbolTableFactory,
       IGhostStateDiagnosticCollector ghostStateDiagnosticCollector,
       ICompilationStatusNotificationPublisher statusPublisher) {
+      this.documentLoader = documentLoader;
       this.parser = parser;
       this.symbolResolver = symbolResolver;
       this.symbolTableFactory = symbolTableFactory;
       this.ghostStateDiagnosticCollector = ghostStateDiagnosticCollector;
       this.statusPublisher = statusPublisher;
-      this.loggerFactory = loggerFactory;
     }
 
     public static TextDocumentLoader Create(
@@ -52,9 +51,9 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       ISymbolTableFactory symbolTableFactory,
       IGhostStateDiagnosticCollector ghostStateDiagnosticCollector,
       ICompilationStatusNotificationPublisher statusPublisher,
-      ILoggerFactory loggerFactory
+      ILogger<ITextDocumentLoader> logger
       ) {
-      return new TextDocumentLoader(loggerFactory, parser, symbolResolver, symbolTableFactory, ghostStateDiagnosticCollector, statusPublisher);
+      return new TextDocumentLoader(logger, parser, symbolResolver, symbolTableFactory, ghostStateDiagnosticCollector, statusPublisher);
     }
 
     public IdeState CreateUnloaded(DafnyProject project) {


### PR DESCRIPTION
### Changes
1. Update `DafnyTextDocumentHandler.cs` so it properly awaits `ProjectManagerDatabase.OpenDocument`, so no new requests can be handled until the ProjectManager's constructor and `OpenDocument` method have been called. Without this change, a call to `CreateAndOpenTestDocument` could deadlock, because the hover request would come in while the OpenDocument request would still create a new compilation, causing the hover to wait for a dud compilation that would never be started. It's not clear why the hover wouldn't return as cancelled.
1. Update `CompilationManager` so it calls its ResolvedDocument and TranslatedDocument tasks when the `CompilationManager` is cancelled before being started.
1. Use `LanguageProtocolTestBase` instead of `LanguageServerTestBase`, which means more code re-use from the library
1. Do not Dispose the entire `ServiceCollection` but only the `ProjectManagerDatabase`, which is safer because we're disposing less but still enough. Hopefully this leads to fewer exceptions in the test runs.

### Testing
1. It's difficult to consistently reproduce the problem, but this change stabilizes the test `OnDiskChangesToProjectFileAffectCodeNavigation`
1. Add a test `CancelUnstartedCompilationLeadsToCancelledTasks`, which tests the second change in the above list.
1. Refactoring, no test needed
1. Refactoring, no test needed

- Add a test `UpdateDuringARequestWillCancelTheRequest`, which tests behavior that's hardcoded into the LSP library we're using, but is good to be aware of nonetheless.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
