### PR TITLE
Use Cargo to build Rust sources, to support runtime dependencies

### DIFF
--- a/Source/DafnyCore/Compilers/Rust/Compiler-rust.cs
+++ b/Source/DafnyCore/Compilers/Rust/Compiler-rust.cs
@@ -9,11 +9,7 @@ namespace Microsoft.Dafny.Compilers {
   class RustCompiler : DafnyWrittenCompiler {
 
     public override ISequence<Rune> Compile(Sequence<DAST.Module> program) {
-      var assembly = System.Reflection.Assembly.Load("DafnyPipeline");
-      var stream = assembly.GetManifestResourceStream("DafnyRuntimeRust.rs");
-      var contents = new StreamReader(stream).ReadToEnd();
-
-      return COMP.Compile(program, Sequence<Rune>.UnicodeFromString(contents));
+      return COMP.Compile(program);
     }
 
     public override ISequence<Rune> EmitCallToMain(string fullName) {

--- a/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
@@ -691,9 +691,9 @@ module {:extern "DCOMP"} DCOMP {
       }
     }
 
-    static method Compile(p: seq<Module>, runtime: string) returns (s: string) {
+    static method Compile(p: seq<Module>) returns (s: string) {
       s := "#![allow(warnings, unconditional_panic)]\n";
-      s := s + "mod dafny_runtime {\n" + runtime + "\n}\n";
+      s := s + "extern crate dafny_runtime;\n";
 
       var i := 0;
       while i < |p| {

--- a/Source/DafnyCore/Compilers/Rust/RustBackend.cs
+++ b/Source/DafnyCore/Compilers/Rust/RustBackend.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Dafny.Compilers;
@@ -22,28 +23,99 @@ public class RustBackend : DafnyExecutableBackend {
   public override string TargetBasename(string dafnyProgramName) =>
     Regex.Replace(base.TargetBasename(dafnyProgramName), "[^_A-Za-z0-9]", "_");
 
+  public override string TargetBaseDir(string dafnyProgramName) =>
+    $"{Path.GetFileNameWithoutExtension(dafnyProgramName)}-rust/src";
+
   protected override DafnyWrittenCompiler CreateDafnyWrittenCompiler() {
     return new RustCompiler();
   }
 
   private string ComputeExeName(string targetFilename) {
-    return Path.ChangeExtension(Path.GetFullPath(targetFilename), "exe");
+    var targetDirectory = Path.GetDirectoryName(Path.GetDirectoryName(targetFilename));
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+      return Path.Combine(targetDirectory, "target", "debug", Path.GetFileNameWithoutExtension(targetFilename) + ".exe");
+    } else {
+      return Path.Combine(targetDirectory, "target", "debug", Path.GetFileNameWithoutExtension(targetFilename));
+    }
   }
 
   public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText,
       string /*?*/ callToMain, string /*?*/ targetFilename, ReadOnlyCollection<string> otherFileNames,
       bool runAfterCompile, TextWriter outputWriter, out object compilationResult) {
+    var targetDirectory = Path.GetDirectoryName(Path.GetDirectoryName(targetFilename));
+    var runtimeDirectory = Path.Combine(targetDirectory, "runtime");
+    if (Directory.Exists(runtimeDirectory)) {
+      Directory.Delete(runtimeDirectory, true);
+    }
+    Directory.CreateDirectory(runtimeDirectory);
+
+    var assembly = System.Reflection.Assembly.Load("DafnyPipeline");
+    assembly.GetManifestResourceNames().Where(f => f.StartsWith("DafnyPipeline.DafnyRuntimeRust")).ToList().ForEach(f => {
+      var stream = assembly.GetManifestResourceStream(f);
+      var dotToSlashPath = "";
+      var parts = f.Replace("DafnyPipeline.DafnyRuntimeRust.", "").Split('.');
+      for (var i = 0; i < parts.Length; i++) {
+        dotToSlashPath += parts[i];
+
+        if (i < parts.Length - 2) {
+          dotToSlashPath += "/";
+        } else if (i == parts.Length - 2) {
+          // extension
+          dotToSlashPath += ".";
+        }
+      }
+
+      var containingDirectory = Path.Combine(runtimeDirectory, Path.GetDirectoryName(dotToSlashPath));
+      if (!Directory.Exists(containingDirectory)) {
+        Directory.CreateDirectory(containingDirectory);
+      }
+
+      using var outFile = new FileStream(Path.Combine(runtimeDirectory, dotToSlashPath), FileMode.Create, FileAccess.Write);
+      stream.CopyTo(outFile);
+    });
+
+    using (var cargoToml = new FileStream(Path.Combine(targetDirectory, "Cargo.toml"), FileMode.Create, FileAccess.Write)) {
+      using var cargoTomlWriter = new StreamWriter(cargoToml);
+      cargoTomlWriter.WriteLine("[package]");
+      var packageName = Path.GetFileNameWithoutExtension(targetFilename);
+      // package name cannot start with a digit
+      if (char.IsDigit(packageName[0])) {
+        packageName = "_" + packageName;
+      }
+      cargoTomlWriter.WriteLine("name = \"{0}\"", packageName);
+      cargoTomlWriter.WriteLine("version = \"0.1.0\"");
+      cargoTomlWriter.WriteLine("edition = \"2021\"");
+      cargoTomlWriter.WriteLine();
+      cargoTomlWriter.WriteLine("[dependencies]");
+      cargoTomlWriter.WriteLine("dafny_runtime = { path = \"runtime\" }");
+      cargoTomlWriter.WriteLine();
+
+      if (callToMain == null) {
+        cargoTomlWriter.WriteLine("[lib]");
+        cargoTomlWriter.WriteLine("path = \"src/" + Path.GetFileName(targetFilename) + "\"");
+        cargoTomlWriter.WriteLine();
+      } else {
+        cargoTomlWriter.WriteLine("[[bin]]");
+        cargoTomlWriter.WriteLine("name = \"{0}\"", Path.GetFileNameWithoutExtension(targetFilename));
+        cargoTomlWriter.WriteLine("path = \"src/" + Path.GetFileName(targetFilename) + "\"");
+        cargoTomlWriter.WriteLine();
+      }
+    }
+
     compilationResult = null;
     var args = new List<string> {
-      "-o", ComputeExeName(targetFilename),
-      targetFilename
+      "build"
     };
 
     if (callToMain == null) {
-      args.Add("--crate-type=lib");
+      args.Add("--lib");
+    } else {
+      args.Add("--bin");
+      args.Add(Path.GetFileNameWithoutExtension(targetFilename));
     }
 
-    var psi = PrepareProcessStartInfo("rustc", args);
+    var psi = PrepareProcessStartInfo("cargo", args);
+    psi.WorkingDirectory = targetDirectory;
     return 0 == RunProcess(psi, outputWriter, outputWriter, "Error while compiling Rust files.");
   }
 

--- a/Source/DafnyCore/GeneratedFromDafnyRust.cs
+++ b/Source/DafnyCore/GeneratedFromDafnyRust.cs
@@ -3652,10 +3652,10 @@ namespace DCOMP {
         }
       }
     }
-    public static Dafny.ISequence<Dafny.Rune> Compile(Dafny.ISequence<DAST._IModule> p, Dafny.ISequence<Dafny.Rune> runtime) {
+    public static Dafny.ISequence<Dafny.Rune> Compile(Dafny.ISequence<DAST._IModule> p) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#![allow(warnings, unconditional_panic)]\n");
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("mod dafny_runtime {\n")), runtime), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("extern crate dafny_runtime;\n"));
       BigInteger _288_i;
       _288_i = BigInteger.Zero;
       while ((_288_i) < (new BigInteger((p).Count))) {

--- a/Source/DafnyPipeline/DafnyPipeline.csproj
+++ b/Source/DafnyPipeline/DafnyPipeline.csproj
@@ -64,10 +64,10 @@
       <LogicalName>DafnyRuntime.py</LogicalName>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimeRust\src\lib.rs">
-      <LogicalName>DafnyRuntimeRust.rs</LogicalName>
+    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimeRust\**" LinkBase="DafnyRuntimeRust">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Remove="..\DafnyRuntime\DafnyRuntimeRust\target\**"/>
   </ItemGroup>
 
 </Project>

--- a/Source/DafnyRuntime/DafnyRuntimeRust/Cargo.lock
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "dafny_runtime_rust"
+name = "dafny_runtime"
 version = "0.1.0"

--- a/Source/DafnyRuntime/DafnyRuntimeRust/Cargo.toml
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dafny_runtime_rust"
+name = "dafny_runtime"
 version = "0.1.0"
 edition = "2021"
 

--- a/Test/.gitignore
+++ b/Test/.gitignore
@@ -29,7 +29,7 @@
 **/*-py
 
 # Rust output
-**/*.rs
+**/*-rust
 
 node_modules/
 package-lock.json


### PR DESCRIPTION
Use Cargo to build Rust sources, to support runtime dependencies




<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/dafny-lang/dafny/pull/4341).
* #4346
* #4343
* __->__ #4341