### PR TITLE
Use reference counting when compiling datatypes to Rust

### DIFF
--- a/Source/DafnyCore/Compilers/Dafny/AST.dfy
+++ b/Source/DafnyCore/Compilers/Dafny/AST.dfy
@@ -7,7 +7,7 @@ module {:extern "DAST"} DAST {
 
   datatype Type = Path(seq<Ident>, typeArgs: seq<Type>, resolved: ResolvedType) | Tuple(seq<Type>) | Passthrough(string) | TypeArg(Ident)
 
-  datatype ResolvedType = Datatype(path: seq<Ident>) | Primitive
+  datatype ResolvedType = Datatype(path: seq<Ident>) | Newtype
 
   datatype Ident = Ident(id: string)
 

--- a/Source/DafnyCore/Compilers/Dafny/AST.dfy
+++ b/Source/DafnyCore/Compilers/Dafny/AST.dfy
@@ -5,13 +5,15 @@ module {:extern "DAST"} DAST {
 
   datatype Newtype = Newtype(name: string, base: Type)
 
-  datatype Type = Path(seq<Ident>) | Tuple(seq<Type>) | Passthrough(string) | TypeArg(Ident)
+  datatype Type = Path(seq<Ident>, typeArgs: seq<Type>, resolved: ResolvedType) | Tuple(seq<Type>) | Passthrough(string) | TypeArg(Ident)
+
+  datatype ResolvedType = Datatype(path: seq<Ident>) | Primitive
 
   datatype Ident = Ident(id: string)
 
   datatype Class = Class(name: string, body: seq<ClassItem>)
 
-  datatype Datatype = Datatype(name: string, enclosingModule: Ident, ctors: seq<DatatypeCtor>, body: seq<ClassItem>)
+  datatype Datatype = Datatype(name: string, enclosingModule: Ident, typeParams: seq<Type>, ctors: seq<DatatypeCtor>, body: seq<ClassItem>)
 
   datatype DatatypeCtor = DatatypeCtor(name: string, args: seq<Formal>, hasAnyArgs: bool /* includes ghost */)
 
@@ -35,14 +37,14 @@ module {:extern "DAST"} DAST {
   datatype Expression =
     Literal(Literal) |
     Ident(string) |
-    Companion(Type) |
+    Companion(seq<Ident>) |
     Tuple(seq<Expression>) |
-    DatatypeValue(typ: Type, variant: string, contents: seq<(string, Expression)>) |
+    DatatypeValue(path: seq<Ident>, variant: string, contents: seq<(string, Expression)>) |
     BinOp(op: string, left: Expression, right: Expression) |
     Select(expr: Expression, field: string, onDatatype: bool) |
     TupleSelect(expr: Expression, index: nat) |
     Call(on: Expression, name: string, typeArgs: seq<Type>, args: seq<Expression>) |
-    TypeTest(on: Expression, dType: Type, variant: string) |
+    TypeTest(on: Expression, dType: seq<Ident>, variant: string) |
     InitializationValue(typ: Type)
 
   datatype Literal = BoolLiteral(bool) | IntLiteral(int) | DecLiteral(string) | StringLiteral(string)

--- a/Source/DafnyCore/Compilers/Dafny/ASTBuilder.cs
+++ b/Source/DafnyCore/Compilers/Dafny/ASTBuilder.cs
@@ -125,8 +125,8 @@ namespace Microsoft.Dafny.Compilers {
   interface DatatypeContainer {
     void AddDatatype(Datatype item);
 
-    public DatatypeBuilder Datatype(string name, ISequence<Rune> enclosingModule, List<DAST.DatatypeCtor> ctors) {
-      return new DatatypeBuilder(this, name, enclosingModule, ctors);
+    public DatatypeBuilder Datatype(string name, ISequence<Rune> enclosingModule, List<DAST.Type> typeParams, List<DAST.DatatypeCtor> ctors) {
+      return new DatatypeBuilder(this, name, enclosingModule, typeParams, ctors);
     }
   }
 
@@ -134,12 +134,14 @@ namespace Microsoft.Dafny.Compilers {
     readonly DatatypeContainer parent;
     readonly string name;
     readonly ISequence<Rune> enclosingModule;
+    readonly List<DAST.Type> typeParams;
     readonly List<DAST.DatatypeCtor> ctors;
     readonly List<ClassItem> body = new();
 
-    public DatatypeBuilder(DatatypeContainer parent, string name, ISequence<Rune> enclosingModule, List<DAST.DatatypeCtor> ctors) {
+    public DatatypeBuilder(DatatypeContainer parent, string name, ISequence<Rune> enclosingModule, List<DAST.Type> typeParams, List<DAST.DatatypeCtor> ctors) {
       this.parent = parent;
       this.name = name;
+      this.typeParams = typeParams;
       this.enclosingModule = enclosingModule;
       this.ctors = ctors;
     }
@@ -156,6 +158,7 @@ namespace Microsoft.Dafny.Compilers {
       parent.AddDatatype((Datatype)Datatype.create(
         Sequence<Rune>.UnicodeFromString(this.name),
         this.enclosingModule,
+        Sequence<DAST.Type>.FromArray(typeParams.ToArray()),
         Sequence<DAST.DatatypeCtor>.FromArray(ctors.ToArray()),
         Sequence<ClassItem>.FromArray(body.ToArray())
       ));

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -861,10 +861,10 @@ namespace Microsoft.Dafny.Compilers {
 
       ResolvedType resolvedType;
       if (topLevel is NewtypeDecl) {
-        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Primitive();
+        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Newtype();
       } else if (topLevel is TraitDecl) {
         // TODO(shadaj): have a separate type when we properly support traits
-        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Primitive();
+        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Newtype();
       } else if (topLevel is DatatypeDecl) {
         resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Datatype(path);
       } else if (topLevel is ClassDecl) {

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -166,6 +166,11 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override IClassWriter DeclareDatatype(DatatypeDecl dt, ConcreteSyntaxTree wr) {
       if (currentBuilder is DatatypeContainer builder) {
+        List<DAST.Type> typeParams = new();
+        foreach (var tp in dt.TypeArgs) {
+          typeParams.Add((DAST.Type)DAST.Type.create_TypeArg(Sequence<Rune>.UnicodeFromString(IdProtect(tp.GetCompileName(Options)))));
+        }
+
         List<DAST.DatatypeCtor> ctors = new();
         foreach (var ctor in dt.Ctors) {
           List<DAST.Formal> args = new();
@@ -177,7 +182,7 @@ namespace Microsoft.Dafny.Compilers {
           ctors.Add((DAST.DatatypeCtor)DAST.DatatypeCtor.create_DatatypeCtor(Sequence<Rune>.UnicodeFromString(ctor.GetCompileName(Options)), Sequence<DAST.Formal>.FromArray(args.ToArray()), ctor.Formals.Count > 0));
         }
 
-        return new ClassWriter(this, builder.Datatype(dt.GetCompileName(Options), Sequence<Rune>.UnicodeFromString(dt.EnclosingModuleDefinition.GetCompileName(Options)), ctors));
+        return new ClassWriter(this, builder.Datatype(dt.GetCompileName(Options), Sequence<Rune>.UnicodeFromString(dt.EnclosingModuleDefinition.GetCompileName(Options)), typeParams, ctors));
       } else {
         throw new InvalidOperationException("Cannot declare datatype outside of a module: " + currentBuilder);
       }
@@ -213,12 +218,12 @@ namespace Microsoft.Dafny.Compilers {
         return (DAST.Type)(AsNativeType(typ).Sel switch {
           NativeType.Selection.Byte => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u8")),
           NativeType.Selection.SByte => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i8")),
-          NativeType.Selection.Short => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u16")),
-          NativeType.Selection.UShort => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i16")),
-          NativeType.Selection.Int => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u32")),
-          NativeType.Selection.UInt => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i32")),
-          NativeType.Selection.Long => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u64")),
-          NativeType.Selection.ULong => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i64")),
+          NativeType.Selection.Short => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i16")),
+          NativeType.Selection.UShort => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u16")),
+          NativeType.Selection.Int => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i32")),
+          NativeType.Selection.UInt => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u32")),
+          NativeType.Selection.Long => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("i64")),
+          NativeType.Selection.ULong => DAST.Type.create_Passthrough(Sequence<Rune>.UnicodeFromString("u64")),
           _ => throw new InvalidOperationException(),
         });
       } else {
@@ -423,10 +428,10 @@ namespace Microsoft.Dafny.Compilers {
 
       if (type.NormalizeExpandKeepConstraints() is UserDefinedType udt && udt.ResolvedClass is DatatypeDecl dt &&
           DatatypeWrapperEraser.IsErasableDatatypeWrapper(Options, dt, out _)) {
-        actualBuilder.AddExpr((DAST.Expression)DAST.Expression.create_Companion(FullTypeNameAST(udt, member)));
+        actualBuilder.AddExpr((DAST.Expression)DAST.Expression.create_Companion(PathFromTopLevel(udt.ResolvedClass)));
         return "";
       } else {
-        actualBuilder.AddExpr((DAST.Expression)DAST.Expression.create_Companion(GenType(type)));
+        actualBuilder.AddExpr((DAST.Expression)DAST.Expression.create_Companion(PathFromTopLevel(type.AsTopLevelTypeWithMembers)));
         return "";
       }
     }
@@ -644,7 +649,7 @@ namespace Microsoft.Dafny.Compilers {
       throw new NotImplementedException();
     }
 
-    private IfElseBuilder builderForElse = null;
+    private ElseBuilder builderForElse = null;
 
     protected override ConcreteSyntaxTree EmitIf(out ConcreteSyntaxTree guardWriter, bool hasElse, ConcreteSyntaxTree wr) {
       if (builderForElse != null) { // else-if
@@ -652,7 +657,7 @@ namespace Microsoft.Dafny.Compilers {
         builderForElse = null;
 
         if (hasElse) {
-          builderForElse = ifBuilder;
+          builderForElse = ifBuilder.Else();
         }
 
         guardWriter = new BuilderSyntaxTree<ExprContainer>(ifBuilder);
@@ -660,7 +665,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (wr is BuilderSyntaxTree<StatementContainer> statementContainer) {
         var ifBuilder = statementContainer.Builder.IfElse();
         if (hasElse) {
-          builderForElse = ifBuilder;
+          builderForElse = ifBuilder.Else();
         }
 
         guardWriter = new BuilderSyntaxTree<ExprContainer>(ifBuilder);
@@ -672,7 +677,7 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override ConcreteSyntaxTree EmitBlock(ConcreteSyntaxTree wr) {
       if (builderForElse != null) {
-        var ret = new BuilderSyntaxTree<StatementContainer>(builderForElse.Else());
+        var ret = new BuilderSyntaxTree<StatementContainer>(builderForElse);
         builderForElse = null;
         return ret;
       } else {
@@ -840,15 +845,40 @@ namespace Microsoft.Dafny.Compilers {
             udt.TypeArgs.Select(m => GenType(m)).ToArray()
           ));
         default:
-          return TypeNameASTFromTopLevel(cl);
+          return TypeNameASTFromTopLevel(cl, udt.TypeArgs);
       }
     }
 
-    private DAST.Type TypeNameASTFromTopLevel(TopLevelDecl topLevel) {
+    private ISequence<ISequence<Rune>> PathFromTopLevel(TopLevelDecl topLevel) {
       List<ISequence<Rune>> path = new();
       path.Add(Sequence<Rune>.UnicodeFromString(topLevel.EnclosingModuleDefinition.GetCompileName(Options)));
       path.Add(Sequence<Rune>.UnicodeFromString(topLevel.GetCompileName(Options)));
-      return (DAST.Type)DAST.Type.create_Path(Sequence<ISequence<Rune>>.FromArray(path.ToArray()));
+      return Sequence<ISequence<Rune>>.FromArray(path.ToArray());
+    }
+
+    private DAST.Type TypeNameASTFromTopLevel(TopLevelDecl topLevel, List<Type> typeArgs) {
+      var path = PathFromTopLevel(topLevel);
+
+      ResolvedType resolvedType;
+      if (topLevel is NewtypeDecl) {
+        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Primitive();
+      } else if (topLevel is TraitDecl) {
+        // TODO(shadaj): have a separate type when we properly support traits
+        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Primitive();
+      } else if (topLevel is DatatypeDecl) {
+        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Datatype(path);
+      } else if (topLevel is ClassDecl) {
+        // TODO(shadaj): have a separate type when we properly support classes
+        resolvedType = (DAST.ResolvedType)DAST.ResolvedType.create_Datatype(path);
+      } else {
+        throw new InvalidOperationException(topLevel.GetType().ToString());
+      }
+
+      return (DAST.Type)DAST.Type.create_Path(
+        path,
+        Sequence<DAST.Type>.FromArray(typeArgs.Select(m => GenType(m)).ToArray()),
+        resolvedType
+      );
     }
 
     public override ConcreteSyntaxTree Expr(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wStmts) {
@@ -920,9 +950,9 @@ namespace Microsoft.Dafny.Compilers {
             Sequence<DAST.Expression>.FromArray(namedContents.Select(x => x.dtor__1).ToArray())
           ));
         } else {
-          DAST.Type datatypeType = TypeNameASTFromTopLevel(dtv.Ctor.EnclosingDatatype);
+          var dtPath = PathFromTopLevel(dtv.Ctor.EnclosingDatatype);
           builder.Builder.AddExpr((DAST.Expression)DAST.Expression.create_DatatypeValue(
-            datatypeType,
+            dtPath,
             Sequence<Rune>.UnicodeFromString(dtv.Ctor.GetCompileName(Options)),
             Sequence<_System._ITuple2<ISequence<Rune>, DAST.Expression>>.FromArray(namedContents.ToArray())
           ));
@@ -982,7 +1012,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (member is SpecialField sf2 && sf2.SpecialId == SpecialField.ID.UseIdParam && sf2.IdParam is string fieldName && fieldName.StartsWith("is_")) {
         return new ExprLvalue((DAST.Expression)DAST.Expression.create_TypeTest(
           objExpr,
-          GenType(objType),
+          PathFromTopLevel(objType.AsTopLevelTypeWithMembers),
           Sequence<Rune>.UnicodeFromString(fieldName.Substring(3))
         ));
       } else {

--- a/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
@@ -54,6 +54,19 @@ module {:extern "DCOMP"} DCOMP {
     }
 
     static method GenDatatype(c: Datatype) returns (s: string) {
+      var typeParams := "";
+      var tpI := 0;
+      if |c.typeParams| > 0 {
+        typeParams := "<";
+        while tpI < |c.typeParams| {
+          var tp := c.typeParams[tpI];
+          var genTp := GenType(tp);
+          typeParams := typeParams + "r#" + genTp + ", ";
+          tpI := tpI + 1;
+        }
+        typeParams := typeParams + ">";
+      }
+
       var ctors := "";
       var i := 0;
       while i < |c.ctors| {
@@ -115,7 +128,7 @@ module {:extern "DCOMP"} DCOMP {
 
             methodBody := methodBody + "}\n";
 
-            implBody := implBody + "pub fn " + formal.name + "(&self) -> &" + formalType + " {\n" + methodBody + "}\n";
+            implBody := implBody + "pub fn r#" + formal.name + "(&self) -> &" + formalType + " {\n" + methodBody + "}\n";
           }
           j := j + 1;
         }
@@ -123,9 +136,26 @@ module {:extern "DCOMP"} DCOMP {
         i := i + 1;
       }
 
-      var enumBody := "#[derive(Clone, PartialEq)]\npub enum r#" + c.name + " {\n" + ctors +  "\n}" + "\n" + "impl r#" + c.name + " {\n" + implBody + "\n}";
+      var constrainedTypeParams := "";
+      if |c.typeParams| > 0 {
+        tpI := 0;
+        constrainedTypeParams := "<";
+        while tpI < |c.typeParams| {
+          if tpI > 0 {
+            constrainedTypeParams := constrainedTypeParams + ", ";
+          }
 
-      var printImpl := "impl ::dafny_runtime::DafnyPrint for r#" + c.name + " {\n" + "fn fmt_print(&self, f: &mut ::std::fmt::Formatter) -> std::fmt::Result {\n" + "match self {\n";
+          var tp := c.typeParams[tpI];
+          var genTp := GenType(tp);
+          constrainedTypeParams := constrainedTypeParams + "r#" + genTp + ": Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default";
+          tpI := tpI + 1;
+        }
+        constrainedTypeParams := constrainedTypeParams + ">";
+      }
+
+      var enumBody := "#[derive(Clone, PartialEq)]\npub enum r#" + c.name + typeParams + " {\n" + ctors +  "\n}" + "\n" + "impl " + constrainedTypeParams + " r#" + c.name + typeParams + " {\n" + implBody + "\n}";
+
+      var printImpl := "impl " + constrainedTypeParams + " ::dafny_runtime::DafnyPrint for r#" + c.name + typeParams + " {\n" + "fn fmt_print(&self, f: &mut ::std::fmt::Formatter) -> std::fmt::Result {\n" + "match self {\n";
       i := 0;
       while i < |c.ctors| {
         var ctor := c.ctors[i];
@@ -163,11 +193,11 @@ module {:extern "DCOMP"} DCOMP {
 
       var defaultImpl := "";
       if |c.ctors| > 0 {
-        defaultImpl := "impl Default for r#" + c.name + " {\n" + "fn default() -> Self {\n" + "r#" + c.name + "::r#" + c.ctors[0].name + " {\n";
+        defaultImpl := "impl " + constrainedTypeParams + " ::std::default::Default for r#" + c.name + typeParams + " {\n" + "fn default() -> Self {\n" + "r#" + c.name + "::r#" + c.ctors[0].name + " {\n";
         i := 0;
         while i < |c.ctors[0].args| {
           var formal := c.ctors[0].args[i];
-          defaultImpl := defaultImpl + formal.name + ": Default::default(),\n";
+          defaultImpl := defaultImpl + formal.name + ": std::default::Default::default(),\n";
           i := i + 1;
         }
 
@@ -177,19 +207,45 @@ module {:extern "DCOMP"} DCOMP {
       s := enumBody + "\n" + printImpl + "\n" + defaultImpl;
     }
 
+    static method GenPath(p: seq<Ident>) returns (s: string) {
+      s := "super::";
+      var i := 0;
+      while i < |p| {
+        if i > 0 {
+          s := s + "::";
+        }
+
+        s := s + "r#" + p[i].id;
+
+        i := i + 1;
+      }
+    }
+
     static method GenType(c: Type) returns (s: string) {
       match c {
-        case Path(p) => {
-          s := "super::";
-          var i := 0;
-          while i < |p| {
-            if i > 0 {
-              s := s + "::";
+        case Path(p, args, resolved) => {
+          s := GenPath(p);
+
+          if |args| > 0 {
+            s := s + "<";
+            var i := 0;
+            while i < |args| {
+              if i > 0 {
+                s := s + ", ";
+              }
+
+              var genTp := GenType(args[i]);
+              s := s + genTp;
+              i := i + 1;
             }
+            s := s + ">";
+          }
 
-            s := s + "r#" + p[i].id;
-
-            i := i + 1;
+          match resolved {
+            case Datatype(_) => {
+              s := "::std::rc::Rc<" + s + ">";
+            }
+            case Primitive => {}
           }
         }
         case Tuple(types) => {
@@ -237,7 +293,7 @@ module {:extern "DCOMP"} DCOMP {
       while i < |params| {
         var param := params[i];
         var paramType := GenType(param.typ);
-        s := s + "r#" + param.name + ": " + paramType;
+        s := s + "r#" + param.name + ": &" + paramType;
 
         if i < |params| - 1 {
           s := s + ", ";
@@ -249,6 +305,13 @@ module {:extern "DCOMP"} DCOMP {
 
     static method GenMethod(m: Method) returns (s: string) {
       var params := GenParams(m.params);
+      var paramNames := {};
+      var paramI := 0;
+      while paramI < |m.params| {
+        paramNames := paramNames + {m.params[paramI].name};
+        paramI := paramI + 1;
+      }
+
       if (!m.isStatic) {
         params := "&self, " + params;
       }
@@ -283,7 +346,7 @@ module {:extern "DCOMP"} DCOMP {
           }
 
           var typeString := GenType(m.typeParams[i]);
-          s := s + typeString + ": std::default::Default";
+          s := s + typeString + ": Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default";
 
           i := i + 1;
         }
@@ -311,7 +374,7 @@ module {:extern "DCOMP"} DCOMP {
         case None => {}
       }
 
-      var body := GenStmts(m.body, earlyReturn);
+      var body := GenStmts(m.body, paramNames, earlyReturn);
       match m.outVars {
         case Some(outVars) => {
           body := body + "\n" + earlyReturn;
@@ -322,12 +385,12 @@ module {:extern "DCOMP"} DCOMP {
       s := s + "(" + params + ") -> " + retType + " {\n" + body + "\n}\n";
     }
 
-    static method GenStmts(stmts: seq<Statement>, earlyReturn: string) returns (generated: string) {
+    static method GenStmts(stmts: seq<Statement>, params: set<string>, earlyReturn: string) returns (generated: string) {
       generated := "";
       var i := 0;
       while i < |stmts| {
         var stmt := stmts[i];
-        var stmtString := GenStmt(stmt, earlyReturn);
+        var stmtString := GenStmt(stmt, params, earlyReturn);
 
         if i > 0 {
           generated := generated + "\n";
@@ -338,10 +401,10 @@ module {:extern "DCOMP"} DCOMP {
       }
     }
 
-    static method GenStmt(stmt: Statement, earlyReturn: string) returns (generated: string) {
+    static method GenStmt(stmt: Statement, params: set<string>, earlyReturn: string) returns (generated: string) {
       match stmt {
         case DeclareVar(name, typ, Some(expression)) => {
-          var expr := GenExpr(expression);
+          var expr, _ := GenExpr(expression, params, true);
           var typeString := GenType(typ);
           generated := "let mut r#" + name + ": " + typeString + " = " + expr + ";";
         }
@@ -350,13 +413,13 @@ module {:extern "DCOMP"} DCOMP {
           generated := "let mut r#" + name + ": " + typeString + ";";
         }
         case Assign(name, expression) => {
-          var expr := GenExpr(expression);
+          var expr, _ := GenExpr(expression, params, true);
           generated := "r#" + name + " = " + expr + ";";
         }
         case If(cond, thn, els) => {
-          var condString := GenExpr(cond);
-          var thnString := GenStmts(thn, earlyReturn);
-          var elsString := GenStmts(els, earlyReturn);
+          var condString, _ := GenExpr(cond, params, true);
+          var thnString := GenStmts(thn, params, earlyReturn);
+          var elsString := GenStmts(els, params, earlyReturn);
           generated := "if " + condString + " {\n" + thnString + "\n} else {\n" + elsString + "\n}";
         }
         case Call(on, name, typeArgs, args, maybeOutVars) => {
@@ -384,19 +447,19 @@ module {:extern "DCOMP"} DCOMP {
               argString := argString + ", ";
             }
 
-            var argExpr := GenExpr(args[i]);
-            argString := argString + argExpr;
+            var argExpr, isOwned := GenExpr(args[i], params, false);
+            argString := argString + (if isOwned then "&" else "") + argExpr;
 
             i := i + 1;
           }
 
-          var enclosingString := GenExpr(on);
+          var enclosingString, _ := GenExpr(on, params, true);
           match on {
             case Companion(_) => {
               enclosingString := enclosingString + "::";
             }
             case _ => {
-              enclosingString := enclosingString + ".";
+              enclosingString := "(" + enclosingString + ").";
             }
           }
 
@@ -429,26 +492,28 @@ module {:extern "DCOMP"} DCOMP {
             enclosingString + "r#" + name + typeArgString + "(" + argString + ");";
         }
         case Return(expr) => {
-          var exprString := GenExpr(expr);
+          var exprString, _ := GenExpr(expr, params, true);
           generated := "return " + exprString + ";";
         }
         case EarlyReturn() => {
           generated := earlyReturn;
         }
         case Print(e) => {
-          var printedExpr := GenExpr(e);
-          generated := "print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper(&" + printedExpr + "));";
+          var printedExpr, isOwned := GenExpr(e, params, false);
+          generated := "print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper(" + (if isOwned then "&" else "") + printedExpr + "));";
         }
       }
     }
 
-    static method GenExpr(e: Expression) returns (s: string) {
+    static method GenExpr(e: Expression, params: set<string>, mustOwn: bool) returns (s: string, isOwned: bool) {
       match e {
         case Literal(BoolLiteral(false)) => {
           s := "false";
+          isOwned := true;
         }
         case Literal(BoolLiteral(true)) => {
           s := "true";
+          isOwned := true;
         }
         case Literal(IntLiteral(i)) => {
           if (i < 0) {
@@ -456,23 +521,45 @@ module {:extern "DCOMP"} DCOMP {
           } else {
             s := natToString(i);
           }
+
+          isOwned := true;
         }
         case Literal(DecLiteral(l)) => {
-          // TODO(shadaj): handle unicode properly
           s := l;
+          isOwned := true;
         }
         case Literal(StringLiteral(l)) => {
           // TODO(shadaj): handle unicode properly
           s := "\"" + l + "\"";
+          isOwned := true;
         }
         case Ident(name) => {
           s := "r#" + name;
+
+          if name in params {
+            if mustOwn {
+              s := s + ".clone()";
+              isOwned := true;
+            } else {
+              isOwned := false;
+            }
+          } else {
+            if mustOwn {
+              s := s + ".clone()";
+              isOwned := true;
+            } else {
+              s := "&" + s;
+              isOwned := false;
+            }
+          }
         }
-        case Companion(typ) => {
-          s := GenType(typ);
+        case Companion(path) => {
+          s := GenPath(path);
+          isOwned := true;
         }
         case InitializationValue(typ) => {
           s := "std::default::Default::default()";
+          isOwned := true;
         }
         case Tuple(values) => {
           s := "(";
@@ -482,16 +569,17 @@ module {:extern "DCOMP"} DCOMP {
               s := s + " ";
             }
 
-            var recursiveGen := GenExpr(values[i]);
+            var recursiveGen, _ := GenExpr(values[i], params, true);
             s := s + recursiveGen + ",";
 
             i := i + 1;
           }
           s := s + ")";
+          isOwned := true;
         }
-        case DatatypeValue(typ, variant, values) => {
-          s := GenType(typ);
-          s := s + "::r#" + variant;
+        case DatatypeValue(path, variant, values) => {
+          var path := GenPath(path);
+          s := "::std::rc::Rc::new(" + path + "::r#" + variant;
 
           var i := 0;
           s := s + " {";
@@ -500,29 +588,49 @@ module {:extern "DCOMP"} DCOMP {
             if i > 0 {
               s := s + ", ";
             }
-            var recursiveGen := GenExpr(value);
+            var recursiveGen, _ := GenExpr(value, params, true);
             s := s + "r#" + name + ": " + recursiveGen;
             i := i + 1;
           }
-          s := s + " }";
+          s := s + " })";
+          isOwned := true;
         }
         case BinOp(op, l, r) => {
-          var left := GenExpr(l);
-          var right := GenExpr(r);
+          var left, _ := GenExpr(l, params, true);
+          var right, _ := GenExpr(r, params, true);
           s := "(" + left + " " + op + " " + right + ")";
+          isOwned := true;
         }
         case Select(on, field, isDatatype) => {
-          var onString := GenExpr(on);
+          var onString, _ := GenExpr(on, params, false);
 
           if isDatatype {
-            s := onString + ".r#" + field + "().clone()";
+            s := "(" + onString + ")" + ".r#" + field + "()";
+            if mustOwn {
+              s := "(" + s + ").clone()";
+              isOwned := true;
+            } else {
+              isOwned := false;
+            }
           } else {
-            s := onString + ".r#" + field + ".clone()";
+            s := "(" + onString + ")" + ".r#" + field;
+            if mustOwn {
+              s := "(" + s + ").clone()";
+              isOwned := true;
+            } else {
+              isOwned := false;
+            }
           }
         }
         case TupleSelect(on, idx) => {
-          var onString := GenExpr(on);
-          s := onString + "." + natToString(idx) + ".clone()";
+          var onString, _ := GenExpr(on, params, false);
+          s := onString + "." + natToString(idx);
+          if mustOwn {
+            s := s + ".clone()";
+            isOwned := true;
+          } else {
+            isOwned := false;
+          }
         }
         case Call(on, name, typeArgs, args) => {
           var typeArgString := "";
@@ -549,28 +657,30 @@ module {:extern "DCOMP"} DCOMP {
               argString := argString + ", ";
             }
 
-            var argExpr := GenExpr(args[i]);
-            argString := argString + argExpr;
+            var argExpr, isOwned := GenExpr(args[i], params, false);
+            argString := argString + (if isOwned then "&" else "") + argExpr;
 
             i := i + 1;
           }
 
-          var enclosingString := GenExpr(on);
+          var enclosingString, _ := GenExpr(on, params, false);
           match on {
             case Companion(_) => {
               enclosingString := enclosingString + "::";
             }
             case _ => {
-              enclosingString := enclosingString + ".";
+              enclosingString := "(" + enclosingString + ").";
             }
           }
 
           s := enclosingString + "r#" + name + typeArgString + "(" + argString + ")";
+          isOwned := true;
         }
         case TypeTest(on, dType, variant) => {
-          var exprGen := GenExpr(on);
-          var typeGen := GenType(dType);
-          s := "matches!(" + exprGen + ", " + typeGen + "::r#" + variant + "{ .. })";
+          var exprGen, _ := GenExpr(on, params, false);
+          var dTypePath := GenPath(dType);
+          s := "matches!(" + exprGen + ".as_ref(), " + dTypePath + "::r#" + variant + "{ .. })";
+          isOwned := true;
         }
       }
     }

--- a/Source/DafnyCore/GeneratedFromDafnyRust.cs
+++ b/Source/DafnyCore/GeneratedFromDafnyRust.cs
@@ -318,6 +318,8 @@ namespace DAST {
     bool is_Passthrough { get; }
     bool is_TypeArg { get; }
     Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_Path_a0 { get; }
+    Dafny.ISequence<DAST._IType> dtor_typeArgs { get; }
+    DAST._IResolvedType dtor_resolved { get; }
     Dafny.ISequence<DAST._IType> dtor_Tuple_a0 { get; }
     Dafny.ISequence<Dafny.Rune> dtor_Passthrough_a0 { get; }
     Dafny.ISequence<Dafny.Rune> dtor_TypeArg_a0 { get; }
@@ -326,7 +328,7 @@ namespace DAST {
   public abstract class Type : _IType {
     public Type() {
     }
-    private static readonly DAST._IType theDefault = create_Path(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Empty);
+    private static readonly DAST._IType theDefault = create_Path(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Empty, Dafny.Sequence<DAST._IType>.Empty, DAST.ResolvedType.Default());
     public static DAST._IType Default() {
       return theDefault;
     }
@@ -334,8 +336,8 @@ namespace DAST {
     public static Dafny.TypeDescriptor<DAST._IType> _TypeDescriptor() {
       return _TYPE;
     }
-    public static _IType create_Path(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0) {
-      return new Type_Path(_a0);
+    public static _IType create_Path(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0, Dafny.ISequence<DAST._IType> typeArgs, DAST._IResolvedType resolved) {
+      return new Type_Path(_a0, typeArgs, resolved);
     }
     public static _IType create_Tuple(Dafny.ISequence<DAST._IType> _a0) {
       return new Type_Tuple(_a0);
@@ -354,6 +356,18 @@ namespace DAST {
       get {
         var d = this;
         return ((Type_Path)d)._a0;
+      }
+    }
+    public Dafny.ISequence<DAST._IType> dtor_typeArgs {
+      get {
+        var d = this;
+        return ((Type_Path)d)._typeArgs;
+      }
+    }
+    public DAST._IResolvedType dtor_resolved {
+      get {
+        var d = this;
+        return ((Type_Path)d)._resolved;
       }
     }
     public Dafny.ISequence<DAST._IType> dtor_Tuple_a0 {
@@ -378,27 +392,37 @@ namespace DAST {
   }
   public class Type_Path : Type {
     public readonly Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0;
-    public Type_Path(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0) : base() {
+    public readonly Dafny.ISequence<DAST._IType> _typeArgs;
+    public readonly DAST._IResolvedType _resolved;
+    public Type_Path(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0, Dafny.ISequence<DAST._IType> typeArgs, DAST._IResolvedType resolved) : base() {
       this._a0 = _a0;
+      this._typeArgs = typeArgs;
+      this._resolved = resolved;
     }
     public override _IType DowncastClone() {
       if (this is _IType dt) { return dt; }
-      return new Type_Path(_a0);
+      return new Type_Path(_a0, _typeArgs, _resolved);
     }
     public override bool Equals(object other) {
       var oth = other as DAST.Type_Path;
-      return oth != null && object.Equals(this._a0, oth._a0);
+      return oth != null && object.Equals(this._a0, oth._a0) && object.Equals(this._typeArgs, oth._typeArgs) && object.Equals(this._resolved, oth._resolved);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 0;
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._a0));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._typeArgs));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._resolved));
       return (int)hash;
     }
     public override string ToString() {
       string s = "DAST.Type.Path";
       s += "(";
       s += Dafny.Helpers.ToString(this._a0);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._typeArgs);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._resolved);
       s += ")";
       return s;
     }
@@ -481,6 +505,88 @@ namespace DAST {
       s += "(";
       s += Dafny.Helpers.ToString(this._a0);
       s += ")";
+      return s;
+    }
+  }
+
+  public interface _IResolvedType {
+    bool is_Datatype { get; }
+    bool is_Primitive { get; }
+    Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_path { get; }
+    _IResolvedType DowncastClone();
+  }
+  public abstract class ResolvedType : _IResolvedType {
+    public ResolvedType() {
+    }
+    private static readonly DAST._IResolvedType theDefault = create_Datatype(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Empty);
+    public static DAST._IResolvedType Default() {
+      return theDefault;
+    }
+    private static readonly Dafny.TypeDescriptor<DAST._IResolvedType> _TYPE = new Dafny.TypeDescriptor<DAST._IResolvedType>(DAST.ResolvedType.Default());
+    public static Dafny.TypeDescriptor<DAST._IResolvedType> _TypeDescriptor() {
+      return _TYPE;
+    }
+    public static _IResolvedType create_Datatype(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> path) {
+      return new ResolvedType_Datatype(path);
+    }
+    public static _IResolvedType create_Primitive() {
+      return new ResolvedType_Primitive();
+    }
+    public bool is_Datatype { get { return this is ResolvedType_Datatype; } }
+    public bool is_Primitive { get { return this is ResolvedType_Primitive; } }
+    public Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_path {
+      get {
+        var d = this;
+        return ((ResolvedType_Datatype)d)._path;
+      }
+    }
+    public abstract _IResolvedType DowncastClone();
+  }
+  public class ResolvedType_Datatype : ResolvedType {
+    public readonly Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _path;
+    public ResolvedType_Datatype(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> path) : base() {
+      this._path = path;
+    }
+    public override _IResolvedType DowncastClone() {
+      if (this is _IResolvedType dt) { return dt; }
+      return new ResolvedType_Datatype(_path);
+    }
+    public override bool Equals(object other) {
+      var oth = other as DAST.ResolvedType_Datatype;
+      return oth != null && object.Equals(this._path, oth._path);
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 0;
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._path));
+      return (int)hash;
+    }
+    public override string ToString() {
+      string s = "DAST.ResolvedType.Datatype";
+      s += "(";
+      s += Dafny.Helpers.ToString(this._path);
+      s += ")";
+      return s;
+    }
+  }
+  public class ResolvedType_Primitive : ResolvedType {
+    public ResolvedType_Primitive() : base() {
+    }
+    public override _IResolvedType DowncastClone() {
+      if (this is _IResolvedType dt) { return dt; }
+      return new ResolvedType_Primitive();
+    }
+    public override bool Equals(object other) {
+      var oth = other as DAST.ResolvedType_Primitive;
+      return oth != null;
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 1;
+      return (int)hash;
+    }
+    public override string ToString() {
+      string s = "DAST.ResolvedType.Primitive";
       return s;
     }
   }
@@ -604,6 +710,7 @@ namespace DAST {
     bool is_Datatype { get; }
     Dafny.ISequence<Dafny.Rune> dtor_name { get; }
     Dafny.ISequence<Dafny.Rune> dtor_enclosingModule { get; }
+    Dafny.ISequence<DAST._IType> dtor_typeParams { get; }
     Dafny.ISequence<DAST._IDatatypeCtor> dtor_ctors { get; }
     Dafny.ISequence<DAST._IClassItem> dtor_body { get; }
     _IDatatype DowncastClone();
@@ -611,27 +718,30 @@ namespace DAST {
   public class Datatype : _IDatatype {
     public readonly Dafny.ISequence<Dafny.Rune> _name;
     public readonly Dafny.ISequence<Dafny.Rune> _enclosingModule;
+    public readonly Dafny.ISequence<DAST._IType> _typeParams;
     public readonly Dafny.ISequence<DAST._IDatatypeCtor> _ctors;
     public readonly Dafny.ISequence<DAST._IClassItem> _body;
-    public Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body) {
+    public Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body) {
       this._name = name;
       this._enclosingModule = enclosingModule;
+      this._typeParams = typeParams;
       this._ctors = ctors;
       this._body = body;
     }
     public _IDatatype DowncastClone() {
       if (this is _IDatatype dt) { return dt; }
-      return new Datatype(_name, _enclosingModule, _ctors, _body);
+      return new Datatype(_name, _enclosingModule, _typeParams, _ctors, _body);
     }
     public override bool Equals(object other) {
       var oth = other as DAST.Datatype;
-      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._enclosingModule, oth._enclosingModule) && object.Equals(this._ctors, oth._ctors) && object.Equals(this._body, oth._body);
+      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._enclosingModule, oth._enclosingModule) && object.Equals(this._typeParams, oth._typeParams) && object.Equals(this._ctors, oth._ctors) && object.Equals(this._body, oth._body);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 0;
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._name));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._enclosingModule));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._typeParams));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._ctors));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._body));
       return (int)hash;
@@ -643,13 +753,15 @@ namespace DAST {
       s += ", ";
       s += Dafny.Helpers.ToString(this._enclosingModule);
       s += ", ";
+      s += Dafny.Helpers.ToString(this._typeParams);
+      s += ", ";
       s += Dafny.Helpers.ToString(this._ctors);
       s += ", ";
       s += Dafny.Helpers.ToString(this._body);
       s += ")";
       return s;
     }
-    private static readonly DAST._IDatatype theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IDatatypeCtor>.Empty, Dafny.Sequence<DAST._IClassItem>.Empty);
+    private static readonly DAST._IDatatype theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IDatatypeCtor>.Empty, Dafny.Sequence<DAST._IClassItem>.Empty);
     public static DAST._IDatatype Default() {
       return theDefault;
     }
@@ -657,11 +769,11 @@ namespace DAST {
     public static Dafny.TypeDescriptor<DAST._IDatatype> _TypeDescriptor() {
       return _TYPE;
     }
-    public static _IDatatype create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body) {
-      return new Datatype(name, enclosingModule, ctors, body);
+    public static _IDatatype create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body) {
+      return new Datatype(name, enclosingModule, typeParams, ctors, body);
     }
-    public static _IDatatype create_Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body) {
-      return create(name, enclosingModule, ctors, body);
+    public static _IDatatype create_Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body) {
+      return create(name, enclosingModule, typeParams, ctors, body);
     }
     public bool is_Datatype { get { return true; } }
     public Dafny.ISequence<Dafny.Rune> dtor_name {
@@ -672,6 +784,11 @@ namespace DAST {
     public Dafny.ISequence<Dafny.Rune> dtor_enclosingModule {
       get {
         return this._enclosingModule;
+      }
+    }
+    public Dafny.ISequence<DAST._IType> dtor_typeParams {
+      get {
+        return this._typeParams;
       }
     }
     public Dafny.ISequence<DAST._IDatatypeCtor> dtor_ctors {
@@ -1506,9 +1623,9 @@ namespace DAST {
     bool is_InitializationValue { get; }
     DAST._ILiteral dtor_Literal_a0 { get; }
     Dafny.ISequence<Dafny.Rune> dtor_Ident_a0 { get; }
-    DAST._IType dtor_Companion_a0 { get; }
+    Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_Companion_a0 { get; }
     Dafny.ISequence<DAST._IExpression> dtor_Tuple_a0 { get; }
-    DAST._IType dtor_typ { get; }
+    Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_path { get; }
     Dafny.ISequence<Dafny.Rune> dtor_variant { get; }
     Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> dtor_contents { get; }
     Dafny.ISequence<Dafny.Rune> dtor_op { get; }
@@ -1522,7 +1639,8 @@ namespace DAST {
     Dafny.ISequence<Dafny.Rune> dtor_name { get; }
     Dafny.ISequence<DAST._IType> dtor_typeArgs { get; }
     Dafny.ISequence<DAST._IExpression> dtor_args { get; }
-    DAST._IType dtor_dType { get; }
+    Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_dType { get; }
+    DAST._IType dtor_typ { get; }
     _IExpression DowncastClone();
   }
   public abstract class Expression : _IExpression {
@@ -1542,14 +1660,14 @@ namespace DAST {
     public static _IExpression create_Ident(Dafny.ISequence<Dafny.Rune> _a0) {
       return new Expression_Ident(_a0);
     }
-    public static _IExpression create_Companion(DAST._IType _a0) {
+    public static _IExpression create_Companion(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0) {
       return new Expression_Companion(_a0);
     }
     public static _IExpression create_Tuple(Dafny.ISequence<DAST._IExpression> _a0) {
       return new Expression_Tuple(_a0);
     }
-    public static _IExpression create_DatatypeValue(DAST._IType typ, Dafny.ISequence<Dafny.Rune> variant, Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> contents) {
-      return new Expression_DatatypeValue(typ, variant, contents);
+    public static _IExpression create_DatatypeValue(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> path, Dafny.ISequence<Dafny.Rune> variant, Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> contents) {
+      return new Expression_DatatypeValue(path, variant, contents);
     }
     public static _IExpression create_BinOp(Dafny.ISequence<Dafny.Rune> op, DAST._IExpression left, DAST._IExpression right) {
       return new Expression_BinOp(op, left, right);
@@ -1563,7 +1681,7 @@ namespace DAST {
     public static _IExpression create_Call(DAST._IExpression @on, Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeArgs, Dafny.ISequence<DAST._IExpression> args) {
       return new Expression_Call(@on, name, typeArgs, args);
     }
-    public static _IExpression create_TypeTest(DAST._IExpression @on, DAST._IType dType, Dafny.ISequence<Dafny.Rune> variant) {
+    public static _IExpression create_TypeTest(DAST._IExpression @on, Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dType, Dafny.ISequence<Dafny.Rune> variant) {
       return new Expression_TypeTest(@on, dType, variant);
     }
     public static _IExpression create_InitializationValue(DAST._IType typ) {
@@ -1592,7 +1710,7 @@ namespace DAST {
         return ((Expression_Ident)d)._a0;
       }
     }
-    public DAST._IType dtor_Companion_a0 {
+    public Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_Companion_a0 {
       get {
         var d = this;
         return ((Expression_Companion)d)._a0;
@@ -1604,11 +1722,10 @@ namespace DAST {
         return ((Expression_Tuple)d)._a0;
       }
     }
-    public DAST._IType dtor_typ {
+    public Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_path {
       get {
         var d = this;
-        if (d is Expression_DatatypeValue) { return ((Expression_DatatypeValue)d)._typ; }
-        return ((Expression_InitializationValue)d)._typ;
+        return ((Expression_DatatypeValue)d)._path;
       }
     }
     public Dafny.ISequence<Dafny.Rune> dtor_variant {
@@ -1692,10 +1809,16 @@ namespace DAST {
         return ((Expression_Call)d)._args;
       }
     }
-    public DAST._IType dtor_dType {
+    public Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_dType {
       get {
         var d = this;
         return ((Expression_TypeTest)d)._dType;
+      }
+    }
+    public DAST._IType dtor_typ {
+      get {
+        var d = this;
+        return ((Expression_InitializationValue)d)._typ;
       }
     }
     public abstract _IExpression DowncastClone();
@@ -1755,8 +1878,8 @@ namespace DAST {
     }
   }
   public class Expression_Companion : Expression {
-    public readonly DAST._IType _a0;
-    public Expression_Companion(DAST._IType _a0) : base() {
+    public readonly Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0;
+    public Expression_Companion(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _a0) : base() {
       this._a0 = _a0;
     }
     public override _IExpression DowncastClone() {
@@ -1809,26 +1932,26 @@ namespace DAST {
     }
   }
   public class Expression_DatatypeValue : Expression {
-    public readonly DAST._IType _typ;
+    public readonly Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _path;
     public readonly Dafny.ISequence<Dafny.Rune> _variant;
     public readonly Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _contents;
-    public Expression_DatatypeValue(DAST._IType typ, Dafny.ISequence<Dafny.Rune> variant, Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> contents) : base() {
-      this._typ = typ;
+    public Expression_DatatypeValue(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> path, Dafny.ISequence<Dafny.Rune> variant, Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> contents) : base() {
+      this._path = path;
       this._variant = variant;
       this._contents = contents;
     }
     public override _IExpression DowncastClone() {
       if (this is _IExpression dt) { return dt; }
-      return new Expression_DatatypeValue(_typ, _variant, _contents);
+      return new Expression_DatatypeValue(_path, _variant, _contents);
     }
     public override bool Equals(object other) {
       var oth = other as DAST.Expression_DatatypeValue;
-      return oth != null && object.Equals(this._typ, oth._typ) && object.Equals(this._variant, oth._variant) && object.Equals(this._contents, oth._contents);
+      return oth != null && object.Equals(this._path, oth._path) && object.Equals(this._variant, oth._variant) && object.Equals(this._contents, oth._contents);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 4;
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._typ));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._path));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._variant));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._contents));
       return (int)hash;
@@ -1836,7 +1959,7 @@ namespace DAST {
     public override string ToString() {
       string s = "DAST.Expression.DatatypeValue";
       s += "(";
-      s += Dafny.Helpers.ToString(this._typ);
+      s += Dafny.Helpers.ToString(this._path);
       s += ", ";
       s += this._variant.ToVerbatimString(true);
       s += ", ";
@@ -1995,9 +2118,9 @@ namespace DAST {
   }
   public class Expression_TypeTest : Expression {
     public readonly DAST._IExpression _on;
-    public readonly DAST._IType _dType;
+    public readonly Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _dType;
     public readonly Dafny.ISequence<Dafny.Rune> _variant;
-    public Expression_TypeTest(DAST._IExpression @on, DAST._IType dType, Dafny.ISequence<Dafny.Rune> variant) : base() {
+    public Expression_TypeTest(DAST._IExpression @on, Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dType, Dafny.ISequence<Dafny.Rune> variant) : base() {
       this._on = @on;
       this._dType = dType;
       this._variant = variant;
@@ -2345,189 +2468,263 @@ namespace DCOMP {
     }
     public static Dafny.ISequence<Dafny.Rune> GenDatatype(DAST._IDatatype c) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISequence<Dafny.Rune> _13_ctors;
-      _13_ctors = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _14_i;
-      _14_i = BigInteger.Zero;
-      while ((_14_i) < (new BigInteger(((c).dtor_ctors).Count))) {
-        DAST._IDatatypeCtor _15_ctor;
-        _15_ctor = ((c).dtor_ctors).Select(_14_i);
-        Dafny.ISequence<Dafny.Rune> _16_ctorBody;
-        _16_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_15_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
-        BigInteger _17_j;
-        _17_j = BigInteger.Zero;
-        while ((_17_j) < (new BigInteger(((_15_ctor).dtor_args).Count))) {
-          DAST._IFormal _18_formal;
-          _18_formal = ((_15_ctor).dtor_args).Select(_17_j);
-          Dafny.ISequence<Dafny.Rune> _19_formalType;
+      Dafny.ISequence<Dafny.Rune> _13_typeParams;
+      _13_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      BigInteger _14_tpI;
+      _14_tpI = BigInteger.Zero;
+      if ((new BigInteger(((c).dtor_typeParams).Count)).Sign == 1) {
+        _13_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
+        while ((_14_tpI) < (new BigInteger(((c).dtor_typeParams).Count))) {
+          DAST._IType _15_tp;
+          _15_tp = ((c).dtor_typeParams).Select(_14_tpI);
+          Dafny.ISequence<Dafny.Rune> _16_genTp;
           Dafny.ISequence<Dafny.Rune> _out7;
-          _out7 = DCOMP.COMP.GenType((_18_formal).dtor_typ);
-          _19_formalType = _out7;
-          _16_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_16_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_18_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _19_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-          _17_j = (_17_j) + (BigInteger.One);
+          _out7 = DCOMP.COMP.GenType(_15_tp);
+          _16_genTp = _out7;
+          _13_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_13_typeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _16_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          _14_tpI = (_14_tpI) + (BigInteger.One);
         }
-        _16_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(_16_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
-        _13_ctors = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_13_ctors, _16_ctorBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
-        _14_i = (_14_i) + (BigInteger.One);
+        _13_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(_13_typeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
-      Dafny.ISequence<Dafny.Rune> _20_implBody;
-      Dafny.ISequence<Dafny.Rune> _out8;
-      _out8 = DCOMP.COMP.GenClassImplBody((c).dtor_body);
-      _20_implBody = _out8;
-      _14_i = BigInteger.Zero;
-      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _21_emittedFields;
-      _21_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-      while ((_14_i) < (new BigInteger(((c).dtor_ctors).Count))) {
-        DAST._IDatatypeCtor _22_ctor;
-        _22_ctor = ((c).dtor_ctors).Select(_14_i);
-        BigInteger _23_j;
-        _23_j = BigInteger.Zero;
-        while ((_23_j) < (new BigInteger(((_22_ctor).dtor_args).Count))) {
-          DAST._IFormal _24_formal;
-          _24_formal = ((_22_ctor).dtor_args).Select(_23_j);
-          if (!((_21_emittedFields).Contains((_24_formal).dtor_name))) {
-            _21_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_21_emittedFields, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((_24_formal).dtor_name));
-            Dafny.ISequence<Dafny.Rune> _25_formalType;
-            Dafny.ISequence<Dafny.Rune> _out9;
-            _out9 = DCOMP.COMP.GenType((_24_formal).dtor_typ);
-            _25_formalType = _out9;
-            Dafny.ISequence<Dafny.Rune> _26_methodBody;
-            _26_methodBody = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n");
-            BigInteger _27_k;
-            _27_k = BigInteger.Zero;
-            while ((_27_k) < (new BigInteger(((c).dtor_ctors).Count))) {
-              DAST._IDatatypeCtor _28_ctor2;
-              _28_ctor2 = ((c).dtor_ctors).Select(_27_k);
-              Dafny.ISequence<Dafny.Rune> _29_ctorMatch;
-              _29_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_28_ctor2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
-              BigInteger _30_l;
-              _30_l = BigInteger.Zero;
-              bool _31_hasMatchingField;
-              _31_hasMatchingField = false;
-              while ((_30_l) < (new BigInteger(((_28_ctor2).dtor_args).Count))) {
-                DAST._IFormal _32_formal2;
-                _32_formal2 = ((_28_ctor2).dtor_args).Select(_30_l);
-                if (((_24_formal).dtor_name).Equals((_32_formal2).dtor_name)) {
-                  _31_hasMatchingField = true;
+      Dafny.ISequence<Dafny.Rune> _17_ctors;
+      _17_ctors = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      BigInteger _18_i;
+      _18_i = BigInteger.Zero;
+      while ((_18_i) < (new BigInteger(((c).dtor_ctors).Count))) {
+        DAST._IDatatypeCtor _19_ctor;
+        _19_ctor = ((c).dtor_ctors).Select(_18_i);
+        Dafny.ISequence<Dafny.Rune> _20_ctorBody;
+        _20_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_19_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
+        BigInteger _21_j;
+        _21_j = BigInteger.Zero;
+        while ((_21_j) < (new BigInteger(((_19_ctor).dtor_args).Count))) {
+          DAST._IFormal _22_formal;
+          _22_formal = ((_19_ctor).dtor_args).Select(_21_j);
+          Dafny.ISequence<Dafny.Rune> _23_formalType;
+          Dafny.ISequence<Dafny.Rune> _out8;
+          _out8 = DCOMP.COMP.GenType((_22_formal).dtor_typ);
+          _23_formalType = _out8;
+          _20_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_20_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_22_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _23_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          _21_j = (_21_j) + (BigInteger.One);
+        }
+        _20_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(_20_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
+        _17_ctors = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_17_ctors, _20_ctorBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
+        _18_i = (_18_i) + (BigInteger.One);
+      }
+      Dafny.ISequence<Dafny.Rune> _24_implBody;
+      Dafny.ISequence<Dafny.Rune> _out9;
+      _out9 = DCOMP.COMP.GenClassImplBody((c).dtor_body);
+      _24_implBody = _out9;
+      _18_i = BigInteger.Zero;
+      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _25_emittedFields;
+      _25_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+      while ((_18_i) < (new BigInteger(((c).dtor_ctors).Count))) {
+        DAST._IDatatypeCtor _26_ctor;
+        _26_ctor = ((c).dtor_ctors).Select(_18_i);
+        BigInteger _27_j;
+        _27_j = BigInteger.Zero;
+        while ((_27_j) < (new BigInteger(((_26_ctor).dtor_args).Count))) {
+          DAST._IFormal _28_formal;
+          _28_formal = ((_26_ctor).dtor_args).Select(_27_j);
+          if (!((_25_emittedFields).Contains((_28_formal).dtor_name))) {
+            _25_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_25_emittedFields, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((_28_formal).dtor_name));
+            Dafny.ISequence<Dafny.Rune> _29_formalType;
+            Dafny.ISequence<Dafny.Rune> _out10;
+            _out10 = DCOMP.COMP.GenType((_28_formal).dtor_typ);
+            _29_formalType = _out10;
+            Dafny.ISequence<Dafny.Rune> _30_methodBody;
+            _30_methodBody = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n");
+            BigInteger _31_k;
+            _31_k = BigInteger.Zero;
+            while ((_31_k) < (new BigInteger(((c).dtor_ctors).Count))) {
+              DAST._IDatatypeCtor _32_ctor2;
+              _32_ctor2 = ((c).dtor_ctors).Select(_31_k);
+              Dafny.ISequence<Dafny.Rune> _33_ctorMatch;
+              _33_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_32_ctor2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
+              BigInteger _34_l;
+              _34_l = BigInteger.Zero;
+              bool _35_hasMatchingField;
+              _35_hasMatchingField = false;
+              while ((_34_l) < (new BigInteger(((_32_ctor2).dtor_args).Count))) {
+                DAST._IFormal _36_formal2;
+                _36_formal2 = ((_32_ctor2).dtor_args).Select(_34_l);
+                if (((_28_formal).dtor_name).Equals((_36_formal2).dtor_name)) {
+                  _35_hasMatchingField = true;
                 }
-                _29_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_29_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_32_formal2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-                _30_l = (_30_l) + (BigInteger.One);
+                _33_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_33_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_36_formal2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+                _34_l = (_34_l) + (BigInteger.One);
               }
-              if (_31_hasMatchingField) {
-                _29_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_29_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => ")), (_24_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
+              if (_35_hasMatchingField) {
+                _33_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_33_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => ")), (_28_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
               } else {
-                _29_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_29_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => panic!(\"field does not exist on this variant\"),\n"));
+                _33_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_33_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => panic!(\"field does not exist on this variant\"),\n"));
               }
-              _26_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_26_methodBody, _29_ctorMatch);
-              _27_k = (_27_k) + (BigInteger.One);
+              _30_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_30_methodBody, _33_ctorMatch);
+              _31_k = (_31_k) + (BigInteger.One);
             }
-            _26_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_26_methodBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-            _20_implBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_20_implBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn ")), (_24_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(&self) -> &")), _25_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _26_methodBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+            _30_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_30_methodBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+            _24_implBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_24_implBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn r#")), (_28_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(&self) -> &")), _29_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _30_methodBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
           }
-          _23_j = (_23_j) + (BigInteger.One);
+          _27_j = (_27_j) + (BigInteger.One);
         }
-        _14_i = (_14_i) + (BigInteger.One);
+        _18_i = (_18_i) + (BigInteger.One);
       }
-      Dafny.ISequence<Dafny.Rune> _33_enumBody;
-      _33_enumBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(Clone, PartialEq)]\npub enum r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _13_ctors), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _20_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
-      Dafny.ISequence<Dafny.Rune> _34_printImpl;
-      _34_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ::dafny_runtime::DafnyPrint for r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, f: &mut ::std::fmt::Formatter) -> std::fmt::Result {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n"));
-      _14_i = BigInteger.Zero;
-      while ((_14_i) < (new BigInteger(((c).dtor_ctors).Count))) {
-        DAST._IDatatypeCtor _35_ctor;
-        _35_ctor = ((c).dtor_ctors).Select(_14_i);
-        Dafny.ISequence<Dafny.Rune> _36_ctorMatch;
-        _36_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_35_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
-        Dafny.ISequence<Dafny.Rune> _37_modulePrefix;
-        _37_modulePrefix = (((((c).dtor_enclosingModule)).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_module"))) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.Concat(((c).dtor_enclosingModule), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."))));
-        Dafny.ISequence<Dafny.Rune> _38_printRhs;
-        _38_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("write!(f, \""), _37_modulePrefix), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), (_35_ctor).dtor_name), (((_35_ctor).dtor_hasAnyArgs) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(\")?;")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\")?;"))));
-        BigInteger _39_j;
-        _39_j = BigInteger.Zero;
-        while ((_39_j) < (new BigInteger(((_35_ctor).dtor_args).Count))) {
-          DAST._IFormal _40_formal;
-          _40_formal = ((_35_ctor).dtor_args).Select(_39_j);
-          _36_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_36_ctorMatch, (_40_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-          if ((_39_j).Sign == 1) {
-            _38_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_38_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(f, \", \")?;"));
+      Dafny.ISequence<Dafny.Rune> _37_constrainedTypeParams;
+      _37_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      if ((new BigInteger(((c).dtor_typeParams).Count)).Sign == 1) {
+        _14_tpI = BigInteger.Zero;
+        _37_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
+        while ((_14_tpI) < (new BigInteger(((c).dtor_typeParams).Count))) {
+          if ((_14_tpI).Sign == 1) {
+            _37_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(_37_constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
           }
-          _38_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_38_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n::dafny_runtime::DafnyPrint::fmt_print(")), (_40_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", f)?;"));
-          _39_j = (_39_j) + (BigInteger.One);
+          DAST._IType _38_tp;
+          _38_tp = ((c).dtor_typeParams).Select(_14_tpI);
+          Dafny.ISequence<Dafny.Rune> _39_genTp;
+          Dafny.ISequence<Dafny.Rune> _out11;
+          _out11 = DCOMP.COMP.GenType(_38_tp);
+          _39_genTp = _out11;
+          _37_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_37_constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _39_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default"));
+          _14_tpI = (_14_tpI) + (BigInteger.One);
         }
-        _36_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_36_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
-        if ((_35_ctor).dtor_hasAnyArgs) {
-          _38_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_38_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(f, \")\")?;"));
-        }
-        _38_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_38_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nOk(())"));
-        _34_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_34_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), _36_ctorMatch), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" => {\n")), _38_printRhs), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
-        _14_i = (_14_i) + (BigInteger.One);
+        _37_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(_37_constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
-      _34_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(_34_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
-      Dafny.ISequence<Dafny.Rune> _41_defaultImpl;
-      _41_defaultImpl = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      Dafny.ISequence<Dafny.Rune> _40_enumBody;
+      _40_enumBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(Clone, PartialEq)]\npub enum r#"), (c).dtor_name), _13_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _17_ctors), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _37_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" r#")), (c).dtor_name), _13_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _24_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+      Dafny.ISequence<Dafny.Rune> _41_printImpl;
+      _41_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _37_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyPrint for r#")), (c).dtor_name), _13_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, f: &mut ::std::fmt::Formatter) -> std::fmt::Result {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n"));
+      _18_i = BigInteger.Zero;
+      while ((_18_i) < (new BigInteger(((c).dtor_ctors).Count))) {
+        DAST._IDatatypeCtor _42_ctor;
+        _42_ctor = ((c).dtor_ctors).Select(_18_i);
+        Dafny.ISequence<Dafny.Rune> _43_ctorMatch;
+        _43_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_42_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
+        Dafny.ISequence<Dafny.Rune> _44_modulePrefix;
+        _44_modulePrefix = (((((c).dtor_enclosingModule)).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_module"))) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.Concat(((c).dtor_enclosingModule), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."))));
+        Dafny.ISequence<Dafny.Rune> _45_printRhs;
+        _45_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("write!(f, \""), _44_modulePrefix), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), (_42_ctor).dtor_name), (((_42_ctor).dtor_hasAnyArgs) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(\")?;")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\")?;"))));
+        BigInteger _46_j;
+        _46_j = BigInteger.Zero;
+        while ((_46_j) < (new BigInteger(((_42_ctor).dtor_args).Count))) {
+          DAST._IFormal _47_formal;
+          _47_formal = ((_42_ctor).dtor_args).Select(_46_j);
+          _43_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_43_ctorMatch, (_47_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          if ((_46_j).Sign == 1) {
+            _45_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_45_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(f, \", \")?;"));
+          }
+          _45_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_45_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n::dafny_runtime::DafnyPrint::fmt_print(")), (_47_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", f)?;"));
+          _46_j = (_46_j) + (BigInteger.One);
+        }
+        _43_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_43_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
+        if ((_42_ctor).dtor_hasAnyArgs) {
+          _45_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_45_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(f, \")\")?;"));
+        }
+        _45_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_45_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nOk(())"));
+        _41_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_41_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), _43_ctorMatch), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" => {\n")), _45_printRhs), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
+        _18_i = (_18_i) + (BigInteger.One);
+      }
+      _41_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(_41_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
+      Dafny.ISequence<Dafny.Rune> _48_defaultImpl;
+      _48_defaultImpl = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
       if ((new BigInteger(((c).dtor_ctors).Count)).Sign == 1) {
-        _41_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl Default for r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn default() -> Self {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), (((c).dtor_ctors).Select(BigInteger.Zero)).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-        _14_i = BigInteger.Zero;
-        while ((_14_i) < (new BigInteger(((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Count))) {
-          DAST._IFormal _42_formal;
-          _42_formal = ((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Select(_14_i);
-          _41_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_41_defaultImpl, (_42_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": Default::default(),\n"));
-          _14_i = (_14_i) + (BigInteger.One);
+        _48_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _37_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::std::default::Default for r#")), (c).dtor_name), _13_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn default() -> Self {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), (((c).dtor_ctors).Select(BigInteger.Zero)).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+        _18_i = BigInteger.Zero;
+        while ((_18_i) < (new BigInteger(((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Count))) {
+          DAST._IFormal _49_formal;
+          _49_formal = ((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Select(_18_i);
+          _48_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_48_defaultImpl, (_49_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": std::default::Default::default(),\n"));
+          _18_i = (_18_i) + (BigInteger.One);
         }
-        _41_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(_41_defaultImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
+        _48_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(_48_defaultImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
       }
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_33_enumBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _34_printImpl), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _41_defaultImpl);
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_40_enumBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _41_printImpl), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _48_defaultImpl);
+      return s;
+    }
+    public static Dafny.ISequence<Dafny.Rune> GenPath(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> p) {
+      Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
+      s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("super::");
+      BigInteger _50_i;
+      _50_i = BigInteger.Zero;
+      while ((_50_i) < (new BigInteger((p).Count))) {
+        if ((_50_i).Sign == 1) {
+          s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+        }
+        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), ((p).Select(_50_i)));
+        _50_i = (_50_i) + (BigInteger.One);
+      }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenType(DAST._IType c) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       DAST._IType _source1 = c;
       if (_source1.is_Path) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _43___mcc_h0 = _source1.dtor_Path_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _44_p = _43___mcc_h0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _51___mcc_h0 = _source1.dtor_Path_a0;
+        Dafny.ISequence<DAST._IType> _52___mcc_h1 = _source1.dtor_typeArgs;
+        DAST._IResolvedType _53___mcc_h2 = _source1.dtor_resolved;
+        DAST._IResolvedType _54_resolved = _53___mcc_h2;
+        Dafny.ISequence<DAST._IType> _55_args = _52___mcc_h1;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _56_p = _51___mcc_h0;
         {
-          s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("super::");
-          BigInteger _45_i;
-          _45_i = BigInteger.Zero;
-          while ((_45_i) < (new BigInteger((_44_p).Count))) {
-            if ((_45_i).Sign == 1) {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+          Dafny.ISequence<Dafny.Rune> _out12;
+          _out12 = DCOMP.COMP.GenPath(_56_p);
+          s = _out12;
+          if ((new BigInteger((_55_args).Count)).Sign == 1) {
+            s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"));
+            BigInteger _57_i;
+            _57_i = BigInteger.Zero;
+            while ((_57_i) < (new BigInteger((_55_args).Count))) {
+              if ((_57_i).Sign == 1) {
+                s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+              }
+              Dafny.ISequence<Dafny.Rune> _58_genTp;
+              Dafny.ISequence<Dafny.Rune> _out13;
+              _out13 = DCOMP.COMP.GenType((_55_args).Select(_57_i));
+              _58_genTp = _out13;
+              s = Dafny.Sequence<Dafny.Rune>.Concat(s, _58_genTp);
+              _57_i = (_57_i) + (BigInteger.One);
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), ((_44_p).Select(_45_i)));
-            _45_i = (_45_i) + (BigInteger.One);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          }
+          DAST._IResolvedType _source2 = _54_resolved;
+          if (_source2.is_Datatype) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _59___mcc_h7 = _source2.dtor_path;
+            {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc<"), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+            }
+          } else {
           }
         }
       } else if (_source1.is_Tuple) {
-        Dafny.ISequence<DAST._IType> _46___mcc_h1 = _source1.dtor_Tuple_a0;
-        Dafny.ISequence<DAST._IType> _47_types = _46___mcc_h1;
+        Dafny.ISequence<DAST._IType> _60___mcc_h3 = _source1.dtor_Tuple_a0;
+        Dafny.ISequence<DAST._IType> _61_types = _60___mcc_h3;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-          BigInteger _48_i;
-          _48_i = BigInteger.Zero;
-          while ((_48_i) < (new BigInteger((_47_types).Count))) {
-            if ((_48_i).Sign == 1) {
+          BigInteger _62_i;
+          _62_i = BigInteger.Zero;
+          while ((_62_i) < (new BigInteger((_61_types).Count))) {
+            if ((_62_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" "));
             }
-            Dafny.ISequence<Dafny.Rune> _49_generated;
-            Dafny.ISequence<Dafny.Rune> _out10;
-            _out10 = DCOMP.COMP.GenType((_47_types).Select(_48_i));
-            _49_generated = _out10;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _49_generated), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
-            _48_i = (_48_i) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _63_generated;
+            Dafny.ISequence<Dafny.Rune> _out14;
+            _out14 = DCOMP.COMP.GenType((_61_types).Select(_62_i));
+            _63_generated = _out14;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _63_generated), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
+            _62_i = (_62_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
         }
       } else if (_source1.is_Passthrough) {
-        Dafny.ISequence<Dafny.Rune> _50___mcc_h2 = _source1.dtor_Passthrough_a0;
-        Dafny.ISequence<Dafny.Rune> _51_v = _50___mcc_h2;
-        s = _51_v;
+        Dafny.ISequence<Dafny.Rune> _64___mcc_h4 = _source1.dtor_Passthrough_a0;
+        Dafny.ISequence<Dafny.Rune> _65_v = _64___mcc_h4;
+        s = _65_v;
       } else {
-        Dafny.ISequence<Dafny.Rune> _52___mcc_h3 = _source1.dtor_TypeArg_a0;
-        Dafny.ISequence<Dafny.Rune> _source2 = _52___mcc_h3;
+        Dafny.ISequence<Dafny.Rune> _66___mcc_h5 = _source1.dtor_TypeArg_a0;
+        Dafny.ISequence<Dafny.Rune> _source3 = _66___mcc_h5;
         {
-          Dafny.ISequence<Dafny.Rune> _53___mcc_h4 = _source2;
-          Dafny.ISequence<Dafny.Rune> _54_name = _53___mcc_h4;
-          s = _54_name;
+          Dafny.ISequence<Dafny.Rune> _67___mcc_h6 = _source3;
+          Dafny.ISequence<Dafny.Rune> _68_name = _67___mcc_h6;
+          s = _68_name;
         }
       }
       return s;
@@ -2535,727 +2732,830 @@ namespace DCOMP {
     public static Dafny.ISequence<Dafny.Rune> GenClassImplBody(Dafny.ISequence<DAST._IClassItem> body) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _55_i;
-      _55_i = BigInteger.Zero;
-      while ((_55_i) < (new BigInteger((body).Count))) {
-        Dafny.ISequence<Dafny.Rune> _56_generated = Dafny.Sequence<Dafny.Rune>.Empty;
-        DAST._IClassItem _source3 = (body).Select(_55_i);
-        if (_source3.is_Method) {
-          DAST._IMethod _57___mcc_h0 = _source3.dtor_Method_a0;
-          DAST._IMethod _58_m = _57___mcc_h0;
-          Dafny.ISequence<Dafny.Rune> _out11;
-          _out11 = DCOMP.COMP.GenMethod(_58_m);
-          _56_generated = _out11;
+      BigInteger _69_i;
+      _69_i = BigInteger.Zero;
+      while ((_69_i) < (new BigInteger((body).Count))) {
+        Dafny.ISequence<Dafny.Rune> _70_generated = Dafny.Sequence<Dafny.Rune>.Empty;
+        DAST._IClassItem _source4 = (body).Select(_69_i);
+        if (_source4.is_Method) {
+          DAST._IMethod _71___mcc_h0 = _source4.dtor_Method_a0;
+          DAST._IMethod _72_m = _71___mcc_h0;
+          Dafny.ISequence<Dafny.Rune> _out15;
+          _out15 = DCOMP.COMP.GenMethod(_72_m);
+          _70_generated = _out15;
         } else {
-          DAST._IFormal _59___mcc_h1 = _source3.dtor_Field_a0;
-          DAST._IFormal _60_f = _59___mcc_h1;
-          _56_generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("TODO");
+          DAST._IFormal _73___mcc_h1 = _source4.dtor_Field_a0;
+          DAST._IFormal _74_f = _73___mcc_h1;
+          _70_generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("TODO");
         }
-        if ((_55_i).Sign == 1) {
+        if ((_69_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _56_generated);
-        _55_i = (_55_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _70_generated);
+        _69_i = (_69_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenParams(Dafny.ISequence<DAST._IFormal> @params) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _61_i;
-      _61_i = BigInteger.Zero;
-      while ((_61_i) < (new BigInteger((@params).Count))) {
-        DAST._IFormal _62_param;
-        _62_param = (@params).Select(_61_i);
-        Dafny.ISequence<Dafny.Rune> _63_paramType;
-        Dafny.ISequence<Dafny.Rune> _out12;
-        _out12 = DCOMP.COMP.GenType((_62_param).dtor_typ);
-        _63_paramType = _out12;
-        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_62_param).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _63_paramType);
-        if ((_61_i) < ((new BigInteger((@params).Count)) - (BigInteger.One))) {
+      BigInteger _75_i;
+      _75_i = BigInteger.Zero;
+      while ((_75_i) < (new BigInteger((@params).Count))) {
+        DAST._IFormal _76_param;
+        _76_param = (@params).Select(_75_i);
+        Dafny.ISequence<Dafny.Rune> _77_paramType;
+        Dafny.ISequence<Dafny.Rune> _out16;
+        _out16 = DCOMP.COMP.GenType((_76_param).dtor_typ);
+        _77_paramType = _out16;
+        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_76_param).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _77_paramType);
+        if ((_75_i) < ((new BigInteger((@params).Count)) - (BigInteger.One))) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
         }
-        _61_i = (_61_i) + (BigInteger.One);
+        _75_i = (_75_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenMethod(DAST._IMethod m) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISequence<Dafny.Rune> _64_params;
-      Dafny.ISequence<Dafny.Rune> _out13;
-      _out13 = DCOMP.COMP.GenParams((m).dtor_params);
-      _64_params = _out13;
-      if (!((m).dtor_isStatic)) {
-        _64_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self, "), _64_params);
+      Dafny.ISequence<Dafny.Rune> _78_params;
+      Dafny.ISequence<Dafny.Rune> _out17;
+      _out17 = DCOMP.COMP.GenParams((m).dtor_params);
+      _78_params = _out17;
+      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _79_paramNames;
+      _79_paramNames = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+      BigInteger _80_paramI;
+      _80_paramI = BigInteger.Zero;
+      while ((_80_paramI) < (new BigInteger(((m).dtor_params).Count))) {
+        _79_paramNames = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_79_paramNames, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((((m).dtor_params).Select(_80_paramI)).dtor_name));
+        _80_paramI = (_80_paramI) + (BigInteger.One);
       }
-      Dafny.ISequence<Dafny.Rune> _65_retType;
-      _65_retType = (((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")));
-      BigInteger _66_typeI;
-      _66_typeI = BigInteger.Zero;
-      while ((_66_typeI) < (new BigInteger(((m).dtor_outTypes).Count))) {
-        if ((_66_typeI).Sign == 1) {
-          _65_retType = Dafny.Sequence<Dafny.Rune>.Concat(_65_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+      if (!((m).dtor_isStatic)) {
+        _78_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self, "), _78_params);
+      }
+      Dafny.ISequence<Dafny.Rune> _81_retType;
+      _81_retType = (((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")));
+      BigInteger _82_typeI;
+      _82_typeI = BigInteger.Zero;
+      while ((_82_typeI) < (new BigInteger(((m).dtor_outTypes).Count))) {
+        if ((_82_typeI).Sign == 1) {
+          _81_retType = Dafny.Sequence<Dafny.Rune>.Concat(_81_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
         }
-        Dafny.ISequence<Dafny.Rune> _67_typeString;
-        Dafny.ISequence<Dafny.Rune> _out14;
-        _out14 = DCOMP.COMP.GenType(((m).dtor_outTypes).Select(_66_typeI));
-        _67_typeString = _out14;
-        _65_retType = Dafny.Sequence<Dafny.Rune>.Concat(_65_retType, _67_typeString);
-        _66_typeI = (_66_typeI) + (BigInteger.One);
+        Dafny.ISequence<Dafny.Rune> _83_typeString;
+        Dafny.ISequence<Dafny.Rune> _out18;
+        _out18 = DCOMP.COMP.GenType(((m).dtor_outTypes).Select(_82_typeI));
+        _83_typeString = _out18;
+        _81_retType = Dafny.Sequence<Dafny.Rune>.Concat(_81_retType, _83_typeString);
+        _82_typeI = (_82_typeI) + (BigInteger.One);
       }
       if ((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) {
-        _65_retType = Dafny.Sequence<Dafny.Rune>.Concat(_65_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+        _81_retType = Dafny.Sequence<Dafny.Rune>.Concat(_81_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
       }
       s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn r#"), (m).dtor_name);
       if ((new BigInteger(((m).dtor_typeParams).Count)).Sign == 1) {
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"));
-        BigInteger _68_i;
-        _68_i = BigInteger.Zero;
-        while ((_68_i) < (new BigInteger(((m).dtor_typeParams).Count))) {
-          if ((_68_i).Sign == 1) {
+        BigInteger _84_i;
+        _84_i = BigInteger.Zero;
+        while ((_84_i) < (new BigInteger(((m).dtor_typeParams).Count))) {
+          if ((_84_i).Sign == 1) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
           }
-          Dafny.ISequence<Dafny.Rune> _69_typeString;
-          Dafny.ISequence<Dafny.Rune> _out15;
-          _out15 = DCOMP.COMP.GenType(((m).dtor_typeParams).Select(_68_i));
-          _69_typeString = _out15;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _69_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": std::default::Default"));
-          _68_i = (_68_i) + (BigInteger.One);
+          Dafny.ISequence<Dafny.Rune> _85_typeString;
+          Dafny.ISequence<Dafny.Rune> _out19;
+          _out19 = DCOMP.COMP.GenType(((m).dtor_typeParams).Select(_84_i));
+          _85_typeString = _out19;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _85_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default"));
+          _84_i = (_84_i) + (BigInteger.One);
         }
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
-      Dafny.ISequence<Dafny.Rune> _70_earlyReturn;
-      _70_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return;");
-      DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source4 = (m).dtor_outVars;
-      if (_source4.is_Some) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _71___mcc_h0 = _source4.dtor_Some_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _72_outVars = _71___mcc_h0;
-        {
-          _70_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return (");
-          BigInteger _73_outI;
-          _73_outI = BigInteger.Zero;
-          while ((_73_outI) < (new BigInteger((_72_outVars).Count))) {
-            if ((_73_outI).Sign == 1) {
-              _70_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_70_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-            }
-            Dafny.ISequence<Dafny.Rune> _74_outVar;
-            _74_outVar = (_72_outVars).Select(_73_outI);
-            _70_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_70_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_74_outVar));
-            _73_outI = (_73_outI) + (BigInteger.One);
-          }
-          _70_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_70_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
-        }
-      } else {
-      }
-      Dafny.ISequence<Dafny.Rune> _75_body;
-      Dafny.ISequence<Dafny.Rune> _out16;
-      _out16 = DCOMP.COMP.GenStmts((m).dtor_body, _70_earlyReturn);
-      _75_body = _out16;
+      Dafny.ISequence<Dafny.Rune> _86_earlyReturn;
+      _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return;");
       DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source5 = (m).dtor_outVars;
       if (_source5.is_Some) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _76___mcc_h1 = _source5.dtor_Some_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _77_outVars = _76___mcc_h1;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _87___mcc_h0 = _source5.dtor_Some_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _88_outVars = _87___mcc_h0;
         {
-          _75_body = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_75_body, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _70_earlyReturn);
+          _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return (");
+          BigInteger _89_outI;
+          _89_outI = BigInteger.Zero;
+          while ((_89_outI) < (new BigInteger((_88_outVars).Count))) {
+            if ((_89_outI).Sign == 1) {
+              _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_86_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+            }
+            Dafny.ISequence<Dafny.Rune> _90_outVar;
+            _90_outVar = (_88_outVars).Select(_89_outI);
+            _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_86_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_90_outVar));
+            _89_outI = (_89_outI) + (BigInteger.One);
+          }
+          _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_86_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
         }
       } else {
       }
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _64_params), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _65_retType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _75_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
+      Dafny.ISequence<Dafny.Rune> _91_body;
+      Dafny.ISequence<Dafny.Rune> _out20;
+      _out20 = DCOMP.COMP.GenStmts((m).dtor_body, _79_paramNames, _86_earlyReturn);
+      _91_body = _out20;
+      DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source6 = (m).dtor_outVars;
+      if (_source6.is_Some) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _92___mcc_h1 = _source6.dtor_Some_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _93_outVars = _92___mcc_h1;
+        {
+          _91_body = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_91_body, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _86_earlyReturn);
+        }
+      } else {
+      }
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _78_params), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _81_retType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _91_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
       return s;
     }
-    public static Dafny.ISequence<Dafny.Rune> GenStmts(Dafny.ISequence<DAST._IStatement> stmts, Dafny.ISequence<Dafny.Rune> earlyReturn) {
+    public static Dafny.ISequence<Dafny.Rune> GenStmts(Dafny.ISequence<DAST._IStatement> stmts, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> @params, Dafny.ISequence<Dafny.Rune> earlyReturn) {
       Dafny.ISequence<Dafny.Rune> generated = Dafny.Sequence<Dafny.Rune>.Empty;
       generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _78_i;
-      _78_i = BigInteger.Zero;
-      while ((_78_i) < (new BigInteger((stmts).Count))) {
-        DAST._IStatement _79_stmt;
-        _79_stmt = (stmts).Select(_78_i);
-        Dafny.ISequence<Dafny.Rune> _80_stmtString;
-        Dafny.ISequence<Dafny.Rune> _out17;
-        _out17 = DCOMP.COMP.GenStmt(_79_stmt, earlyReturn);
-        _80_stmtString = _out17;
-        if ((_78_i).Sign == 1) {
+      BigInteger _94_i;
+      _94_i = BigInteger.Zero;
+      while ((_94_i) < (new BigInteger((stmts).Count))) {
+        DAST._IStatement _95_stmt;
+        _95_stmt = (stmts).Select(_94_i);
+        Dafny.ISequence<Dafny.Rune> _96_stmtString;
+        Dafny.ISequence<Dafny.Rune> _out21;
+        _out21 = DCOMP.COMP.GenStmt(_95_stmt, @params, earlyReturn);
+        _96_stmtString = _out21;
+        if ((_94_i).Sign == 1) {
           generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, _80_stmtString);
-        _78_i = (_78_i) + (BigInteger.One);
+        generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, _96_stmtString);
+        _94_i = (_94_i) + (BigInteger.One);
       }
       return generated;
     }
-    public static Dafny.ISequence<Dafny.Rune> GenStmt(DAST._IStatement stmt, Dafny.ISequence<Dafny.Rune> earlyReturn) {
+    public static Dafny.ISequence<Dafny.Rune> GenStmt(DAST._IStatement stmt, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> @params, Dafny.ISequence<Dafny.Rune> earlyReturn) {
       Dafny.ISequence<Dafny.Rune> generated = Dafny.Sequence<Dafny.Rune>.Empty;
-      DAST._IStatement _source6 = stmt;
-      if (_source6.is_DeclareVar) {
-        Dafny.ISequence<Dafny.Rune> _81___mcc_h0 = _source6.dtor_name;
-        DAST._IType _82___mcc_h1 = _source6.dtor_typ;
-        DAST._IOptional<DAST._IExpression> _83___mcc_h2 = _source6.dtor_maybeValue;
-        DAST._IOptional<DAST._IExpression> _source7 = _83___mcc_h2;
-        if (_source7.is_Some) {
-          DAST._IExpression _84___mcc_h3 = _source7.dtor_Some_a0;
-          DAST._IExpression _85_expression = _84___mcc_h3;
-          DAST._IType _86_typ = _82___mcc_h1;
-          Dafny.ISequence<Dafny.Rune> _87_name = _81___mcc_h0;
+      DAST._IStatement _source7 = stmt;
+      if (_source7.is_DeclareVar) {
+        Dafny.ISequence<Dafny.Rune> _97___mcc_h0 = _source7.dtor_name;
+        DAST._IType _98___mcc_h1 = _source7.dtor_typ;
+        DAST._IOptional<DAST._IExpression> _99___mcc_h2 = _source7.dtor_maybeValue;
+        DAST._IOptional<DAST._IExpression> _source8 = _99___mcc_h2;
+        if (_source8.is_Some) {
+          DAST._IExpression _100___mcc_h3 = _source8.dtor_Some_a0;
+          DAST._IExpression _101_expression = _100___mcc_h3;
+          DAST._IType _102_typ = _98___mcc_h1;
+          Dafny.ISequence<Dafny.Rune> _103_name = _97___mcc_h0;
           {
-            Dafny.ISequence<Dafny.Rune> _88_expr;
-            Dafny.ISequence<Dafny.Rune> _out18;
-            _out18 = DCOMP.COMP.GenExpr(_85_expression);
-            _88_expr = _out18;
-            Dafny.ISequence<Dafny.Rune> _89_typeString;
-            Dafny.ISequence<Dafny.Rune> _out19;
-            _out19 = DCOMP.COMP.GenType(_86_typ);
-            _89_typeString = _out19;
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _87_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _89_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _88_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            Dafny.ISequence<Dafny.Rune> _104_expr;
+            bool _105___v2;
+            Dafny.ISequence<Dafny.Rune> _out22;
+            bool _out23;
+            DCOMP.COMP.GenExpr(_101_expression, @params, true, out _out22, out _out23);
+            _104_expr = _out22;
+            _105___v2 = _out23;
+            Dafny.ISequence<Dafny.Rune> _106_typeString;
+            Dafny.ISequence<Dafny.Rune> _out24;
+            _out24 = DCOMP.COMP.GenType(_102_typ);
+            _106_typeString = _out24;
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _103_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _106_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _104_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
           }
         } else {
-          DAST._IType _90_typ = _82___mcc_h1;
-          Dafny.ISequence<Dafny.Rune> _91_name = _81___mcc_h0;
+          DAST._IType _107_typ = _98___mcc_h1;
+          Dafny.ISequence<Dafny.Rune> _108_name = _97___mcc_h0;
           {
-            Dafny.ISequence<Dafny.Rune> _92_typeString;
-            Dafny.ISequence<Dafny.Rune> _out20;
-            _out20 = DCOMP.COMP.GenType(_90_typ);
-            _92_typeString = _out20;
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _91_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _92_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            Dafny.ISequence<Dafny.Rune> _109_typeString;
+            Dafny.ISequence<Dafny.Rune> _out25;
+            _out25 = DCOMP.COMP.GenType(_107_typ);
+            _109_typeString = _out25;
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _108_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _109_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
           }
         }
-      } else if (_source6.is_Assign) {
-        Dafny.ISequence<Dafny.Rune> _93___mcc_h4 = _source6.dtor_name;
-        DAST._IExpression _94___mcc_h5 = _source6.dtor_value;
-        DAST._IExpression _95_expression = _94___mcc_h5;
-        Dafny.ISequence<Dafny.Rune> _96_name = _93___mcc_h4;
+      } else if (_source7.is_Assign) {
+        Dafny.ISequence<Dafny.Rune> _110___mcc_h4 = _source7.dtor_name;
+        DAST._IExpression _111___mcc_h5 = _source7.dtor_value;
+        DAST._IExpression _112_expression = _111___mcc_h5;
+        Dafny.ISequence<Dafny.Rune> _113_name = _110___mcc_h4;
         {
-          Dafny.ISequence<Dafny.Rune> _97_expr;
-          Dafny.ISequence<Dafny.Rune> _out21;
-          _out21 = DCOMP.COMP.GenExpr(_95_expression);
-          _97_expr = _out21;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _96_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _97_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+          Dafny.ISequence<Dafny.Rune> _114_expr;
+          bool _115___v3;
+          Dafny.ISequence<Dafny.Rune> _out26;
+          bool _out27;
+          DCOMP.COMP.GenExpr(_112_expression, @params, true, out _out26, out _out27);
+          _114_expr = _out26;
+          _115___v3 = _out27;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _113_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _114_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
         }
-      } else if (_source6.is_If) {
-        DAST._IExpression _98___mcc_h6 = _source6.dtor_cond;
-        Dafny.ISequence<DAST._IStatement> _99___mcc_h7 = _source6.dtor_thn;
-        Dafny.ISequence<DAST._IStatement> _100___mcc_h8 = _source6.dtor_els;
-        Dafny.ISequence<DAST._IStatement> _101_els = _100___mcc_h8;
-        Dafny.ISequence<DAST._IStatement> _102_thn = _99___mcc_h7;
-        DAST._IExpression _103_cond = _98___mcc_h6;
+      } else if (_source7.is_If) {
+        DAST._IExpression _116___mcc_h6 = _source7.dtor_cond;
+        Dafny.ISequence<DAST._IStatement> _117___mcc_h7 = _source7.dtor_thn;
+        Dafny.ISequence<DAST._IStatement> _118___mcc_h8 = _source7.dtor_els;
+        Dafny.ISequence<DAST._IStatement> _119_els = _118___mcc_h8;
+        Dafny.ISequence<DAST._IStatement> _120_thn = _117___mcc_h7;
+        DAST._IExpression _121_cond = _116___mcc_h6;
         {
-          Dafny.ISequence<Dafny.Rune> _104_condString;
-          Dafny.ISequence<Dafny.Rune> _out22;
-          _out22 = DCOMP.COMP.GenExpr(_103_cond);
-          _104_condString = _out22;
-          Dafny.ISequence<Dafny.Rune> _105_thnString;
-          Dafny.ISequence<Dafny.Rune> _out23;
-          _out23 = DCOMP.COMP.GenStmts(_102_thn, earlyReturn);
-          _105_thnString = _out23;
-          Dafny.ISequence<Dafny.Rune> _106_elsString;
-          Dafny.ISequence<Dafny.Rune> _out24;
-          _out24 = DCOMP.COMP.GenStmts(_101_els, earlyReturn);
-          _106_elsString = _out24;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if "), _104_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _105_thnString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _106_elsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
-        }
-      } else if (_source6.is_Call) {
-        DAST._IExpression _107___mcc_h9 = _source6.dtor_on;
-        Dafny.ISequence<Dafny.Rune> _108___mcc_h10 = _source6.dtor_name;
-        Dafny.ISequence<DAST._IType> _109___mcc_h11 = _source6.dtor_typeArgs;
-        Dafny.ISequence<DAST._IExpression> _110___mcc_h12 = _source6.dtor_args;
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _111___mcc_h13 = _source6.dtor_outs;
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _112_maybeOutVars = _111___mcc_h13;
-        Dafny.ISequence<DAST._IExpression> _113_args = _110___mcc_h12;
-        Dafny.ISequence<DAST._IType> _114_typeArgs = _109___mcc_h11;
-        Dafny.ISequence<Dafny.Rune> _115_name = _108___mcc_h10;
-        DAST._IExpression _116_on = _107___mcc_h9;
-        {
-          Dafny.ISequence<Dafny.Rune> _117_typeArgString;
-          _117_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          if ((new BigInteger((_114_typeArgs).Count)) >= (BigInteger.One)) {
-            BigInteger _118_typeI;
-            _118_typeI = BigInteger.Zero;
-            _117_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
-            while ((_118_typeI) < (new BigInteger((_114_typeArgs).Count))) {
-              if ((_118_typeI).Sign == 1) {
-                _117_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_117_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-              }
-              Dafny.ISequence<Dafny.Rune> _119_typeString;
-              Dafny.ISequence<Dafny.Rune> _out25;
-              _out25 = DCOMP.COMP.GenType((_114_typeArgs).Select(_118_typeI));
-              _119_typeString = _out25;
-              _117_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_117_typeArgString, _119_typeString);
-              _118_typeI = (_118_typeI) + (BigInteger.One);
-            }
-            _117_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_117_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
-          }
-          Dafny.ISequence<Dafny.Rune> _120_argString;
-          _120_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _121_i;
-          _121_i = BigInteger.Zero;
-          while ((_121_i) < (new BigInteger((_113_args).Count))) {
-            if ((_121_i).Sign == 1) {
-              _120_argString = Dafny.Sequence<Dafny.Rune>.Concat(_120_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-            }
-            Dafny.ISequence<Dafny.Rune> _122_argExpr;
-            Dafny.ISequence<Dafny.Rune> _out26;
-            _out26 = DCOMP.COMP.GenExpr((_113_args).Select(_121_i));
-            _122_argExpr = _out26;
-            _120_argString = Dafny.Sequence<Dafny.Rune>.Concat(_120_argString, _122_argExpr);
-            _121_i = (_121_i) + (BigInteger.One);
-          }
-          Dafny.ISequence<Dafny.Rune> _123_enclosingString;
-          Dafny.ISequence<Dafny.Rune> _out27;
-          _out27 = DCOMP.COMP.GenExpr(_116_on);
-          _123_enclosingString = _out27;
-          DAST._IExpression _source8 = _116_on;
-          if (_source8.is_Literal) {
-            DAST._ILiteral _124___mcc_h16 = _source8.dtor_Literal_a0;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_Ident) {
-            Dafny.ISequence<Dafny.Rune> _125___mcc_h18 = _source8.dtor_Ident_a0;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_Companion) {
-            DAST._IType _126___mcc_h20 = _source8.dtor_Companion_a0;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
-            }
-          } else if (_source8.is_Tuple) {
-            Dafny.ISequence<DAST._IExpression> _127___mcc_h22 = _source8.dtor_Tuple_a0;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_DatatypeValue) {
-            DAST._IType _128___mcc_h24 = _source8.dtor_typ;
-            Dafny.ISequence<Dafny.Rune> _129___mcc_h25 = _source8.dtor_variant;
-            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _130___mcc_h26 = _source8.dtor_contents;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_BinOp) {
-            Dafny.ISequence<Dafny.Rune> _131___mcc_h30 = _source8.dtor_op;
-            DAST._IExpression _132___mcc_h31 = _source8.dtor_left;
-            DAST._IExpression _133___mcc_h32 = _source8.dtor_right;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_Select) {
-            DAST._IExpression _134___mcc_h36 = _source8.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _135___mcc_h37 = _source8.dtor_field;
-            bool _136___mcc_h38 = _source8.dtor_onDatatype;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_TupleSelect) {
-            DAST._IExpression _137___mcc_h42 = _source8.dtor_expr;
-            BigInteger _138___mcc_h43 = _source8.dtor_index;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_Call) {
-            DAST._IExpression _139___mcc_h46 = _source8.dtor_on;
-            Dafny.ISequence<Dafny.Rune> _140___mcc_h47 = _source8.dtor_name;
-            Dafny.ISequence<DAST._IType> _141___mcc_h48 = _source8.dtor_typeArgs;
-            Dafny.ISequence<DAST._IExpression> _142___mcc_h49 = _source8.dtor_args;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else if (_source8.is_TypeTest) {
-            DAST._IExpression _143___mcc_h54 = _source8.dtor_on;
-            DAST._IType _144___mcc_h55 = _source8.dtor_dType;
-            Dafny.ISequence<Dafny.Rune> _145___mcc_h56 = _source8.dtor_variant;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          } else {
-            DAST._IType _146___mcc_h60 = _source8.dtor_typ;
-            {
-              _123_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_123_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
-            }
-          }
-          Dafny.ISequence<Dafny.Rune> _147_receiver;
-          _147_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source9 = _112_maybeOutVars;
-          if (_source9.is_Some) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _148___mcc_h62 = _source9.dtor_Some_a0;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _149_outVars = _148___mcc_h62;
-            {
-              if ((new BigInteger((_149_outVars).Count)) > (BigInteger.One)) {
-                _147_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-              }
-              BigInteger _150_outI;
-              _150_outI = BigInteger.Zero;
-              while ((_150_outI) < (new BigInteger((_149_outVars).Count))) {
-                if ((_150_outI).Sign == 1) {
-                  _147_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_147_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-                }
-                Dafny.ISequence<Dafny.Rune> _151_outVar;
-                _151_outVar = (_149_outVars).Select(_150_outI);
-                _147_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_147_receiver, (_151_outVar));
-                _150_outI = (_150_outI) + (BigInteger.One);
-              }
-              if ((new BigInteger((_149_outVars).Count)) > (BigInteger.One)) {
-                _147_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_147_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-              }
-            }
-          } else {
-          }
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(((!(_147_receiver).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))) ? (Dafny.Sequence<Dafny.Rune>.Concat(_147_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = "))) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))), _123_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _115_name), _117_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _120_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
-        }
-      } else if (_source6.is_Return) {
-        DAST._IExpression _152___mcc_h14 = _source6.dtor_expr;
-        DAST._IExpression _153_expr = _152___mcc_h14;
-        {
-          Dafny.ISequence<Dafny.Rune> _154_exprString;
+          Dafny.ISequence<Dafny.Rune> _122_condString;
+          bool _123___v4;
           Dafny.ISequence<Dafny.Rune> _out28;
-          _out28 = DCOMP.COMP.GenExpr(_153_expr);
-          _154_exprString = _out28;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return "), _154_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+          bool _out29;
+          DCOMP.COMP.GenExpr(_121_cond, @params, true, out _out28, out _out29);
+          _122_condString = _out28;
+          _123___v4 = _out29;
+          Dafny.ISequence<Dafny.Rune> _124_thnString;
+          Dafny.ISequence<Dafny.Rune> _out30;
+          _out30 = DCOMP.COMP.GenStmts(_120_thn, @params, earlyReturn);
+          _124_thnString = _out30;
+          Dafny.ISequence<Dafny.Rune> _125_elsString;
+          Dafny.ISequence<Dafny.Rune> _out31;
+          _out31 = DCOMP.COMP.GenStmts(_119_els, @params, earlyReturn);
+          _125_elsString = _out31;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if "), _122_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _124_thnString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _125_elsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
         }
-      } else if (_source6.is_EarlyReturn) {
+      } else if (_source7.is_Call) {
+        DAST._IExpression _126___mcc_h9 = _source7.dtor_on;
+        Dafny.ISequence<Dafny.Rune> _127___mcc_h10 = _source7.dtor_name;
+        Dafny.ISequence<DAST._IType> _128___mcc_h11 = _source7.dtor_typeArgs;
+        Dafny.ISequence<DAST._IExpression> _129___mcc_h12 = _source7.dtor_args;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _130___mcc_h13 = _source7.dtor_outs;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _131_maybeOutVars = _130___mcc_h13;
+        Dafny.ISequence<DAST._IExpression> _132_args = _129___mcc_h12;
+        Dafny.ISequence<DAST._IType> _133_typeArgs = _128___mcc_h11;
+        Dafny.ISequence<Dafny.Rune> _134_name = _127___mcc_h10;
+        DAST._IExpression _135_on = _126___mcc_h9;
+        {
+          Dafny.ISequence<Dafny.Rune> _136_typeArgString;
+          _136_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          if ((new BigInteger((_133_typeArgs).Count)) >= (BigInteger.One)) {
+            BigInteger _137_typeI;
+            _137_typeI = BigInteger.Zero;
+            _136_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
+            while ((_137_typeI) < (new BigInteger((_133_typeArgs).Count))) {
+              if ((_137_typeI).Sign == 1) {
+                _136_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_136_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+              }
+              Dafny.ISequence<Dafny.Rune> _138_typeString;
+              Dafny.ISequence<Dafny.Rune> _out32;
+              _out32 = DCOMP.COMP.GenType((_133_typeArgs).Select(_137_typeI));
+              _138_typeString = _out32;
+              _136_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_136_typeArgString, _138_typeString);
+              _137_typeI = (_137_typeI) + (BigInteger.One);
+            }
+            _136_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_136_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          }
+          Dafny.ISequence<Dafny.Rune> _139_argString;
+          _139_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _140_i;
+          _140_i = BigInteger.Zero;
+          while ((_140_i) < (new BigInteger((_132_args).Count))) {
+            if ((_140_i).Sign == 1) {
+              _139_argString = Dafny.Sequence<Dafny.Rune>.Concat(_139_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+            }
+            Dafny.ISequence<Dafny.Rune> _141_argExpr;
+            bool _142_isOwned;
+            Dafny.ISequence<Dafny.Rune> _out33;
+            bool _out34;
+            DCOMP.COMP.GenExpr((_132_args).Select(_140_i), @params, false, out _out33, out _out34);
+            _141_argExpr = _out33;
+            _142_isOwned = _out34;
+            _139_argString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_139_argString, ((_142_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _141_argExpr);
+            _140_i = (_140_i) + (BigInteger.One);
+          }
+          Dafny.ISequence<Dafny.Rune> _143_enclosingString;
+          bool _144___v5;
+          Dafny.ISequence<Dafny.Rune> _out35;
+          bool _out36;
+          DCOMP.COMP.GenExpr(_135_on, @params, true, out _out35, out _out36);
+          _143_enclosingString = _out35;
+          _144___v5 = _out36;
+          DAST._IExpression _source9 = _135_on;
+          if (_source9.is_Literal) {
+            DAST._ILiteral _145___mcc_h16 = _source9.dtor_Literal_a0;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_Ident) {
+            Dafny.ISequence<Dafny.Rune> _146___mcc_h18 = _source9.dtor_Ident_a0;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_Companion) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _147___mcc_h20 = _source9.dtor_Companion_a0;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_143_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+            }
+          } else if (_source9.is_Tuple) {
+            Dafny.ISequence<DAST._IExpression> _148___mcc_h22 = _source9.dtor_Tuple_a0;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_DatatypeValue) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _149___mcc_h24 = _source9.dtor_path;
+            Dafny.ISequence<Dafny.Rune> _150___mcc_h25 = _source9.dtor_variant;
+            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _151___mcc_h26 = _source9.dtor_contents;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_BinOp) {
+            Dafny.ISequence<Dafny.Rune> _152___mcc_h30 = _source9.dtor_op;
+            DAST._IExpression _153___mcc_h31 = _source9.dtor_left;
+            DAST._IExpression _154___mcc_h32 = _source9.dtor_right;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_Select) {
+            DAST._IExpression _155___mcc_h36 = _source9.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _156___mcc_h37 = _source9.dtor_field;
+            bool _157___mcc_h38 = _source9.dtor_onDatatype;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_TupleSelect) {
+            DAST._IExpression _158___mcc_h42 = _source9.dtor_expr;
+            BigInteger _159___mcc_h43 = _source9.dtor_index;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_Call) {
+            DAST._IExpression _160___mcc_h46 = _source9.dtor_on;
+            Dafny.ISequence<Dafny.Rune> _161___mcc_h47 = _source9.dtor_name;
+            Dafny.ISequence<DAST._IType> _162___mcc_h48 = _source9.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _163___mcc_h49 = _source9.dtor_args;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source9.is_TypeTest) {
+            DAST._IExpression _164___mcc_h54 = _source9.dtor_on;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _165___mcc_h55 = _source9.dtor_dType;
+            Dafny.ISequence<Dafny.Rune> _166___mcc_h56 = _source9.dtor_variant;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else {
+            DAST._IType _167___mcc_h60 = _source9.dtor_typ;
+            {
+              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          }
+          Dafny.ISequence<Dafny.Rune> _168_receiver;
+          _168_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source10 = _131_maybeOutVars;
+          if (_source10.is_Some) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _169___mcc_h62 = _source10.dtor_Some_a0;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _170_outVars = _169___mcc_h62;
+            {
+              if ((new BigInteger((_170_outVars).Count)) > (BigInteger.One)) {
+                _168_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
+              }
+              BigInteger _171_outI;
+              _171_outI = BigInteger.Zero;
+              while ((_171_outI) < (new BigInteger((_170_outVars).Count))) {
+                if ((_171_outI).Sign == 1) {
+                  _168_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+                }
+                Dafny.ISequence<Dafny.Rune> _172_outVar;
+                _172_outVar = (_170_outVars).Select(_171_outI);
+                _168_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, (_172_outVar));
+                _171_outI = (_171_outI) + (BigInteger.One);
+              }
+              if ((new BigInteger((_170_outVars).Count)) > (BigInteger.One)) {
+                _168_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              }
+            }
+          } else {
+          }
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(((!(_168_receiver).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))) ? (Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = "))) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _134_name), _136_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _139_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
+        }
+      } else if (_source7.is_Return) {
+        DAST._IExpression _173___mcc_h14 = _source7.dtor_expr;
+        DAST._IExpression _174_expr = _173___mcc_h14;
+        {
+          Dafny.ISequence<Dafny.Rune> _175_exprString;
+          bool _176___v8;
+          Dafny.ISequence<Dafny.Rune> _out37;
+          bool _out38;
+          DCOMP.COMP.GenExpr(_174_expr, @params, true, out _out37, out _out38);
+          _175_exprString = _out37;
+          _176___v8 = _out38;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return "), _175_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+        }
+      } else if (_source7.is_EarlyReturn) {
         {
           generated = earlyReturn;
         }
       } else {
-        DAST._IExpression _155___mcc_h15 = _source6.dtor_Print_a0;
-        DAST._IExpression _156_e = _155___mcc_h15;
+        DAST._IExpression _177___mcc_h15 = _source7.dtor_Print_a0;
+        DAST._IExpression _178_e = _177___mcc_h15;
         {
-          Dafny.ISequence<Dafny.Rune> _157_printedExpr;
-          Dafny.ISequence<Dafny.Rune> _out29;
-          _out29 = DCOMP.COMP.GenExpr(_156_e);
-          _157_printedExpr = _out29;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper(&"), _157_printedExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("));"));
+          Dafny.ISequence<Dafny.Rune> _179_printedExpr;
+          bool _180_isOwned;
+          Dafny.ISequence<Dafny.Rune> _out39;
+          bool _out40;
+          DCOMP.COMP.GenExpr(_178_e, @params, false, out _out39, out _out40);
+          _179_printedExpr = _out39;
+          _180_isOwned = _out40;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper("), ((_180_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _179_printedExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("));"));
         }
       }
       return generated;
     }
-    public static Dafny.ISequence<Dafny.Rune> GenExpr(DAST._IExpression e) {
-      Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      DAST._IExpression _source10 = e;
-      if (_source10.is_Literal) {
-        DAST._ILiteral _158___mcc_h0 = _source10.dtor_Literal_a0;
-        DAST._ILiteral _source11 = _158___mcc_h0;
-        if (_source11.is_BoolLiteral) {
-          bool _159___mcc_h1 = _source11.dtor_BoolLiteral_a0;
-          if ((_159___mcc_h1) == (false)) {
+    public static void GenExpr(DAST._IExpression e, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> @params, bool mustOwn, out Dafny.ISequence<Dafny.Rune> s, out bool isOwned) {
+      s = Dafny.Sequence<Dafny.Rune>.Empty;
+      isOwned = false;
+      DAST._IExpression _source11 = e;
+      if (_source11.is_Literal) {
+        DAST._ILiteral _181___mcc_h0 = _source11.dtor_Literal_a0;
+        DAST._ILiteral _source12 = _181___mcc_h0;
+        if (_source12.is_BoolLiteral) {
+          bool _182___mcc_h1 = _source12.dtor_BoolLiteral_a0;
+          if ((_182___mcc_h1) == (false)) {
             {
               s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("false");
+              isOwned = true;
             }
           } else {
             {
               s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("true");
+              isOwned = true;
             }
           }
-        } else if (_source11.is_IntLiteral) {
-          BigInteger _160___mcc_h2 = _source11.dtor_IntLiteral_a0;
-          BigInteger _161_i = _160___mcc_h2;
+        } else if (_source12.is_IntLiteral) {
+          BigInteger _183___mcc_h2 = _source12.dtor_IntLiteral_a0;
+          BigInteger _184_i = _183___mcc_h2;
           {
-            if ((_161_i).Sign == -1) {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("-"), DCOMP.__default.natToString((BigInteger.Zero) - (_161_i)));
+            if ((_184_i).Sign == -1) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("-"), DCOMP.__default.natToString((BigInteger.Zero) - (_184_i)));
             } else {
-              s = DCOMP.__default.natToString(_161_i);
+              s = DCOMP.__default.natToString(_184_i);
             }
+            isOwned = true;
           }
-        } else if (_source11.is_DecLiteral) {
-          Dafny.ISequence<Dafny.Rune> _162___mcc_h3 = _source11.dtor_DecLiteral_a0;
-          Dafny.ISequence<Dafny.Rune> _163_l = _162___mcc_h3;
+        } else if (_source12.is_DecLiteral) {
+          Dafny.ISequence<Dafny.Rune> _185___mcc_h3 = _source12.dtor_DecLiteral_a0;
+          Dafny.ISequence<Dafny.Rune> _186_l = _185___mcc_h3;
           {
-            s = _163_l;
+            s = _186_l;
+            isOwned = true;
           }
         } else {
-          Dafny.ISequence<Dafny.Rune> _164___mcc_h4 = _source11.dtor_StringLiteral_a0;
-          Dafny.ISequence<Dafny.Rune> _165_l = _164___mcc_h4;
+          Dafny.ISequence<Dafny.Rune> _187___mcc_h4 = _source12.dtor_StringLiteral_a0;
+          Dafny.ISequence<Dafny.Rune> _188_l = _187___mcc_h4;
           {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""), _165_l), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""), _188_l), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""));
+            isOwned = true;
           }
         }
-      } else if (_source10.is_Ident) {
-        Dafny.ISequence<Dafny.Rune> _166___mcc_h5 = _source10.dtor_Ident_a0;
-        Dafny.ISequence<Dafny.Rune> _167_name = _166___mcc_h5;
+      } else if (_source11.is_Ident) {
+        Dafny.ISequence<Dafny.Rune> _189___mcc_h5 = _source11.dtor_Ident_a0;
+        Dafny.ISequence<Dafny.Rune> _190_name = _189___mcc_h5;
         {
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _167_name);
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _190_name);
+          if ((@params).Contains(_190_name)) {
+            if (mustOwn) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
+              isOwned = true;
+            } else {
+              isOwned = false;
+            }
+          } else {
+            if (mustOwn) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
+              isOwned = true;
+            } else {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), s);
+              isOwned = false;
+            }
+          }
         }
-      } else if (_source10.is_Companion) {
-        DAST._IType _168___mcc_h6 = _source10.dtor_Companion_a0;
-        DAST._IType _169_typ = _168___mcc_h6;
+      } else if (_source11.is_Companion) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _191___mcc_h6 = _source11.dtor_Companion_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _192_path = _191___mcc_h6;
         {
-          Dafny.ISequence<Dafny.Rune> _out30;
-          _out30 = DCOMP.COMP.GenType(_169_typ);
-          s = _out30;
+          Dafny.ISequence<Dafny.Rune> _out41;
+          _out41 = DCOMP.COMP.GenPath(_192_path);
+          s = _out41;
+          isOwned = true;
         }
-      } else if (_source10.is_Tuple) {
-        Dafny.ISequence<DAST._IExpression> _170___mcc_h7 = _source10.dtor_Tuple_a0;
-        Dafny.ISequence<DAST._IExpression> _171_values = _170___mcc_h7;
+      } else if (_source11.is_Tuple) {
+        Dafny.ISequence<DAST._IExpression> _193___mcc_h7 = _source11.dtor_Tuple_a0;
+        Dafny.ISequence<DAST._IExpression> _194_values = _193___mcc_h7;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-          BigInteger _172_i;
-          _172_i = BigInteger.Zero;
-          while ((_172_i) < (new BigInteger((_171_values).Count))) {
-            if ((_172_i).Sign == 1) {
+          BigInteger _195_i;
+          _195_i = BigInteger.Zero;
+          while ((_195_i) < (new BigInteger((_194_values).Count))) {
+            if ((_195_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" "));
             }
-            Dafny.ISequence<Dafny.Rune> _173_recursiveGen;
-            Dafny.ISequence<Dafny.Rune> _out31;
-            _out31 = DCOMP.COMP.GenExpr((_171_values).Select(_172_i));
-            _173_recursiveGen = _out31;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _173_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
-            _172_i = (_172_i) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _196_recursiveGen;
+            bool _197___v9;
+            Dafny.ISequence<Dafny.Rune> _out42;
+            bool _out43;
+            DCOMP.COMP.GenExpr((_194_values).Select(_195_i), @params, true, out _out42, out _out43);
+            _196_recursiveGen = _out42;
+            _197___v9 = _out43;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _196_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
+            _195_i = (_195_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          isOwned = true;
         }
-      } else if (_source10.is_DatatypeValue) {
-        DAST._IType _174___mcc_h8 = _source10.dtor_typ;
-        Dafny.ISequence<Dafny.Rune> _175___mcc_h9 = _source10.dtor_variant;
-        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _176___mcc_h10 = _source10.dtor_contents;
-        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _177_values = _176___mcc_h10;
-        Dafny.ISequence<Dafny.Rune> _178_variant = _175___mcc_h9;
-        DAST._IType _179_typ = _174___mcc_h8;
+      } else if (_source11.is_DatatypeValue) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _198___mcc_h8 = _source11.dtor_path;
+        Dafny.ISequence<Dafny.Rune> _199___mcc_h9 = _source11.dtor_variant;
+        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _200___mcc_h10 = _source11.dtor_contents;
+        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _201_values = _200___mcc_h10;
+        Dafny.ISequence<Dafny.Rune> _202_variant = _199___mcc_h9;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _203_path = _198___mcc_h8;
         {
-          Dafny.ISequence<Dafny.Rune> _out32;
-          _out32 = DCOMP.COMP.GenType(_179_typ);
-          s = _out32;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _178_variant);
-          BigInteger _180_i;
-          _180_i = BigInteger.Zero;
+          Dafny.ISequence<Dafny.Rune> _204_path;
+          Dafny.ISequence<Dafny.Rune> _out44;
+          _out44 = DCOMP.COMP.GenPath(_203_path);
+          _204_path = _out44;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _204_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _202_variant);
+          BigInteger _205_i;
+          _205_i = BigInteger.Zero;
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {"));
-          while ((_180_i) < (new BigInteger((_177_values).Count))) {
-            _System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression> _let_tmp_rhs0 = (_177_values).Select(_180_i);
-            Dafny.ISequence<Dafny.Rune> _181_name = _let_tmp_rhs0.dtor__0;
-            DAST._IExpression _182_value = _let_tmp_rhs0.dtor__1;
-            if ((_180_i).Sign == 1) {
+          while ((_205_i) < (new BigInteger((_201_values).Count))) {
+            _System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression> _let_tmp_rhs0 = (_201_values).Select(_205_i);
+            Dafny.ISequence<Dafny.Rune> _206_name = _let_tmp_rhs0.dtor__0;
+            DAST._IExpression _207_value = _let_tmp_rhs0.dtor__1;
+            if ((_205_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _183_recursiveGen;
-            Dafny.ISequence<Dafny.Rune> _out33;
-            _out33 = DCOMP.COMP.GenExpr(_182_value);
-            _183_recursiveGen = _out33;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _181_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _183_recursiveGen);
-            _180_i = (_180_i) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _208_recursiveGen;
+            bool _209___v10;
+            Dafny.ISequence<Dafny.Rune> _out45;
+            bool _out46;
+            DCOMP.COMP.GenExpr(_207_value, @params, true, out _out45, out _out46);
+            _208_recursiveGen = _out45;
+            _209___v10 = _out46;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _206_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _208_recursiveGen);
+            _205_i = (_205_i) + (BigInteger.One);
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" }"));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" })"));
+          isOwned = true;
         }
-      } else if (_source10.is_BinOp) {
-        Dafny.ISequence<Dafny.Rune> _184___mcc_h11 = _source10.dtor_op;
-        DAST._IExpression _185___mcc_h12 = _source10.dtor_left;
-        DAST._IExpression _186___mcc_h13 = _source10.dtor_right;
-        DAST._IExpression _187_r = _186___mcc_h13;
-        DAST._IExpression _188_l = _185___mcc_h12;
-        Dafny.ISequence<Dafny.Rune> _189_op = _184___mcc_h11;
+      } else if (_source11.is_BinOp) {
+        Dafny.ISequence<Dafny.Rune> _210___mcc_h11 = _source11.dtor_op;
+        DAST._IExpression _211___mcc_h12 = _source11.dtor_left;
+        DAST._IExpression _212___mcc_h13 = _source11.dtor_right;
+        DAST._IExpression _213_r = _212___mcc_h13;
+        DAST._IExpression _214_l = _211___mcc_h12;
+        Dafny.ISequence<Dafny.Rune> _215_op = _210___mcc_h11;
         {
-          Dafny.ISequence<Dafny.Rune> _190_left;
-          Dafny.ISequence<Dafny.Rune> _out34;
-          _out34 = DCOMP.COMP.GenExpr(_188_l);
-          _190_left = _out34;
-          Dafny.ISequence<Dafny.Rune> _191_right;
-          Dafny.ISequence<Dafny.Rune> _out35;
-          _out35 = DCOMP.COMP.GenExpr(_187_r);
-          _191_right = _out35;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _190_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _189_op), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _191_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          Dafny.ISequence<Dafny.Rune> _216_left;
+          bool _217___v11;
+          Dafny.ISequence<Dafny.Rune> _out47;
+          bool _out48;
+          DCOMP.COMP.GenExpr(_214_l, @params, true, out _out47, out _out48);
+          _216_left = _out47;
+          _217___v11 = _out48;
+          Dafny.ISequence<Dafny.Rune> _218_right;
+          bool _219___v12;
+          Dafny.ISequence<Dafny.Rune> _out49;
+          bool _out50;
+          DCOMP.COMP.GenExpr(_213_r, @params, true, out _out49, out _out50);
+          _218_right = _out49;
+          _219___v12 = _out50;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _216_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _215_op), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _218_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          isOwned = true;
         }
-      } else if (_source10.is_Select) {
-        DAST._IExpression _192___mcc_h14 = _source10.dtor_expr;
-        Dafny.ISequence<Dafny.Rune> _193___mcc_h15 = _source10.dtor_field;
-        bool _194___mcc_h16 = _source10.dtor_onDatatype;
-        bool _195_isDatatype = _194___mcc_h16;
-        Dafny.ISequence<Dafny.Rune> _196_field = _193___mcc_h15;
-        DAST._IExpression _197_on = _192___mcc_h14;
+      } else if (_source11.is_Select) {
+        DAST._IExpression _220___mcc_h14 = _source11.dtor_expr;
+        Dafny.ISequence<Dafny.Rune> _221___mcc_h15 = _source11.dtor_field;
+        bool _222___mcc_h16 = _source11.dtor_onDatatype;
+        bool _223_isDatatype = _222___mcc_h16;
+        Dafny.ISequence<Dafny.Rune> _224_field = _221___mcc_h15;
+        DAST._IExpression _225_on = _220___mcc_h14;
         {
-          Dafny.ISequence<Dafny.Rune> _198_onString;
-          Dafny.ISequence<Dafny.Rune> _out36;
-          _out36 = DCOMP.COMP.GenExpr(_197_on);
-          _198_onString = _out36;
-          if (_195_isDatatype) {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_198_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _196_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("().clone()"));
+          Dafny.ISequence<Dafny.Rune> _226_onString;
+          bool _227___v13;
+          Dafny.ISequence<Dafny.Rune> _out51;
+          bool _out52;
+          DCOMP.COMP.GenExpr(_225_on, @params, false, out _out51, out _out52);
+          _226_onString = _out51;
+          _227___v13 = _out52;
+          if (_223_isDatatype) {
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _226_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _224_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("()"));
+            if (mustOwn) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
+              isOwned = true;
+            } else {
+              isOwned = false;
+            }
           } else {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_198_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _196_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _226_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _224_field);
+            if (mustOwn) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
+              isOwned = true;
+            } else {
+              isOwned = false;
+            }
           }
         }
-      } else if (_source10.is_TupleSelect) {
-        DAST._IExpression _199___mcc_h17 = _source10.dtor_expr;
-        BigInteger _200___mcc_h18 = _source10.dtor_index;
-        BigInteger _201_idx = _200___mcc_h18;
-        DAST._IExpression _202_on = _199___mcc_h17;
+      } else if (_source11.is_TupleSelect) {
+        DAST._IExpression _228___mcc_h17 = _source11.dtor_expr;
+        BigInteger _229___mcc_h18 = _source11.dtor_index;
+        BigInteger _230_idx = _229___mcc_h18;
+        DAST._IExpression _231_on = _228___mcc_h17;
         {
-          Dafny.ISequence<Dafny.Rune> _203_onString;
-          Dafny.ISequence<Dafny.Rune> _out37;
-          _out37 = DCOMP.COMP.GenExpr(_202_on);
-          _203_onString = _out37;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_203_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), DCOMP.__default.natToString(_201_idx)), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
+          Dafny.ISequence<Dafny.Rune> _232_onString;
+          bool _233___v14;
+          Dafny.ISequence<Dafny.Rune> _out53;
+          bool _out54;
+          DCOMP.COMP.GenExpr(_231_on, @params, false, out _out53, out _out54);
+          _232_onString = _out53;
+          _233___v14 = _out54;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_232_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), DCOMP.__default.natToString(_230_idx));
+          if (mustOwn) {
+            s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
+            isOwned = true;
+          } else {
+            isOwned = false;
+          }
         }
-      } else if (_source10.is_Call) {
-        DAST._IExpression _204___mcc_h19 = _source10.dtor_on;
-        Dafny.ISequence<Dafny.Rune> _205___mcc_h20 = _source10.dtor_name;
-        Dafny.ISequence<DAST._IType> _206___mcc_h21 = _source10.dtor_typeArgs;
-        Dafny.ISequence<DAST._IExpression> _207___mcc_h22 = _source10.dtor_args;
-        Dafny.ISequence<DAST._IExpression> _208_args = _207___mcc_h22;
-        Dafny.ISequence<DAST._IType> _209_typeArgs = _206___mcc_h21;
-        Dafny.ISequence<Dafny.Rune> _210_name = _205___mcc_h20;
-        DAST._IExpression _211_on = _204___mcc_h19;
+      } else if (_source11.is_Call) {
+        DAST._IExpression _234___mcc_h19 = _source11.dtor_on;
+        Dafny.ISequence<Dafny.Rune> _235___mcc_h20 = _source11.dtor_name;
+        Dafny.ISequence<DAST._IType> _236___mcc_h21 = _source11.dtor_typeArgs;
+        Dafny.ISequence<DAST._IExpression> _237___mcc_h22 = _source11.dtor_args;
+        Dafny.ISequence<DAST._IExpression> _238_args = _237___mcc_h22;
+        Dafny.ISequence<DAST._IType> _239_typeArgs = _236___mcc_h21;
+        Dafny.ISequence<Dafny.Rune> _240_name = _235___mcc_h20;
+        DAST._IExpression _241_on = _234___mcc_h19;
         {
-          Dafny.ISequence<Dafny.Rune> _212_typeArgString;
-          _212_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          if ((new BigInteger((_209_typeArgs).Count)) >= (BigInteger.One)) {
-            BigInteger _213_typeI;
-            _213_typeI = BigInteger.Zero;
-            _212_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
-            while ((_213_typeI) < (new BigInteger((_209_typeArgs).Count))) {
-              if ((_213_typeI).Sign == 1) {
-                _212_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_212_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _242_typeArgString;
+          _242_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          if ((new BigInteger((_239_typeArgs).Count)) >= (BigInteger.One)) {
+            BigInteger _243_typeI;
+            _243_typeI = BigInteger.Zero;
+            _242_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
+            while ((_243_typeI) < (new BigInteger((_239_typeArgs).Count))) {
+              if ((_243_typeI).Sign == 1) {
+                _242_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_242_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
               }
-              Dafny.ISequence<Dafny.Rune> _214_typeString;
-              Dafny.ISequence<Dafny.Rune> _out38;
-              _out38 = DCOMP.COMP.GenType((_209_typeArgs).Select(_213_typeI));
-              _214_typeString = _out38;
-              _212_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_212_typeArgString, _214_typeString);
-              _213_typeI = (_213_typeI) + (BigInteger.One);
+              Dafny.ISequence<Dafny.Rune> _244_typeString;
+              Dafny.ISequence<Dafny.Rune> _out55;
+              _out55 = DCOMP.COMP.GenType((_239_typeArgs).Select(_243_typeI));
+              _244_typeString = _out55;
+              _242_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_242_typeArgString, _244_typeString);
+              _243_typeI = (_243_typeI) + (BigInteger.One);
             }
-            _212_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_212_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+            _242_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_242_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
           }
-          Dafny.ISequence<Dafny.Rune> _215_argString;
-          _215_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _216_i;
-          _216_i = BigInteger.Zero;
-          while ((_216_i) < (new BigInteger((_208_args).Count))) {
-            if ((_216_i).Sign == 1) {
-              _215_argString = Dafny.Sequence<Dafny.Rune>.Concat(_215_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _245_argString;
+          _245_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _246_i;
+          _246_i = BigInteger.Zero;
+          while ((_246_i) < (new BigInteger((_238_args).Count))) {
+            if ((_246_i).Sign == 1) {
+              _245_argString = Dafny.Sequence<Dafny.Rune>.Concat(_245_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _217_argExpr;
-            Dafny.ISequence<Dafny.Rune> _out39;
-            _out39 = DCOMP.COMP.GenExpr((_208_args).Select(_216_i));
-            _217_argExpr = _out39;
-            _215_argString = Dafny.Sequence<Dafny.Rune>.Concat(_215_argString, _217_argExpr);
-            _216_i = (_216_i) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _247_argExpr;
+            bool _248_isOwned;
+            Dafny.ISequence<Dafny.Rune> _out56;
+            bool _out57;
+            DCOMP.COMP.GenExpr((_238_args).Select(_246_i), @params, false, out _out56, out _out57);
+            _247_argExpr = _out56;
+            _248_isOwned = _out57;
+            _245_argString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_245_argString, ((_248_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _247_argExpr);
+            _246_i = (_246_i) + (BigInteger.One);
           }
-          Dafny.ISequence<Dafny.Rune> _218_enclosingString;
-          Dafny.ISequence<Dafny.Rune> _out40;
-          _out40 = DCOMP.COMP.GenExpr(_211_on);
-          _218_enclosingString = _out40;
-          DAST._IExpression _source12 = _211_on;
-          if (_source12.is_Literal) {
-            DAST._ILiteral _219___mcc_h27 = _source12.dtor_Literal_a0;
+          Dafny.ISequence<Dafny.Rune> _249_enclosingString;
+          bool _250___v15;
+          Dafny.ISequence<Dafny.Rune> _out58;
+          bool _out59;
+          DCOMP.COMP.GenExpr(_241_on, @params, false, out _out58, out _out59);
+          _249_enclosingString = _out58;
+          _250___v15 = _out59;
+          DAST._IExpression _source13 = _241_on;
+          if (_source13.is_Literal) {
+            DAST._ILiteral _251___mcc_h27 = _source13.dtor_Literal_a0;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_Ident) {
-            Dafny.ISequence<Dafny.Rune> _220___mcc_h29 = _source12.dtor_Ident_a0;
+          } else if (_source13.is_Ident) {
+            Dafny.ISequence<Dafny.Rune> _252___mcc_h29 = _source13.dtor_Ident_a0;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_Companion) {
-            DAST._IType _221___mcc_h31 = _source12.dtor_Companion_a0;
+          } else if (_source13.is_Companion) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _253___mcc_h31 = _source13.dtor_Companion_a0;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_249_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
             }
-          } else if (_source12.is_Tuple) {
-            Dafny.ISequence<DAST._IExpression> _222___mcc_h33 = _source12.dtor_Tuple_a0;
+          } else if (_source13.is_Tuple) {
+            Dafny.ISequence<DAST._IExpression> _254___mcc_h33 = _source13.dtor_Tuple_a0;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_DatatypeValue) {
-            DAST._IType _223___mcc_h35 = _source12.dtor_typ;
-            Dafny.ISequence<Dafny.Rune> _224___mcc_h36 = _source12.dtor_variant;
-            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _225___mcc_h37 = _source12.dtor_contents;
+          } else if (_source13.is_DatatypeValue) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _255___mcc_h35 = _source13.dtor_path;
+            Dafny.ISequence<Dafny.Rune> _256___mcc_h36 = _source13.dtor_variant;
+            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _257___mcc_h37 = _source13.dtor_contents;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_BinOp) {
-            Dafny.ISequence<Dafny.Rune> _226___mcc_h41 = _source12.dtor_op;
-            DAST._IExpression _227___mcc_h42 = _source12.dtor_left;
-            DAST._IExpression _228___mcc_h43 = _source12.dtor_right;
+          } else if (_source13.is_BinOp) {
+            Dafny.ISequence<Dafny.Rune> _258___mcc_h41 = _source13.dtor_op;
+            DAST._IExpression _259___mcc_h42 = _source13.dtor_left;
+            DAST._IExpression _260___mcc_h43 = _source13.dtor_right;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_Select) {
-            DAST._IExpression _229___mcc_h47 = _source12.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _230___mcc_h48 = _source12.dtor_field;
-            bool _231___mcc_h49 = _source12.dtor_onDatatype;
+          } else if (_source13.is_Select) {
+            DAST._IExpression _261___mcc_h47 = _source13.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _262___mcc_h48 = _source13.dtor_field;
+            bool _263___mcc_h49 = _source13.dtor_onDatatype;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_TupleSelect) {
-            DAST._IExpression _232___mcc_h53 = _source12.dtor_expr;
-            BigInteger _233___mcc_h54 = _source12.dtor_index;
+          } else if (_source13.is_TupleSelect) {
+            DAST._IExpression _264___mcc_h53 = _source13.dtor_expr;
+            BigInteger _265___mcc_h54 = _source13.dtor_index;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_Call) {
-            DAST._IExpression _234___mcc_h57 = _source12.dtor_on;
-            Dafny.ISequence<Dafny.Rune> _235___mcc_h58 = _source12.dtor_name;
-            Dafny.ISequence<DAST._IType> _236___mcc_h59 = _source12.dtor_typeArgs;
-            Dafny.ISequence<DAST._IExpression> _237___mcc_h60 = _source12.dtor_args;
+          } else if (_source13.is_Call) {
+            DAST._IExpression _266___mcc_h57 = _source13.dtor_on;
+            Dafny.ISequence<Dafny.Rune> _267___mcc_h58 = _source13.dtor_name;
+            Dafny.ISequence<DAST._IType> _268___mcc_h59 = _source13.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _269___mcc_h60 = _source13.dtor_args;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source12.is_TypeTest) {
-            DAST._IExpression _238___mcc_h65 = _source12.dtor_on;
-            DAST._IType _239___mcc_h66 = _source12.dtor_dType;
-            Dafny.ISequence<Dafny.Rune> _240___mcc_h67 = _source12.dtor_variant;
+          } else if (_source13.is_TypeTest) {
+            DAST._IExpression _270___mcc_h65 = _source13.dtor_on;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _271___mcc_h66 = _source13.dtor_dType;
+            Dafny.ISequence<Dafny.Rune> _272___mcc_h67 = _source13.dtor_variant;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else {
-            DAST._IType _241___mcc_h71 = _source12.dtor_typ;
+            DAST._IType _273___mcc_h71 = _source13.dtor_typ;
             {
-              _218_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."));
+              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_218_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _210_name), _212_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _215_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_249_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _240_name), _242_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _245_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          isOwned = true;
         }
-      } else if (_source10.is_TypeTest) {
-        DAST._IExpression _242___mcc_h23 = _source10.dtor_on;
-        DAST._IType _243___mcc_h24 = _source10.dtor_dType;
-        Dafny.ISequence<Dafny.Rune> _244___mcc_h25 = _source10.dtor_variant;
-        Dafny.ISequence<Dafny.Rune> _245_variant = _244___mcc_h25;
-        DAST._IType _246_dType = _243___mcc_h24;
-        DAST._IExpression _247_on = _242___mcc_h23;
+      } else if (_source11.is_TypeTest) {
+        DAST._IExpression _274___mcc_h23 = _source11.dtor_on;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _275___mcc_h24 = _source11.dtor_dType;
+        Dafny.ISequence<Dafny.Rune> _276___mcc_h25 = _source11.dtor_variant;
+        Dafny.ISequence<Dafny.Rune> _277_variant = _276___mcc_h25;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _278_dType = _275___mcc_h24;
+        DAST._IExpression _279_on = _274___mcc_h23;
         {
-          Dafny.ISequence<Dafny.Rune> _248_exprGen;
-          Dafny.ISequence<Dafny.Rune> _out41;
-          _out41 = DCOMP.COMP.GenExpr(_247_on);
-          _248_exprGen = _out41;
-          Dafny.ISequence<Dafny.Rune> _249_typeGen;
-          Dafny.ISequence<Dafny.Rune> _out42;
-          _out42 = DCOMP.COMP.GenType(_246_dType);
-          _249_typeGen = _out42;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("matches!("), _248_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _249_typeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _245_variant), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ .. })"));
+          Dafny.ISequence<Dafny.Rune> _280_exprGen;
+          bool _281___v18;
+          Dafny.ISequence<Dafny.Rune> _out60;
+          bool _out61;
+          DCOMP.COMP.GenExpr(_279_on, @params, false, out _out60, out _out61);
+          _280_exprGen = _out60;
+          _281___v18 = _out61;
+          Dafny.ISequence<Dafny.Rune> _282_dTypePath;
+          Dafny.ISequence<Dafny.Rune> _out62;
+          _out62 = DCOMP.COMP.GenPath(_278_dType);
+          _282_dTypePath = _out62;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("matches!("), _280_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".as_ref(), ")), _282_dTypePath), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _277_variant), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ .. })"));
+          isOwned = true;
         }
       } else {
-        DAST._IType _250___mcc_h26 = _source10.dtor_typ;
-        DAST._IType _251_typ = _250___mcc_h26;
+        DAST._IType _283___mcc_h26 = _source11.dtor_typ;
+        DAST._IType _284_typ = _283___mcc_h26;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("std::default::Default::default()");
+          isOwned = true;
         }
       }
-      return s;
     }
     public static Dafny.ISequence<Dafny.Rune> Compile(Dafny.ISequence<DAST._IModule> p, Dafny.ISequence<Dafny.Rune> runtime) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#![allow(warnings, unconditional_panic)]\n");
       s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("mod dafny_runtime {\n")), runtime), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
-      BigInteger _252_i;
-      _252_i = BigInteger.Zero;
-      while ((_252_i) < (new BigInteger((p).Count))) {
-        Dafny.ISequence<Dafny.Rune> _253_generated = Dafny.Sequence<Dafny.Rune>.Empty;
-        Dafny.ISequence<Dafny.Rune> _out43;
-        _out43 = DCOMP.COMP.GenModule((p).Select(_252_i));
-        _253_generated = _out43;
-        if ((_252_i).Sign == 1) {
+      BigInteger _285_i;
+      _285_i = BigInteger.Zero;
+      while ((_285_i) < (new BigInteger((p).Count))) {
+        Dafny.ISequence<Dafny.Rune> _286_generated = Dafny.Sequence<Dafny.Rune>.Empty;
+        Dafny.ISequence<Dafny.Rune> _out63;
+        _out63 = DCOMP.COMP.GenModule((p).Select(_285_i));
+        _286_generated = _out63;
+        if ((_285_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _253_generated);
-        _252_i = (_252_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _286_generated);
+        _285_i = (_285_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> EmitCallToMain(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> fullName) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nfn main() {\n");
-      BigInteger _254_i;
-      _254_i = BigInteger.Zero;
-      while ((_254_i) < (new BigInteger((fullName).Count))) {
-        if ((_254_i).Sign == 1) {
+      BigInteger _287_i;
+      _287_i = BigInteger.Zero;
+      while ((_287_i) < (new BigInteger((fullName).Count))) {
+        if ((_287_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, (fullName).Select(_254_i));
-        _254_i = (_254_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, (fullName).Select(_287_i));
+        _287_i = (_287_i) + (BigInteger.One);
       }
       s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("();\n}"));
       return s;

--- a/Source/DafnyCore/GeneratedFromDafnyRust.cs
+++ b/Source/DafnyCore/GeneratedFromDafnyRust.cs
@@ -511,7 +511,7 @@ namespace DAST {
 
   public interface _IResolvedType {
     bool is_Datatype { get; }
-    bool is_Primitive { get; }
+    bool is_Newtype { get; }
     Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_path { get; }
     _IResolvedType DowncastClone();
   }
@@ -529,11 +529,11 @@ namespace DAST {
     public static _IResolvedType create_Datatype(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> path) {
       return new ResolvedType_Datatype(path);
     }
-    public static _IResolvedType create_Primitive() {
-      return new ResolvedType_Primitive();
+    public static _IResolvedType create_Newtype() {
+      return new ResolvedType_Newtype();
     }
     public bool is_Datatype { get { return this is ResolvedType_Datatype; } }
-    public bool is_Primitive { get { return this is ResolvedType_Primitive; } }
+    public bool is_Newtype { get { return this is ResolvedType_Newtype; } }
     public Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_path {
       get {
         var d = this;
@@ -569,15 +569,15 @@ namespace DAST {
       return s;
     }
   }
-  public class ResolvedType_Primitive : ResolvedType {
-    public ResolvedType_Primitive() : base() {
+  public class ResolvedType_Newtype : ResolvedType {
+    public ResolvedType_Newtype() : base() {
     }
     public override _IResolvedType DowncastClone() {
       if (this is _IResolvedType dt) { return dt; }
-      return new ResolvedType_Primitive();
+      return new ResolvedType_Newtype();
     }
     public override bool Equals(object other) {
-      var oth = other as DAST.ResolvedType_Primitive;
+      var oth = other as DAST.ResolvedType_Newtype;
       return oth != null;
     }
     public override int GetHashCode() {
@@ -586,7 +586,7 @@ namespace DAST {
       return (int)hash;
     }
     public override string ToString() {
-      string s = "DAST.ResolvedType.Primitive";
+      string s = "DAST.ResolvedType.Newtype";
       return s;
     }
   }
@@ -2692,39 +2692,40 @@ namespace DCOMP {
               s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc<"), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
             }
           } else {
+            DAST._IResolvedType _60_Primitive = _54_resolved;
           }
         }
       } else if (_source1.is_Tuple) {
-        Dafny.ISequence<DAST._IType> _60___mcc_h3 = _source1.dtor_Tuple_a0;
-        Dafny.ISequence<DAST._IType> _61_types = _60___mcc_h3;
+        Dafny.ISequence<DAST._IType> _61___mcc_h3 = _source1.dtor_Tuple_a0;
+        Dafny.ISequence<DAST._IType> _62_types = _61___mcc_h3;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-          BigInteger _62_i;
-          _62_i = BigInteger.Zero;
-          while ((_62_i) < (new BigInteger((_61_types).Count))) {
-            if ((_62_i).Sign == 1) {
+          BigInteger _63_i;
+          _63_i = BigInteger.Zero;
+          while ((_63_i) < (new BigInteger((_62_types).Count))) {
+            if ((_63_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" "));
             }
-            Dafny.ISequence<Dafny.Rune> _63_generated;
+            Dafny.ISequence<Dafny.Rune> _64_generated;
             Dafny.ISequence<Dafny.Rune> _out14;
-            _out14 = DCOMP.COMP.GenType((_61_types).Select(_62_i));
-            _63_generated = _out14;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _63_generated), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
-            _62_i = (_62_i) + (BigInteger.One);
+            _out14 = DCOMP.COMP.GenType((_62_types).Select(_63_i));
+            _64_generated = _out14;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _64_generated), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
+            _63_i = (_63_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
         }
       } else if (_source1.is_Passthrough) {
-        Dafny.ISequence<Dafny.Rune> _64___mcc_h4 = _source1.dtor_Passthrough_a0;
-        Dafny.ISequence<Dafny.Rune> _65_v = _64___mcc_h4;
-        s = _65_v;
+        Dafny.ISequence<Dafny.Rune> _65___mcc_h4 = _source1.dtor_Passthrough_a0;
+        Dafny.ISequence<Dafny.Rune> _66_v = _65___mcc_h4;
+        s = _66_v;
       } else {
-        Dafny.ISequence<Dafny.Rune> _66___mcc_h5 = _source1.dtor_TypeArg_a0;
-        Dafny.ISequence<Dafny.Rune> _source3 = _66___mcc_h5;
+        Dafny.ISequence<Dafny.Rune> _67___mcc_h5 = _source1.dtor_TypeArg_a0;
+        Dafny.ISequence<Dafny.Rune> _source3 = _67___mcc_h5;
         {
-          Dafny.ISequence<Dafny.Rune> _67___mcc_h6 = _source3;
-          Dafny.ISequence<Dafny.Rune> _68_name = _67___mcc_h6;
-          s = _68_name;
+          Dafny.ISequence<Dafny.Rune> _68___mcc_h6 = _source3;
+          Dafny.ISequence<Dafny.Rune> _69_name = _68___mcc_h6;
+          s = _69_name;
         }
       }
       return s;
@@ -2732,159 +2733,159 @@ namespace DCOMP {
     public static Dafny.ISequence<Dafny.Rune> GenClassImplBody(Dafny.ISequence<DAST._IClassItem> body) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _69_i;
-      _69_i = BigInteger.Zero;
-      while ((_69_i) < (new BigInteger((body).Count))) {
-        Dafny.ISequence<Dafny.Rune> _70_generated = Dafny.Sequence<Dafny.Rune>.Empty;
-        DAST._IClassItem _source4 = (body).Select(_69_i);
+      BigInteger _70_i;
+      _70_i = BigInteger.Zero;
+      while ((_70_i) < (new BigInteger((body).Count))) {
+        Dafny.ISequence<Dafny.Rune> _71_generated = Dafny.Sequence<Dafny.Rune>.Empty;
+        DAST._IClassItem _source4 = (body).Select(_70_i);
         if (_source4.is_Method) {
-          DAST._IMethod _71___mcc_h0 = _source4.dtor_Method_a0;
-          DAST._IMethod _72_m = _71___mcc_h0;
+          DAST._IMethod _72___mcc_h0 = _source4.dtor_Method_a0;
+          DAST._IMethod _73_m = _72___mcc_h0;
           Dafny.ISequence<Dafny.Rune> _out15;
-          _out15 = DCOMP.COMP.GenMethod(_72_m);
-          _70_generated = _out15;
+          _out15 = DCOMP.COMP.GenMethod(_73_m);
+          _71_generated = _out15;
         } else {
-          DAST._IFormal _73___mcc_h1 = _source4.dtor_Field_a0;
-          DAST._IFormal _74_f = _73___mcc_h1;
-          _70_generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("TODO");
+          DAST._IFormal _74___mcc_h1 = _source4.dtor_Field_a0;
+          DAST._IFormal _75_f = _74___mcc_h1;
+          _71_generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("TODO");
         }
-        if ((_69_i).Sign == 1) {
+        if ((_70_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _70_generated);
-        _69_i = (_69_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _71_generated);
+        _70_i = (_70_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenParams(Dafny.ISequence<DAST._IFormal> @params) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _75_i;
-      _75_i = BigInteger.Zero;
-      while ((_75_i) < (new BigInteger((@params).Count))) {
-        DAST._IFormal _76_param;
-        _76_param = (@params).Select(_75_i);
-        Dafny.ISequence<Dafny.Rune> _77_paramType;
+      BigInteger _76_i;
+      _76_i = BigInteger.Zero;
+      while ((_76_i) < (new BigInteger((@params).Count))) {
+        DAST._IFormal _77_param;
+        _77_param = (@params).Select(_76_i);
+        Dafny.ISequence<Dafny.Rune> _78_paramType;
         Dafny.ISequence<Dafny.Rune> _out16;
-        _out16 = DCOMP.COMP.GenType((_76_param).dtor_typ);
-        _77_paramType = _out16;
-        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_76_param).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _77_paramType);
-        if ((_75_i) < ((new BigInteger((@params).Count)) - (BigInteger.One))) {
+        _out16 = DCOMP.COMP.GenType((_77_param).dtor_typ);
+        _78_paramType = _out16;
+        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_77_param).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _78_paramType);
+        if ((_76_i) < ((new BigInteger((@params).Count)) - (BigInteger.One))) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
         }
-        _75_i = (_75_i) + (BigInteger.One);
+        _76_i = (_76_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenMethod(DAST._IMethod m) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISequence<Dafny.Rune> _78_params;
+      Dafny.ISequence<Dafny.Rune> _79_params;
       Dafny.ISequence<Dafny.Rune> _out17;
       _out17 = DCOMP.COMP.GenParams((m).dtor_params);
-      _78_params = _out17;
-      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _79_paramNames;
-      _79_paramNames = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-      BigInteger _80_paramI;
-      _80_paramI = BigInteger.Zero;
-      while ((_80_paramI) < (new BigInteger(((m).dtor_params).Count))) {
-        _79_paramNames = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_79_paramNames, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((((m).dtor_params).Select(_80_paramI)).dtor_name));
-        _80_paramI = (_80_paramI) + (BigInteger.One);
+      _79_params = _out17;
+      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _80_paramNames;
+      _80_paramNames = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+      BigInteger _81_paramI;
+      _81_paramI = BigInteger.Zero;
+      while ((_81_paramI) < (new BigInteger(((m).dtor_params).Count))) {
+        _80_paramNames = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_80_paramNames, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((((m).dtor_params).Select(_81_paramI)).dtor_name));
+        _81_paramI = (_81_paramI) + (BigInteger.One);
       }
       if (!((m).dtor_isStatic)) {
-        _78_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self, "), _78_params);
+        _79_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self, "), _79_params);
       }
-      Dafny.ISequence<Dafny.Rune> _81_retType;
-      _81_retType = (((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")));
-      BigInteger _82_typeI;
-      _82_typeI = BigInteger.Zero;
-      while ((_82_typeI) < (new BigInteger(((m).dtor_outTypes).Count))) {
-        if ((_82_typeI).Sign == 1) {
-          _81_retType = Dafny.Sequence<Dafny.Rune>.Concat(_81_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+      Dafny.ISequence<Dafny.Rune> _82_retType;
+      _82_retType = (((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")));
+      BigInteger _83_typeI;
+      _83_typeI = BigInteger.Zero;
+      while ((_83_typeI) < (new BigInteger(((m).dtor_outTypes).Count))) {
+        if ((_83_typeI).Sign == 1) {
+          _82_retType = Dafny.Sequence<Dafny.Rune>.Concat(_82_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
         }
-        Dafny.ISequence<Dafny.Rune> _83_typeString;
+        Dafny.ISequence<Dafny.Rune> _84_typeString;
         Dafny.ISequence<Dafny.Rune> _out18;
-        _out18 = DCOMP.COMP.GenType(((m).dtor_outTypes).Select(_82_typeI));
-        _83_typeString = _out18;
-        _81_retType = Dafny.Sequence<Dafny.Rune>.Concat(_81_retType, _83_typeString);
-        _82_typeI = (_82_typeI) + (BigInteger.One);
+        _out18 = DCOMP.COMP.GenType(((m).dtor_outTypes).Select(_83_typeI));
+        _84_typeString = _out18;
+        _82_retType = Dafny.Sequence<Dafny.Rune>.Concat(_82_retType, _84_typeString);
+        _83_typeI = (_83_typeI) + (BigInteger.One);
       }
       if ((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) {
-        _81_retType = Dafny.Sequence<Dafny.Rune>.Concat(_81_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+        _82_retType = Dafny.Sequence<Dafny.Rune>.Concat(_82_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
       }
       s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn r#"), (m).dtor_name);
       if ((new BigInteger(((m).dtor_typeParams).Count)).Sign == 1) {
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"));
-        BigInteger _84_i;
-        _84_i = BigInteger.Zero;
-        while ((_84_i) < (new BigInteger(((m).dtor_typeParams).Count))) {
-          if ((_84_i).Sign == 1) {
+        BigInteger _85_i;
+        _85_i = BigInteger.Zero;
+        while ((_85_i) < (new BigInteger(((m).dtor_typeParams).Count))) {
+          if ((_85_i).Sign == 1) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
           }
-          Dafny.ISequence<Dafny.Rune> _85_typeString;
+          Dafny.ISequence<Dafny.Rune> _86_typeString;
           Dafny.ISequence<Dafny.Rune> _out19;
-          _out19 = DCOMP.COMP.GenType(((m).dtor_typeParams).Select(_84_i));
-          _85_typeString = _out19;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _85_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default"));
-          _84_i = (_84_i) + (BigInteger.One);
+          _out19 = DCOMP.COMP.GenType(((m).dtor_typeParams).Select(_85_i));
+          _86_typeString = _out19;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _86_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default"));
+          _85_i = (_85_i) + (BigInteger.One);
         }
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
-      Dafny.ISequence<Dafny.Rune> _86_earlyReturn;
-      _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return;");
+      Dafny.ISequence<Dafny.Rune> _87_earlyReturn;
+      _87_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return;");
       DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source5 = (m).dtor_outVars;
       if (_source5.is_Some) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _87___mcc_h0 = _source5.dtor_Some_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _88_outVars = _87___mcc_h0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _88___mcc_h0 = _source5.dtor_Some_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _89_outVars = _88___mcc_h0;
         {
-          _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return (");
-          BigInteger _89_outI;
-          _89_outI = BigInteger.Zero;
-          while ((_89_outI) < (new BigInteger((_88_outVars).Count))) {
-            if ((_89_outI).Sign == 1) {
-              _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_86_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          _87_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return (");
+          BigInteger _90_outI;
+          _90_outI = BigInteger.Zero;
+          while ((_90_outI) < (new BigInteger((_89_outVars).Count))) {
+            if ((_90_outI).Sign == 1) {
+              _87_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_87_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _90_outVar;
-            _90_outVar = (_88_outVars).Select(_89_outI);
-            _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_86_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_90_outVar));
-            _89_outI = (_89_outI) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _91_outVar;
+            _91_outVar = (_89_outVars).Select(_90_outI);
+            _87_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_87_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_91_outVar));
+            _90_outI = (_90_outI) + (BigInteger.One);
           }
-          _86_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_86_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
+          _87_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_87_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
         }
       } else {
       }
-      Dafny.ISequence<Dafny.Rune> _91_body;
+      Dafny.ISequence<Dafny.Rune> _92_body;
       Dafny.ISequence<Dafny.Rune> _out20;
-      _out20 = DCOMP.COMP.GenStmts((m).dtor_body, _79_paramNames, _86_earlyReturn);
-      _91_body = _out20;
+      _out20 = DCOMP.COMP.GenStmts((m).dtor_body, _80_paramNames, _87_earlyReturn);
+      _92_body = _out20;
       DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source6 = (m).dtor_outVars;
       if (_source6.is_Some) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _92___mcc_h1 = _source6.dtor_Some_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _93_outVars = _92___mcc_h1;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _93___mcc_h1 = _source6.dtor_Some_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _94_outVars = _93___mcc_h1;
         {
-          _91_body = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_91_body, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _86_earlyReturn);
+          _92_body = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_92_body, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _87_earlyReturn);
         }
       } else {
       }
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _78_params), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _81_retType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _91_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _79_params), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _82_retType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _92_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenStmts(Dafny.ISequence<DAST._IStatement> stmts, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> @params, Dafny.ISequence<Dafny.Rune> earlyReturn) {
       Dafny.ISequence<Dafny.Rune> generated = Dafny.Sequence<Dafny.Rune>.Empty;
       generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _94_i;
-      _94_i = BigInteger.Zero;
-      while ((_94_i) < (new BigInteger((stmts).Count))) {
-        DAST._IStatement _95_stmt;
-        _95_stmt = (stmts).Select(_94_i);
-        Dafny.ISequence<Dafny.Rune> _96_stmtString;
+      BigInteger _95_i;
+      _95_i = BigInteger.Zero;
+      while ((_95_i) < (new BigInteger((stmts).Count))) {
+        DAST._IStatement _96_stmt;
+        _96_stmt = (stmts).Select(_95_i);
+        Dafny.ISequence<Dafny.Rune> _97_stmtString;
         Dafny.ISequence<Dafny.Rune> _out21;
-        _out21 = DCOMP.COMP.GenStmt(_95_stmt, @params, earlyReturn);
-        _96_stmtString = _out21;
-        if ((_94_i).Sign == 1) {
+        _out21 = DCOMP.COMP.GenStmt(_96_stmt, @params, earlyReturn);
+        _97_stmtString = _out21;
+        if ((_95_i).Sign == 1) {
           generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, _96_stmtString);
-        _94_i = (_94_i) + (BigInteger.One);
+        generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, _97_stmtString);
+        _95_i = (_95_i) + (BigInteger.One);
       }
       return generated;
     }
@@ -2892,263 +2893,263 @@ namespace DCOMP {
       Dafny.ISequence<Dafny.Rune> generated = Dafny.Sequence<Dafny.Rune>.Empty;
       DAST._IStatement _source7 = stmt;
       if (_source7.is_DeclareVar) {
-        Dafny.ISequence<Dafny.Rune> _97___mcc_h0 = _source7.dtor_name;
-        DAST._IType _98___mcc_h1 = _source7.dtor_typ;
-        DAST._IOptional<DAST._IExpression> _99___mcc_h2 = _source7.dtor_maybeValue;
-        DAST._IOptional<DAST._IExpression> _source8 = _99___mcc_h2;
+        Dafny.ISequence<Dafny.Rune> _98___mcc_h0 = _source7.dtor_name;
+        DAST._IType _99___mcc_h1 = _source7.dtor_typ;
+        DAST._IOptional<DAST._IExpression> _100___mcc_h2 = _source7.dtor_maybeValue;
+        DAST._IOptional<DAST._IExpression> _source8 = _100___mcc_h2;
         if (_source8.is_Some) {
-          DAST._IExpression _100___mcc_h3 = _source8.dtor_Some_a0;
-          DAST._IExpression _101_expression = _100___mcc_h3;
-          DAST._IType _102_typ = _98___mcc_h1;
-          Dafny.ISequence<Dafny.Rune> _103_name = _97___mcc_h0;
+          DAST._IExpression _101___mcc_h3 = _source8.dtor_Some_a0;
+          DAST._IExpression _102_expression = _101___mcc_h3;
+          DAST._IType _103_typ = _99___mcc_h1;
+          Dafny.ISequence<Dafny.Rune> _104_name = _98___mcc_h0;
           {
-            Dafny.ISequence<Dafny.Rune> _104_expr;
-            bool _105___v2;
+            Dafny.ISequence<Dafny.Rune> _105_expr;
+            bool _106___v2;
             Dafny.ISequence<Dafny.Rune> _out22;
             bool _out23;
-            DCOMP.COMP.GenExpr(_101_expression, @params, true, out _out22, out _out23);
-            _104_expr = _out22;
-            _105___v2 = _out23;
-            Dafny.ISequence<Dafny.Rune> _106_typeString;
+            DCOMP.COMP.GenExpr(_102_expression, @params, true, out _out22, out _out23);
+            _105_expr = _out22;
+            _106___v2 = _out23;
+            Dafny.ISequence<Dafny.Rune> _107_typeString;
             Dafny.ISequence<Dafny.Rune> _out24;
-            _out24 = DCOMP.COMP.GenType(_102_typ);
-            _106_typeString = _out24;
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _103_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _106_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _104_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            _out24 = DCOMP.COMP.GenType(_103_typ);
+            _107_typeString = _out24;
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _104_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _107_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _105_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
           }
         } else {
-          DAST._IType _107_typ = _98___mcc_h1;
-          Dafny.ISequence<Dafny.Rune> _108_name = _97___mcc_h0;
+          DAST._IType _108_typ = _99___mcc_h1;
+          Dafny.ISequence<Dafny.Rune> _109_name = _98___mcc_h0;
           {
-            Dafny.ISequence<Dafny.Rune> _109_typeString;
+            Dafny.ISequence<Dafny.Rune> _110_typeString;
             Dafny.ISequence<Dafny.Rune> _out25;
-            _out25 = DCOMP.COMP.GenType(_107_typ);
-            _109_typeString = _out25;
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _108_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _109_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            _out25 = DCOMP.COMP.GenType(_108_typ);
+            _110_typeString = _out25;
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _109_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _110_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
           }
         }
       } else if (_source7.is_Assign) {
-        Dafny.ISequence<Dafny.Rune> _110___mcc_h4 = _source7.dtor_name;
-        DAST._IExpression _111___mcc_h5 = _source7.dtor_value;
-        DAST._IExpression _112_expression = _111___mcc_h5;
-        Dafny.ISequence<Dafny.Rune> _113_name = _110___mcc_h4;
+        Dafny.ISequence<Dafny.Rune> _111___mcc_h4 = _source7.dtor_name;
+        DAST._IExpression _112___mcc_h5 = _source7.dtor_value;
+        DAST._IExpression _113_expression = _112___mcc_h5;
+        Dafny.ISequence<Dafny.Rune> _114_name = _111___mcc_h4;
         {
-          Dafny.ISequence<Dafny.Rune> _114_expr;
-          bool _115___v3;
+          Dafny.ISequence<Dafny.Rune> _115_expr;
+          bool _116___v3;
           Dafny.ISequence<Dafny.Rune> _out26;
           bool _out27;
-          DCOMP.COMP.GenExpr(_112_expression, @params, true, out _out26, out _out27);
-          _114_expr = _out26;
-          _115___v3 = _out27;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _113_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _114_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+          DCOMP.COMP.GenExpr(_113_expression, @params, true, out _out26, out _out27);
+          _115_expr = _out26;
+          _116___v3 = _out27;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _114_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _115_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
         }
       } else if (_source7.is_If) {
-        DAST._IExpression _116___mcc_h6 = _source7.dtor_cond;
-        Dafny.ISequence<DAST._IStatement> _117___mcc_h7 = _source7.dtor_thn;
-        Dafny.ISequence<DAST._IStatement> _118___mcc_h8 = _source7.dtor_els;
-        Dafny.ISequence<DAST._IStatement> _119_els = _118___mcc_h8;
-        Dafny.ISequence<DAST._IStatement> _120_thn = _117___mcc_h7;
-        DAST._IExpression _121_cond = _116___mcc_h6;
+        DAST._IExpression _117___mcc_h6 = _source7.dtor_cond;
+        Dafny.ISequence<DAST._IStatement> _118___mcc_h7 = _source7.dtor_thn;
+        Dafny.ISequence<DAST._IStatement> _119___mcc_h8 = _source7.dtor_els;
+        Dafny.ISequence<DAST._IStatement> _120_els = _119___mcc_h8;
+        Dafny.ISequence<DAST._IStatement> _121_thn = _118___mcc_h7;
+        DAST._IExpression _122_cond = _117___mcc_h6;
         {
-          Dafny.ISequence<Dafny.Rune> _122_condString;
-          bool _123___v4;
+          Dafny.ISequence<Dafny.Rune> _123_condString;
+          bool _124___v4;
           Dafny.ISequence<Dafny.Rune> _out28;
           bool _out29;
-          DCOMP.COMP.GenExpr(_121_cond, @params, true, out _out28, out _out29);
-          _122_condString = _out28;
-          _123___v4 = _out29;
-          Dafny.ISequence<Dafny.Rune> _124_thnString;
+          DCOMP.COMP.GenExpr(_122_cond, @params, true, out _out28, out _out29);
+          _123_condString = _out28;
+          _124___v4 = _out29;
+          Dafny.ISequence<Dafny.Rune> _125_thnString;
           Dafny.ISequence<Dafny.Rune> _out30;
-          _out30 = DCOMP.COMP.GenStmts(_120_thn, @params, earlyReturn);
-          _124_thnString = _out30;
-          Dafny.ISequence<Dafny.Rune> _125_elsString;
+          _out30 = DCOMP.COMP.GenStmts(_121_thn, @params, earlyReturn);
+          _125_thnString = _out30;
+          Dafny.ISequence<Dafny.Rune> _126_elsString;
           Dafny.ISequence<Dafny.Rune> _out31;
-          _out31 = DCOMP.COMP.GenStmts(_119_els, @params, earlyReturn);
-          _125_elsString = _out31;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if "), _122_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _124_thnString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _125_elsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+          _out31 = DCOMP.COMP.GenStmts(_120_els, @params, earlyReturn);
+          _126_elsString = _out31;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if "), _123_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _125_thnString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _126_elsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
         }
       } else if (_source7.is_Call) {
-        DAST._IExpression _126___mcc_h9 = _source7.dtor_on;
-        Dafny.ISequence<Dafny.Rune> _127___mcc_h10 = _source7.dtor_name;
-        Dafny.ISequence<DAST._IType> _128___mcc_h11 = _source7.dtor_typeArgs;
-        Dafny.ISequence<DAST._IExpression> _129___mcc_h12 = _source7.dtor_args;
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _130___mcc_h13 = _source7.dtor_outs;
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _131_maybeOutVars = _130___mcc_h13;
-        Dafny.ISequence<DAST._IExpression> _132_args = _129___mcc_h12;
-        Dafny.ISequence<DAST._IType> _133_typeArgs = _128___mcc_h11;
-        Dafny.ISequence<Dafny.Rune> _134_name = _127___mcc_h10;
-        DAST._IExpression _135_on = _126___mcc_h9;
+        DAST._IExpression _127___mcc_h9 = _source7.dtor_on;
+        Dafny.ISequence<Dafny.Rune> _128___mcc_h10 = _source7.dtor_name;
+        Dafny.ISequence<DAST._IType> _129___mcc_h11 = _source7.dtor_typeArgs;
+        Dafny.ISequence<DAST._IExpression> _130___mcc_h12 = _source7.dtor_args;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _131___mcc_h13 = _source7.dtor_outs;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _132_maybeOutVars = _131___mcc_h13;
+        Dafny.ISequence<DAST._IExpression> _133_args = _130___mcc_h12;
+        Dafny.ISequence<DAST._IType> _134_typeArgs = _129___mcc_h11;
+        Dafny.ISequence<Dafny.Rune> _135_name = _128___mcc_h10;
+        DAST._IExpression _136_on = _127___mcc_h9;
         {
-          Dafny.ISequence<Dafny.Rune> _136_typeArgString;
-          _136_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          if ((new BigInteger((_133_typeArgs).Count)) >= (BigInteger.One)) {
-            BigInteger _137_typeI;
-            _137_typeI = BigInteger.Zero;
-            _136_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
-            while ((_137_typeI) < (new BigInteger((_133_typeArgs).Count))) {
-              if ((_137_typeI).Sign == 1) {
-                _136_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_136_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _137_typeArgString;
+          _137_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          if ((new BigInteger((_134_typeArgs).Count)) >= (BigInteger.One)) {
+            BigInteger _138_typeI;
+            _138_typeI = BigInteger.Zero;
+            _137_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
+            while ((_138_typeI) < (new BigInteger((_134_typeArgs).Count))) {
+              if ((_138_typeI).Sign == 1) {
+                _137_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_137_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
               }
-              Dafny.ISequence<Dafny.Rune> _138_typeString;
+              Dafny.ISequence<Dafny.Rune> _139_typeString;
               Dafny.ISequence<Dafny.Rune> _out32;
-              _out32 = DCOMP.COMP.GenType((_133_typeArgs).Select(_137_typeI));
-              _138_typeString = _out32;
-              _136_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_136_typeArgString, _138_typeString);
-              _137_typeI = (_137_typeI) + (BigInteger.One);
+              _out32 = DCOMP.COMP.GenType((_134_typeArgs).Select(_138_typeI));
+              _139_typeString = _out32;
+              _137_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_137_typeArgString, _139_typeString);
+              _138_typeI = (_138_typeI) + (BigInteger.One);
             }
-            _136_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_136_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+            _137_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_137_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
           }
-          Dafny.ISequence<Dafny.Rune> _139_argString;
-          _139_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _140_i;
-          _140_i = BigInteger.Zero;
-          while ((_140_i) < (new BigInteger((_132_args).Count))) {
-            if ((_140_i).Sign == 1) {
-              _139_argString = Dafny.Sequence<Dafny.Rune>.Concat(_139_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _140_argString;
+          _140_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _141_i;
+          _141_i = BigInteger.Zero;
+          while ((_141_i) < (new BigInteger((_133_args).Count))) {
+            if ((_141_i).Sign == 1) {
+              _140_argString = Dafny.Sequence<Dafny.Rune>.Concat(_140_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _141_argExpr;
-            bool _142_isOwned;
+            Dafny.ISequence<Dafny.Rune> _142_argExpr;
+            bool _143_isOwned;
             Dafny.ISequence<Dafny.Rune> _out33;
             bool _out34;
-            DCOMP.COMP.GenExpr((_132_args).Select(_140_i), @params, false, out _out33, out _out34);
-            _141_argExpr = _out33;
-            _142_isOwned = _out34;
-            _139_argString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_139_argString, ((_142_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _141_argExpr);
-            _140_i = (_140_i) + (BigInteger.One);
+            DCOMP.COMP.GenExpr((_133_args).Select(_141_i), @params, false, out _out33, out _out34);
+            _142_argExpr = _out33;
+            _143_isOwned = _out34;
+            _140_argString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_140_argString, ((_143_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _142_argExpr);
+            _141_i = (_141_i) + (BigInteger.One);
           }
-          Dafny.ISequence<Dafny.Rune> _143_enclosingString;
-          bool _144___v5;
+          Dafny.ISequence<Dafny.Rune> _144_enclosingString;
+          bool _145___v5;
           Dafny.ISequence<Dafny.Rune> _out35;
           bool _out36;
-          DCOMP.COMP.GenExpr(_135_on, @params, true, out _out35, out _out36);
-          _143_enclosingString = _out35;
-          _144___v5 = _out36;
-          DAST._IExpression _source9 = _135_on;
+          DCOMP.COMP.GenExpr(_136_on, @params, true, out _out35, out _out36);
+          _144_enclosingString = _out35;
+          _145___v5 = _out36;
+          DAST._IExpression _source9 = _136_on;
           if (_source9.is_Literal) {
-            DAST._ILiteral _145___mcc_h16 = _source9.dtor_Literal_a0;
+            DAST._ILiteral _146___mcc_h16 = _source9.dtor_Literal_a0;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_Ident) {
-            Dafny.ISequence<Dafny.Rune> _146___mcc_h18 = _source9.dtor_Ident_a0;
+            Dafny.ISequence<Dafny.Rune> _147___mcc_h18 = _source9.dtor_Ident_a0;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_Companion) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _147___mcc_h20 = _source9.dtor_Companion_a0;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _148___mcc_h20 = _source9.dtor_Companion_a0;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_143_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_144_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
             }
           } else if (_source9.is_Tuple) {
-            Dafny.ISequence<DAST._IExpression> _148___mcc_h22 = _source9.dtor_Tuple_a0;
+            Dafny.ISequence<DAST._IExpression> _149___mcc_h22 = _source9.dtor_Tuple_a0;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_DatatypeValue) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _149___mcc_h24 = _source9.dtor_path;
-            Dafny.ISequence<Dafny.Rune> _150___mcc_h25 = _source9.dtor_variant;
-            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _151___mcc_h26 = _source9.dtor_contents;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _150___mcc_h24 = _source9.dtor_path;
+            Dafny.ISequence<Dafny.Rune> _151___mcc_h25 = _source9.dtor_variant;
+            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _152___mcc_h26 = _source9.dtor_contents;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_BinOp) {
-            Dafny.ISequence<Dafny.Rune> _152___mcc_h30 = _source9.dtor_op;
-            DAST._IExpression _153___mcc_h31 = _source9.dtor_left;
-            DAST._IExpression _154___mcc_h32 = _source9.dtor_right;
+            Dafny.ISequence<Dafny.Rune> _153___mcc_h30 = _source9.dtor_op;
+            DAST._IExpression _154___mcc_h31 = _source9.dtor_left;
+            DAST._IExpression _155___mcc_h32 = _source9.dtor_right;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_Select) {
-            DAST._IExpression _155___mcc_h36 = _source9.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _156___mcc_h37 = _source9.dtor_field;
-            bool _157___mcc_h38 = _source9.dtor_onDatatype;
+            DAST._IExpression _156___mcc_h36 = _source9.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _157___mcc_h37 = _source9.dtor_field;
+            bool _158___mcc_h38 = _source9.dtor_onDatatype;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_TupleSelect) {
-            DAST._IExpression _158___mcc_h42 = _source9.dtor_expr;
-            BigInteger _159___mcc_h43 = _source9.dtor_index;
+            DAST._IExpression _159___mcc_h42 = _source9.dtor_expr;
+            BigInteger _160___mcc_h43 = _source9.dtor_index;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_Call) {
-            DAST._IExpression _160___mcc_h46 = _source9.dtor_on;
-            Dafny.ISequence<Dafny.Rune> _161___mcc_h47 = _source9.dtor_name;
-            Dafny.ISequence<DAST._IType> _162___mcc_h48 = _source9.dtor_typeArgs;
-            Dafny.ISequence<DAST._IExpression> _163___mcc_h49 = _source9.dtor_args;
+            DAST._IExpression _161___mcc_h46 = _source9.dtor_on;
+            Dafny.ISequence<Dafny.Rune> _162___mcc_h47 = _source9.dtor_name;
+            Dafny.ISequence<DAST._IType> _163___mcc_h48 = _source9.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _164___mcc_h49 = _source9.dtor_args;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source9.is_TypeTest) {
-            DAST._IExpression _164___mcc_h54 = _source9.dtor_on;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _165___mcc_h55 = _source9.dtor_dType;
-            Dafny.ISequence<Dafny.Rune> _166___mcc_h56 = _source9.dtor_variant;
+            DAST._IExpression _165___mcc_h54 = _source9.dtor_on;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _166___mcc_h55 = _source9.dtor_dType;
+            Dafny.ISequence<Dafny.Rune> _167___mcc_h56 = _source9.dtor_variant;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else {
-            DAST._IType _167___mcc_h60 = _source9.dtor_typ;
+            DAST._IType _168___mcc_h60 = _source9.dtor_typ;
             {
-              _143_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _144_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           }
-          Dafny.ISequence<Dafny.Rune> _168_receiver;
-          _168_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source10 = _131_maybeOutVars;
+          Dafny.ISequence<Dafny.Rune> _169_receiver;
+          _169_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source10 = _132_maybeOutVars;
           if (_source10.is_Some) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _169___mcc_h62 = _source10.dtor_Some_a0;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _170_outVars = _169___mcc_h62;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _170___mcc_h62 = _source10.dtor_Some_a0;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _171_outVars = _170___mcc_h62;
             {
-              if ((new BigInteger((_170_outVars).Count)) > (BigInteger.One)) {
-                _168_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
+              if ((new BigInteger((_171_outVars).Count)) > (BigInteger.One)) {
+                _169_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
               }
-              BigInteger _171_outI;
-              _171_outI = BigInteger.Zero;
-              while ((_171_outI) < (new BigInteger((_170_outVars).Count))) {
-                if ((_171_outI).Sign == 1) {
-                  _168_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+              BigInteger _172_outI;
+              _172_outI = BigInteger.Zero;
+              while ((_172_outI) < (new BigInteger((_171_outVars).Count))) {
+                if ((_172_outI).Sign == 1) {
+                  _169_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_169_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
                 }
-                Dafny.ISequence<Dafny.Rune> _172_outVar;
-                _172_outVar = (_170_outVars).Select(_171_outI);
-                _168_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, (_172_outVar));
-                _171_outI = (_171_outI) + (BigInteger.One);
+                Dafny.ISequence<Dafny.Rune> _173_outVar;
+                _173_outVar = (_171_outVars).Select(_172_outI);
+                _169_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_169_receiver, (_173_outVar));
+                _172_outI = (_172_outI) + (BigInteger.One);
               }
-              if ((new BigInteger((_170_outVars).Count)) > (BigInteger.One)) {
-                _168_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              if ((new BigInteger((_171_outVars).Count)) > (BigInteger.One)) {
+                _169_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_169_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
               }
             }
           } else {
           }
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(((!(_168_receiver).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))) ? (Dafny.Sequence<Dafny.Rune>.Concat(_168_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = "))) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))), _143_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _134_name), _136_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _139_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(((!(_169_receiver).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))) ? (Dafny.Sequence<Dafny.Rune>.Concat(_169_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = "))) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))), _144_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _135_name), _137_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _140_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
         }
       } else if (_source7.is_Return) {
-        DAST._IExpression _173___mcc_h14 = _source7.dtor_expr;
-        DAST._IExpression _174_expr = _173___mcc_h14;
+        DAST._IExpression _174___mcc_h14 = _source7.dtor_expr;
+        DAST._IExpression _175_expr = _174___mcc_h14;
         {
-          Dafny.ISequence<Dafny.Rune> _175_exprString;
-          bool _176___v8;
+          Dafny.ISequence<Dafny.Rune> _176_exprString;
+          bool _177___v8;
           Dafny.ISequence<Dafny.Rune> _out37;
           bool _out38;
-          DCOMP.COMP.GenExpr(_174_expr, @params, true, out _out37, out _out38);
-          _175_exprString = _out37;
-          _176___v8 = _out38;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return "), _175_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+          DCOMP.COMP.GenExpr(_175_expr, @params, true, out _out37, out _out38);
+          _176_exprString = _out37;
+          _177___v8 = _out38;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return "), _176_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
         }
       } else if (_source7.is_EarlyReturn) {
         {
           generated = earlyReturn;
         }
       } else {
-        DAST._IExpression _177___mcc_h15 = _source7.dtor_Print_a0;
-        DAST._IExpression _178_e = _177___mcc_h15;
+        DAST._IExpression _178___mcc_h15 = _source7.dtor_Print_a0;
+        DAST._IExpression _179_e = _178___mcc_h15;
         {
-          Dafny.ISequence<Dafny.Rune> _179_printedExpr;
-          bool _180_isOwned;
+          Dafny.ISequence<Dafny.Rune> _180_printedExpr;
+          bool _181_isOwned;
           Dafny.ISequence<Dafny.Rune> _out39;
           bool _out40;
-          DCOMP.COMP.GenExpr(_178_e, @params, false, out _out39, out _out40);
-          _179_printedExpr = _out39;
-          _180_isOwned = _out40;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper("), ((_180_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _179_printedExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("));"));
+          DCOMP.COMP.GenExpr(_179_e, @params, false, out _out39, out _out40);
+          _180_printedExpr = _out39;
+          _181_isOwned = _out40;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper("), ((_181_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _180_printedExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("));"));
         }
       }
       return generated;
@@ -3158,11 +3159,11 @@ namespace DCOMP {
       isOwned = false;
       DAST._IExpression _source11 = e;
       if (_source11.is_Literal) {
-        DAST._ILiteral _181___mcc_h0 = _source11.dtor_Literal_a0;
-        DAST._ILiteral _source12 = _181___mcc_h0;
+        DAST._ILiteral _182___mcc_h0 = _source11.dtor_Literal_a0;
+        DAST._ILiteral _source12 = _182___mcc_h0;
         if (_source12.is_BoolLiteral) {
-          bool _182___mcc_h1 = _source12.dtor_BoolLiteral_a0;
-          if ((_182___mcc_h1) == (false)) {
+          bool _183___mcc_h1 = _source12.dtor_BoolLiteral_a0;
+          if ((_183___mcc_h1) == (false)) {
             {
               s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("false");
               isOwned = true;
@@ -3174,37 +3175,37 @@ namespace DCOMP {
             }
           }
         } else if (_source12.is_IntLiteral) {
-          BigInteger _183___mcc_h2 = _source12.dtor_IntLiteral_a0;
-          BigInteger _184_i = _183___mcc_h2;
+          BigInteger _184___mcc_h2 = _source12.dtor_IntLiteral_a0;
+          BigInteger _185_i = _184___mcc_h2;
           {
-            if ((_184_i).Sign == -1) {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("-"), DCOMP.__default.natToString((BigInteger.Zero) - (_184_i)));
+            if ((_185_i).Sign == -1) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("-"), DCOMP.__default.natToString((BigInteger.Zero) - (_185_i)));
             } else {
-              s = DCOMP.__default.natToString(_184_i);
+              s = DCOMP.__default.natToString(_185_i);
             }
             isOwned = true;
           }
         } else if (_source12.is_DecLiteral) {
-          Dafny.ISequence<Dafny.Rune> _185___mcc_h3 = _source12.dtor_DecLiteral_a0;
-          Dafny.ISequence<Dafny.Rune> _186_l = _185___mcc_h3;
+          Dafny.ISequence<Dafny.Rune> _186___mcc_h3 = _source12.dtor_DecLiteral_a0;
+          Dafny.ISequence<Dafny.Rune> _187_l = _186___mcc_h3;
           {
-            s = _186_l;
+            s = _187_l;
             isOwned = true;
           }
         } else {
-          Dafny.ISequence<Dafny.Rune> _187___mcc_h4 = _source12.dtor_StringLiteral_a0;
-          Dafny.ISequence<Dafny.Rune> _188_l = _187___mcc_h4;
+          Dafny.ISequence<Dafny.Rune> _188___mcc_h4 = _source12.dtor_StringLiteral_a0;
+          Dafny.ISequence<Dafny.Rune> _189_l = _188___mcc_h4;
           {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""), _188_l), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""), _189_l), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""));
             isOwned = true;
           }
         }
       } else if (_source11.is_Ident) {
-        Dafny.ISequence<Dafny.Rune> _189___mcc_h5 = _source11.dtor_Ident_a0;
-        Dafny.ISequence<Dafny.Rune> _190_name = _189___mcc_h5;
+        Dafny.ISequence<Dafny.Rune> _190___mcc_h5 = _source11.dtor_Ident_a0;
+        Dafny.ISequence<Dafny.Rune> _191_name = _190___mcc_h5;
         {
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _190_name);
-          if ((@params).Contains(_190_name)) {
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _191_name);
+          if ((@params).Contains(_191_name)) {
             if (mustOwn) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
               isOwned = true;
@@ -3222,116 +3223,116 @@ namespace DCOMP {
           }
         }
       } else if (_source11.is_Companion) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _191___mcc_h6 = _source11.dtor_Companion_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _192_path = _191___mcc_h6;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _192___mcc_h6 = _source11.dtor_Companion_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _193_path = _192___mcc_h6;
         {
           Dafny.ISequence<Dafny.Rune> _out41;
-          _out41 = DCOMP.COMP.GenPath(_192_path);
+          _out41 = DCOMP.COMP.GenPath(_193_path);
           s = _out41;
           isOwned = true;
         }
       } else if (_source11.is_Tuple) {
-        Dafny.ISequence<DAST._IExpression> _193___mcc_h7 = _source11.dtor_Tuple_a0;
-        Dafny.ISequence<DAST._IExpression> _194_values = _193___mcc_h7;
+        Dafny.ISequence<DAST._IExpression> _194___mcc_h7 = _source11.dtor_Tuple_a0;
+        Dafny.ISequence<DAST._IExpression> _195_values = _194___mcc_h7;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-          BigInteger _195_i;
-          _195_i = BigInteger.Zero;
-          while ((_195_i) < (new BigInteger((_194_values).Count))) {
-            if ((_195_i).Sign == 1) {
+          BigInteger _196_i;
+          _196_i = BigInteger.Zero;
+          while ((_196_i) < (new BigInteger((_195_values).Count))) {
+            if ((_196_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" "));
             }
-            Dafny.ISequence<Dafny.Rune> _196_recursiveGen;
-            bool _197___v9;
+            Dafny.ISequence<Dafny.Rune> _197_recursiveGen;
+            bool _198___v9;
             Dafny.ISequence<Dafny.Rune> _out42;
             bool _out43;
-            DCOMP.COMP.GenExpr((_194_values).Select(_195_i), @params, true, out _out42, out _out43);
-            _196_recursiveGen = _out42;
-            _197___v9 = _out43;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _196_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
-            _195_i = (_195_i) + (BigInteger.One);
+            DCOMP.COMP.GenExpr((_195_values).Select(_196_i), @params, true, out _out42, out _out43);
+            _197_recursiveGen = _out42;
+            _198___v9 = _out43;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _197_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
+            _196_i = (_196_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
         }
       } else if (_source11.is_DatatypeValue) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _198___mcc_h8 = _source11.dtor_path;
-        Dafny.ISequence<Dafny.Rune> _199___mcc_h9 = _source11.dtor_variant;
-        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _200___mcc_h10 = _source11.dtor_contents;
-        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _201_values = _200___mcc_h10;
-        Dafny.ISequence<Dafny.Rune> _202_variant = _199___mcc_h9;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _203_path = _198___mcc_h8;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _199___mcc_h8 = _source11.dtor_path;
+        Dafny.ISequence<Dafny.Rune> _200___mcc_h9 = _source11.dtor_variant;
+        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _201___mcc_h10 = _source11.dtor_contents;
+        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _202_values = _201___mcc_h10;
+        Dafny.ISequence<Dafny.Rune> _203_variant = _200___mcc_h9;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _204_path = _199___mcc_h8;
         {
-          Dafny.ISequence<Dafny.Rune> _204_path;
+          Dafny.ISequence<Dafny.Rune> _205_path;
           Dafny.ISequence<Dafny.Rune> _out44;
-          _out44 = DCOMP.COMP.GenPath(_203_path);
-          _204_path = _out44;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _204_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _202_variant);
-          BigInteger _205_i;
-          _205_i = BigInteger.Zero;
+          _out44 = DCOMP.COMP.GenPath(_204_path);
+          _205_path = _out44;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _205_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _203_variant);
+          BigInteger _206_i;
+          _206_i = BigInteger.Zero;
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {"));
-          while ((_205_i) < (new BigInteger((_201_values).Count))) {
-            _System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression> _let_tmp_rhs0 = (_201_values).Select(_205_i);
-            Dafny.ISequence<Dafny.Rune> _206_name = _let_tmp_rhs0.dtor__0;
-            DAST._IExpression _207_value = _let_tmp_rhs0.dtor__1;
-            if ((_205_i).Sign == 1) {
+          while ((_206_i) < (new BigInteger((_202_values).Count))) {
+            _System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression> _let_tmp_rhs0 = (_202_values).Select(_206_i);
+            Dafny.ISequence<Dafny.Rune> _207_name = _let_tmp_rhs0.dtor__0;
+            DAST._IExpression _208_value = _let_tmp_rhs0.dtor__1;
+            if ((_206_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _208_recursiveGen;
-            bool _209___v10;
+            Dafny.ISequence<Dafny.Rune> _209_recursiveGen;
+            bool _210___v10;
             Dafny.ISequence<Dafny.Rune> _out45;
             bool _out46;
-            DCOMP.COMP.GenExpr(_207_value, @params, true, out _out45, out _out46);
-            _208_recursiveGen = _out45;
-            _209___v10 = _out46;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _206_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _208_recursiveGen);
-            _205_i = (_205_i) + (BigInteger.One);
+            DCOMP.COMP.GenExpr(_208_value, @params, true, out _out45, out _out46);
+            _209_recursiveGen = _out45;
+            _210___v10 = _out46;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _207_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _209_recursiveGen);
+            _206_i = (_206_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" })"));
           isOwned = true;
         }
       } else if (_source11.is_BinOp) {
-        Dafny.ISequence<Dafny.Rune> _210___mcc_h11 = _source11.dtor_op;
-        DAST._IExpression _211___mcc_h12 = _source11.dtor_left;
-        DAST._IExpression _212___mcc_h13 = _source11.dtor_right;
-        DAST._IExpression _213_r = _212___mcc_h13;
-        DAST._IExpression _214_l = _211___mcc_h12;
-        Dafny.ISequence<Dafny.Rune> _215_op = _210___mcc_h11;
+        Dafny.ISequence<Dafny.Rune> _211___mcc_h11 = _source11.dtor_op;
+        DAST._IExpression _212___mcc_h12 = _source11.dtor_left;
+        DAST._IExpression _213___mcc_h13 = _source11.dtor_right;
+        DAST._IExpression _214_r = _213___mcc_h13;
+        DAST._IExpression _215_l = _212___mcc_h12;
+        Dafny.ISequence<Dafny.Rune> _216_op = _211___mcc_h11;
         {
-          Dafny.ISequence<Dafny.Rune> _216_left;
-          bool _217___v11;
+          Dafny.ISequence<Dafny.Rune> _217_left;
+          bool _218___v11;
           Dafny.ISequence<Dafny.Rune> _out47;
           bool _out48;
-          DCOMP.COMP.GenExpr(_214_l, @params, true, out _out47, out _out48);
-          _216_left = _out47;
-          _217___v11 = _out48;
-          Dafny.ISequence<Dafny.Rune> _218_right;
-          bool _219___v12;
+          DCOMP.COMP.GenExpr(_215_l, @params, true, out _out47, out _out48);
+          _217_left = _out47;
+          _218___v11 = _out48;
+          Dafny.ISequence<Dafny.Rune> _219_right;
+          bool _220___v12;
           Dafny.ISequence<Dafny.Rune> _out49;
           bool _out50;
-          DCOMP.COMP.GenExpr(_213_r, @params, true, out _out49, out _out50);
-          _218_right = _out49;
-          _219___v12 = _out50;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _216_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _215_op), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _218_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          DCOMP.COMP.GenExpr(_214_r, @params, true, out _out49, out _out50);
+          _219_right = _out49;
+          _220___v12 = _out50;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _217_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _216_op), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _219_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
         }
       } else if (_source11.is_Select) {
-        DAST._IExpression _220___mcc_h14 = _source11.dtor_expr;
-        Dafny.ISequence<Dafny.Rune> _221___mcc_h15 = _source11.dtor_field;
-        bool _222___mcc_h16 = _source11.dtor_onDatatype;
-        bool _223_isDatatype = _222___mcc_h16;
-        Dafny.ISequence<Dafny.Rune> _224_field = _221___mcc_h15;
-        DAST._IExpression _225_on = _220___mcc_h14;
+        DAST._IExpression _221___mcc_h14 = _source11.dtor_expr;
+        Dafny.ISequence<Dafny.Rune> _222___mcc_h15 = _source11.dtor_field;
+        bool _223___mcc_h16 = _source11.dtor_onDatatype;
+        bool _224_isDatatype = _223___mcc_h16;
+        Dafny.ISequence<Dafny.Rune> _225_field = _222___mcc_h15;
+        DAST._IExpression _226_on = _221___mcc_h14;
         {
-          Dafny.ISequence<Dafny.Rune> _226_onString;
-          bool _227___v13;
+          Dafny.ISequence<Dafny.Rune> _227_onString;
+          bool _228___v13;
           Dafny.ISequence<Dafny.Rune> _out51;
           bool _out52;
-          DCOMP.COMP.GenExpr(_225_on, @params, false, out _out51, out _out52);
-          _226_onString = _out51;
-          _227___v13 = _out52;
-          if (_223_isDatatype) {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _226_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _224_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("()"));
+          DCOMP.COMP.GenExpr(_226_on, @params, false, out _out51, out _out52);
+          _227_onString = _out51;
+          _228___v13 = _out52;
+          if (_224_isDatatype) {
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _227_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _225_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("()"));
             if (mustOwn) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
               isOwned = true;
@@ -3339,7 +3340,7 @@ namespace DCOMP {
               isOwned = false;
             }
           } else {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _226_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _224_field);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _227_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _225_field);
             if (mustOwn) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
               isOwned = true;
@@ -3349,19 +3350,19 @@ namespace DCOMP {
           }
         }
       } else if (_source11.is_TupleSelect) {
-        DAST._IExpression _228___mcc_h17 = _source11.dtor_expr;
-        BigInteger _229___mcc_h18 = _source11.dtor_index;
-        BigInteger _230_idx = _229___mcc_h18;
-        DAST._IExpression _231_on = _228___mcc_h17;
+        DAST._IExpression _229___mcc_h17 = _source11.dtor_expr;
+        BigInteger _230___mcc_h18 = _source11.dtor_index;
+        BigInteger _231_idx = _230___mcc_h18;
+        DAST._IExpression _232_on = _229___mcc_h17;
         {
-          Dafny.ISequence<Dafny.Rune> _232_onString;
-          bool _233___v14;
+          Dafny.ISequence<Dafny.Rune> _233_onString;
+          bool _234___v14;
           Dafny.ISequence<Dafny.Rune> _out53;
           bool _out54;
-          DCOMP.COMP.GenExpr(_231_on, @params, false, out _out53, out _out54);
-          _232_onString = _out53;
-          _233___v14 = _out54;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_232_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), DCOMP.__default.natToString(_230_idx));
+          DCOMP.COMP.GenExpr(_232_on, @params, false, out _out53, out _out54);
+          _233_onString = _out53;
+          _234___v14 = _out54;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_233_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), DCOMP.__default.natToString(_231_idx));
           if (mustOwn) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
             isOwned = true;
@@ -3370,156 +3371,156 @@ namespace DCOMP {
           }
         }
       } else if (_source11.is_Call) {
-        DAST._IExpression _234___mcc_h19 = _source11.dtor_on;
-        Dafny.ISequence<Dafny.Rune> _235___mcc_h20 = _source11.dtor_name;
-        Dafny.ISequence<DAST._IType> _236___mcc_h21 = _source11.dtor_typeArgs;
-        Dafny.ISequence<DAST._IExpression> _237___mcc_h22 = _source11.dtor_args;
-        Dafny.ISequence<DAST._IExpression> _238_args = _237___mcc_h22;
-        Dafny.ISequence<DAST._IType> _239_typeArgs = _236___mcc_h21;
-        Dafny.ISequence<Dafny.Rune> _240_name = _235___mcc_h20;
-        DAST._IExpression _241_on = _234___mcc_h19;
+        DAST._IExpression _235___mcc_h19 = _source11.dtor_on;
+        Dafny.ISequence<Dafny.Rune> _236___mcc_h20 = _source11.dtor_name;
+        Dafny.ISequence<DAST._IType> _237___mcc_h21 = _source11.dtor_typeArgs;
+        Dafny.ISequence<DAST._IExpression> _238___mcc_h22 = _source11.dtor_args;
+        Dafny.ISequence<DAST._IExpression> _239_args = _238___mcc_h22;
+        Dafny.ISequence<DAST._IType> _240_typeArgs = _237___mcc_h21;
+        Dafny.ISequence<Dafny.Rune> _241_name = _236___mcc_h20;
+        DAST._IExpression _242_on = _235___mcc_h19;
         {
-          Dafny.ISequence<Dafny.Rune> _242_typeArgString;
-          _242_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          if ((new BigInteger((_239_typeArgs).Count)) >= (BigInteger.One)) {
-            BigInteger _243_typeI;
-            _243_typeI = BigInteger.Zero;
-            _242_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
-            while ((_243_typeI) < (new BigInteger((_239_typeArgs).Count))) {
-              if ((_243_typeI).Sign == 1) {
-                _242_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_242_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _243_typeArgString;
+          _243_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          if ((new BigInteger((_240_typeArgs).Count)) >= (BigInteger.One)) {
+            BigInteger _244_typeI;
+            _244_typeI = BigInteger.Zero;
+            _243_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
+            while ((_244_typeI) < (new BigInteger((_240_typeArgs).Count))) {
+              if ((_244_typeI).Sign == 1) {
+                _243_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_243_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
               }
-              Dafny.ISequence<Dafny.Rune> _244_typeString;
+              Dafny.ISequence<Dafny.Rune> _245_typeString;
               Dafny.ISequence<Dafny.Rune> _out55;
-              _out55 = DCOMP.COMP.GenType((_239_typeArgs).Select(_243_typeI));
-              _244_typeString = _out55;
-              _242_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_242_typeArgString, _244_typeString);
-              _243_typeI = (_243_typeI) + (BigInteger.One);
+              _out55 = DCOMP.COMP.GenType((_240_typeArgs).Select(_244_typeI));
+              _245_typeString = _out55;
+              _243_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_243_typeArgString, _245_typeString);
+              _244_typeI = (_244_typeI) + (BigInteger.One);
             }
-            _242_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_242_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+            _243_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_243_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
           }
-          Dafny.ISequence<Dafny.Rune> _245_argString;
-          _245_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _246_i;
-          _246_i = BigInteger.Zero;
-          while ((_246_i) < (new BigInteger((_238_args).Count))) {
-            if ((_246_i).Sign == 1) {
-              _245_argString = Dafny.Sequence<Dafny.Rune>.Concat(_245_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _246_argString;
+          _246_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _247_i;
+          _247_i = BigInteger.Zero;
+          while ((_247_i) < (new BigInteger((_239_args).Count))) {
+            if ((_247_i).Sign == 1) {
+              _246_argString = Dafny.Sequence<Dafny.Rune>.Concat(_246_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _247_argExpr;
-            bool _248_isOwned;
+            Dafny.ISequence<Dafny.Rune> _248_argExpr;
+            bool _249_isOwned;
             Dafny.ISequence<Dafny.Rune> _out56;
             bool _out57;
-            DCOMP.COMP.GenExpr((_238_args).Select(_246_i), @params, false, out _out56, out _out57);
-            _247_argExpr = _out56;
-            _248_isOwned = _out57;
-            _245_argString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_245_argString, ((_248_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _247_argExpr);
-            _246_i = (_246_i) + (BigInteger.One);
+            DCOMP.COMP.GenExpr((_239_args).Select(_247_i), @params, false, out _out56, out _out57);
+            _248_argExpr = _out56;
+            _249_isOwned = _out57;
+            _246_argString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_246_argString, ((_249_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _248_argExpr);
+            _247_i = (_247_i) + (BigInteger.One);
           }
-          Dafny.ISequence<Dafny.Rune> _249_enclosingString;
-          bool _250___v15;
+          Dafny.ISequence<Dafny.Rune> _250_enclosingString;
+          bool _251___v15;
           Dafny.ISequence<Dafny.Rune> _out58;
           bool _out59;
-          DCOMP.COMP.GenExpr(_241_on, @params, false, out _out58, out _out59);
-          _249_enclosingString = _out58;
-          _250___v15 = _out59;
-          DAST._IExpression _source13 = _241_on;
+          DCOMP.COMP.GenExpr(_242_on, @params, false, out _out58, out _out59);
+          _250_enclosingString = _out58;
+          _251___v15 = _out59;
+          DAST._IExpression _source13 = _242_on;
           if (_source13.is_Literal) {
-            DAST._ILiteral _251___mcc_h27 = _source13.dtor_Literal_a0;
+            DAST._ILiteral _252___mcc_h27 = _source13.dtor_Literal_a0;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_Ident) {
-            Dafny.ISequence<Dafny.Rune> _252___mcc_h29 = _source13.dtor_Ident_a0;
+            Dafny.ISequence<Dafny.Rune> _253___mcc_h29 = _source13.dtor_Ident_a0;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_Companion) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _253___mcc_h31 = _source13.dtor_Companion_a0;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _254___mcc_h31 = _source13.dtor_Companion_a0;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_249_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_250_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
             }
           } else if (_source13.is_Tuple) {
-            Dafny.ISequence<DAST._IExpression> _254___mcc_h33 = _source13.dtor_Tuple_a0;
+            Dafny.ISequence<DAST._IExpression> _255___mcc_h33 = _source13.dtor_Tuple_a0;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_DatatypeValue) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _255___mcc_h35 = _source13.dtor_path;
-            Dafny.ISequence<Dafny.Rune> _256___mcc_h36 = _source13.dtor_variant;
-            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _257___mcc_h37 = _source13.dtor_contents;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _256___mcc_h35 = _source13.dtor_path;
+            Dafny.ISequence<Dafny.Rune> _257___mcc_h36 = _source13.dtor_variant;
+            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _258___mcc_h37 = _source13.dtor_contents;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_BinOp) {
-            Dafny.ISequence<Dafny.Rune> _258___mcc_h41 = _source13.dtor_op;
-            DAST._IExpression _259___mcc_h42 = _source13.dtor_left;
-            DAST._IExpression _260___mcc_h43 = _source13.dtor_right;
+            Dafny.ISequence<Dafny.Rune> _259___mcc_h41 = _source13.dtor_op;
+            DAST._IExpression _260___mcc_h42 = _source13.dtor_left;
+            DAST._IExpression _261___mcc_h43 = _source13.dtor_right;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_Select) {
-            DAST._IExpression _261___mcc_h47 = _source13.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _262___mcc_h48 = _source13.dtor_field;
-            bool _263___mcc_h49 = _source13.dtor_onDatatype;
+            DAST._IExpression _262___mcc_h47 = _source13.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _263___mcc_h48 = _source13.dtor_field;
+            bool _264___mcc_h49 = _source13.dtor_onDatatype;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_TupleSelect) {
-            DAST._IExpression _264___mcc_h53 = _source13.dtor_expr;
-            BigInteger _265___mcc_h54 = _source13.dtor_index;
+            DAST._IExpression _265___mcc_h53 = _source13.dtor_expr;
+            BigInteger _266___mcc_h54 = _source13.dtor_index;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_Call) {
-            DAST._IExpression _266___mcc_h57 = _source13.dtor_on;
-            Dafny.ISequence<Dafny.Rune> _267___mcc_h58 = _source13.dtor_name;
-            Dafny.ISequence<DAST._IType> _268___mcc_h59 = _source13.dtor_typeArgs;
-            Dafny.ISequence<DAST._IExpression> _269___mcc_h60 = _source13.dtor_args;
+            DAST._IExpression _267___mcc_h57 = _source13.dtor_on;
+            Dafny.ISequence<Dafny.Rune> _268___mcc_h58 = _source13.dtor_name;
+            Dafny.ISequence<DAST._IType> _269___mcc_h59 = _source13.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _270___mcc_h60 = _source13.dtor_args;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else if (_source13.is_TypeTest) {
-            DAST._IExpression _270___mcc_h65 = _source13.dtor_on;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _271___mcc_h66 = _source13.dtor_dType;
-            Dafny.ISequence<Dafny.Rune> _272___mcc_h67 = _source13.dtor_variant;
+            DAST._IExpression _271___mcc_h65 = _source13.dtor_on;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _272___mcc_h66 = _source13.dtor_dType;
+            Dafny.ISequence<Dafny.Rune> _273___mcc_h67 = _source13.dtor_variant;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else {
-            DAST._IType _273___mcc_h71 = _source13.dtor_typ;
+            DAST._IType _274___mcc_h71 = _source13.dtor_typ;
             {
-              _249_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _249_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _250_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _250_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_249_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _240_name), _242_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _245_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_250_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _241_name), _243_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _246_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
         }
       } else if (_source11.is_TypeTest) {
-        DAST._IExpression _274___mcc_h23 = _source11.dtor_on;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _275___mcc_h24 = _source11.dtor_dType;
-        Dafny.ISequence<Dafny.Rune> _276___mcc_h25 = _source11.dtor_variant;
-        Dafny.ISequence<Dafny.Rune> _277_variant = _276___mcc_h25;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _278_dType = _275___mcc_h24;
-        DAST._IExpression _279_on = _274___mcc_h23;
+        DAST._IExpression _275___mcc_h23 = _source11.dtor_on;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _276___mcc_h24 = _source11.dtor_dType;
+        Dafny.ISequence<Dafny.Rune> _277___mcc_h25 = _source11.dtor_variant;
+        Dafny.ISequence<Dafny.Rune> _278_variant = _277___mcc_h25;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _279_dType = _276___mcc_h24;
+        DAST._IExpression _280_on = _275___mcc_h23;
         {
-          Dafny.ISequence<Dafny.Rune> _280_exprGen;
-          bool _281___v18;
+          Dafny.ISequence<Dafny.Rune> _281_exprGen;
+          bool _282___v18;
           Dafny.ISequence<Dafny.Rune> _out60;
           bool _out61;
-          DCOMP.COMP.GenExpr(_279_on, @params, false, out _out60, out _out61);
-          _280_exprGen = _out60;
-          _281___v18 = _out61;
-          Dafny.ISequence<Dafny.Rune> _282_dTypePath;
+          DCOMP.COMP.GenExpr(_280_on, @params, false, out _out60, out _out61);
+          _281_exprGen = _out60;
+          _282___v18 = _out61;
+          Dafny.ISequence<Dafny.Rune> _283_dTypePath;
           Dafny.ISequence<Dafny.Rune> _out62;
-          _out62 = DCOMP.COMP.GenPath(_278_dType);
-          _282_dTypePath = _out62;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("matches!("), _280_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".as_ref(), ")), _282_dTypePath), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _277_variant), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ .. })"));
+          _out62 = DCOMP.COMP.GenPath(_279_dType);
+          _283_dTypePath = _out62;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("matches!("), _281_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".as_ref(), ")), _283_dTypePath), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _278_variant), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ .. })"));
           isOwned = true;
         }
       } else {
-        DAST._IType _283___mcc_h26 = _source11.dtor_typ;
-        DAST._IType _284_typ = _283___mcc_h26;
+        DAST._IType _284___mcc_h26 = _source11.dtor_typ;
+        DAST._IType _285_typ = _284___mcc_h26;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("std::default::Default::default()");
           isOwned = true;
@@ -3530,32 +3531,32 @@ namespace DCOMP {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#![allow(warnings, unconditional_panic)]\n");
       s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("mod dafny_runtime {\n")), runtime), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
-      BigInteger _285_i;
-      _285_i = BigInteger.Zero;
-      while ((_285_i) < (new BigInteger((p).Count))) {
-        Dafny.ISequence<Dafny.Rune> _286_generated = Dafny.Sequence<Dafny.Rune>.Empty;
+      BigInteger _286_i;
+      _286_i = BigInteger.Zero;
+      while ((_286_i) < (new BigInteger((p).Count))) {
+        Dafny.ISequence<Dafny.Rune> _287_generated = Dafny.Sequence<Dafny.Rune>.Empty;
         Dafny.ISequence<Dafny.Rune> _out63;
-        _out63 = DCOMP.COMP.GenModule((p).Select(_285_i));
-        _286_generated = _out63;
-        if ((_285_i).Sign == 1) {
+        _out63 = DCOMP.COMP.GenModule((p).Select(_286_i));
+        _287_generated = _out63;
+        if ((_286_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _286_generated);
-        _285_i = (_285_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _287_generated);
+        _286_i = (_286_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> EmitCallToMain(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> fullName) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nfn main() {\n");
-      BigInteger _287_i;
-      _287_i = BigInteger.Zero;
-      while ((_287_i) < (new BigInteger((fullName).Count))) {
-        if ((_287_i).Sign == 1) {
+      BigInteger _288_i;
+      _288_i = BigInteger.Zero;
+      while ((_288_i) < (new BigInteger((fullName).Count))) {
+        if ((_288_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, (fullName).Select(_287_i));
-        _287_i = (_287_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, (fullName).Select(_288_i));
+        _288_i = (_288_i) + (BigInteger.One);
       }
       s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("();\n}"));
       return s;

--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Formatter};
+use std::{fmt::{Display, Formatter}, rc::Rc};
 
 pub struct DafnyPrintWrapper<T>(pub T);
 impl <T: DafnyPrint> Display for DafnyPrintWrapper<&T> {
@@ -40,6 +40,12 @@ impl_print_display! { f64 }
 impl DafnyPrint for () {
     fn fmt_print(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "()")
+    }
+}
+
+impl <T: DafnyPrint> DafnyPrint for Rc<T> {
+    fn fmt_print(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.as_ref().fmt_print(f)
     }
 }
 


### PR DESCRIPTION
Fixes compilation failures with recursive types and makes our codegen more careful about borrowing vs copying.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
