### PR TITLE
Fix backwards compatibility with regards to the VerifyOnMode option

### DIFF
--- a/Source/DafnyLanguageServer/ServerCommand.cs
+++ b/Source/DafnyLanguageServer/ServerCommand.cs
@@ -35,9 +35,9 @@ public class ServerCommand : ICommandSpec {
 (experimental, API will change)
 Send notifications that indicate which lines are ghost.".TrimStart());
 
-  public static readonly Option<VerifyOnMode> Verification = new("--verify-on", () => VerifyOnMode.ChangeFile, @"
+  public static readonly Option<VerifyOnMode> Verification = new("--verify-on", () => VerifyOnMode.Change, @"
 (experimental)
-Determine when to automatically verify the program. Choose from: Never, OnChangeFile, OnChangeProject or OnSave.".TrimStart()) {
+Determine when to automatically verify the program. Choose from: Never, OnChange (verify everything in a file when changing the file), OnChangeProject or OnSave.".TrimStart()) {
     ArgumentHelpName = "event"
   };
 

--- a/Source/DafnyLanguageServer/StandaloneServerCli.cs
+++ b/Source/DafnyLanguageServer/StandaloneServerCli.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Dafny.LanguageServer {
       configuration.Bind(DocumentOptions.Section, documentOptions);
       var mode = documentOptions.Verify switch {
         AutoVerification.Never => VerifyOnMode.Never,
-        AutoVerification.OnChange => VerifyOnMode.ChangeFile,
+        AutoVerification.OnChange => VerifyOnMode.Change,
         AutoVerification.OnSave => VerifyOnMode.Save,
         _ => throw new ArgumentOutOfRangeException()
       };

--- a/Source/DafnyLanguageServer/Workspace/ProjectManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManager.cs
@@ -151,8 +151,8 @@ public class ProjectManager : IDisposable {
   }
 
   public void TriggerVerificationForFile(Uri triggeringFile) {
-    if (AutomaticVerificationMode is VerifyOnMode.ChangeFile or VerifyOnMode.ChangeProject) {
-      var _ = VerifyEverythingAsync(AutomaticVerificationMode == VerifyOnMode.ChangeFile ? triggeringFile : null);
+    if (AutomaticVerificationMode is VerifyOnMode.Change or VerifyOnMode.ChangeProject) {
+      var _ = VerifyEverythingAsync(AutomaticVerificationMode == VerifyOnMode.Change ? triggeringFile : null);
     } else {
       logger.LogDebug("Setting result for workCompletedForCurrentVersion");
     }

--- a/Source/DafnyLanguageServer/Workspace/VerifyOnMode.cs
+++ b/Source/DafnyLanguageServer/Workspace/VerifyOnMode.cs
@@ -4,7 +4,7 @@
   /// </summary>
   public enum VerifyOnMode {
     Never,
-    ChangeFile,
+    Change,
     ChangeProject,
     Save
   }


### PR DESCRIPTION
Rename CLI option back to its previous name, for backwards compatibility reasons.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
