### PR TITLE
Fix flickering and incorrect results in the verification status bar, and improve responsiveness of diagnostics

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DiagnosticsTest.cs
@@ -958,24 +958,6 @@ method test()
     }
 
     [Fact]
-    public async Task NoIncrementalVerificationDiagnosticsBetweenAssertionBatches() {
-      var source = @"
-method test(x: int) {
-  assert x != 2;
-  assert {:split_here} true;
-  assert x != 3;
-}
-".TrimStart();
-      await SetUp(options => options.Set(BoogieOptionBag.Cores, 1U));
-      var documentItem = CreateTestDocument(source);
-      client.OpenDocument(documentItem);
-      var firstVerificationDiagnostics = await diagnosticsReceiver.AwaitNextDiagnosticsAsync(CancellationToken, documentItem);
-
-      Assert.Equal(2, firstVerificationDiagnostics.Length);
-      await AssertNoDiagnosticsAreComing(CancellationToken);
-    }
-
-    [Fact]
     public async Task NoDiagnosticFlickeringWhenIncremental() {
       var source = @"
 method test() {

--- a/docs/dev/news/4413.fix
+++ b/docs/dev/news/4413.fix
@@ -1,0 +1,1 @@
+Fix flickering and incorrect results in the verification status bar, and improve responsiveness of verification diagnostics


### PR DESCRIPTION
Fixes https://github.com/dafny-lang/ide-vscode/issues/409

### Changes
- Previously, due to a bug in `StatusFromBoogieStatus`, a BatchCompleted notification would cause the status bar to consider this verifiable to have finished verification, even if other batches were still running. This is the cause for the behavior "status bar flickers between Verification Succeeded" and "Could not prove the declaration"", because it will show the status of the last completed batch.
- Update diagnostics after each completed batch. This improves the behavior "whole lot of errors finally appear in the "problems" window"

### Testing
- Add test `NoFlickeringWhenMixingCorrectAndErrorBatches`
- Add test `IncrementalBatchDiagnostics`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
