### PR TITLE
Fix z3 download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ z3-mac-arm:
 	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-08-02/z3-4.12.1-arm64-macos-11-bin.zip
 	unzip z3-4.12.1-arm64-macos-11-bin.zip
 	rm z3-4.12.1-arm64-macos-11-bin.zip
-	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-08-02/z3-4.8.5-arm64-macos-11-bin.zip
-	unzip z3-4.8.5-arm64-macos-11-bin.zip
-	rm z3-4.8.5-arm64-macos-11-bin.zip
+	wget https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-08-02/z3-4.8.5-x64-macos-11-bin.zip
+	unzip z3-4.8.5-x64-macos-11-bin.zip
+	rm z3-4.8.5-x64-macos-11-bin.zip
 	mv z3-* ${DIR}/Binaries/z3/bin/
 	chmod +x ${DIR}/Binaries/z3/bin/z3-*
 

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -20,7 +20,7 @@ import ntpath
 # Configuration
 
 Z3_VERSIONS = [ "4.8.5", "4.12.1" ]
-Z3_URL_BASE = "https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-02-17"
+Z3_URL_BASE = "https://github.com/dafny-lang/solver-builds/releases/download/snapshot-2023-08-02"
 
 ## How many times we allow ourselves to try to download Z3
 Z3_MAX_DOWNLOAD_ATTEMPTS = 5


### PR DESCRIPTION
Fixes the download URLs for Z3 in a couple of places.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
