### PR TITLE
Add more logging for OnDiskProducerVerificationErrors

### DIFF
--- a/Source/DafnyLanguageServer.Test/ProjectFiles/MultipleFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/MultipleFilesTest.cs
@@ -105,10 +105,18 @@ method Bar() {
 
     var diagnostics1 = await diagnosticsReceiver.AwaitNextNotificationAsync(CancellationToken);
     var diagnostics2 = await diagnosticsReceiver.AwaitNextNotificationAsync(CancellationToken);
-    Assert.Single(diagnostics1.Diagnostics);
-    Assert.Contains("assertion might not hold", diagnostics1.Diagnostics.First().Message);
-    Assert.Single(diagnostics2.Diagnostics);
-    Assert.Contains("assertion might not hold", diagnostics2.Diagnostics.First().Message);
+    try {
+      Assert.Single(diagnostics1.Diagnostics);
+      Assert.Contains("assertion might not hold", diagnostics1.Diagnostics.First().Message);
+      Assert.Single(diagnostics2.Diagnostics);
+      Assert.Contains("assertion might not hold", diagnostics2.Diagnostics.First().Message);
+    } catch (Exception) {
+      await output.WriteLineAsync($"diagnostics1: {diagnostics1.Stringify()}");
+      await output.WriteLineAsync($"diagnostics2: {diagnostics2.Stringify()}");
+      var diagnostics3 = await diagnosticsReceiver.AwaitNextNotificationAsync(CancellationToken);
+      await output.WriteLineAsync($"diagnostics3: {diagnostics3.Stringify()}");
+      throw;
+    }
   }
 
   [Fact]


### PR DESCRIPTION
This test is nondeterministic failing and we need more logging to understand why

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
