### PR TITLE
Leave Rust testing out of quicktest.sh until a release supports it

### DIFF
--- a/Scripts/quicktest.sh
+++ b/Scripts/quicktest.sh
@@ -41,8 +41,8 @@ echo Running with Go
 $DAFNY run -t:go c.dfy | diff - $tmp || exit 1
 echo Running with Python
 $DAFNY run -t:py c.dfy | diff - $tmp || exit 1
-echo Running with Rust
-$DAFNY run -t:rs c.dfy | diff - $tmp || exit 1
+#echo Running with Rust
+#$DAFNY run -t:rs c.dfy | diff - $tmp || exit 1
 
 rm -rf c-go c-java c-py c.jar c c.dll c.exe c.js c.runtimeconfig.json
 echo "" > $tmp
@@ -65,8 +65,8 @@ $DAFNY build -t:go c.dfy | diff - $tmp || exit 1
 echo Building with Python
 $DAFNY build -t:py c.dfy | diff - $tmp || exit 1
 python c-py/c.py | diff - $tmpx || exit 1
-echo Building with Rust
-$DAFNY build -t:rs c.dfy | diff - $tmp || exit 1
+#echo Building with Rust
+#$DAFNY build -t:rs c.dfy | diff - $tmp || exit 1
 ./c.exe | diff - $tmpx || exit 1
 
 echo Quicktest script succeeded


### PR DESCRIPTION
The current setup breaks Homebrew testing that we run in every PR

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
