### PR TITLE
Add extra telemetry to record cache hits

### DIFF
--- a/Source/DafnyLanguageServer/Caching/PruneIfNotUsedSinceLastPruneCache.cs
+++ b/Source/DafnyLanguageServer/Caching/PruneIfNotUsedSinceLastPruneCache.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.Dafny.LanguageServer.Workspace;
 
 namespace Microsoft.Dafny; 
 
@@ -21,21 +23,26 @@ public class PruneIfNotUsedSinceLastPruneCache<TKey, TValue>
   private readonly ConcurrentDictionary<TKey, Item> items;
 
   public IEnumerable<TValue> Values => items.Select(i => i.Value.Value);
+  public int Count => items.Count;
 
   public PruneIfNotUsedSinceLastPruneCache(IEqualityComparer<TKey> comparer) {
     items = new(comparer);
   }
 
-  public void Prune() {
+  public int Prune() {
     var keys = items.Keys.ToList();
+    var removedCount = 0;
     foreach (var key in keys) {
       var item = items[key];
       if (!item.Accessed) {
         items.TryRemove(key, out _);
+        removedCount++;
       }
 
       item.Accessed = false;
     }
+
+    return removedCount;
   }
 
   public void Set(TKey key, TValue value) {

--- a/Source/DafnyLanguageServer/Language/CacheExtensions.cs
+++ b/Source/DafnyLanguageServer/Language/CacheExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.Dafny.LanguageServer.Workspace;
+
+namespace Microsoft.Dafny.LanguageServer.Language;
+
+static class CacheExtensions {
+  public static T ProfileAndPruneCache<T, Key, Value>(this PruneIfNotUsedSinceLastPruneCache<Key, Value> cache,
+    Func<T> useCache, ITelemetryPublisher telemetryPublisher, string programName, string activity)
+    where Value : class where Key : notnull {
+    var beforeTotal = cache.Count;
+    var result = useCache();
+    var afterCount = cache.Count;
+    var added = afterCount - beforeTotal;
+    cache.Prune();
+    var hitsOrAdded = cache.Count;
+    var hits = hitsOrAdded - added;
+    telemetryPublisher.PublishTelemetry(ImmutableDictionary<string, object>.Empty.
+      Add("subject", "caching").
+      Add("activity", activity).
+      Add("resource", programName.ToString()).
+      Add("hits", hits).
+      Add("total", hitsOrAdded));
+    return result;
+  }
+}

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       this.telemetryPublisher = telemetryPublisher;
       this.logger = logger;
       programParser = options.Get(ServerCommand.UseCaching)
-        ? new CachingParser(innerParserLogger, fileSystem)
+        ? new CachingParser(innerParserLogger, fileSystem, telemetryPublisher)
         : new ProgramParser(innerParserLogger, fileSystem);
     }
 

--- a/Source/DafnyLanguageServer/Language/Symbols/DafnyLangSymbolResolver.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/DafnyLangSymbolResolver.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
       var beforeResolution = DateTime.Now;
       try {
         var resolver = program.Options.Get(ServerCommand.UseCaching)
-          ? new CachingResolver(program, innerLogger, resolutionCache)
+          ? new CachingResolver(program, innerLogger, telemetryPublisher, resolutionCache)
           : new ProgramResolver(program);
         resolver.Resolve(cancellationToken);
         int resolverErrors = resolver.Reporter.ErrorCountUntilResolver;

--- a/Source/DafnyLanguageServer/Workspace/ITelemetryPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/ITelemetryPublisher.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     protected void PublishTelemetry(TelemetryEventKind kind, object? payload) {
-      PublishTelemetry(kind.ToString(), ImmutableDictionary.Create<string, object>().Add("payload", payload!));
+      PublishTelemetry(ImmutableDictionary.Create<string, object>().Add("kind", kind).Add("payload", payload!));
     }
 
-    protected void PublishTelemetry(string kind, ImmutableDictionary<string, object> payload);
+    public void PublishTelemetry(ImmutableDictionary<string, object> data);
 
     /// <summary>
     /// Signal the completion of a document update.
@@ -38,6 +38,11 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     public void PublishSolverPath(string solverPath) {
       PublishTelemetry(TelemetryEventKind.SolverPath, solverPath);
+    }
+
+    public void PublishCount(string activity, string resource, TimeSpan span) {
+      PublishTelemetry(TelemetryEventKind.Time, ImmutableDictionary.Create<string, object>().
+        Add("activity", activity).Add("resource", resource).Add("time", span.TotalMilliseconds));
     }
 
     public void PublishTime(string activity, string resource, TimeSpan span) {

--- a/Source/DafnyLanguageServer/Workspace/TelemetryPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/TelemetryPublisher.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     public void PublishUnhandledException(Exception e) {
       logger.LogError(e, "exception occurred");
-      PublishTelemetry(ITelemetryPublisher.TelemetryEventKind.UnhandledException.ToString(),
-        ImmutableDictionary.Create<string, object>().Add("payload", e.ToString()));
+      PublishTelemetry(ImmutableDictionary.Create<string, object>().
+          Add("kind", ITelemetryPublisher.TelemetryEventKind.UnhandledException).
+          Add("payload", e.ToString()));
     }
 
-    public void PublishTelemetry(string kind, ImmutableDictionary<string, object> payload) {
-      var data = payload.Add("kind", kind);
+    public void PublishTelemetry(ImmutableDictionary<string, object> data) {
       languageServer.Window.SendTelemetryEvent(new TelemetryEventParams {
         ExtensionData = data
       });


### PR DESCRIPTION
### Changes

Add telemetry to record parsing and resolution cache hits

### Testing

Manually inspected the new telemetry

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
