### PR TITLE
Stop sharing verification trees between compilations

### DIFF
--- a/Source/DafnyLanguageServer/Workspace/Documents/CompilationAfterParsing.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/CompilationAfterParsing.cs
@@ -33,7 +33,7 @@ public class CompilationAfterParsing : Compilation {
       ResolutionDiagnostics = ResolutionDiagnostics.ToDictionary(
         kv => kv.Key,
         kv => (IReadOnlyList<Diagnostic>)kv.Value.Select(d => d.ToLspDiagnostic()).ToList()),
-      VerificationTree = baseResult.VerificationTree ?? GetVerificationTree()
+      VerificationTree = baseResult.VerificationTree ?? GetVerificationTree()?.GetCopyForNotification()
     };
   }
 

--- a/Source/DafnyLanguageServer/Workspace/Documents/CompilationAfterTranslation.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/CompilationAfterTranslation.cs
@@ -52,7 +52,7 @@ public class CompilationAfterTranslation : CompilationAfterResolution {
     });
     return base.ToIdeState(previousState) with {
       ImplementationsWereUpdated = true,
-      VerificationTree = GetVerificationTree(),
+      VerificationTree = GetVerificationTree()?.GetCopyForNotification(),
       Counterexamples = new List<Counterexample>(Counterexamples),
       ImplementationIdToView = new Dictionary<ImplementationId, IdeImplementationView>(implementationViewsWithMigratedDiagnostics)
     };

--- a/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       var verificationStatusGutter = VerificationStatusGutter.ComputeFrom(
         root,
         filesystem.GetVersion(root)!.Value,
-        state.VerificationTree.Children.Select(child => child.GetCopyForNotification()).ToArray(),
+        state.VerificationTree.Children,
         errors,
         linesCount,
         verificationStarted

--- a/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
+++ b/Source/DafnyLanguageServer/Workspace/Notifications/VerificationDiagnosticsParams.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
     public static VerificationStatusGutter ComputeFrom(
         DocumentUri uri,
         int version,
-        VerificationTree[] verificationTrees,
+        ICollection<VerificationTree> verificationTrees,
         Container<Diagnostic> resolutionErrors,
         int linesCount,
         bool verificationStarted) {
@@ -39,13 +39,13 @@ namespace Microsoft.Dafny.LanguageServer.Workspace.Notifications {
 
     public static LineVerificationStatus[] RenderPerLineDiagnostics(
       DocumentUri uri,
-      VerificationTree[] verificationTrees,
+      ICollection<VerificationTree> verificationTrees,
       int numberOfLines,
       bool verificationStarted,
       Container<Diagnostic> parseAndResolutionErrors) {
       var result = new LineVerificationStatus[numberOfLines];
 
-      if (verificationTrees.Length == 0 && !parseAndResolutionErrors.Any() && verificationStarted) {
+      if (verificationTrees.Count == 0 && !parseAndResolutionErrors.Any() && verificationStarted) {
         for (var line = 0; line < numberOfLines; line++) {
           result[line] = LineVerificationStatus.Verified;
         }


### PR DESCRIPTION
Hopefully fixes non-deterministic failures in verification tree based tests.

What we're seeing is that events triggered by update X also end up affecting notifications belonging to update X+1, so this change is a good candidate for fixing those issues.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
