### PR TITLE
Fix: Making default export set opaque no longer crashing the resolver on inductive datatypes

### DIFF
--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -173,8 +173,6 @@ public abstract class Type : TokenNode {
           if (rtd is ClassLikeDecl cl) {
             Contract.Assert(cl.NonNullTypeDecl != null);
             Contract.Assert(cl.NonNullTypeDecl.IsVisibleInScope(scope));
-          } else {
-            Contract.Assert(rtd is AbstractTypeDecl);
           }
         }
 

--- a/Test/git-issues/git-issue-4334.dfy
+++ b/Test/git-issues/git-issue-4334.dfy
@@ -1,0 +1,24 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Crash {
+  export Body
+    reveals *
+
+  datatype Sort =
+    | Int
+    | Re
+ 
+  datatype Func =
+    | ReUnion
+    | ReLoop {
+
+      predicate wellFormedFunction(args: seq<Sort>) {
+        match this {
+          case ReUnion => (forall arg | arg in args :: arg.Re?)
+          case _ => false
+        }
+      }
+
+    }
+}

--- a/Test/git-issues/git-issue-4334.dfy
+++ b/Test/git-issues/git-issue-4334.dfy
@@ -11,14 +11,14 @@ module Crash {
  
   datatype Func =
     | ReUnion
-    | ReLoop {
-
-      predicate wellFormedFunction(args: seq<Sort>) {
-        match this {
-          case ReUnion => (forall arg | arg in args :: arg.Re?)
-          case _ => false
-        }
+    | ReLoop
+  {
+    predicate wellFormedFunction(args: seq<Sort>) {
+      match this {
+        case ReUnion => (forall arg | arg in args :: arg.Re?)
+        case _ => false
       }
-
     }
+
+  }
 }

--- a/Test/git-issues/git-issue-4334.dfy.expect
+++ b/Test/git-issues/git-issue-4334.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Test/git-issues/git-issue-4334.dfy.expect
+++ b/Test/git-issues/git-issue-4334.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with TODO verified, TODO errors
+Dafny program verifier finished with 0 verified, 0 errors

--- a/docs/dev/news/4334.fix
+++ b/docs/dev/news/4334.fix
@@ -1,0 +1,1 @@
+Making default export set opaque no longer crashing the resolver on inductive datatypes


### PR DESCRIPTION
This PR fixes #4334

Looking at the debugger, it arrives at the line that I deleted with the fact that it's not an AbstractTypeDecl, but an InductiveTypeDecl. It just happen that it is no visible in the default scope because there is an export declaration. So there should be no reason to assume it should be an AbstractTypeDecl in my opinion, but I might be missing something. as well.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>