### PR TITLE
Fix MSBuild issues by removing the duplicate DafnyRuntime reference

### DIFF
--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -754,7 +754,6 @@ namespace Microsoft.Dafny.Compilers {
         switch (e) {
           case CharLiteralExpr:
             throw new NotImplementedException();
-            break;
           case StringLiteralExpr str:
             builder.Builder.AddExpr((DAST.Expression)DAST.Expression.create_Literal(DAST.Literal.create_StringLiteral(
               Sequence<Rune>.UnicodeFromString(str.AsStringLiteral())
@@ -762,12 +761,10 @@ namespace Microsoft.Dafny.Compilers {
             break;
           case StaticReceiverExpr:
             throw new NotImplementedException();
-            break;
           default:
             switch (e.Value) {
               case null:
                 throw new NotImplementedException();
-                break;
               case bool value:
                 builder.Builder.AddExpr((DAST.Expression)DAST.Expression.create_Literal(DAST.Literal.create_BoolLiteral(value)));
                 break;

--- a/Source/DafnyPipeline/DafnyPipeline.csproj
+++ b/Source/DafnyPipeline/DafnyPipeline.csproj
@@ -23,16 +23,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\DafnyCore\DafnyCore.csproj" />
-    <ProjectReference Include="..\DafnyRuntime\DafnyRuntime.csproj">
-      <!-- 
-      This reference is just to ensure that DafnyRuntime is built before this package,
-      so that each runtime artifact is built and can be embedded,
-      but we don't actually want to have a dependency on DafnyRuntime.dll.
-      In the long term we should not even embed each runtime here and should
-      fetch them as published artifacts through nuget/maven/npm/etc.
-      -->
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
   </ItemGroup>
 
   <!-- 


### PR DESCRIPTION
Fixes "GetTargetPath" target not found issue when building in Rider, and likely also the nightly build.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
