### PR TITLE
Turn off brew release workflow

### DIFF
--- a/.github/workflows/release-brew.yml
+++ b/.github/workflows/release-brew.yml
@@ -2,9 +2,6 @@ name: Test Brew release on Mac
 
 on:
   workflow_dispatch:
-  # This would make more sense as a scheduled build like deep-tests.yml
-  pull_request:
-    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -67,6 +67,13 @@
     and other members of the community may update the formula
     in the meantime anyway.
 
+1. Once the Homebrew formula is merged, test that it works correctly by
+   going to <https://github.com/dafny-lang/dafny/actions> and manually
+   running the "Test Brew release on Mac" workflow. It doesn't matter
+   what branch you run it on because it won't actually check out the
+   code. It will just install Dafny from Homebrew and run it on some
+   examples.
+
 If something goes wrong with the `prepare` step:
 
 - Remove the release commit (`git reset --hard HEAD~1`)


### PR DESCRIPTION
Stop testing something installed by brew on our PR builds.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
