### PR TITLE
Fix clone of module export decl

### DIFF
--- a/Source/DafnyCore/AST/Modules/ModuleExportDecl.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleExportDecl.cs
@@ -30,6 +30,7 @@ public class ModuleExportDecl : ModuleDecl, ICanFormat {
     ProvideAll = original.ProvideAll;
     RevealAll = original.RevealAll;
     IsRefining = original.IsRefining;
+    IsDefault = original.IsDefault;
     ThisScope = new VisibilityScope(FullSanitizedName);
   }
 

--- a/docs/dev/news/fix.4328
+++ b/docs/dev/news/fix.4328
@@ -1,0 +1,1 @@
+Fix issue that would prevent the IDE from correctly handling default export sets


### PR DESCRIPTION
Fixes #4328

### Changes
Fix clone method of ModuleExportDecl

### Testing
We should run part of the testsuite using the IDE instead of the CLI, since the IDE runs additional code (caching code, which currently uses cloning, which isn't tested well)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
