### PR TITLE
Fix: Existential assertions are printed correctly

### DIFF
--- a/Source/DafnyCore/AST/Grammar/Printer.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer.cs
@@ -2990,7 +2990,13 @@ NoGhost - disable printing of functions, ghost methods, and proof
       Contract.Requires(boundVars != null);
       string sep = "";
       foreach (BoundVar bv in boundVars) {
-        wr.Write("{0}{1}", sep, bv.DisplayName);
+        wr.Write("{0}", sep);
+        if (printFlags.UseOriginalDafnyNames) {
+          wr.Write(bv.DafnyName);
+        } else {
+          wr.Write(bv.DisplayName);
+        }
+
         PrintType(": ", bv.Type);
         sep = ", ";
       }

--- a/Source/DafnyLanguageServer.Test/CodeActions/CodeActionsTest.cs
+++ b/Source/DafnyLanguageServer.Test/CodeActions/CodeActionsTest.cs
@@ -28,6 +28,32 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.CodeActions {
     }
 
     [Fact]
+    public async Task GitIssue4401CorrectInsertionPlace() {
+      await TestCodeAction(@"
+predicate P(i: int)
+
+method Test() {(>Insert explicit failing assertion->
+  assert exists x: int :: P(x);<)
+  var x :><| P(x);
+}");
+    }
+
+    [Fact]
+    public async Task GitIssue4401CorrectInsertionPlaceModule() {
+      await TestCodeAction(@"
+module Test {
+  class TheTest {
+    predicate P(i: int)
+
+    method Test() {(>Insert explicit failing assertion->
+      assert exists x: int :: P(x);<)
+      var x :><| P(x);
+    }
+  }
+}");
+    }
+
+    [Fact]
     public async Task CodeActionSuggestsRemovingUnderscore() {
       await TestCodeAction(@"
 method Foo()

--- a/Source/DafnyLanguageServer/Language/ImplicitFailingAssertionCodeActionProvider.cs
+++ b/Source/DafnyLanguageServer/Language/ImplicitFailingAssertionCodeActionProvider.cs
@@ -70,7 +70,7 @@ class ImplicitFailingAssertionCodeActionProvider : DiagnosticDafnyCodeActionProv
         var node = nodesTillFailure[i];
         var nextNode = i < nodesTillFailure.Count - 1 ? nodesTillFailure[i + 1] : null;
         if (node is Statement or LetExpr &&
-            (node is not UpdateStmt && nextNode is not VarDeclStmt && nextNode is not AssignSuchThatStmt)) {
+            node is not UpdateStmt && nextNode is not VarDeclStmt && nextNode is not AssignSuchThatStmt) {
           insertionNode = node;
           break;
         }

--- a/Source/DafnyLanguageServer/Language/ImplicitFailingAssertionCodeActionProvider.cs
+++ b/Source/DafnyLanguageServer/Language/ImplicitFailingAssertionCodeActionProvider.cs
@@ -35,7 +35,7 @@ class ImplicitFailingAssertionCodeActionProvider : DiagnosticDafnyCodeActionProv
       }
     }
 
-    return new List<INode> { node };
+    return node.StartToken.line > 0 ? new List<INode> { node } : null;
   }
 
   class ExplicitAssertionDafnyCodeAction : DafnyCodeAction {
@@ -70,7 +70,7 @@ class ImplicitFailingAssertionCodeActionProvider : DiagnosticDafnyCodeActionProv
         var node = nodesTillFailure[i];
         var nextNode = i < nodesTillFailure.Count - 1 ? nodesTillFailure[i + 1] : null;
         if (node is Statement or LetExpr &&
-            (node is not UpdateStmt || nextNode is not VarDeclStmt)) {
+            (node is not UpdateStmt && nextNode is not VarDeclStmt && nextNode is not AssignSuchThatStmt)) {
           insertionNode = node;
           break;
         }

--- a/docs/dev/news/4401.fix
+++ b/docs/dev/news/4401.fix
@@ -1,0 +1,1 @@
+Existential assertions are now printed correctly


### PR DESCRIPTION
Fixes #4401

Previously, implicit assertions were inserted at the wrong place in the presence of modules, and implicit existential assertions were printed with wrong variables. This PR fixes both.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
