### PR TITLE
Remove redundant `GenerateLhsDecl` from `SinglePassCompiler`

### DIFF
--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -1910,10 +1910,6 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override string GenerateLhsDecl(string target, Type/*?*/ type, ConcreteSyntaxTree wr, IToken tok) {
-      return (type != null ? TypeName(type, wr, tok) : "var") + " " + target;
-    }
-
     // ----- Statements -------------------------------------------------------------
 
     protected override void EmitPrintStmt(ConcreteSyntaxTree wr, Expression arg) {

--- a/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
+++ b/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
@@ -1233,10 +1233,6 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(ActualTypeArgs(typeArgs));
     }
 
-    protected override string GenerateLhsDecl(string target, Type/*?*/ type, ConcreteSyntaxTree wr, IToken tok) {
-      return "auto " + target;
-    }
-
     protected void EmitNullText(Type type, ConcreteSyntaxTree wr) {
       var xType = type.NormalizeExpand();
       if (xType.IsArrayType) {

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -561,10 +561,6 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override string GenerateLhsDecl(string target, Type type, ConcreteSyntaxTree wr, IToken tok) {
-      throw new NotImplementedException();
-    }
-
     private class BuilderLvalue : ILvalue {
       readonly DafnyCompiler compiler;
       readonly string name;

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -1842,10 +1842,6 @@ namespace Microsoft.Dafny.Compilers {
       // emit nothing; this is only for actual parametric polymorphism, not RTDs
     }
 
-    protected override string GenerateLhsDecl(string target, Type/*?*/ type, ConcreteSyntaxTree wr, IToken tok) {
-      return "var " + target;
-    }
-
     // ----- Statements -------------------------------------------------------------
 
     protected override void EmitMultiAssignment(List<Expression> lhsExprs, List<ILvalue> wLhss, List<Type> lhsTypes, out List<ConcreteSyntaxTree> wRhss, List<Type> rhsTypes, ConcreteSyntaxTree wr) {

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -2416,10 +2416,6 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(protectedName);
     }
 
-    protected override string GenerateLhsDecl(string target, Type type, ConcreteSyntaxTree wr, IToken tok) {
-      return TypeName(type, wr, tok) + " " + target;
-    }
-
     protected override void EmitNew(Type type, IToken tok, CallStmt initCall, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var ctor = (Constructor)initCall?.Method; // correctness of cast follows from precondition of "EmitNew"
       wr.Write($"new {TypeName(type, wr, tok)}(");

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -1107,10 +1107,6 @@ namespace Microsoft.Dafny.Compilers {
       // emit nothing
     }
 
-    protected override string GenerateLhsDecl(string target, Type/*?*/ type, ConcreteSyntaxTree wr, IToken tok) {
-      return "let " + target;
-    }
-
     // ----- Statements -------------------------------------------------------------
 
     protected override void EmitPrintStmt(ConcreteSyntaxTree wr, Expression arg) {

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -858,10 +858,6 @@ namespace Microsoft.Dafny.Compilers {
       // emit nothing
     }
 
-    protected override string GenerateLhsDecl(string target, Type type, ConcreteSyntaxTree wr, IToken tok) {
-      return $"{target}: {TypeName(type, wr, tok)}";
-    }
-
     protected override void EmitPrintStmt(ConcreteSyntaxTree wr, Expression arg) {
       var wStmts = wr.Fork();
       wr.Write($"{DafnyRuntimeModule}.print(");

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -375,7 +375,6 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(protectedName);
       EmitActualTypeArgs(typeArgs, tok, wr);
     }
-    protected abstract string GenerateLhsDecl(string target, Type/*?*/ type, ConcreteSyntaxTree wr, IToken tok);
 
     protected virtual ConcreteSyntaxTree EmitAssignment(ILvalue wLhs, Type lhsType /*?*/, Type rhsType /*?*/,
       ConcreteSyntaxTree wr, IToken tok) {
@@ -420,10 +419,7 @@ namespace Microsoft.Dafny.Compilers {
     protected virtual string EmitAssignmentLhs(Expression e, ConcreteSyntaxTree wr) {
       var wStmts = wr.Fork();
       var target = ProtectedFreshId("_lhs");
-      wr.Write(GenerateLhsDecl(target, e.Type, wr, e.tok));
-      wr.Write(AssignmentSymbol);
-      EmitExpr(e, false, wr, wStmts);
-      EndStmt(wr);
+      EmitExpr(e, false, DeclareLocalVar(target, e.Type, e.tok, wr), wStmts);
       return target;
     }
 
@@ -3321,8 +3317,7 @@ namespace Microsoft.Dafny.Compilers {
           // introduce a variable to hold the value of the end-expression
           endVarName = ProtectedFreshId(s.GoingUp ? "_hi" : "_lo");
           wStmts = wr.Fork();
-          wr.Write(GenerateLhsDecl(endVarName, s.End.Type, wr, s.End.tok));
-          EmitAssignmentRhs(s.End, false, wr, wStmts);
+          EmitExpr(s.End, false, DeclareLocalVar(endVarName, s.End.Type, s.End.tok, wr), wStmts);
         }
         var startExprWriter = EmitForStmt(s.Tok, s.LoopIndex, s.GoingUp, endVarName, s.Body.Body, s.Labels, wr);
         EmitExpr(s.Start, false, startExprWriter, wStmts);

--- a/Source/DafnyRuntime/DafnyRuntimeGo/DafnyRuntimeFromDafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/DafnyRuntimeFromDafny.go
@@ -309,7 +309,8 @@ func (_static *CompanionStruct_Sequence_) Create(cardinality uint32, initFn func
 func (_static *CompanionStruct_Sequence_) EqualUpTo(left Sequence, right Sequence, index uint32) bool {
   var ret bool = false
   _ = ret
-  var _hi0 = index
+  var _hi0 uint32 = index
+  _ = _hi0
   for _14_i := uint32(0); _14_i < _hi0; _14_i++ {
     var _15_leftElement interface{}
     _ = _15_leftElement
@@ -374,7 +375,8 @@ func (_static *CompanionStruct_Sequence_) IsProperPrefixOf(left Sequence, right 
 func (_static *CompanionStruct_Sequence_) Contains(s Sequence, t interface{}) bool {
   var _hresult bool = false
   _ = _hresult
-  var _hi1 = (s).Cardinality()
+  var _hi1 uint32 = (s).Cardinality()
+  _ = _hi1
   for _17_i := Companion_Default___.ZERO__SIZE(); _17_i < _hi1; _17_i++ {
     var _18_element interface{}
     _ = _18_element


### PR DESCRIPTION
Remove redundant `GenerateLhsDecl` from `SinglePassCompiler`


Its usage throughout all backends is subsumed by `DeclareLocalVar`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
