### PR TITLE
Support class fields in the Rust backend

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -127,7 +127,7 @@ jobs:
           reportgenerator \
             -reports:"./**/coverage.cobertura.xml" \
             -reporttypes:Cobertura -targetdir:coverage-cobertura \
-            -classfilters:"-Microsoft.Dafny.*PreType*;-Microsoft.Dafny.ResolverPass;-Microsoft.Dafny.*Underspecification*;-Microsoft.Dafny.DetectUnderspecificationVisitor;-Microsoft.Dafny.Microsoft.Dafny.UnderspecificationDetector;-DAST.*;-DCOMP.*"
+            -classfilters:"-Microsoft.Dafny.*PreType*;-Microsoft.Dafny.ResolverPass;-Microsoft.Dafny.*Underspecification*;-Microsoft.Dafny.DetectUnderspecificationVisitor;-Microsoft.Dafny.Microsoft.Dafny.UnderspecificationDetector;-Microsoft.Dafny.Compilers.DafnyCompiler;-DAST.*;-DCOMP.*"
           # Generate HTML from combined report, leaving out XUnitExtensions
           reportgenerator \
             -reports:"coverage-cobertura/Cobertura.xml" \

--- a/Source/DafnyCore/Compilers/Dafny/AST.dfy
+++ b/Source/DafnyCore/Compilers/Dafny/AST.dfy
@@ -3,8 +3,6 @@ module {:extern "DAST"} DAST {
 
   datatype ModuleItem = Module(Module) | Class(Class) | Trait(Trait) | Newtype(Newtype) | Datatype(Datatype)
 
-  datatype Newtype = Newtype(name: string, typeParams: seq<Type>, base: Type, witnessStmts: seq<Statement>, witnessExpr: Optional<Expression>)
-
   datatype Type =
     Path(seq<Ident>, typeArgs: seq<Type>, resolved: ResolvedType) |
     Tuple(seq<Type>) |
@@ -23,7 +21,7 @@ module {:extern "DAST"} DAST {
 
   datatype Ident = Ident(id: string)
 
-  datatype Class = Class(name: string, superClasses: seq<Type>, body: seq<ClassItem>)
+  datatype Class = Class(name: string, typeParams: seq<Type>, superClasses: seq<Type>, fields: seq<Field>, body: seq<ClassItem>)
 
   datatype Trait = Trait(name: string, typeParams: seq<Type>, body: seq<ClassItem>)
 
@@ -31,7 +29,11 @@ module {:extern "DAST"} DAST {
 
   datatype DatatypeCtor = DatatypeCtor(name: string, args: seq<Formal>, hasAnyArgs: bool /* includes ghost */)
 
-  datatype ClassItem = Method(Method) | Field(Formal)
+  datatype Newtype = Newtype(name: string, typeParams: seq<Type>, base: Type, witnessStmts: seq<Statement>, witnessExpr: Optional<Expression>)
+
+  datatype ClassItem = Method(Method)
+
+  datatype Field = Field(formal: Formal, defaultValue: Optional<Expression>)
 
   datatype Formal = Formal(name: string, typ: Type)
 
@@ -41,7 +43,7 @@ module {:extern "DAST"} DAST {
 
   datatype Statement =
     DeclareVar(name: string, typ: Type, maybeValue: Optional<Expression>) |
-    Assign(name: string, value: Expression) |
+    Assign(lhs: AssignLhs, value: Expression) |
     If(cond: Expression, thn: seq<Statement>, els: seq<Statement>) |
     While(cond: Expression, body: seq<Statement>) |
     Call(on: Expression, name: string, typeArgs: seq<Type>, args: seq<Expression>, outs: Optional<seq<Ident>>) |
@@ -49,6 +51,8 @@ module {:extern "DAST"} DAST {
     EarlyReturn() |
     Halt() |
     Print(Expression)
+
+  datatype AssignLhs = Ident(Ident) | Select(expr: Expression, field: string)
 
   datatype Expression =
     Literal(Literal) |
@@ -66,7 +70,7 @@ module {:extern "DAST"} DAST {
     Ite(cond: Expression, thn: Expression, els: Expression) |
     UnOp(unOp: UnaryOp, expr: Expression) |
     BinOp(op: string, left: Expression, right: Expression) |
-    Select(expr: Expression, field: string, onDatatype: bool) |
+    Select(expr: Expression, field: string, isConstant: bool, onDatatype: bool) |
     SelectFn(expr: Expression, field: string, onDatatype: bool, isStatic: bool, arity: nat) |
     TupleSelect(expr: Expression, index: nat) |
     Call(on: Expression, name: Ident, typeArgs: seq<Type>, args: seq<Expression>) |

--- a/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
@@ -44,10 +44,58 @@ module {:extern "DCOMP"} DCOMP {
       }
     }
 
+    static method GenTypeParameters(params: seq<Type>) returns (typeParamsSet: set<Type>, typeParams: string, constrainedTypeParams: string) {
+      typeParamsSet := {};
+      typeParams := "";
+      constrainedTypeParams := "";
+      var tpI := 0;
+
+      if |params| > 0 {
+        typeParams := "<";
+        constrainedTypeParams := "<";
+        while tpI < |params| {
+          var tp := params[tpI];
+          typeParamsSet := typeParamsSet + {tp};
+          var genTp := GenType(tp, false, false);
+          typeParams := typeParams + genTp + ", ";
+          constrainedTypeParams := constrainedTypeParams + genTp + ": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<" + genTp + "> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static, ";
+          tpI := tpI + 1;
+        }
+        typeParams := typeParams + ">";
+        constrainedTypeParams := constrainedTypeParams + ">";
+      }
+    }
+
     static method GenClass(c: Class, path: seq<Ident>) returns (s: string) {
-      var implBody, traitBodies := GenClassImplBody(c.body, false, Type.Path(path, [], ResolvedType.Datatype(path)), {});
-      implBody := "pub fn new() -> Self {\n" + "r#" + c.name + " {\n" + "" + "\n}\n}\n" + implBody;
-      s := "pub struct r#" + c.name + " {\n" + "" +  "\n}" + "\n" + "impl r#" + c.name + " {\n" + implBody + "\n}";
+      var typeParamsSet, typeParams, constrainedTypeParams := GenTypeParameters(c.typeParams);
+
+      var fields := "";
+      var fieldInits := "";
+      var fieldI := 0;
+      while fieldI < |c.fields| {
+        var field := c.fields[fieldI];
+        var fieldType := GenType(field.formal.typ, false, false);
+        fields := fields + "pub r#" + field.formal.name + ": ::std::cell::RefCell<" + fieldType + ">,\n";
+
+        match field.defaultValue {
+          case Some(e) => {
+            var eStr, _, _, _ := GenExpr(e, [], true);
+            fieldInits := fieldInits + "r#" + field.formal.name + ": ::std::cell::RefCell::new(" + eStr + "),\n";
+          }
+          case None => {
+            fieldInits := fieldInits + "r#" + field.formal.name + ": ::std::cell::RefCell::new(::std::default::Default::default()),\n";
+          }
+        }
+
+        fieldI := fieldI + 1;
+      }
+
+      s := "#[derive(Default)]\npub struct r#" + c.name + typeParams + " {\n" + fields +  "\n}";
+
+      var implBody, traitBodies := GenClassImplBody(c.body, false, Type.Path([], [], ResolvedType.Datatype(path)), {});
+      implBody := "pub fn new() -> Self {\n" + "r#" + c.name + " {\n" + fieldInits + "\n}\n}\n" + implBody;
+
+      s := s + "\n" + "impl " + constrainedTypeParams + " r#" + c.name + typeParams + " {\n" + implBody + "\n}";
       if (|c.superClasses| > 0) {
         var i := 0;
         while i < |c.superClasses| {
@@ -62,13 +110,33 @@ module {:extern "DCOMP"} DCOMP {
               }
 
               var genSelfPath := GenPath(path);
-              s := s + "\nimpl " + pathStr + typeArgs + " for ::std::rc::Rc<" + genSelfPath + "> {\n" + body + "\n}";
+              s := s + "\nimpl " + pathStr + typeArgs + " for ::std::rc::Rc<" + genSelfPath + typeParams + "> {\n" + body + "\n}";
             }
             case _ => {}
           }
           i := i + 1;
         }
       }
+
+      var printImpl := "impl " + constrainedTypeParams + " ::dafny_runtime::DafnyPrint for r#" + c.name + typeParams + " {\n" + "fn fmt_print(&self, __fmt_print_formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {\n";
+      printImpl := printImpl + "write!(__fmt_print_formatter, \"r#" + c.name + "(" + (if |c.fields| > 0 then "" else ")") + "\")?;";
+      var i := 0;
+      while i < |c.fields| {
+        var field := c.fields[i];
+        if (i > 0) {
+          printImpl := printImpl + "\nwrite!(__fmt_print_formatter, \", \")?;";
+        }
+        printImpl := printImpl + "\n::dafny_runtime::DafnyPrint::fmt_print(::std::ops::Deref::deref(&(self.r#" + field.formal.name + ".borrow())), __fmt_print_formatter, false)?;";
+        i := i + 1;
+      }
+      printImpl := printImpl + "\nwrite!(__fmt_print_formatter, \")\")?;\nOk(())\n}\n}\n";
+
+      var ptrPartialEqImpl := "impl " + constrainedTypeParams + " ::std::cmp::PartialEq for r#" + c.name + typeParams + " {\n";
+      ptrPartialEqImpl := ptrPartialEqImpl + "fn eq(&self, other: &Self) -> bool {\n";
+      ptrPartialEqImpl := ptrPartialEqImpl + "::std::ptr::eq(self, other)";
+      ptrPartialEqImpl := ptrPartialEqImpl + "\n}\n}\n";
+
+      s := s + "\n" + printImpl + "\n" + ptrPartialEqImpl;
     }
 
     static method GenTrait(t: Trait, containingPath: seq<Ident>) returns (s: string) {
@@ -93,24 +161,7 @@ module {:extern "DCOMP"} DCOMP {
     }
 
     static method GenNewtype(c: Newtype) returns (s: string) {
-      var typeParamsSet := {};
-      var typeParams := "";
-      var constrainedTypeParams := "";
-      var tpI := 0;
-      if |c.typeParams| > 0 {
-        typeParams := "<";
-        constrainedTypeParams := "<";
-        while tpI < |c.typeParams| {
-          var tp := c.typeParams[tpI];
-          typeParamsSet := typeParamsSet + {tp};
-          var genTp := GenType(tp, false, false);
-          typeParams := typeParams + genTp + ", ";
-          constrainedTypeParams := constrainedTypeParams + genTp + ": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<" + genTp + "> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static, ";
-          tpI := tpI + 1;
-        }
-        typeParams := typeParams + ">";
-        constrainedTypeParams := constrainedTypeParams + ">";
-      }
+      var typeParamsSet, typeParams, constrainedTypeParams := GenTypeParameters(c.typeParams);
 
       var underlyingType := GenType(c.base, false, false);
       s := "#[derive(Clone, PartialEq)]\n#[repr(transparent)]\npub struct r#" + c.name + typeParams + "(pub " + underlyingType +  ");\n";
@@ -163,20 +214,7 @@ module {:extern "DCOMP"} DCOMP {
     }
 
     static method GenDatatype(c: Datatype) returns (s: string) {
-      var typeParamsSet := {};
-      var typeParams := "";
-      var tpI := 0;
-      if |c.typeParams| > 0 {
-        typeParams := "<";
-        while tpI < |c.typeParams| {
-          var tp := c.typeParams[tpI];
-          typeParamsSet := typeParamsSet + {tp};
-          var genTp := GenType(tp, false, false);
-          typeParams := typeParams + genTp + ", ";
-          tpI := tpI + 1;
-        }
-        typeParams := typeParams + ">";
-      }
+      var typeParamsSet, typeParams, constrainedTypeParams := GenTypeParameters(c.typeParams);
 
       var ctors := "";
       var i := 0;
@@ -254,23 +292,6 @@ module {:extern "DCOMP"} DCOMP {
         }
 
         i := i + 1;
-      }
-
-      var constrainedTypeParams := "";
-      if |c.typeParams| > 0 {
-        tpI := 0;
-        constrainedTypeParams := "<";
-        while tpI < |c.typeParams| {
-          if tpI > 0 {
-            constrainedTypeParams := constrainedTypeParams + ", ";
-          }
-
-          var tp := c.typeParams[tpI];
-          var genTp := GenType(tp, false, false);
-          constrainedTypeParams := constrainedTypeParams + genTp + ": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<" + genTp + "> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static";
-          tpI := tpI + 1;
-        }
-        constrainedTypeParams := constrainedTypeParams + ">";
       }
 
       var enumBody := "#[derive(PartialEq)]\npub enum r#" + c.name + typeParams + " {\n" + ctors +  "\n}" + "\n" + "impl " + constrainedTypeParams + " r#" + c.name + typeParams + " {\n" + implBody + "\n}";
@@ -498,7 +519,6 @@ module {:extern "DCOMP"} DCOMP {
               }
             }
           }
-          case Field(f) => { /* TODO */ }
         }
 
         if |s| > 0 {
@@ -651,6 +671,33 @@ module {:extern "DCOMP"} DCOMP {
       }
     }
 
+    static method GenAssignLhs(lhs: AssignLhs, params: seq<string>) returns (generated: string, needsIIFE: bool, readIdents: set<string>) {
+      match lhs {
+        case Ident(Ident(id)) => {
+          if id in params {
+            generated := "*r#" + id;
+          } else {
+            generated := "r#" + id;
+          }
+
+          readIdents := {id};
+          needsIIFE := false;
+        }
+
+        case Select(on, field) => {
+          var onExpr, onOwned, onErased, recIdents := GenExpr(on, params, false);
+          if !onErased {
+            var eraseFn := if onOwned then "erase_owned" else "erase";
+            onExpr := "::dafny_runtime::DafnyErasable::" + eraseFn + "(" + onExpr + ")";
+          }
+
+          generated := "*(" + onExpr + "." + field + ".borrow_mut())";
+          readIdents := recIdents;
+          needsIIFE := true;
+        }
+      }
+    }
+
     static method GenStmt(stmt: Statement, params: seq<string>, isLast: bool, earlyReturn: string) returns (generated: string, readIdents: set<string>) {
       match stmt {
         case DeclareVar(name, typ, Some(expression)) => {
@@ -668,14 +715,20 @@ module {:extern "DCOMP"} DCOMP {
           generated := "let mut r#" + name + ": " + typeString + ";";
           readIdents := {};
         }
-        case Assign(name, expression) => {
-          var expr, _, recErased, recIdents := GenExpr(expression, params, true);
-          if recErased {
-            expr := "::dafny_runtime::DafnyUnerasable::<_>::unerase_owned(" + expr + ")";
+        case Assign(lhs, expression) => {
+          var lhsGen, needsIIFE, recIdents := GenAssignLhs(lhs, params);
+          var exprGen, _, exprErased, exprIdents := GenExpr(expression, params, true);
+          if exprErased {
+            exprGen := "::dafny_runtime::DafnyUnerasable::<_>::unerase_owned(" + exprGen + ")";
           }
 
-          generated := "r#" + name + " = " + expr + ";";
-          readIdents := recIdents;
+          if needsIIFE {
+            generated := "{ let __rhs = " + exprGen + "; " + lhsGen + " = __rhs; }";
+          } else {
+            generated := lhsGen + " = " + exprGen + ";";
+          }
+
+          readIdents := recIdents + exprIdents;
         }
         case If(cond, thn, els) => {
           var condString, _, condErased, recIdents := GenExpr(cond, params, true);
@@ -739,7 +792,7 @@ module {:extern "DCOMP"} DCOMP {
             i := i + 1;
           }
 
-          var enclosingString, _, _, enclosingIdents := GenExpr(on, params, true);
+          var enclosingString, _, _, enclosingIdents := GenExpr(on, params, false);
           readIdents := readIdents + enclosingIdents;
           match on {
             case Companion(_) => {
@@ -1204,15 +1257,19 @@ module {:extern "DCOMP"} DCOMP {
           isErased := true;
           readIdents := recIdents;
         }
-        case Select(on, field, isDatatype) => {
+        case Select(on, field, isConstant, isDatatype) => {
           var onString, onOwned, onErased, recIdents := GenExpr(on, params, false);
           if !onErased {
             var eraseFn := if onOwned then "erase_owned" else "erase";
             onString := "::dafny_runtime::DafnyErasable::" + eraseFn + "(" + onString + ")";
           }
 
-          if isDatatype {
+          if isDatatype || isConstant {
             s := "(" + onString + ")" + ".r#" + field + "()";
+            if isConstant {
+              s := "&" + s;
+            }
+
             if mustOwn {
               s := "(" + s + ").clone()";
               isOwned := true;
@@ -1220,13 +1277,9 @@ module {:extern "DCOMP"} DCOMP {
               isOwned := false;
             }
           } else {
-            s := "(" + onString + ")" + ".r#" + field;
-            if mustOwn {
-              s := "(" + s + ").clone()";
-              isOwned := true;
-            } else {
-              isOwned := false;
-            }
+            s := "::std::ops::Deref::deref(&((" + onString + ")" + ".r#" + field + ".borrow()))";
+            s := "(" + s + ").clone()"; // TODO(shadaj): think through when we can avoid cloning
+            isOwned := true;
           }
 
           isErased := false;

--- a/Source/DafnyCore/GeneratedFromDafnyRust.cs
+++ b/Source/DafnyCore/GeneratedFromDafnyRust.cs
@@ -287,103 +287,6 @@ namespace DAST {
     }
   }
 
-  public interface _INewtype {
-    bool is_Newtype { get; }
-    Dafny.ISequence<Dafny.Rune> dtor_name { get; }
-    Dafny.ISequence<DAST._IType> dtor_typeParams { get; }
-    DAST._IType dtor_base { get; }
-    Dafny.ISequence<DAST._IStatement> dtor_witnessStmts { get; }
-    DAST._IOptional<DAST._IExpression> dtor_witnessExpr { get; }
-    _INewtype DowncastClone();
-  }
-  public class Newtype : _INewtype {
-    public readonly Dafny.ISequence<Dafny.Rune> _name;
-    public readonly Dafny.ISequence<DAST._IType> _typeParams;
-    public readonly DAST._IType _base;
-    public readonly Dafny.ISequence<DAST._IStatement> _witnessStmts;
-    public readonly DAST._IOptional<DAST._IExpression> _witnessExpr;
-    public Newtype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, DAST._IType @base, Dafny.ISequence<DAST._IStatement> witnessStmts, DAST._IOptional<DAST._IExpression> witnessExpr) {
-      this._name = name;
-      this._typeParams = typeParams;
-      this._base = @base;
-      this._witnessStmts = witnessStmts;
-      this._witnessExpr = witnessExpr;
-    }
-    public _INewtype DowncastClone() {
-      if (this is _INewtype dt) { return dt; }
-      return new Newtype(_name, _typeParams, _base, _witnessStmts, _witnessExpr);
-    }
-    public override bool Equals(object other) {
-      var oth = other as DAST.Newtype;
-      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._typeParams, oth._typeParams) && object.Equals(this._base, oth._base) && object.Equals(this._witnessStmts, oth._witnessStmts) && object.Equals(this._witnessExpr, oth._witnessExpr);
-    }
-    public override int GetHashCode() {
-      ulong hash = 5381;
-      hash = ((hash << 5) + hash) + 0;
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._name));
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._typeParams));
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._base));
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._witnessStmts));
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._witnessExpr));
-      return (int)hash;
-    }
-    public override string ToString() {
-      string s = "DAST.Newtype.Newtype";
-      s += "(";
-      s += this._name.ToVerbatimString(true);
-      s += ", ";
-      s += Dafny.Helpers.ToString(this._typeParams);
-      s += ", ";
-      s += Dafny.Helpers.ToString(this._base);
-      s += ", ";
-      s += Dafny.Helpers.ToString(this._witnessStmts);
-      s += ", ";
-      s += Dafny.Helpers.ToString(this._witnessExpr);
-      s += ")";
-      return s;
-    }
-    private static readonly DAST._INewtype theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, DAST.Type.Default(), Dafny.Sequence<DAST._IStatement>.Empty, DAST.Optional<DAST._IExpression>.Default());
-    public static DAST._INewtype Default() {
-      return theDefault;
-    }
-    private static readonly Dafny.TypeDescriptor<DAST._INewtype> _TYPE = new Dafny.TypeDescriptor<DAST._INewtype>(DAST.Newtype.Default());
-    public static Dafny.TypeDescriptor<DAST._INewtype> _TypeDescriptor() {
-      return _TYPE;
-    }
-    public static _INewtype create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, DAST._IType @base, Dafny.ISequence<DAST._IStatement> witnessStmts, DAST._IOptional<DAST._IExpression> witnessExpr) {
-      return new Newtype(name, typeParams, @base, witnessStmts, witnessExpr);
-    }
-    public static _INewtype create_Newtype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, DAST._IType @base, Dafny.ISequence<DAST._IStatement> witnessStmts, DAST._IOptional<DAST._IExpression> witnessExpr) {
-      return create(name, typeParams, @base, witnessStmts, witnessExpr);
-    }
-    public bool is_Newtype { get { return true; } }
-    public Dafny.ISequence<Dafny.Rune> dtor_name {
-      get {
-        return this._name;
-      }
-    }
-    public Dafny.ISequence<DAST._IType> dtor_typeParams {
-      get {
-        return this._typeParams;
-      }
-    }
-    public DAST._IType dtor_base {
-      get {
-        return this._base;
-      }
-    }
-    public Dafny.ISequence<DAST._IStatement> dtor_witnessStmts {
-      get {
-        return this._witnessStmts;
-      }
-    }
-    public DAST._IOptional<DAST._IExpression> dtor_witnessExpr {
-      get {
-        return this._witnessExpr;
-      }
-    }
-  }
-
   public interface _IType {
     bool is_Path { get; }
     bool is_Tuple { get; }
@@ -1131,32 +1034,40 @@ namespace DAST {
   public interface _IClass {
     bool is_Class { get; }
     Dafny.ISequence<Dafny.Rune> dtor_name { get; }
+    Dafny.ISequence<DAST._IType> dtor_typeParams { get; }
     Dafny.ISequence<DAST._IType> dtor_superClasses { get; }
-    Dafny.ISequence<DAST._IClassItem> dtor_body { get; }
+    Dafny.ISequence<DAST._IField> dtor_fields { get; }
+    Dafny.ISequence<DAST._IMethod> dtor_body { get; }
     _IClass DowncastClone();
   }
   public class Class : _IClass {
     public readonly Dafny.ISequence<Dafny.Rune> _name;
+    public readonly Dafny.ISequence<DAST._IType> _typeParams;
     public readonly Dafny.ISequence<DAST._IType> _superClasses;
-    public readonly Dafny.ISequence<DAST._IClassItem> _body;
-    public Class(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> superClasses, Dafny.ISequence<DAST._IClassItem> body) {
+    public readonly Dafny.ISequence<DAST._IField> _fields;
+    public readonly Dafny.ISequence<DAST._IMethod> _body;
+    public Class(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IType> superClasses, Dafny.ISequence<DAST._IField> fields, Dafny.ISequence<DAST._IMethod> body) {
       this._name = name;
+      this._typeParams = typeParams;
       this._superClasses = superClasses;
+      this._fields = fields;
       this._body = body;
     }
     public _IClass DowncastClone() {
       if (this is _IClass dt) { return dt; }
-      return new Class(_name, _superClasses, _body);
+      return new Class(_name, _typeParams, _superClasses, _fields, _body);
     }
     public override bool Equals(object other) {
       var oth = other as DAST.Class;
-      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._superClasses, oth._superClasses) && object.Equals(this._body, oth._body);
+      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._typeParams, oth._typeParams) && object.Equals(this._superClasses, oth._superClasses) && object.Equals(this._fields, oth._fields) && object.Equals(this._body, oth._body);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 0;
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._name));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._typeParams));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._superClasses));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._fields));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._body));
       return (int)hash;
     }
@@ -1165,13 +1076,17 @@ namespace DAST {
       s += "(";
       s += this._name.ToVerbatimString(true);
       s += ", ";
+      s += Dafny.Helpers.ToString(this._typeParams);
+      s += ", ";
       s += Dafny.Helpers.ToString(this._superClasses);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._fields);
       s += ", ";
       s += Dafny.Helpers.ToString(this._body);
       s += ")";
       return s;
     }
-    private static readonly DAST._IClass theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IClassItem>.Empty);
+    private static readonly DAST._IClass theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IField>.Empty, Dafny.Sequence<DAST._IMethod>.Empty);
     public static DAST._IClass Default() {
       return theDefault;
     }
@@ -1179,11 +1094,11 @@ namespace DAST {
     public static Dafny.TypeDescriptor<DAST._IClass> _TypeDescriptor() {
       return _TYPE;
     }
-    public static _IClass create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> superClasses, Dafny.ISequence<DAST._IClassItem> body) {
-      return new Class(name, superClasses, body);
+    public static _IClass create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IType> superClasses, Dafny.ISequence<DAST._IField> fields, Dafny.ISequence<DAST._IMethod> body) {
+      return new Class(name, typeParams, superClasses, fields, body);
     }
-    public static _IClass create_Class(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> superClasses, Dafny.ISequence<DAST._IClassItem> body) {
-      return create(name, superClasses, body);
+    public static _IClass create_Class(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IType> superClasses, Dafny.ISequence<DAST._IField> fields, Dafny.ISequence<DAST._IMethod> body) {
+      return create(name, typeParams, superClasses, fields, body);
     }
     public bool is_Class { get { return true; } }
     public Dafny.ISequence<Dafny.Rune> dtor_name {
@@ -1191,12 +1106,22 @@ namespace DAST {
         return this._name;
       }
     }
+    public Dafny.ISequence<DAST._IType> dtor_typeParams {
+      get {
+        return this._typeParams;
+      }
+    }
     public Dafny.ISequence<DAST._IType> dtor_superClasses {
       get {
         return this._superClasses;
       }
     }
-    public Dafny.ISequence<DAST._IClassItem> dtor_body {
+    public Dafny.ISequence<DAST._IField> dtor_fields {
+      get {
+        return this._fields;
+      }
+    }
+    public Dafny.ISequence<DAST._IMethod> dtor_body {
       get {
         return this._body;
       }
@@ -1207,14 +1132,14 @@ namespace DAST {
     bool is_Trait { get; }
     Dafny.ISequence<Dafny.Rune> dtor_name { get; }
     Dafny.ISequence<DAST._IType> dtor_typeParams { get; }
-    Dafny.ISequence<DAST._IClassItem> dtor_body { get; }
+    Dafny.ISequence<DAST._IMethod> dtor_body { get; }
     _ITrait DowncastClone();
   }
   public class Trait : _ITrait {
     public readonly Dafny.ISequence<Dafny.Rune> _name;
     public readonly Dafny.ISequence<DAST._IType> _typeParams;
-    public readonly Dafny.ISequence<DAST._IClassItem> _body;
-    public Trait(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IClassItem> body) {
+    public readonly Dafny.ISequence<DAST._IMethod> _body;
+    public Trait(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IMethod> body) {
       this._name = name;
       this._typeParams = typeParams;
       this._body = body;
@@ -1246,7 +1171,7 @@ namespace DAST {
       s += ")";
       return s;
     }
-    private static readonly DAST._ITrait theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IClassItem>.Empty);
+    private static readonly DAST._ITrait theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IMethod>.Empty);
     public static DAST._ITrait Default() {
       return theDefault;
     }
@@ -1254,10 +1179,10 @@ namespace DAST {
     public static Dafny.TypeDescriptor<DAST._ITrait> _TypeDescriptor() {
       return _TYPE;
     }
-    public static _ITrait create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IClassItem> body) {
+    public static _ITrait create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IMethod> body) {
       return new Trait(name, typeParams, body);
     }
-    public static _ITrait create_Trait(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IClassItem> body) {
+    public static _ITrait create_Trait(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IMethod> body) {
       return create(name, typeParams, body);
     }
     public bool is_Trait { get { return true; } }
@@ -1271,7 +1196,7 @@ namespace DAST {
         return this._typeParams;
       }
     }
-    public Dafny.ISequence<DAST._IClassItem> dtor_body {
+    public Dafny.ISequence<DAST._IMethod> dtor_body {
       get {
         return this._body;
       }
@@ -1284,7 +1209,7 @@ namespace DAST {
     Dafny.ISequence<Dafny.Rune> dtor_enclosingModule { get; }
     Dafny.ISequence<DAST._IType> dtor_typeParams { get; }
     Dafny.ISequence<DAST._IDatatypeCtor> dtor_ctors { get; }
-    Dafny.ISequence<DAST._IClassItem> dtor_body { get; }
+    Dafny.ISequence<DAST._IMethod> dtor_body { get; }
     bool dtor_isCo { get; }
     _IDatatype DowncastClone();
   }
@@ -1293,9 +1218,9 @@ namespace DAST {
     public readonly Dafny.ISequence<Dafny.Rune> _enclosingModule;
     public readonly Dafny.ISequence<DAST._IType> _typeParams;
     public readonly Dafny.ISequence<DAST._IDatatypeCtor> _ctors;
-    public readonly Dafny.ISequence<DAST._IClassItem> _body;
+    public readonly Dafny.ISequence<DAST._IMethod> _body;
     public readonly bool _isCo;
-    public Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body, bool isCo) {
+    public Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IMethod> body, bool isCo) {
       this._name = name;
       this._enclosingModule = enclosingModule;
       this._typeParams = typeParams;
@@ -1339,7 +1264,7 @@ namespace DAST {
       s += ")";
       return s;
     }
-    private static readonly DAST._IDatatype theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IDatatypeCtor>.Empty, Dafny.Sequence<DAST._IClassItem>.Empty, false);
+    private static readonly DAST._IDatatype theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, Dafny.Sequence<DAST._IDatatypeCtor>.Empty, Dafny.Sequence<DAST._IMethod>.Empty, false);
     public static DAST._IDatatype Default() {
       return theDefault;
     }
@@ -1347,10 +1272,10 @@ namespace DAST {
     public static Dafny.TypeDescriptor<DAST._IDatatype> _TypeDescriptor() {
       return _TYPE;
     }
-    public static _IDatatype create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body, bool isCo) {
+    public static _IDatatype create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IMethod> body, bool isCo) {
       return new Datatype(name, enclosingModule, typeParams, ctors, body, isCo);
     }
-    public static _IDatatype create_Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IClassItem> body, bool isCo) {
+    public static _IDatatype create_Datatype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<Dafny.Rune> enclosingModule, Dafny.ISequence<DAST._IType> typeParams, Dafny.ISequence<DAST._IDatatypeCtor> ctors, Dafny.ISequence<DAST._IMethod> body, bool isCo) {
       return create(name, enclosingModule, typeParams, ctors, body, isCo);
     }
     public bool is_Datatype { get { return true; } }
@@ -1374,7 +1299,7 @@ namespace DAST {
         return this._ctors;
       }
     }
-    public Dafny.ISequence<DAST._IClassItem> dtor_body {
+    public Dafny.ISequence<DAST._IMethod> dtor_body {
       get {
         return this._body;
       }
@@ -1461,57 +1386,117 @@ namespace DAST {
     }
   }
 
-  public interface _IClassItem {
-    bool is_Method { get; }
-    bool is_Field { get; }
-    DAST._IMethod dtor_Method_a0 { get; }
-    DAST._IFormal dtor_Field_a0 { get; }
-    _IClassItem DowncastClone();
+  public interface _INewtype {
+    bool is_Newtype { get; }
+    Dafny.ISequence<Dafny.Rune> dtor_name { get; }
+    Dafny.ISequence<DAST._IType> dtor_typeParams { get; }
+    DAST._IType dtor_base { get; }
+    Dafny.ISequence<DAST._IStatement> dtor_witnessStmts { get; }
+    DAST._IOptional<DAST._IExpression> dtor_witnessExpr { get; }
+    _INewtype DowncastClone();
   }
-  public abstract class ClassItem : _IClassItem {
-    public ClassItem() {
+  public class Newtype : _INewtype {
+    public readonly Dafny.ISequence<Dafny.Rune> _name;
+    public readonly Dafny.ISequence<DAST._IType> _typeParams;
+    public readonly DAST._IType _base;
+    public readonly Dafny.ISequence<DAST._IStatement> _witnessStmts;
+    public readonly DAST._IOptional<DAST._IExpression> _witnessExpr;
+    public Newtype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, DAST._IType @base, Dafny.ISequence<DAST._IStatement> witnessStmts, DAST._IOptional<DAST._IExpression> witnessExpr) {
+      this._name = name;
+      this._typeParams = typeParams;
+      this._base = @base;
+      this._witnessStmts = witnessStmts;
+      this._witnessExpr = witnessExpr;
     }
-    private static readonly DAST._IClassItem theDefault = create_Method(DAST.Method.Default());
-    public static DAST._IClassItem Default() {
-      return theDefault;
-    }
-    private static readonly Dafny.TypeDescriptor<DAST._IClassItem> _TYPE = new Dafny.TypeDescriptor<DAST._IClassItem>(DAST.ClassItem.Default());
-    public static Dafny.TypeDescriptor<DAST._IClassItem> _TypeDescriptor() {
-      return _TYPE;
-    }
-    public static _IClassItem create_Method(DAST._IMethod _a0) {
-      return new ClassItem_Method(_a0);
-    }
-    public static _IClassItem create_Field(DAST._IFormal _a0) {
-      return new ClassItem_Field(_a0);
-    }
-    public bool is_Method { get { return this is ClassItem_Method; } }
-    public bool is_Field { get { return this is ClassItem_Field; } }
-    public DAST._IMethod dtor_Method_a0 {
-      get {
-        var d = this;
-        return ((ClassItem_Method)d)._a0;
-      }
-    }
-    public DAST._IFormal dtor_Field_a0 {
-      get {
-        var d = this;
-        return ((ClassItem_Field)d)._a0;
-      }
-    }
-    public abstract _IClassItem DowncastClone();
-  }
-  public class ClassItem_Method : ClassItem {
-    public readonly DAST._IMethod _a0;
-    public ClassItem_Method(DAST._IMethod _a0) : base() {
-      this._a0 = _a0;
-    }
-    public override _IClassItem DowncastClone() {
-      if (this is _IClassItem dt) { return dt; }
-      return new ClassItem_Method(_a0);
+    public _INewtype DowncastClone() {
+      if (this is _INewtype dt) { return dt; }
+      return new Newtype(_name, _typeParams, _base, _witnessStmts, _witnessExpr);
     }
     public override bool Equals(object other) {
-      var oth = other as DAST.ClassItem_Method;
+      var oth = other as DAST.Newtype;
+      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._typeParams, oth._typeParams) && object.Equals(this._base, oth._base) && object.Equals(this._witnessStmts, oth._witnessStmts) && object.Equals(this._witnessExpr, oth._witnessExpr);
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 0;
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._name));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._typeParams));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._base));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._witnessStmts));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._witnessExpr));
+      return (int)hash;
+    }
+    public override string ToString() {
+      string s = "DAST.Newtype.Newtype";
+      s += "(";
+      s += this._name.ToVerbatimString(true);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._typeParams);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._base);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._witnessStmts);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._witnessExpr);
+      s += ")";
+      return s;
+    }
+    private static readonly DAST._INewtype theDefault = create(Dafny.Sequence<Dafny.Rune>.Empty, Dafny.Sequence<DAST._IType>.Empty, DAST.Type.Default(), Dafny.Sequence<DAST._IStatement>.Empty, DAST.Optional<DAST._IExpression>.Default());
+    public static DAST._INewtype Default() {
+      return theDefault;
+    }
+    private static readonly Dafny.TypeDescriptor<DAST._INewtype> _TYPE = new Dafny.TypeDescriptor<DAST._INewtype>(DAST.Newtype.Default());
+    public static Dafny.TypeDescriptor<DAST._INewtype> _TypeDescriptor() {
+      return _TYPE;
+    }
+    public static _INewtype create(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, DAST._IType @base, Dafny.ISequence<DAST._IStatement> witnessStmts, DAST._IOptional<DAST._IExpression> witnessExpr) {
+      return new Newtype(name, typeParams, @base, witnessStmts, witnessExpr);
+    }
+    public static _INewtype create_Newtype(Dafny.ISequence<Dafny.Rune> name, Dafny.ISequence<DAST._IType> typeParams, DAST._IType @base, Dafny.ISequence<DAST._IStatement> witnessStmts, DAST._IOptional<DAST._IExpression> witnessExpr) {
+      return create(name, typeParams, @base, witnessStmts, witnessExpr);
+    }
+    public bool is_Newtype { get { return true; } }
+    public Dafny.ISequence<Dafny.Rune> dtor_name {
+      get {
+        return this._name;
+      }
+    }
+    public Dafny.ISequence<DAST._IType> dtor_typeParams {
+      get {
+        return this._typeParams;
+      }
+    }
+    public DAST._IType dtor_base {
+      get {
+        return this._base;
+      }
+    }
+    public Dafny.ISequence<DAST._IStatement> dtor_witnessStmts {
+      get {
+        return this._witnessStmts;
+      }
+    }
+    public DAST._IOptional<DAST._IExpression> dtor_witnessExpr {
+      get {
+        return this._witnessExpr;
+      }
+    }
+  }
+
+  public interface _IClassItem {
+    bool is_Method { get; }
+    DAST._IMethod dtor_Method_a0 { get; }
+  }
+  public class ClassItem : _IClassItem {
+    public readonly DAST._IMethod _a0;
+    public ClassItem(DAST._IMethod _a0) {
+      this._a0 = _a0;
+    }
+    public static DAST._IMethod DowncastClone(DAST._IMethod _this) {
+      return _this;
+    }
+    public override bool Equals(object other) {
+      var oth = other as DAST.ClassItem;
       return oth != null && object.Equals(this._a0, oth._a0);
     }
     public override int GetHashCode() {
@@ -1527,32 +1512,89 @@ namespace DAST {
       s += ")";
       return s;
     }
-  }
-  public class ClassItem_Field : ClassItem {
-    public readonly DAST._IFormal _a0;
-    public ClassItem_Field(DAST._IFormal _a0) : base() {
-      this._a0 = _a0;
+    private static readonly DAST._IMethod theDefault = DAST.Method.Default();
+    public static DAST._IMethod Default() {
+      return theDefault;
     }
-    public override _IClassItem DowncastClone() {
-      if (this is _IClassItem dt) { return dt; }
-      return new ClassItem_Field(_a0);
+    private static readonly Dafny.TypeDescriptor<DAST._IMethod> _TYPE = new Dafny.TypeDescriptor<DAST._IMethod>(DAST.Method.Default());
+    public static Dafny.TypeDescriptor<DAST._IMethod> _TypeDescriptor() {
+      return _TYPE;
+    }
+    public static _IClassItem create(DAST._IMethod _a0) {
+      return new ClassItem(_a0);
+    }
+    public static _IClassItem create_Method(DAST._IMethod _a0) {
+      return create(_a0);
+    }
+    public bool is_Method { get { return true; } }
+    public DAST._IMethod dtor_Method_a0 {
+      get {
+        return this._a0;
+      }
+    }
+  }
+
+  public interface _IField {
+    bool is_Field { get; }
+    DAST._IFormal dtor_formal { get; }
+    DAST._IOptional<DAST._IExpression> dtor_defaultValue { get; }
+    _IField DowncastClone();
+  }
+  public class Field : _IField {
+    public readonly DAST._IFormal _formal;
+    public readonly DAST._IOptional<DAST._IExpression> _defaultValue;
+    public Field(DAST._IFormal formal, DAST._IOptional<DAST._IExpression> defaultValue) {
+      this._formal = formal;
+      this._defaultValue = defaultValue;
+    }
+    public _IField DowncastClone() {
+      if (this is _IField dt) { return dt; }
+      return new Field(_formal, _defaultValue);
     }
     public override bool Equals(object other) {
-      var oth = other as DAST.ClassItem_Field;
-      return oth != null && object.Equals(this._a0, oth._a0);
+      var oth = other as DAST.Field;
+      return oth != null && object.Equals(this._formal, oth._formal) && object.Equals(this._defaultValue, oth._defaultValue);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
-      hash = ((hash << 5) + hash) + 1;
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._a0));
+      hash = ((hash << 5) + hash) + 0;
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._formal));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._defaultValue));
       return (int)hash;
     }
     public override string ToString() {
-      string s = "DAST.ClassItem.Field";
+      string s = "DAST.Field.Field";
       s += "(";
-      s += Dafny.Helpers.ToString(this._a0);
+      s += Dafny.Helpers.ToString(this._formal);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._defaultValue);
       s += ")";
       return s;
+    }
+    private static readonly DAST._IField theDefault = create(DAST.Formal.Default(), DAST.Optional<DAST._IExpression>.Default());
+    public static DAST._IField Default() {
+      return theDefault;
+    }
+    private static readonly Dafny.TypeDescriptor<DAST._IField> _TYPE = new Dafny.TypeDescriptor<DAST._IField>(DAST.Field.Default());
+    public static Dafny.TypeDescriptor<DAST._IField> _TypeDescriptor() {
+      return _TYPE;
+    }
+    public static _IField create(DAST._IFormal formal, DAST._IOptional<DAST._IExpression> defaultValue) {
+      return new Field(formal, defaultValue);
+    }
+    public static _IField create_Field(DAST._IFormal formal, DAST._IOptional<DAST._IExpression> defaultValue) {
+      return create(formal, defaultValue);
+    }
+    public bool is_Field { get { return true; } }
+    public DAST._IFormal dtor_formal {
+      get {
+        return this._formal;
+      }
+    }
+    public DAST._IOptional<DAST._IExpression> dtor_defaultValue {
+      get {
+        return this._defaultValue;
+      }
     }
   }
 
@@ -1854,6 +1896,7 @@ namespace DAST {
     Dafny.ISequence<Dafny.Rune> dtor_name { get; }
     DAST._IType dtor_typ { get; }
     DAST._IOptional<DAST._IExpression> dtor_maybeValue { get; }
+    DAST._IAssignLhs dtor_lhs { get; }
     DAST._IExpression dtor_value { get; }
     DAST._IExpression dtor_cond { get; }
     Dafny.ISequence<DAST._IStatement> dtor_thn { get; }
@@ -1881,8 +1924,8 @@ namespace DAST {
     public static _IStatement create_DeclareVar(Dafny.ISequence<Dafny.Rune> name, DAST._IType typ, DAST._IOptional<DAST._IExpression> maybeValue) {
       return new Statement_DeclareVar(name, typ, maybeValue);
     }
-    public static _IStatement create_Assign(Dafny.ISequence<Dafny.Rune> name, DAST._IExpression @value) {
-      return new Statement_Assign(name, @value);
+    public static _IStatement create_Assign(DAST._IAssignLhs lhs, DAST._IExpression @value) {
+      return new Statement_Assign(lhs, @value);
     }
     public static _IStatement create_If(DAST._IExpression cond, Dafny.ISequence<DAST._IStatement> thn, Dafny.ISequence<DAST._IStatement> els) {
       return new Statement_If(cond, thn, els);
@@ -1918,7 +1961,6 @@ namespace DAST {
       get {
         var d = this;
         if (d is Statement_DeclareVar) { return ((Statement_DeclareVar)d)._name; }
-        if (d is Statement_Assign) { return ((Statement_Assign)d)._name; }
         return ((Statement_Call)d)._name;
       }
     }
@@ -1932,6 +1974,12 @@ namespace DAST {
       get {
         var d = this;
         return ((Statement_DeclareVar)d)._maybeValue;
+      }
+    }
+    public DAST._IAssignLhs dtor_lhs {
+      get {
+        var d = this;
+        return ((Statement_Assign)d)._lhs;
       }
     }
     public DAST._IExpression dtor_value {
@@ -2041,31 +2089,31 @@ namespace DAST {
     }
   }
   public class Statement_Assign : Statement {
-    public readonly Dafny.ISequence<Dafny.Rune> _name;
+    public readonly DAST._IAssignLhs _lhs;
     public readonly DAST._IExpression _value;
-    public Statement_Assign(Dafny.ISequence<Dafny.Rune> name, DAST._IExpression @value) : base() {
-      this._name = name;
+    public Statement_Assign(DAST._IAssignLhs lhs, DAST._IExpression @value) : base() {
+      this._lhs = lhs;
       this._value = @value;
     }
     public override _IStatement DowncastClone() {
       if (this is _IStatement dt) { return dt; }
-      return new Statement_Assign(_name, _value);
+      return new Statement_Assign(_lhs, _value);
     }
     public override bool Equals(object other) {
       var oth = other as DAST.Statement_Assign;
-      return oth != null && object.Equals(this._name, oth._name) && object.Equals(this._value, oth._value);
+      return oth != null && object.Equals(this._lhs, oth._lhs) && object.Equals(this._value, oth._value);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 1;
-      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._name));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._lhs));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._value));
       return (int)hash;
     }
     public override string ToString() {
       string s = "DAST.Statement.Assign";
       s += "(";
-      s += this._name.ToVerbatimString(true);
+      s += Dafny.Helpers.ToString(this._lhs);
       s += ", ";
       s += Dafny.Helpers.ToString(this._value);
       s += ")";
@@ -2285,6 +2333,113 @@ namespace DAST {
     }
   }
 
+  public interface _IAssignLhs {
+    bool is_Ident { get; }
+    bool is_Select { get; }
+    Dafny.ISequence<Dafny.Rune> dtor_Ident_a0 { get; }
+    DAST._IExpression dtor_expr { get; }
+    Dafny.ISequence<Dafny.Rune> dtor_field { get; }
+    _IAssignLhs DowncastClone();
+  }
+  public abstract class AssignLhs : _IAssignLhs {
+    public AssignLhs() {
+    }
+    private static readonly DAST._IAssignLhs theDefault = create_Ident(Dafny.Sequence<Dafny.Rune>.Empty);
+    public static DAST._IAssignLhs Default() {
+      return theDefault;
+    }
+    private static readonly Dafny.TypeDescriptor<DAST._IAssignLhs> _TYPE = new Dafny.TypeDescriptor<DAST._IAssignLhs>(DAST.AssignLhs.Default());
+    public static Dafny.TypeDescriptor<DAST._IAssignLhs> _TypeDescriptor() {
+      return _TYPE;
+    }
+    public static _IAssignLhs create_Ident(Dafny.ISequence<Dafny.Rune> _a0) {
+      return new AssignLhs_Ident(_a0);
+    }
+    public static _IAssignLhs create_Select(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field) {
+      return new AssignLhs_Select(expr, field);
+    }
+    public bool is_Ident { get { return this is AssignLhs_Ident; } }
+    public bool is_Select { get { return this is AssignLhs_Select; } }
+    public Dafny.ISequence<Dafny.Rune> dtor_Ident_a0 {
+      get {
+        var d = this;
+        return ((AssignLhs_Ident)d)._a0;
+      }
+    }
+    public DAST._IExpression dtor_expr {
+      get {
+        var d = this;
+        return ((AssignLhs_Select)d)._expr;
+      }
+    }
+    public Dafny.ISequence<Dafny.Rune> dtor_field {
+      get {
+        var d = this;
+        return ((AssignLhs_Select)d)._field;
+      }
+    }
+    public abstract _IAssignLhs DowncastClone();
+  }
+  public class AssignLhs_Ident : AssignLhs {
+    public readonly Dafny.ISequence<Dafny.Rune> _a0;
+    public AssignLhs_Ident(Dafny.ISequence<Dafny.Rune> _a0) : base() {
+      this._a0 = _a0;
+    }
+    public override _IAssignLhs DowncastClone() {
+      if (this is _IAssignLhs dt) { return dt; }
+      return new AssignLhs_Ident(_a0);
+    }
+    public override bool Equals(object other) {
+      var oth = other as DAST.AssignLhs_Ident;
+      return oth != null && object.Equals(this._a0, oth._a0);
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 0;
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._a0));
+      return (int)hash;
+    }
+    public override string ToString() {
+      string s = "DAST.AssignLhs.Ident";
+      s += "(";
+      s += Dafny.Helpers.ToString(this._a0);
+      s += ")";
+      return s;
+    }
+  }
+  public class AssignLhs_Select : AssignLhs {
+    public readonly DAST._IExpression _expr;
+    public readonly Dafny.ISequence<Dafny.Rune> _field;
+    public AssignLhs_Select(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field) : base() {
+      this._expr = expr;
+      this._field = field;
+    }
+    public override _IAssignLhs DowncastClone() {
+      if (this is _IAssignLhs dt) { return dt; }
+      return new AssignLhs_Select(_expr, _field);
+    }
+    public override bool Equals(object other) {
+      var oth = other as DAST.AssignLhs_Select;
+      return oth != null && object.Equals(this._expr, oth._expr) && object.Equals(this._field, oth._field);
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 1;
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._expr));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._field));
+      return (int)hash;
+    }
+    public override string ToString() {
+      string s = "DAST.AssignLhs.Select";
+      s += "(";
+      s += Dafny.Helpers.ToString(this._expr);
+      s += ", ";
+      s += this._field.ToVerbatimString(true);
+      s += ")";
+      return s;
+    }
+  }
+
   public interface _IExpression {
     bool is_Literal { get; }
     bool is_Ident { get; }
@@ -2332,6 +2487,7 @@ namespace DAST {
     DAST._IExpression dtor_left { get; }
     DAST._IExpression dtor_right { get; }
     Dafny.ISequence<Dafny.Rune> dtor_field { get; }
+    bool dtor_isConstant { get; }
     bool dtor_onDatatype { get; }
     bool dtor_isStatic { get; }
     BigInteger dtor_arity { get; }
@@ -2402,8 +2558,8 @@ namespace DAST {
     public static _IExpression create_BinOp(Dafny.ISequence<Dafny.Rune> op, DAST._IExpression left, DAST._IExpression right) {
       return new Expression_BinOp(op, left, right);
     }
-    public static _IExpression create_Select(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field, bool onDatatype) {
-      return new Expression_Select(expr, field, onDatatype);
+    public static _IExpression create_Select(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field, bool isConstant, bool onDatatype) {
+      return new Expression_Select(expr, field, isConstant, onDatatype);
     }
     public static _IExpression create_SelectFn(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field, bool onDatatype, bool isStatic, BigInteger arity) {
       return new Expression_SelectFn(expr, field, onDatatype, isStatic, arity);
@@ -2597,6 +2753,12 @@ namespace DAST {
         var d = this;
         if (d is Expression_Select) { return ((Expression_Select)d)._field; }
         return ((Expression_SelectFn)d)._field;
+      }
+    }
+    public bool dtor_isConstant {
+      get {
+        var d = this;
+        return ((Expression_Select)d)._isConstant;
       }
     }
     public bool dtor_onDatatype {
@@ -3128,25 +3290,28 @@ namespace DAST {
   public class Expression_Select : Expression {
     public readonly DAST._IExpression _expr;
     public readonly Dafny.ISequence<Dafny.Rune> _field;
+    public readonly bool _isConstant;
     public readonly bool _onDatatype;
-    public Expression_Select(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field, bool onDatatype) : base() {
+    public Expression_Select(DAST._IExpression expr, Dafny.ISequence<Dafny.Rune> field, bool isConstant, bool onDatatype) : base() {
       this._expr = expr;
       this._field = field;
+      this._isConstant = isConstant;
       this._onDatatype = onDatatype;
     }
     public override _IExpression DowncastClone() {
       if (this is _IExpression dt) { return dt; }
-      return new Expression_Select(_expr, _field, _onDatatype);
+      return new Expression_Select(_expr, _field, _isConstant, _onDatatype);
     }
     public override bool Equals(object other) {
       var oth = other as DAST.Expression_Select;
-      return oth != null && object.Equals(this._expr, oth._expr) && object.Equals(this._field, oth._field) && this._onDatatype == oth._onDatatype;
+      return oth != null && object.Equals(this._expr, oth._expr) && object.Equals(this._field, oth._field) && this._isConstant == oth._isConstant && this._onDatatype == oth._onDatatype;
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 15;
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._expr));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._field));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._isConstant));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._onDatatype));
       return (int)hash;
     }
@@ -3156,6 +3321,8 @@ namespace DAST {
       s += Dafny.Helpers.ToString(this._expr);
       s += ", ";
       s += this._field.ToVerbatimString(true);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._isConstant);
       s += ", ";
       s += Dafny.Helpers.ToString(this._onDatatype);
       s += ")";
@@ -3899,215 +4066,187 @@ namespace DCOMP {
       }
       return s;
     }
+    public static void GenTypeParameters(Dafny.ISequence<DAST._IType> @params, out Dafny.ISet<DAST._IType> typeParamsSet, out Dafny.ISequence<Dafny.Rune> typeParams, out Dafny.ISequence<Dafny.Rune> constrainedTypeParams) {
+      typeParamsSet = Dafny.Set<DAST._IType>.Empty;
+      typeParams = Dafny.Sequence<Dafny.Rune>.Empty;
+      constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Empty;
+      typeParamsSet = Dafny.Set<DAST._IType>.FromElements();
+      typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      BigInteger _13_tpI;
+      _13_tpI = BigInteger.Zero;
+      if ((new BigInteger((@params).Count)).Sign == 1) {
+        typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
+        constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
+        while ((_13_tpI) < (new BigInteger((@params).Count))) {
+          DAST._IType _14_tp;
+          _14_tp = (@params).Select(_13_tpI);
+          typeParamsSet = Dafny.Set<DAST._IType>.Union(typeParamsSet, Dafny.Set<DAST._IType>.FromElements(_14_tp));
+          Dafny.ISequence<Dafny.Rune> _15_genTp;
+          Dafny.ISequence<Dafny.Rune> _out6;
+          _out6 = DCOMP.COMP.GenType(_14_tp, false, false);
+          _15_genTp = _out6;
+          typeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(typeParams, _15_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(constrainedTypeParams, _15_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<")), _15_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static, "));
+          _13_tpI = (_13_tpI) + (BigInteger.One);
+        }
+        typeParams = Dafny.Sequence<Dafny.Rune>.Concat(typeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+        constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+      }
+    }
     public static Dafny.ISequence<Dafny.Rune> GenClass(DAST._IClass c, Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> path) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISequence<Dafny.Rune> _13_implBody;
-      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _14_traitBodies;
-      Dafny.ISequence<Dafny.Rune> _out6;
-      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _out7;
-      DCOMP.COMP.GenClassImplBody((c).dtor_body, false, DAST.Type.create_Path(path, Dafny.Sequence<DAST._IType>.FromElements(), DAST.ResolvedType.create_Datatype(path)), Dafny.Set<DAST._IType>.FromElements(), out _out6, out _out7);
-      _13_implBody = _out6;
-      _14_traitBodies = _out7;
-      _13_implBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn new() -> Self {\n"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n}\n")), _13_implBody);
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub struct r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _13_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+      Dafny.ISet<DAST._IType> _16_typeParamsSet;
+      Dafny.ISequence<Dafny.Rune> _17_typeParams;
+      Dafny.ISequence<Dafny.Rune> _18_constrainedTypeParams;
+      Dafny.ISet<DAST._IType> _out7;
+      Dafny.ISequence<Dafny.Rune> _out8;
+      Dafny.ISequence<Dafny.Rune> _out9;
+      DCOMP.COMP.GenTypeParameters((c).dtor_typeParams, out _out7, out _out8, out _out9);
+      _16_typeParamsSet = _out7;
+      _17_typeParams = _out8;
+      _18_constrainedTypeParams = _out9;
+      Dafny.ISequence<Dafny.Rune> _19_fields;
+      _19_fields = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      Dafny.ISequence<Dafny.Rune> _20_fieldInits;
+      _20_fieldInits = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      BigInteger _21_fieldI;
+      _21_fieldI = BigInteger.Zero;
+      while ((_21_fieldI) < (new BigInteger(((c).dtor_fields).Count))) {
+        DAST._IField _22_field;
+        _22_field = ((c).dtor_fields).Select(_21_fieldI);
+        Dafny.ISequence<Dafny.Rune> _23_fieldType;
+        Dafny.ISequence<Dafny.Rune> _out10;
+        _out10 = DCOMP.COMP.GenType(((_22_field).dtor_formal).dtor_typ, false, false);
+        _23_fieldType = _out10;
+        _19_fields = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_19_fields, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub r#")), ((_22_field).dtor_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::std::cell::RefCell<")), _23_fieldType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">,\n"));
+        DAST._IOptional<DAST._IExpression> _source1 = (_22_field).dtor_defaultValue;
+        if (_source1.is_Some) {
+          DAST._IExpression _24___mcc_h0 = _source1.dtor_Some_a0;
+          DAST._IExpression _25_e = _24___mcc_h0;
+          {
+            Dafny.ISequence<Dafny.Rune> _26_eStr;
+            bool _27___v1;
+            bool _28___v2;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _29___v3;
+            Dafny.ISequence<Dafny.Rune> _out11;
+            bool _out12;
+            bool _out13;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out14;
+            DCOMP.COMP.GenExpr(_25_e, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), true, out _out11, out _out12, out _out13, out _out14);
+            _26_eStr = _out11;
+            _27___v1 = _out12;
+            _28___v2 = _out13;
+            _29___v3 = _out14;
+            _20_fieldInits = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_20_fieldInits, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), ((_22_field).dtor_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::std::cell::RefCell::new(")), _26_eStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("),\n"));
+          }
+        } else {
+          {
+            _20_fieldInits = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_20_fieldInits, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), ((_22_field).dtor_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::std::cell::RefCell::new(::std::default::Default::default()),\n"));
+          }
+        }
+        _21_fieldI = (_21_fieldI) + (BigInteger.One);
+      }
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(Default)]\npub struct r#"), (c).dtor_name), _17_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _19_fields), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+      Dafny.ISequence<Dafny.Rune> _30_implBody;
+      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _31_traitBodies;
+      Dafny.ISequence<Dafny.Rune> _out15;
+      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _out16;
+      DCOMP.COMP.GenClassImplBody((c).dtor_body, false, DAST.Type.create_Path(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), Dafny.Sequence<DAST._IType>.FromElements(), DAST.ResolvedType.create_Datatype(path)), Dafny.Set<DAST._IType>.FromElements(), out _out15, out _out16);
+      _30_implBody = _out15;
+      _31_traitBodies = _out16;
+      _30_implBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn new() -> Self {\n"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _20_fieldInits), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n}\n")), _30_implBody);
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _18_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" r#")), (c).dtor_name), _17_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _30_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
       if ((new BigInteger(((c).dtor_superClasses).Count)).Sign == 1) {
-        BigInteger _15_i;
-        _15_i = BigInteger.Zero;
-        while ((_15_i) < (new BigInteger(((c).dtor_superClasses).Count))) {
-          DAST._IType _16_superClass;
-          _16_superClass = ((c).dtor_superClasses).Select(_15_i);
-          DAST._IType _source1 = _16_superClass;
-          if (_source1.is_Path) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _17___mcc_h0 = _source1.dtor_Path_a0;
-            Dafny.ISequence<DAST._IType> _18___mcc_h1 = _source1.dtor_typeArgs;
-            DAST._IResolvedType _19___mcc_h2 = _source1.dtor_resolved;
-            DAST._IResolvedType _source2 = _19___mcc_h2;
-            if (_source2.is_Datatype) {
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _20___mcc_h6 = _source2.dtor_path;
-            } else if (_source2.is_Trait) {
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _21___mcc_h8 = _source2.dtor_path;
-              Dafny.ISequence<DAST._IType> _22_typeArgs = _18___mcc_h1;
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _23_traitPath = _17___mcc_h0;
+        BigInteger _32_i;
+        _32_i = BigInteger.Zero;
+        while ((_32_i) < (new BigInteger(((c).dtor_superClasses).Count))) {
+          DAST._IType _33_superClass;
+          _33_superClass = ((c).dtor_superClasses).Select(_32_i);
+          DAST._IType _source2 = _33_superClass;
+          if (_source2.is_Path) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _34___mcc_h1 = _source2.dtor_Path_a0;
+            Dafny.ISequence<DAST._IType> _35___mcc_h2 = _source2.dtor_typeArgs;
+            DAST._IResolvedType _36___mcc_h3 = _source2.dtor_resolved;
+            DAST._IResolvedType _source3 = _36___mcc_h3;
+            if (_source3.is_Datatype) {
+              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _37___mcc_h7 = _source3.dtor_path;
+            } else if (_source3.is_Trait) {
+              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _38___mcc_h9 = _source3.dtor_path;
+              Dafny.ISequence<DAST._IType> _39_typeArgs = _35___mcc_h2;
+              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _40_traitPath = _34___mcc_h1;
               {
-                Dafny.ISequence<Dafny.Rune> _24_pathStr;
-                Dafny.ISequence<Dafny.Rune> _out8;
-                _out8 = DCOMP.COMP.GenPath(_23_traitPath);
-                _24_pathStr = _out8;
-                Dafny.ISequence<Dafny.Rune> _25_typeArgs;
-                Dafny.ISequence<Dafny.Rune> _out9;
-                _out9 = DCOMP.COMP.GenTypeArgs(_22_typeArgs, false, false);
-                _25_typeArgs = _out9;
-                Dafny.ISequence<Dafny.Rune> _26_body;
-                _26_body = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-                if ((_14_traitBodies).Contains(_23_traitPath)) {
-                  _26_body = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Select(_14_traitBodies, _23_traitPath);
+                Dafny.ISequence<Dafny.Rune> _41_pathStr;
+                Dafny.ISequence<Dafny.Rune> _out17;
+                _out17 = DCOMP.COMP.GenPath(_40_traitPath);
+                _41_pathStr = _out17;
+                Dafny.ISequence<Dafny.Rune> _42_typeArgs;
+                Dafny.ISequence<Dafny.Rune> _out18;
+                _out18 = DCOMP.COMP.GenTypeArgs(_39_typeArgs, false, false);
+                _42_typeArgs = _out18;
+                Dafny.ISequence<Dafny.Rune> _43_body;
+                _43_body = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+                if ((_31_traitBodies).Contains(_40_traitPath)) {
+                  _43_body = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Select(_31_traitBodies, _40_traitPath);
                 }
-                Dafny.ISequence<Dafny.Rune> _27_genSelfPath;
-                Dafny.ISequence<Dafny.Rune> _out10;
-                _out10 = DCOMP.COMP.GenPath(path);
-                _27_genSelfPath = _out10;
-                s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nimpl ")), _24_pathStr), _25_typeArgs), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" for ::std::rc::Rc<")), _27_genSelfPath), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> {\n")), _26_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+                Dafny.ISequence<Dafny.Rune> _44_genSelfPath;
+                Dafny.ISequence<Dafny.Rune> _out19;
+                _out19 = DCOMP.COMP.GenPath(path);
+                _44_genSelfPath = _out19;
+                s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nimpl ")), _41_pathStr), _42_typeArgs), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" for ::std::rc::Rc<")), _44_genSelfPath), _17_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> {\n")), _43_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
               }
             } else {
             }
-          } else if (_source1.is_Tuple) {
-            Dafny.ISequence<DAST._IType> _28___mcc_h10 = _source1.dtor_Tuple_a0;
-          } else if (_source1.is_Array) {
-            DAST._IType _29___mcc_h12 = _source1.dtor_element;
-          } else if (_source1.is_Seq) {
-            DAST._IType _30___mcc_h14 = _source1.dtor_element;
-          } else if (_source1.is_Set) {
-            DAST._IType _31___mcc_h16 = _source1.dtor_element;
-          } else if (_source1.is_Multiset) {
-            DAST._IType _32___mcc_h18 = _source1.dtor_element;
-          } else if (_source1.is_Map) {
-            DAST._IType _33___mcc_h20 = _source1.dtor_key;
-            DAST._IType _34___mcc_h21 = _source1.dtor_value;
-          } else if (_source1.is_Arrow) {
-            Dafny.ISequence<DAST._IType> _35___mcc_h24 = _source1.dtor_args;
-            DAST._IType _36___mcc_h25 = _source1.dtor_result;
-          } else if (_source1.is_Primitive) {
-            DAST._IPrimitive _37___mcc_h28 = _source1.dtor_Primitive_a0;
-          } else if (_source1.is_Passthrough) {
-            Dafny.ISequence<Dafny.Rune> _38___mcc_h30 = _source1.dtor_Passthrough_a0;
+          } else if (_source2.is_Tuple) {
+            Dafny.ISequence<DAST._IType> _45___mcc_h11 = _source2.dtor_Tuple_a0;
+          } else if (_source2.is_Array) {
+            DAST._IType _46___mcc_h13 = _source2.dtor_element;
+          } else if (_source2.is_Seq) {
+            DAST._IType _47___mcc_h15 = _source2.dtor_element;
+          } else if (_source2.is_Set) {
+            DAST._IType _48___mcc_h17 = _source2.dtor_element;
+          } else if (_source2.is_Multiset) {
+            DAST._IType _49___mcc_h19 = _source2.dtor_element;
+          } else if (_source2.is_Map) {
+            DAST._IType _50___mcc_h21 = _source2.dtor_key;
+            DAST._IType _51___mcc_h22 = _source2.dtor_value;
+          } else if (_source2.is_Arrow) {
+            Dafny.ISequence<DAST._IType> _52___mcc_h25 = _source2.dtor_args;
+            DAST._IType _53___mcc_h26 = _source2.dtor_result;
+          } else if (_source2.is_Primitive) {
+            DAST._IPrimitive _54___mcc_h29 = _source2.dtor_Primitive_a0;
+          } else if (_source2.is_Passthrough) {
+            Dafny.ISequence<Dafny.Rune> _55___mcc_h31 = _source2.dtor_Passthrough_a0;
           } else {
-            Dafny.ISequence<Dafny.Rune> _39___mcc_h32 = _source1.dtor_TypeArg_a0;
+            Dafny.ISequence<Dafny.Rune> _56___mcc_h33 = _source2.dtor_TypeArg_a0;
           }
-          _15_i = (_15_i) + (BigInteger.One);
+          _32_i = (_32_i) + (BigInteger.One);
         }
       }
+      Dafny.ISequence<Dafny.Rune> _57_printImpl;
+      _57_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _18_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyPrint for r#")), (c).dtor_name), _17_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, __fmt_print_formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {\n"));
+      _57_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_57_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("write!(__fmt_print_formatter, \"r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), (((new BigInteger(((c).dtor_fields).Count)).Sign == 1) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")))), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\")?;"));
+      BigInteger _58_i;
+      _58_i = BigInteger.Zero;
+      while ((_58_i) < (new BigInteger(((c).dtor_fields).Count))) {
+        DAST._IField _59_field;
+        _59_field = ((c).dtor_fields).Select(_58_i);
+        if ((_58_i).Sign == 1) {
+          _57_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(_57_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(__fmt_print_formatter, \", \")?;"));
+        }
+        _57_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_57_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n::dafny_runtime::DafnyPrint::fmt_print(::std::ops::Deref::deref(&(self.r#")), ((_59_field).dtor_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".borrow())), __fmt_print_formatter, false)?;"));
+        _58_i = (_58_i) + (BigInteger.One);
+      }
+      _57_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(_57_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(__fmt_print_formatter, \")\")?;\nOk(())\n}\n}\n"));
+      Dafny.ISequence<Dafny.Rune> _60_ptrPartialEqImpl;
+      _60_ptrPartialEqImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _18_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::std::cmp::PartialEq for r#")), (c).dtor_name), _17_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+      _60_ptrPartialEqImpl = Dafny.Sequence<Dafny.Rune>.Concat(_60_ptrPartialEqImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn eq(&self, other: &Self) -> bool {\n"));
+      _60_ptrPartialEqImpl = Dafny.Sequence<Dafny.Rune>.Concat(_60_ptrPartialEqImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::ptr::eq(self, other)"));
+      _60_ptrPartialEqImpl = Dafny.Sequence<Dafny.Rune>.Concat(_60_ptrPartialEqImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _57_printImpl), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _60_ptrPartialEqImpl);
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenTrait(DAST._ITrait t, Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> containingPath) {
-      Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISet<DAST._IType> _40_typeParamsSet;
-      _40_typeParamsSet = Dafny.Set<DAST._IType>.FromElements();
-      Dafny.ISequence<Dafny.Rune> _41_typeParams;
-      _41_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _42_tpI;
-      _42_tpI = BigInteger.Zero;
-      if ((new BigInteger(((t).dtor_typeParams).Count)).Sign == 1) {
-        _41_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
-        while ((_42_tpI) < (new BigInteger(((t).dtor_typeParams).Count))) {
-          DAST._IType _43_tp;
-          _43_tp = ((t).dtor_typeParams).Select(_42_tpI);
-          _40_typeParamsSet = Dafny.Set<DAST._IType>.Union(_40_typeParamsSet, Dafny.Set<DAST._IType>.FromElements(_43_tp));
-          Dafny.ISequence<Dafny.Rune> _44_genTp;
-          Dafny.ISequence<Dafny.Rune> _out11;
-          _out11 = DCOMP.COMP.GenType(_43_tp, false, false);
-          _44_genTp = _out11;
-          _41_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_41_typeParams, _44_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-          _42_tpI = (_42_tpI) + (BigInteger.One);
-        }
-        _41_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(_41_typeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
-      }
-      Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _45_fullPath;
-      _45_fullPath = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(containingPath, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((t).dtor_name));
-      Dafny.ISequence<Dafny.Rune> _46_implBody;
-      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _47___v3;
-      Dafny.ISequence<Dafny.Rune> _out12;
-      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _out13;
-      DCOMP.COMP.GenClassImplBody((t).dtor_body, true, DAST.Type.create_Path(_45_fullPath, Dafny.Sequence<DAST._IType>.FromElements(), DAST.ResolvedType.create_Trait(_45_fullPath)), _40_typeParamsSet, out _out12, out _out13);
-      _46_implBody = _out12;
-      _47___v3 = _out13;
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub trait r#"), (t).dtor_name), _41_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _46_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
-      return s;
-    }
-    public static Dafny.ISequence<Dafny.Rune> GenNewtype(DAST._INewtype c) {
-      Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISet<DAST._IType> _48_typeParamsSet;
-      _48_typeParamsSet = Dafny.Set<DAST._IType>.FromElements();
-      Dafny.ISequence<Dafny.Rune> _49_typeParams;
-      _49_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      Dafny.ISequence<Dafny.Rune> _50_constrainedTypeParams;
-      _50_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _51_tpI;
-      _51_tpI = BigInteger.Zero;
-      if ((new BigInteger(((c).dtor_typeParams).Count)).Sign == 1) {
-        _49_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
-        _50_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
-        while ((_51_tpI) < (new BigInteger(((c).dtor_typeParams).Count))) {
-          DAST._IType _52_tp;
-          _52_tp = ((c).dtor_typeParams).Select(_51_tpI);
-          _48_typeParamsSet = Dafny.Set<DAST._IType>.Union(_48_typeParamsSet, Dafny.Set<DAST._IType>.FromElements(_52_tp));
-          Dafny.ISequence<Dafny.Rune> _53_genTp;
-          Dafny.ISequence<Dafny.Rune> _out14;
-          _out14 = DCOMP.COMP.GenType(_52_tp, false, false);
-          _53_genTp = _out14;
-          _49_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_49_typeParams, _53_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-          _50_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_50_constrainedTypeParams, _53_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<")), _53_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static, "));
-          _51_tpI = (_51_tpI) + (BigInteger.One);
-        }
-        _49_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(_49_typeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
-        _50_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(_50_constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
-      }
-      Dafny.ISequence<Dafny.Rune> _54_underlyingType;
-      Dafny.ISequence<Dafny.Rune> _out15;
-      _out15 = DCOMP.COMP.GenType((c).dtor_base, false, false);
-      _54_underlyingType = _out15;
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(Clone, PartialEq)]\n#[repr(transparent)]\npub struct r#"), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(pub ")), _54_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _50_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyErasable for r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("type Erased = ")), _54_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn erase(&self) -> &Self::Erased {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self.0\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn erase_owned(self) -> Self::Erased {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self.0\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _50_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyUnerasable<")), _54_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> for r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase(x: &")), _54_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> &Self {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unsafe { &*(x as *const ")), _54_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" as *const r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") }\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase_owned(x: ")), _54_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> Self {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(x)\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _50_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyUnerasable<r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> for r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase(x: &r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> &Self {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("x\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase_owned(x: r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> Self {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("x\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _50_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::std::default::Default for r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn default() -> Self {\n"));
-      DAST._IOptional<DAST._IExpression> _source3 = (c).dtor_witnessExpr;
-      if (_source3.is_Some) {
-        DAST._IExpression _55___mcc_h0 = _source3.dtor_Some_a0;
-        DAST._IExpression _56_e = _55___mcc_h0;
-        {
-          Dafny.ISequence<Dafny.Rune> _57_eStr;
-          bool _58___v4;
-          bool _59___v5;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _60___v6;
-          Dafny.ISequence<Dafny.Rune> _out16;
-          bool _out17;
-          bool _out18;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out19;
-          DCOMP.COMP.GenExpr(_56_e, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), true, out _out16, out _out17, out _out18, out _out19);
-          _57_eStr = _out16;
-          _58___v4 = _out17;
-          _59___v5 = _out18;
-          _60___v6 = _out19;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _57_eStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")\n"));
-        }
-      } else {
-        {
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(::std::default::Default::default())\n"));
-        }
-      }
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _50_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyPrint for r#")), (c).dtor_name), _49_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, __fmt_print_formatter: &mut ::std::fmt::Formatter, in_seq: bool) -> ::std::fmt::Result {\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyPrint::fmt_print(&self.0, __fmt_print_formatter, in_seq)\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-      return s;
-    }
-    public static Dafny.ISequence<Dafny.Rune> GenDatatype(DAST._IDatatype c) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       Dafny.ISet<DAST._IType> _61_typeParamsSet;
       _61_typeParamsSet = Dafny.Set<DAST._IType>.FromElements();
@@ -4115,11 +4254,11 @@ namespace DCOMP {
       _62_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
       BigInteger _63_tpI;
       _63_tpI = BigInteger.Zero;
-      if ((new BigInteger(((c).dtor_typeParams).Count)).Sign == 1) {
+      if ((new BigInteger(((t).dtor_typeParams).Count)).Sign == 1) {
         _62_typeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
-        while ((_63_tpI) < (new BigInteger(((c).dtor_typeParams).Count))) {
+        while ((_63_tpI) < (new BigInteger(((t).dtor_typeParams).Count))) {
           DAST._IType _64_tp;
-          _64_tp = ((c).dtor_typeParams).Select(_63_tpI);
+          _64_tp = ((t).dtor_typeParams).Select(_63_tpI);
           _61_typeParamsSet = Dafny.Set<DAST._IType>.Union(_61_typeParamsSet, Dafny.Set<DAST._IType>.FromElements(_64_tp));
           Dafny.ISequence<Dafny.Rune> _65_genTp;
           Dafny.ISequence<Dafny.Rune> _out20;
@@ -4130,174 +4269,256 @@ namespace DCOMP {
         }
         _62_typeParams = Dafny.Sequence<Dafny.Rune>.Concat(_62_typeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
-      Dafny.ISequence<Dafny.Rune> _66_ctors;
-      _66_ctors = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _67_i;
-      _67_i = BigInteger.Zero;
-      while ((_67_i) < (new BigInteger(((c).dtor_ctors).Count))) {
-        DAST._IDatatypeCtor _68_ctor;
-        _68_ctor = ((c).dtor_ctors).Select(_67_i);
-        Dafny.ISequence<Dafny.Rune> _69_ctorBody;
-        _69_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_68_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
-        BigInteger _70_j;
-        _70_j = BigInteger.Zero;
-        while ((_70_j) < (new BigInteger(((_68_ctor).dtor_args).Count))) {
-          DAST._IFormal _71_formal;
-          _71_formal = ((_68_ctor).dtor_args).Select(_70_j);
-          Dafny.ISequence<Dafny.Rune> _72_formalType;
-          Dafny.ISequence<Dafny.Rune> _out21;
-          _out21 = DCOMP.COMP.GenType((_71_formal).dtor_typ, false, false);
-          _72_formalType = _out21;
-          if ((c).dtor_isCo) {
-            _69_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_69_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_71_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::LazyFieldWrapper<")), _72_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">, "));
-          } else {
-            _69_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_69_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_71_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _72_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-          }
-          _70_j = (_70_j) + (BigInteger.One);
+      Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _66_fullPath;
+      _66_fullPath = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(containingPath, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((t).dtor_name));
+      Dafny.ISequence<Dafny.Rune> _67_implBody;
+      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _68___v6;
+      Dafny.ISequence<Dafny.Rune> _out21;
+      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _out22;
+      DCOMP.COMP.GenClassImplBody((t).dtor_body, true, DAST.Type.create_Path(_66_fullPath, Dafny.Sequence<DAST._IType>.FromElements(), DAST.ResolvedType.create_Trait(_66_fullPath)), _61_typeParamsSet, out _out21, out _out22);
+      _67_implBody = _out21;
+      _68___v6 = _out22;
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub trait r#"), (t).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _67_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+      return s;
+    }
+    public static Dafny.ISequence<Dafny.Rune> GenNewtype(DAST._INewtype c) {
+      Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
+      Dafny.ISet<DAST._IType> _69_typeParamsSet;
+      Dafny.ISequence<Dafny.Rune> _70_typeParams;
+      Dafny.ISequence<Dafny.Rune> _71_constrainedTypeParams;
+      Dafny.ISet<DAST._IType> _out23;
+      Dafny.ISequence<Dafny.Rune> _out24;
+      Dafny.ISequence<Dafny.Rune> _out25;
+      DCOMP.COMP.GenTypeParameters((c).dtor_typeParams, out _out23, out _out24, out _out25);
+      _69_typeParamsSet = _out23;
+      _70_typeParams = _out24;
+      _71_constrainedTypeParams = _out25;
+      Dafny.ISequence<Dafny.Rune> _72_underlyingType;
+      Dafny.ISequence<Dafny.Rune> _out26;
+      _out26 = DCOMP.COMP.GenType((c).dtor_base, false, false);
+      _72_underlyingType = _out26;
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(Clone, PartialEq)]\n#[repr(transparent)]\npub struct r#"), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(pub ")), _72_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _71_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyErasable for r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("type Erased = ")), _72_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn erase(&self) -> &Self::Erased {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self.0\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn erase_owned(self) -> Self::Erased {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self.0\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _71_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyUnerasable<")), _72_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> for r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase(x: &")), _72_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> &Self {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unsafe { &*(x as *const ")), _72_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" as *const r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") }\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase_owned(x: ")), _72_underlyingType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> Self {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(x)\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _71_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyUnerasable<r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> for r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase(x: &r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> &Self {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("x\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[inline]\nfn unerase_owned(x: r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> Self {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("x\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _71_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::std::default::Default for r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn default() -> Self {\n"));
+      DAST._IOptional<DAST._IExpression> _source4 = (c).dtor_witnessExpr;
+      if (_source4.is_Some) {
+        DAST._IExpression _73___mcc_h0 = _source4.dtor_Some_a0;
+        DAST._IExpression _74_e = _73___mcc_h0;
+        {
+          Dafny.ISequence<Dafny.Rune> _75_eStr;
+          bool _76___v7;
+          bool _77___v8;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _78___v9;
+          Dafny.ISequence<Dafny.Rune> _out27;
+          bool _out28;
+          bool _out29;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out30;
+          DCOMP.COMP.GenExpr(_74_e, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), true, out _out27, out _out28, out _out29, out _out30);
+          _75_eStr = _out27;
+          _76___v7 = _out28;
+          _77___v8 = _out29;
+          _78___v9 = _out30;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _75_eStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")\n"));
         }
-        _69_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(_69_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
-        _66_ctors = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_66_ctors, _69_ctorBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
-        _67_i = (_67_i) + (BigInteger.One);
+      } else {
+        {
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(::std::default::Default::default())\n"));
+        }
       }
-      Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _73_selfPath;
-      _73_selfPath = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((c).dtor_name);
-      Dafny.ISequence<Dafny.Rune> _74_implBody;
-      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _75_traitBodies;
-      Dafny.ISequence<Dafny.Rune> _out22;
-      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _out23;
-      DCOMP.COMP.GenClassImplBody((c).dtor_body, false, DAST.Type.create_Path(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), Dafny.Sequence<DAST._IType>.FromElements(), DAST.ResolvedType.create_Datatype(_73_selfPath)), _61_typeParamsSet, out _out22, out _out23);
-      _74_implBody = _out22;
-      _75_traitBodies = _out23;
-      _67_i = BigInteger.Zero;
-      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _76_emittedFields;
-      _76_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-      while ((_67_i) < (new BigInteger(((c).dtor_ctors).Count))) {
-        DAST._IDatatypeCtor _77_ctor;
-        _77_ctor = ((c).dtor_ctors).Select(_67_i);
-        BigInteger _78_j;
-        _78_j = BigInteger.Zero;
-        while ((_78_j) < (new BigInteger(((_77_ctor).dtor_args).Count))) {
-          DAST._IFormal _79_formal;
-          _79_formal = ((_77_ctor).dtor_args).Select(_78_j);
-          if (!((_76_emittedFields).Contains((_79_formal).dtor_name))) {
-            _76_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_76_emittedFields, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((_79_formal).dtor_name));
-            Dafny.ISequence<Dafny.Rune> _80_formalType;
-            Dafny.ISequence<Dafny.Rune> _out24;
-            _out24 = DCOMP.COMP.GenType((_79_formal).dtor_typ, false, false);
-            _80_formalType = _out24;
-            Dafny.ISequence<Dafny.Rune> _81_methodBody;
-            _81_methodBody = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n");
-            BigInteger _82_k;
-            _82_k = BigInteger.Zero;
-            while ((_82_k) < (new BigInteger(((c).dtor_ctors).Count))) {
-              DAST._IDatatypeCtor _83_ctor2;
-              _83_ctor2 = ((c).dtor_ctors).Select(_82_k);
-              Dafny.ISequence<Dafny.Rune> _84_ctorMatch;
-              _84_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_83_ctor2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
-              BigInteger _85_l;
-              _85_l = BigInteger.Zero;
-              bool _86_hasMatchingField;
-              _86_hasMatchingField = false;
-              while ((_85_l) < (new BigInteger(((_83_ctor2).dtor_args).Count))) {
-                DAST._IFormal _87_formal2;
-                _87_formal2 = ((_83_ctor2).dtor_args).Select(_85_l);
-                if (((_79_formal).dtor_name).Equals((_87_formal2).dtor_name)) {
-                  _86_hasMatchingField = true;
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _71_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyPrint for r#")), (c).dtor_name), _70_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, __fmt_print_formatter: &mut ::std::fmt::Formatter, in_seq: bool) -> ::std::fmt::Result {\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyPrint::fmt_print(&self.0, __fmt_print_formatter, in_seq)\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+      return s;
+    }
+    public static Dafny.ISequence<Dafny.Rune> GenDatatype(DAST._IDatatype c) {
+      Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
+      Dafny.ISet<DAST._IType> _79_typeParamsSet;
+      Dafny.ISequence<Dafny.Rune> _80_typeParams;
+      Dafny.ISequence<Dafny.Rune> _81_constrainedTypeParams;
+      Dafny.ISet<DAST._IType> _out31;
+      Dafny.ISequence<Dafny.Rune> _out32;
+      Dafny.ISequence<Dafny.Rune> _out33;
+      DCOMP.COMP.GenTypeParameters((c).dtor_typeParams, out _out31, out _out32, out _out33);
+      _79_typeParamsSet = _out31;
+      _80_typeParams = _out32;
+      _81_constrainedTypeParams = _out33;
+      Dafny.ISequence<Dafny.Rune> _82_ctors;
+      _82_ctors = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      BigInteger _83_i;
+      _83_i = BigInteger.Zero;
+      while ((_83_i) < (new BigInteger(((c).dtor_ctors).Count))) {
+        DAST._IDatatypeCtor _84_ctor;
+        _84_ctor = ((c).dtor_ctors).Select(_83_i);
+        Dafny.ISequence<Dafny.Rune> _85_ctorBody;
+        _85_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_84_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
+        BigInteger _86_j;
+        _86_j = BigInteger.Zero;
+        while ((_86_j) < (new BigInteger(((_84_ctor).dtor_args).Count))) {
+          DAST._IFormal _87_formal;
+          _87_formal = ((_84_ctor).dtor_args).Select(_86_j);
+          Dafny.ISequence<Dafny.Rune> _88_formalType;
+          Dafny.ISequence<Dafny.Rune> _out34;
+          _out34 = DCOMP.COMP.GenType((_87_formal).dtor_typ, false, false);
+          _88_formalType = _out34;
+          if ((c).dtor_isCo) {
+            _85_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_85_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_87_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::LazyFieldWrapper<")), _88_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">, "));
+          } else {
+            _85_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_85_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_87_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _88_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          }
+          _86_j = (_86_j) + (BigInteger.One);
+        }
+        _85_ctorBody = Dafny.Sequence<Dafny.Rune>.Concat(_85_ctorBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
+        _82_ctors = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_82_ctors, _85_ctorBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
+        _83_i = (_83_i) + (BigInteger.One);
+      }
+      Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _89_selfPath;
+      _89_selfPath = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((c).dtor_name);
+      Dafny.ISequence<Dafny.Rune> _90_implBody;
+      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _91_traitBodies;
+      Dafny.ISequence<Dafny.Rune> _out35;
+      Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> _out36;
+      DCOMP.COMP.GenClassImplBody((c).dtor_body, false, DAST.Type.create_Path(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), Dafny.Sequence<DAST._IType>.FromElements(), DAST.ResolvedType.create_Datatype(_89_selfPath)), _79_typeParamsSet, out _out35, out _out36);
+      _90_implBody = _out35;
+      _91_traitBodies = _out36;
+      _83_i = BigInteger.Zero;
+      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _92_emittedFields;
+      _92_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+      while ((_83_i) < (new BigInteger(((c).dtor_ctors).Count))) {
+        DAST._IDatatypeCtor _93_ctor;
+        _93_ctor = ((c).dtor_ctors).Select(_83_i);
+        BigInteger _94_j;
+        _94_j = BigInteger.Zero;
+        while ((_94_j) < (new BigInteger(((_93_ctor).dtor_args).Count))) {
+          DAST._IFormal _95_formal;
+          _95_formal = ((_93_ctor).dtor_args).Select(_94_j);
+          if (!((_92_emittedFields).Contains((_95_formal).dtor_name))) {
+            _92_emittedFields = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_92_emittedFields, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements((_95_formal).dtor_name));
+            Dafny.ISequence<Dafny.Rune> _96_formalType;
+            Dafny.ISequence<Dafny.Rune> _out37;
+            _out37 = DCOMP.COMP.GenType((_95_formal).dtor_typ, false, false);
+            _96_formalType = _out37;
+            Dafny.ISequence<Dafny.Rune> _97_methodBody;
+            _97_methodBody = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n");
+            BigInteger _98_k;
+            _98_k = BigInteger.Zero;
+            while ((_98_k) < (new BigInteger(((c).dtor_ctors).Count))) {
+              DAST._IDatatypeCtor _99_ctor2;
+              _99_ctor2 = ((c).dtor_ctors).Select(_98_k);
+              Dafny.ISequence<Dafny.Rune> _100_ctorMatch;
+              _100_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_99_ctor2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
+              BigInteger _101_l;
+              _101_l = BigInteger.Zero;
+              bool _102_hasMatchingField;
+              _102_hasMatchingField = false;
+              while ((_101_l) < (new BigInteger(((_99_ctor2).dtor_args).Count))) {
+                DAST._IFormal _103_formal2;
+                _103_formal2 = ((_99_ctor2).dtor_args).Select(_101_l);
+                if (((_95_formal).dtor_name).Equals((_103_formal2).dtor_name)) {
+                  _102_hasMatchingField = true;
                 }
-                _84_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_84_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_87_formal2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-                _85_l = (_85_l) + (BigInteger.One);
+                _100_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_100_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_103_formal2).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+                _101_l = (_101_l) + (BigInteger.One);
               }
-              if (_86_hasMatchingField) {
+              if (_102_hasMatchingField) {
                 if ((c).dtor_isCo) {
-                  _84_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_84_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => ::std::ops::Deref::deref(&")), (_79_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".0),\n"));
+                  _100_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_100_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => ::std::ops::Deref::deref(&")), (_95_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".0),\n"));
                 } else {
-                  _84_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_84_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => ")), (_79_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
+                  _100_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_100_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => ")), (_95_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(",\n"));
                 }
               } else {
-                _84_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_84_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => panic!(\"field does not exist on this variant\"),\n"));
+                _100_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_100_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("} => panic!(\"field does not exist on this variant\"),\n"));
               }
-              _81_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_81_methodBody, _84_ctorMatch);
-              _82_k = (_82_k) + (BigInteger.One);
+              _97_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_97_methodBody, _100_ctorMatch);
+              _98_k = (_98_k) + (BigInteger.One);
             }
-            _81_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_81_methodBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
-            _74_implBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_74_implBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn r#")), (_79_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(&self) -> &")), _80_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _81_methodBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+            _97_methodBody = Dafny.Sequence<Dafny.Rune>.Concat(_97_methodBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
+            _90_implBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_90_implBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn r#")), (_95_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(&self) -> &")), _96_formalType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _97_methodBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
           }
-          _78_j = (_78_j) + (BigInteger.One);
+          _94_j = (_94_j) + (BigInteger.One);
         }
-        _67_i = (_67_i) + (BigInteger.One);
+        _83_i = (_83_i) + (BigInteger.One);
       }
-      Dafny.ISequence<Dafny.Rune> _88_constrainedTypeParams;
-      _88_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      if ((new BigInteger(((c).dtor_typeParams).Count)).Sign == 1) {
-        _63_tpI = BigInteger.Zero;
-        _88_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<");
-        while ((_63_tpI) < (new BigInteger(((c).dtor_typeParams).Count))) {
-          if ((_63_tpI).Sign == 1) {
-            _88_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(_88_constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+      Dafny.ISequence<Dafny.Rune> _104_enumBody;
+      _104_enumBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(PartialEq)]\npub enum r#"), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _82_ctors), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _81_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" r#")), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _90_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+      Dafny.ISequence<Dafny.Rune> _105_identEraseImpls;
+      _105_identEraseImpls = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _81_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyErasable for r#")), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("type Erased = Self;\nfn erase(&self) -> &Self::Erased { self }\nfn erase_owned(self) -> Self::Erased { self }}\n"));
+      _105_identEraseImpls = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_105_identEraseImpls, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _81_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyUnerasable<r#")), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> for r#")), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn unerase(x: &Self) -> &Self { x }\nfn unerase_owned(x: Self) -> Self { x }}\n"));
+      Dafny.ISequence<Dafny.Rune> _106_printImpl;
+      _106_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _81_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyPrint for r#")), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, __fmt_print_formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n"));
+      _83_i = BigInteger.Zero;
+      while ((_83_i) < (new BigInteger(((c).dtor_ctors).Count))) {
+        DAST._IDatatypeCtor _107_ctor;
+        _107_ctor = ((c).dtor_ctors).Select(_83_i);
+        Dafny.ISequence<Dafny.Rune> _108_ctorMatch;
+        _108_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_107_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
+        Dafny.ISequence<Dafny.Rune> _109_modulePrefix;
+        _109_modulePrefix = (((((c).dtor_enclosingModule)).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_module"))) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.Concat(((c).dtor_enclosingModule), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."))));
+        Dafny.ISequence<Dafny.Rune> _110_printRhs;
+        _110_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("write!(__fmt_print_formatter, \""), _109_modulePrefix), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), (_107_ctor).dtor_name), (((_107_ctor).dtor_hasAnyArgs) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(\")?;")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\")?;"))));
+        BigInteger _111_j;
+        _111_j = BigInteger.Zero;
+        while ((_111_j) < (new BigInteger(((_107_ctor).dtor_args).Count))) {
+          DAST._IFormal _112_formal;
+          _112_formal = ((_107_ctor).dtor_args).Select(_111_j);
+          _108_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_108_ctorMatch, (_112_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          if ((_111_j).Sign == 1) {
+            _110_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_110_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(__fmt_print_formatter, \", \")?;"));
           }
-          DAST._IType _89_tp;
-          _89_tp = ((c).dtor_typeParams).Select(_63_tpI);
-          Dafny.ISequence<Dafny.Rune> _90_genTp;
-          Dafny.ISequence<Dafny.Rune> _out25;
-          _out25 = DCOMP.COMP.GenType(_89_tp, false, false);
-          _90_genTp = _out25;
-          _88_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_88_constrainedTypeParams, _90_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<")), _90_genTp), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static"));
-          _63_tpI = (_63_tpI) + (BigInteger.One);
+          _110_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_110_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n::dafny_runtime::DafnyPrint::fmt_print(")), (_112_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", __fmt_print_formatter, false)?;"));
+          _111_j = (_111_j) + (BigInteger.One);
         }
-        _88_constrainedTypeParams = Dafny.Sequence<Dafny.Rune>.Concat(_88_constrainedTypeParams, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+        _108_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_108_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
+        if ((_107_ctor).dtor_hasAnyArgs) {
+          _110_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_110_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(__fmt_print_formatter, \")\")?;"));
+        }
+        _110_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_110_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nOk(())"));
+        _106_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_106_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), _108_ctorMatch), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" => {\n")), _110_printRhs), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
+        _83_i = (_83_i) + (BigInteger.One);
       }
-      Dafny.ISequence<Dafny.Rune> _91_enumBody;
-      _91_enumBody = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#[derive(PartialEq)]\npub enum r#"), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _66_ctors), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _88_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" r#")), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _74_implBody), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
-      Dafny.ISequence<Dafny.Rune> _92_identEraseImpls;
-      _92_identEraseImpls = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _88_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyErasable for r#")), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("type Erased = Self;\nfn erase(&self) -> &Self::Erased { self }\nfn erase_owned(self) -> Self::Erased { self }}\n"));
-      _92_identEraseImpls = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_92_identEraseImpls, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl ")), _88_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyUnerasable<r#")), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> for r#")), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn unerase(x: &Self) -> &Self { x }\nfn unerase_owned(x: Self) -> Self { x }}\n"));
-      Dafny.ISequence<Dafny.Rune> _93_printImpl;
-      _93_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _88_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::dafny_runtime::DafnyPrint for r#")), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn fmt_print(&self, __fmt_print_formatter: &mut ::std::fmt::Formatter, _in_seq: bool) -> std::fmt::Result {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match self {\n"));
-      _67_i = BigInteger.Zero;
-      while ((_67_i) < (new BigInteger(((c).dtor_ctors).Count))) {
-        DAST._IDatatypeCtor _94_ctor;
-        _94_ctor = ((c).dtor_ctors).Select(_67_i);
-        Dafny.ISequence<Dafny.Rune> _95_ctorMatch;
-        _95_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), (_94_ctor).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" { "));
-        Dafny.ISequence<Dafny.Rune> _96_modulePrefix;
-        _96_modulePrefix = (((((c).dtor_enclosingModule)).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_module"))) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.Concat(((c).dtor_enclosingModule), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("."))));
-        Dafny.ISequence<Dafny.Rune> _97_printRhs;
-        _97_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("write!(__fmt_print_formatter, \""), _96_modulePrefix), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), (_94_ctor).dtor_name), (((_94_ctor).dtor_hasAnyArgs) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(\")?;")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\")?;"))));
-        BigInteger _98_j;
-        _98_j = BigInteger.Zero;
-        while ((_98_j) < (new BigInteger(((_94_ctor).dtor_args).Count))) {
-          DAST._IFormal _99_formal;
-          _99_formal = ((_94_ctor).dtor_args).Select(_98_j);
-          _95_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_95_ctorMatch, (_99_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-          if ((_98_j).Sign == 1) {
-            _97_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_97_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(__fmt_print_formatter, \", \")?;"));
-          }
-          _97_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_97_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n::dafny_runtime::DafnyPrint::fmt_print(")), (_99_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", __fmt_print_formatter, false)?;"));
-          _98_j = (_98_j) + (BigInteger.One);
-        }
-        _95_ctorMatch = Dafny.Sequence<Dafny.Rune>.Concat(_95_ctorMatch, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
-        if ((_94_ctor).dtor_hasAnyArgs) {
-          _97_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_97_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nwrite!(__fmt_print_formatter, \")\")?;"));
-        }
-        _97_printRhs = Dafny.Sequence<Dafny.Rune>.Concat(_97_printRhs, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nOk(())"));
-        _93_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_93_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), _95_ctorMatch), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" => {\n")), _97_printRhs), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
-        _67_i = (_67_i) + (BigInteger.One);
-      }
-      _93_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(_93_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
-      Dafny.ISequence<Dafny.Rune> _100_defaultImpl;
-      _100_defaultImpl = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+      _106_printImpl = Dafny.Sequence<Dafny.Rune>.Concat(_106_printImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
+      Dafny.ISequence<Dafny.Rune> _113_defaultImpl;
+      _113_defaultImpl = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
       if ((new BigInteger(((c).dtor_ctors).Count)).Sign == 1) {
-        _100_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _88_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::std::default::Default for r#")), (c).dtor_name), _62_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn default() -> Self {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), (((c).dtor_ctors).Select(BigInteger.Zero)).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
-        _67_i = BigInteger.Zero;
-        while ((_67_i) < (new BigInteger(((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Count))) {
-          DAST._IFormal _101_formal;
-          _101_formal = ((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Select(_67_i);
-          _100_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_100_defaultImpl, (_101_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": std::default::Default::default(),\n"));
-          _67_i = (_67_i) + (BigInteger.One);
+        _113_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl "), _81_constrainedTypeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ::std::default::Default for r#")), (c).dtor_name), _80_typeParams), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn default() -> Self {\n")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (c).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), (((c).dtor_ctors).Select(BigInteger.Zero)).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n"));
+        _83_i = BigInteger.Zero;
+        while ((_83_i) < (new BigInteger(((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Count))) {
+          DAST._IFormal _114_formal;
+          _114_formal = ((((c).dtor_ctors).Select(BigInteger.Zero)).dtor_args).Select(_83_i);
+          _113_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_113_defaultImpl, (_114_formal).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": std::default::Default::default(),\n"));
+          _83_i = (_83_i) + (BigInteger.One);
         }
-        _100_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(_100_defaultImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
+        _113_defaultImpl = Dafny.Sequence<Dafny.Rune>.Concat(_113_defaultImpl, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n}\n}\n"));
       }
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_91_enumBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _92_identEraseImpls), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _93_printImpl), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _100_defaultImpl);
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_104_enumBody, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _105_identEraseImpls), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _106_printImpl), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _113_defaultImpl);
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenPath(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> p) {
@@ -4307,14 +4528,14 @@ namespace DCOMP {
         return s;
       } else {
         s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("super::");
-        BigInteger _102_i;
-        _102_i = BigInteger.Zero;
-        while ((_102_i) < (new BigInteger((p).Count))) {
-          if ((_102_i).Sign == 1) {
+        BigInteger _115_i;
+        _115_i = BigInteger.Zero;
+        while ((_115_i) < (new BigInteger((p).Count))) {
+          if ((_115_i).Sign == 1) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), ((p).Select(_102_i)));
-          _102_i = (_102_i) + (BigInteger.One);
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), ((p).Select(_115_i)));
+          _115_i = (_115_i) + (BigInteger.One);
         }
       }
       return s;
@@ -4324,18 +4545,18 @@ namespace DCOMP {
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
       if ((new BigInteger((args).Count)).Sign == 1) {
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"));
-        BigInteger _103_i;
-        _103_i = BigInteger.Zero;
-        while ((_103_i) < (new BigInteger((args).Count))) {
-          if ((_103_i).Sign == 1) {
+        BigInteger _116_i;
+        _116_i = BigInteger.Zero;
+        while ((_116_i) < (new BigInteger((args).Count))) {
+          if ((_116_i).Sign == 1) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
           }
-          Dafny.ISequence<Dafny.Rune> _104_genTp;
-          Dafny.ISequence<Dafny.Rune> _out26;
-          _out26 = DCOMP.COMP.GenType((args).Select(_103_i), inBinding, inFn);
-          _104_genTp = _out26;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(s, _104_genTp);
-          _103_i = (_103_i) + (BigInteger.One);
+          Dafny.ISequence<Dafny.Rune> _117_genTp;
+          Dafny.ISequence<Dafny.Rune> _out38;
+          _out38 = DCOMP.COMP.GenType((args).Select(_116_i), inBinding, inFn);
+          _117_genTp = _out38;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(s, _117_genTp);
+          _116_i = (_116_i) + (BigInteger.One);
         }
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
@@ -4343,31 +4564,31 @@ namespace DCOMP {
     }
     public static Dafny.ISequence<Dafny.Rune> GenType(DAST._IType c, bool inBinding, bool inFn) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      DAST._IType _source4 = c;
-      if (_source4.is_Path) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _105___mcc_h0 = _source4.dtor_Path_a0;
-        Dafny.ISequence<DAST._IType> _106___mcc_h1 = _source4.dtor_typeArgs;
-        DAST._IResolvedType _107___mcc_h2 = _source4.dtor_resolved;
-        DAST._IResolvedType _108_resolved = _107___mcc_h2;
-        Dafny.ISequence<DAST._IType> _109_args = _106___mcc_h1;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _110_p = _105___mcc_h0;
+      DAST._IType _source5 = c;
+      if (_source5.is_Path) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _118___mcc_h0 = _source5.dtor_Path_a0;
+        Dafny.ISequence<DAST._IType> _119___mcc_h1 = _source5.dtor_typeArgs;
+        DAST._IResolvedType _120___mcc_h2 = _source5.dtor_resolved;
+        DAST._IResolvedType _121_resolved = _120___mcc_h2;
+        Dafny.ISequence<DAST._IType> _122_args = _119___mcc_h1;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _123_p = _118___mcc_h0;
         {
-          Dafny.ISequence<Dafny.Rune> _out27;
-          _out27 = DCOMP.COMP.GenPath(_110_p);
-          s = _out27;
-          Dafny.ISequence<Dafny.Rune> _111_typeArgs;
-          Dafny.ISequence<Dafny.Rune> _out28;
-          _out28 = DCOMP.COMP.GenTypeArgs(_109_args, inBinding, inFn);
-          _111_typeArgs = _out28;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(s, _111_typeArgs);
-          DAST._IResolvedType _source5 = _108_resolved;
-          if (_source5.is_Datatype) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _112___mcc_h16 = _source5.dtor_path;
+          Dafny.ISequence<Dafny.Rune> _out39;
+          _out39 = DCOMP.COMP.GenPath(_123_p);
+          s = _out39;
+          Dafny.ISequence<Dafny.Rune> _124_typeArgs;
+          Dafny.ISequence<Dafny.Rune> _out40;
+          _out40 = DCOMP.COMP.GenTypeArgs(_122_args, inBinding, inFn);
+          _124_typeArgs = _out40;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(s, _124_typeArgs);
+          DAST._IResolvedType _source6 = _121_resolved;
+          if (_source6.is_Datatype) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _125___mcc_h16 = _source6.dtor_path;
             {
               s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc<"), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
             }
-          } else if (_source5.is_Trait) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _113___mcc_h18 = _source5.dtor_path;
+          } else if (_source6.is_Trait) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _126___mcc_h18 = _source6.dtor_path;
             {
               if (inBinding) {
                 s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_");
@@ -4376,90 +4597,90 @@ namespace DCOMP {
               }
             }
           } else {
-            DAST._IResolvedType _114_Primitive = _108_resolved;
+            DAST._IResolvedType _127_Primitive = _121_resolved;
           }
         }
-      } else if (_source4.is_Tuple) {
-        Dafny.ISequence<DAST._IType> _115___mcc_h3 = _source4.dtor_Tuple_a0;
-        Dafny.ISequence<DAST._IType> _116_types = _115___mcc_h3;
+      } else if (_source5.is_Tuple) {
+        Dafny.ISequence<DAST._IType> _128___mcc_h3 = _source5.dtor_Tuple_a0;
+        Dafny.ISequence<DAST._IType> _129_types = _128___mcc_h3;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-          BigInteger _117_i;
-          _117_i = BigInteger.Zero;
-          while ((_117_i) < (new BigInteger((_116_types).Count))) {
-            if ((_117_i).Sign == 1) {
+          BigInteger _130_i;
+          _130_i = BigInteger.Zero;
+          while ((_130_i) < (new BigInteger((_129_types).Count))) {
+            if ((_130_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" "));
             }
-            Dafny.ISequence<Dafny.Rune> _118_generated;
-            Dafny.ISequence<Dafny.Rune> _out29;
-            _out29 = DCOMP.COMP.GenType((_116_types).Select(_117_i), inBinding, inFn);
-            _118_generated = _out29;
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _118_generated), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
-            _117_i = (_117_i) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _131_generated;
+            Dafny.ISequence<Dafny.Rune> _out41;
+            _out41 = DCOMP.COMP.GenType((_129_types).Select(_130_i), inBinding, inFn);
+            _131_generated = _out41;
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _131_generated), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
+            _130_i = (_130_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
         }
-      } else if (_source4.is_Array) {
-        DAST._IType _119___mcc_h4 = _source4.dtor_element;
-        DAST._IType _120_element = _119___mcc_h4;
+      } else if (_source5.is_Array) {
+        DAST._IType _132___mcc_h4 = _source5.dtor_element;
+        DAST._IType _133_element = _132___mcc_h4;
         {
-          Dafny.ISequence<Dafny.Rune> _121_elemStr;
-          Dafny.ISequence<Dafny.Rune> _out30;
-          _out30 = DCOMP.COMP.GenType(_120_element, inBinding, inFn);
-          _121_elemStr = _out30;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::vec::Vec<"), _121_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          Dafny.ISequence<Dafny.Rune> _134_elemStr;
+          Dafny.ISequence<Dafny.Rune> _out42;
+          _out42 = DCOMP.COMP.GenType(_133_element, inBinding, inFn);
+          _134_elemStr = _out42;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::vec::Vec<"), _134_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
         }
-      } else if (_source4.is_Seq) {
-        DAST._IType _122___mcc_h5 = _source4.dtor_element;
-        DAST._IType _123_element = _122___mcc_h5;
+      } else if (_source5.is_Seq) {
+        DAST._IType _135___mcc_h5 = _source5.dtor_element;
+        DAST._IType _136_element = _135___mcc_h5;
         {
-          Dafny.ISequence<Dafny.Rune> _124_elemStr;
-          Dafny.ISequence<Dafny.Rune> _out31;
-          _out31 = DCOMP.COMP.GenType(_123_element, inBinding, inFn);
-          _124_elemStr = _out31;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::vec::Vec<"), _124_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          Dafny.ISequence<Dafny.Rune> _137_elemStr;
+          Dafny.ISequence<Dafny.Rune> _out43;
+          _out43 = DCOMP.COMP.GenType(_136_element, inBinding, inFn);
+          _137_elemStr = _out43;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::vec::Vec<"), _137_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
         }
-      } else if (_source4.is_Set) {
-        DAST._IType _125___mcc_h6 = _source4.dtor_element;
-        DAST._IType _126_element = _125___mcc_h6;
+      } else if (_source5.is_Set) {
+        DAST._IType _138___mcc_h6 = _source5.dtor_element;
+        DAST._IType _139_element = _138___mcc_h6;
         {
-          Dafny.ISequence<Dafny.Rune> _127_elemStr;
-          Dafny.ISequence<Dafny.Rune> _out32;
-          _out32 = DCOMP.COMP.GenType(_126_element, inBinding, inFn);
-          _127_elemStr = _out32;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::collections::HashSet<"), _127_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          Dafny.ISequence<Dafny.Rune> _140_elemStr;
+          Dafny.ISequence<Dafny.Rune> _out44;
+          _out44 = DCOMP.COMP.GenType(_139_element, inBinding, inFn);
+          _140_elemStr = _out44;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::collections::HashSet<"), _140_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
         }
-      } else if (_source4.is_Multiset) {
-        DAST._IType _128___mcc_h7 = _source4.dtor_element;
-        DAST._IType _129_element = _128___mcc_h7;
+      } else if (_source5.is_Multiset) {
+        DAST._IType _141___mcc_h7 = _source5.dtor_element;
+        DAST._IType _142_element = _141___mcc_h7;
         {
-          Dafny.ISequence<Dafny.Rune> _130_elemStr;
-          Dafny.ISequence<Dafny.Rune> _out33;
-          _out33 = DCOMP.COMP.GenType(_129_element, inBinding, inFn);
-          _130_elemStr = _out33;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::collections::HashMap<"), _130_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", u64>"));
+          Dafny.ISequence<Dafny.Rune> _143_elemStr;
+          Dafny.ISequence<Dafny.Rune> _out45;
+          _out45 = DCOMP.COMP.GenType(_142_element, inBinding, inFn);
+          _143_elemStr = _out45;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::collections::HashMap<"), _143_elemStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", u64>"));
         }
-      } else if (_source4.is_Map) {
-        DAST._IType _131___mcc_h8 = _source4.dtor_key;
-        DAST._IType _132___mcc_h9 = _source4.dtor_value;
-        DAST._IType _133_value = _132___mcc_h9;
-        DAST._IType _134_key = _131___mcc_h8;
+      } else if (_source5.is_Map) {
+        DAST._IType _144___mcc_h8 = _source5.dtor_key;
+        DAST._IType _145___mcc_h9 = _source5.dtor_value;
+        DAST._IType _146_value = _145___mcc_h9;
+        DAST._IType _147_key = _144___mcc_h8;
         {
-          Dafny.ISequence<Dafny.Rune> _135_keyStr;
-          Dafny.ISequence<Dafny.Rune> _out34;
-          _out34 = DCOMP.COMP.GenType(_134_key, inBinding, inFn);
-          _135_keyStr = _out34;
-          Dafny.ISequence<Dafny.Rune> _136_valueStr;
-          Dafny.ISequence<Dafny.Rune> _out35;
-          _out35 = DCOMP.COMP.GenType(_133_value, inBinding, inFn);
-          _136_valueStr = _out35;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::collections::HashMap<"), _135_keyStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _136_valueStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          Dafny.ISequence<Dafny.Rune> _148_keyStr;
+          Dafny.ISequence<Dafny.Rune> _out46;
+          _out46 = DCOMP.COMP.GenType(_147_key, inBinding, inFn);
+          _148_keyStr = _out46;
+          Dafny.ISequence<Dafny.Rune> _149_valueStr;
+          Dafny.ISequence<Dafny.Rune> _out47;
+          _out47 = DCOMP.COMP.GenType(_146_value, inBinding, inFn);
+          _149_valueStr = _out47;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::collections::HashMap<"), _148_keyStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _149_valueStr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
         }
-      } else if (_source4.is_Arrow) {
-        Dafny.ISequence<DAST._IType> _137___mcc_h10 = _source4.dtor_args;
-        DAST._IType _138___mcc_h11 = _source4.dtor_result;
-        DAST._IType _139_result = _138___mcc_h11;
-        Dafny.ISequence<DAST._IType> _140_args = _137___mcc_h10;
+      } else if (_source5.is_Arrow) {
+        Dafny.ISequence<DAST._IType> _150___mcc_h10 = _source5.dtor_args;
+        DAST._IType _151___mcc_h11 = _source5.dtor_result;
+        DAST._IType _152_result = _151___mcc_h11;
+        Dafny.ISequence<DAST._IType> _153_args = _150___mcc_h10;
         {
           if (inBinding) {
             s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::FunctionWrapper<_>");
@@ -4469,248 +4690,243 @@ namespace DCOMP {
             } else {
               s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::FunctionWrapper<impl ::std::ops::Fn(");
             }
-            BigInteger _141_i;
-            _141_i = BigInteger.Zero;
-            while ((_141_i) < (new BigInteger((_140_args).Count))) {
-              if ((_141_i).Sign == 1) {
+            BigInteger _154_i;
+            _154_i = BigInteger.Zero;
+            while ((_154_i) < (new BigInteger((_153_args).Count))) {
+              if ((_154_i).Sign == 1) {
                 s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
               }
-              Dafny.ISequence<Dafny.Rune> _142_generated;
-              Dafny.ISequence<Dafny.Rune> _out36;
-              _out36 = DCOMP.COMP.GenType((_140_args).Select(_141_i), inBinding, true);
-              _142_generated = _out36;
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")), _142_generated);
-              _141_i = (_141_i) + (BigInteger.One);
+              Dafny.ISequence<Dafny.Rune> _155_generated;
+              Dafny.ISequence<Dafny.Rune> _out48;
+              _out48 = DCOMP.COMP.GenType((_153_args).Select(_154_i), inBinding, true);
+              _155_generated = _out48;
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")), _155_generated);
+              _154_i = (_154_i) + (BigInteger.One);
             }
-            Dafny.ISequence<Dafny.Rune> _143_resultType;
-            Dafny.ISequence<Dafny.Rune> _out37;
-            _out37 = DCOMP.COMP.GenType(_139_result, inBinding, inFn);
-            _143_resultType = _out37;
+            Dafny.ISequence<Dafny.Rune> _156_resultType;
+            Dafny.ISequence<Dafny.Rune> _out49;
+            _out49 = DCOMP.COMP.GenType(_152_result, inBinding, inFn);
+            _156_resultType = _out49;
             if (inFn) {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _143_resultType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" + 'static>>"));
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _156_resultType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" + 'static>>"));
             } else {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _143_resultType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" + Clone + 'static>"));
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _156_resultType), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" + Clone + 'static>"));
             }
           }
         }
-      } else if (_source4.is_Primitive) {
-        DAST._IPrimitive _144___mcc_h12 = _source4.dtor_Primitive_a0;
-        DAST._IPrimitive _145_p = _144___mcc_h12;
+      } else if (_source5.is_Primitive) {
+        DAST._IPrimitive _157___mcc_h12 = _source5.dtor_Primitive_a0;
+        DAST._IPrimitive _158_p = _157___mcc_h12;
         {
-          DAST._IPrimitive _source6 = _145_p;
-          if (_source6.is_String) {
+          DAST._IPrimitive _source7 = _158_p;
+          if (_source7.is_String) {
             s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("Vec<char>");
-          } else if (_source6.is_Bool) {
+          } else if (_source7.is_Bool) {
             s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("bool");
           } else {
             s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("char");
           }
         }
-      } else if (_source4.is_Passthrough) {
-        Dafny.ISequence<Dafny.Rune> _146___mcc_h13 = _source4.dtor_Passthrough_a0;
-        Dafny.ISequence<Dafny.Rune> _147_v = _146___mcc_h13;
-        s = _147_v;
+      } else if (_source5.is_Passthrough) {
+        Dafny.ISequence<Dafny.Rune> _159___mcc_h13 = _source5.dtor_Passthrough_a0;
+        Dafny.ISequence<Dafny.Rune> _160_v = _159___mcc_h13;
+        s = _160_v;
       } else {
-        Dafny.ISequence<Dafny.Rune> _148___mcc_h14 = _source4.dtor_TypeArg_a0;
-        Dafny.ISequence<Dafny.Rune> _source7 = _148___mcc_h14;
-        Dafny.ISequence<Dafny.Rune> _149___mcc_h15 = _source7;
-        Dafny.ISequence<Dafny.Rune> _150_name = _149___mcc_h15;
-        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _150_name);
+        Dafny.ISequence<Dafny.Rune> _161___mcc_h14 = _source5.dtor_TypeArg_a0;
+        Dafny.ISequence<Dafny.Rune> _source8 = _161___mcc_h14;
+        Dafny.ISequence<Dafny.Rune> _162___mcc_h15 = _source8;
+        Dafny.ISequence<Dafny.Rune> _163_name = _162___mcc_h15;
+        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _163_name);
       }
       return s;
     }
-    public static void GenClassImplBody(Dafny.ISequence<DAST._IClassItem> body, bool forTrait, DAST._IType enclosingType, Dafny.ISet<DAST._IType> enclosingTypeParams, out Dafny.ISequence<Dafny.Rune> s, out Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> traitBodies) {
+    public static void GenClassImplBody(Dafny.ISequence<DAST._IMethod> body, bool forTrait, DAST._IType enclosingType, Dafny.ISet<DAST._IType> enclosingTypeParams, out Dafny.ISequence<Dafny.Rune> s, out Dafny.IMap<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>> traitBodies) {
       s = Dafny.Sequence<Dafny.Rune>.Empty;
       traitBodies = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
       traitBodies = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.FromElements();
-      BigInteger _151_i;
-      _151_i = BigInteger.Zero;
-      while ((_151_i) < (new BigInteger((body).Count))) {
-        DAST._IClassItem _source8 = (body).Select(_151_i);
-        if (_source8.is_Method) {
-          DAST._IMethod _152___mcc_h0 = _source8.dtor_Method_a0;
-          DAST._IMethod _153_m = _152___mcc_h0;
-          {
-            DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source9 = (_153_m).dtor_overridingPath;
-            if (_source9.is_Some) {
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _154___mcc_h2 = _source9.dtor_Some_a0;
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _155_p = _154___mcc_h2;
-              {
-                Dafny.ISequence<Dafny.Rune> _156_existing;
-                _156_existing = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-                if ((traitBodies).Contains(_155_p)) {
-                  _156_existing = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Select(traitBodies, _155_p);
-                }
-                if ((new BigInteger((_156_existing).Count)).Sign == 1) {
-                  _156_existing = Dafny.Sequence<Dafny.Rune>.Concat(_156_existing, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
-                }
-                Dafny.ISequence<Dafny.Rune> _157_genMethod;
-                Dafny.ISequence<Dafny.Rune> _out38;
-                _out38 = DCOMP.COMP.GenMethod(_153_m, true, enclosingType, enclosingTypeParams);
-                _157_genMethod = _out38;
-                _156_existing = Dafny.Sequence<Dafny.Rune>.Concat(_156_existing, _157_genMethod);
-                traitBodies = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Merge(traitBodies, Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.FromElements(new Dafny.Pair<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>(_155_p, _156_existing)));
+      BigInteger _164_i;
+      _164_i = BigInteger.Zero;
+      while ((_164_i) < (new BigInteger((body).Count))) {
+        DAST._IMethod _source9 = (body).Select(_164_i);
+        DAST._IMethod _165___mcc_h0 = _source9;
+        DAST._IMethod _166_m = _165___mcc_h0;
+        {
+          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source10 = (_166_m).dtor_overridingPath;
+          if (_source10.is_Some) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _167___mcc_h1 = _source10.dtor_Some_a0;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _168_p = _167___mcc_h1;
+            {
+              Dafny.ISequence<Dafny.Rune> _169_existing;
+              _169_existing = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+              if ((traitBodies).Contains(_168_p)) {
+                _169_existing = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Select(traitBodies, _168_p);
               }
-            } else {
-              {
-                Dafny.ISequence<Dafny.Rune> _158_generated;
-                Dafny.ISequence<Dafny.Rune> _out39;
-                _out39 = DCOMP.COMP.GenMethod(_153_m, forTrait, enclosingType, enclosingTypeParams);
-                _158_generated = _out39;
-                s = Dafny.Sequence<Dafny.Rune>.Concat(s, _158_generated);
+              if ((new BigInteger((_169_existing).Count)).Sign == 1) {
+                _169_existing = Dafny.Sequence<Dafny.Rune>.Concat(_169_existing, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
               }
+              Dafny.ISequence<Dafny.Rune> _170_genMethod;
+              Dafny.ISequence<Dafny.Rune> _out50;
+              _out50 = DCOMP.COMP.GenMethod(_166_m, true, enclosingType, enclosingTypeParams);
+              _170_genMethod = _out50;
+              _169_existing = Dafny.Sequence<Dafny.Rune>.Concat(_169_existing, _170_genMethod);
+              traitBodies = Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.Merge(traitBodies, Dafny.Map<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>.FromElements(new Dafny.Pair<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISequence<Dafny.Rune>>(_168_p, _169_existing)));
+            }
+          } else {
+            {
+              Dafny.ISequence<Dafny.Rune> _171_generated;
+              Dafny.ISequence<Dafny.Rune> _out51;
+              _out51 = DCOMP.COMP.GenMethod(_166_m, forTrait, enclosingType, enclosingTypeParams);
+              _171_generated = _out51;
+              s = Dafny.Sequence<Dafny.Rune>.Concat(s, _171_generated);
             }
           }
-        } else {
-          DAST._IFormal _159___mcc_h1 = _source8.dtor_Field_a0;
-          DAST._IFormal _160_f = _159___mcc_h1;
         }
         if ((new BigInteger((s).Count)).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        _151_i = (_151_i) + (BigInteger.One);
+        _164_i = (_164_i) + (BigInteger.One);
       }
     }
     public static Dafny.ISequence<Dafny.Rune> GenParams(Dafny.ISequence<DAST._IFormal> @params) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-      BigInteger _161_i;
-      _161_i = BigInteger.Zero;
-      while ((_161_i) < (new BigInteger((@params).Count))) {
-        DAST._IFormal _162_param;
-        _162_param = (@params).Select(_161_i);
-        Dafny.ISequence<Dafny.Rune> _163_paramType;
-        Dafny.ISequence<Dafny.Rune> _out40;
-        _out40 = DCOMP.COMP.GenType((_162_param).dtor_typ, false, false);
-        _163_paramType = _out40;
-        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_162_param).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _163_paramType);
-        if ((_161_i) < ((new BigInteger((@params).Count)) - (BigInteger.One))) {
+      BigInteger _172_i;
+      _172_i = BigInteger.Zero;
+      while ((_172_i) < (new BigInteger((@params).Count))) {
+        DAST._IFormal _173_param;
+        _173_param = (@params).Select(_172_i);
+        Dafny.ISequence<Dafny.Rune> _174_paramType;
+        Dafny.ISequence<Dafny.Rune> _out52;
+        _out52 = DCOMP.COMP.GenType((_173_param).dtor_typ, false, false);
+        _174_paramType = _out52;
+        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_173_param).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _174_paramType);
+        if ((_172_i) < ((new BigInteger((@params).Count)) - (BigInteger.One))) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
         }
-        _161_i = (_161_i) + (BigInteger.One);
+        _172_i = (_172_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> GenMethod(DAST._IMethod m, bool forTrait, DAST._IType enclosingType, Dafny.ISet<DAST._IType> enclosingTypeParams) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
-      Dafny.ISequence<Dafny.Rune> _164_params;
-      Dafny.ISequence<Dafny.Rune> _out41;
-      _out41 = DCOMP.COMP.GenParams((m).dtor_params);
-      _164_params = _out41;
-      Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _165_paramNames;
-      _165_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements();
-      BigInteger _166_paramI;
-      _166_paramI = BigInteger.Zero;
-      while ((_166_paramI) < (new BigInteger(((m).dtor_params).Count))) {
-        _165_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(_165_paramNames, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((((m).dtor_params).Select(_166_paramI)).dtor_name));
-        _166_paramI = (_166_paramI) + (BigInteger.One);
+      Dafny.ISequence<Dafny.Rune> _175_params;
+      Dafny.ISequence<Dafny.Rune> _out53;
+      _out53 = DCOMP.COMP.GenParams((m).dtor_params);
+      _175_params = _out53;
+      Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _176_paramNames;
+      _176_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements();
+      BigInteger _177_paramI;
+      _177_paramI = BigInteger.Zero;
+      while ((_177_paramI) < (new BigInteger(((m).dtor_params).Count))) {
+        _176_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(_176_paramNames, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((((m).dtor_params).Select(_177_paramI)).dtor_name));
+        _177_paramI = (_177_paramI) + (BigInteger.One);
       }
       if (!((m).dtor_isStatic)) {
         if (forTrait) {
-          _164_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _164_params);
+          _175_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&self"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _175_params);
         } else {
-          Dafny.ISequence<Dafny.Rune> _167_enclosingTypeString;
-          Dafny.ISequence<Dafny.Rune> _out42;
-          _out42 = DCOMP.COMP.GenType(enclosingType, false, false);
-          _167_enclosingTypeString = _out42;
-          _164_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self: &"), _167_enclosingTypeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _164_params);
+          Dafny.ISequence<Dafny.Rune> _178_enclosingTypeString;
+          Dafny.ISequence<Dafny.Rune> _out54;
+          _out54 = DCOMP.COMP.GenType(enclosingType, false, false);
+          _178_enclosingTypeString = _out54;
+          _175_params = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self: &"), _178_enclosingTypeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", ")), _175_params);
         }
       }
-      Dafny.ISequence<Dafny.Rune> _168_retType;
-      _168_retType = (((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")));
-      BigInteger _169_typeI;
-      _169_typeI = BigInteger.Zero;
-      while ((_169_typeI) < (new BigInteger(((m).dtor_outTypes).Count))) {
-        if ((_169_typeI).Sign == 1) {
-          _168_retType = Dafny.Sequence<Dafny.Rune>.Concat(_168_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+      Dafny.ISequence<Dafny.Rune> _179_retType;
+      _179_retType = (((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")));
+      BigInteger _180_typeI;
+      _180_typeI = BigInteger.Zero;
+      while ((_180_typeI) < (new BigInteger(((m).dtor_outTypes).Count))) {
+        if ((_180_typeI).Sign == 1) {
+          _179_retType = Dafny.Sequence<Dafny.Rune>.Concat(_179_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
         }
-        Dafny.ISequence<Dafny.Rune> _170_typeString;
-        Dafny.ISequence<Dafny.Rune> _out43;
-        _out43 = DCOMP.COMP.GenType(((m).dtor_outTypes).Select(_169_typeI), false, false);
-        _170_typeString = _out43;
-        _168_retType = Dafny.Sequence<Dafny.Rune>.Concat(_168_retType, _170_typeString);
-        _169_typeI = (_169_typeI) + (BigInteger.One);
+        Dafny.ISequence<Dafny.Rune> _181_typeString;
+        Dafny.ISequence<Dafny.Rune> _out55;
+        _out55 = DCOMP.COMP.GenType(((m).dtor_outTypes).Select(_180_typeI), false, false);
+        _181_typeString = _out55;
+        _179_retType = Dafny.Sequence<Dafny.Rune>.Concat(_179_retType, _181_typeString);
+        _180_typeI = (_180_typeI) + (BigInteger.One);
       }
       if ((new BigInteger(((m).dtor_outTypes).Count)) != (BigInteger.One)) {
-        _168_retType = Dafny.Sequence<Dafny.Rune>.Concat(_168_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+        _179_retType = Dafny.Sequence<Dafny.Rune>.Concat(_179_retType, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
       }
       if (forTrait) {
         s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn r#"), (m).dtor_name);
       } else {
         s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub fn r#"), (m).dtor_name);
       }
-      Dafny.ISequence<DAST._IType> _171_typeParamsFiltered;
-      _171_typeParamsFiltered = Dafny.Sequence<DAST._IType>.FromElements();
-      BigInteger _172_typeParamI;
-      _172_typeParamI = BigInteger.Zero;
-      while ((_172_typeParamI) < (new BigInteger(((m).dtor_typeParams).Count))) {
-        DAST._IType _173_typeParam;
-        _173_typeParam = ((m).dtor_typeParams).Select(_172_typeParamI);
-        if (!((enclosingTypeParams).Contains(_173_typeParam))) {
-          _171_typeParamsFiltered = Dafny.Sequence<DAST._IType>.Concat(_171_typeParamsFiltered, Dafny.Sequence<DAST._IType>.FromElements(_173_typeParam));
+      Dafny.ISequence<DAST._IType> _182_typeParamsFiltered;
+      _182_typeParamsFiltered = Dafny.Sequence<DAST._IType>.FromElements();
+      BigInteger _183_typeParamI;
+      _183_typeParamI = BigInteger.Zero;
+      while ((_183_typeParamI) < (new BigInteger(((m).dtor_typeParams).Count))) {
+        DAST._IType _184_typeParam;
+        _184_typeParam = ((m).dtor_typeParams).Select(_183_typeParamI);
+        if (!((enclosingTypeParams).Contains(_184_typeParam))) {
+          _182_typeParamsFiltered = Dafny.Sequence<DAST._IType>.Concat(_182_typeParamsFiltered, Dafny.Sequence<DAST._IType>.FromElements(_184_typeParam));
         }
-        _172_typeParamI = (_172_typeParamI) + (BigInteger.One);
+        _183_typeParamI = (_183_typeParamI) + (BigInteger.One);
       }
-      if ((new BigInteger((_171_typeParamsFiltered).Count)).Sign == 1) {
+      if ((new BigInteger((_182_typeParamsFiltered).Count)).Sign == 1) {
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"));
-        BigInteger _174_i;
-        _174_i = BigInteger.Zero;
-        while ((_174_i) < (new BigInteger((_171_typeParamsFiltered).Count))) {
-          if ((_174_i).Sign == 1) {
+        BigInteger _185_i;
+        _185_i = BigInteger.Zero;
+        while ((_185_i) < (new BigInteger((_182_typeParamsFiltered).Count))) {
+          if ((_185_i).Sign == 1) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
           }
-          Dafny.ISequence<Dafny.Rune> _175_typeString;
-          Dafny.ISequence<Dafny.Rune> _out44;
-          _out44 = DCOMP.COMP.GenType((_171_typeParamsFiltered).Select(_174_i), false, false);
-          _175_typeString = _out44;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _175_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<")), _175_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static"));
-          _174_i = (_174_i) + (BigInteger.One);
+          Dafny.ISequence<Dafny.Rune> _186_typeString;
+          Dafny.ISequence<Dafny.Rune> _out56;
+          _out56 = DCOMP.COMP.GenType((_182_typeParamsFiltered).Select(_185_i), false, false);
+          _186_typeString = _out56;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _186_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::DafnyErasable + ::dafny_runtime::DafnyUnerasable<")), _186_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("> + Clone + ::std::cmp::PartialEq + ::dafny_runtime::DafnyPrint + ::std::default::Default + 'static"));
+          _185_i = (_185_i) + (BigInteger.One);
         }
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
       }
-      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _164_params), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _168_retType);
+      s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _175_params), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") -> ")), _179_retType);
       if ((m).dtor_hasBody) {
-        Dafny.ISequence<Dafny.Rune> _176_earlyReturn;
-        _176_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return;");
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source10 = (m).dtor_outVars;
-        if (_source10.is_Some) {
-          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _177___mcc_h0 = _source10.dtor_Some_a0;
-          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _178_outVars = _177___mcc_h0;
-          {
-            _176_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return (");
-            BigInteger _179_outI;
-            _179_outI = BigInteger.Zero;
-            while ((_179_outI) < (new BigInteger((_178_outVars).Count))) {
-              if ((_179_outI).Sign == 1) {
-                _176_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_176_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-              }
-              Dafny.ISequence<Dafny.Rune> _180_outVar;
-              _180_outVar = (_178_outVars).Select(_179_outI);
-              _176_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_176_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_180_outVar));
-              _179_outI = (_179_outI) + (BigInteger.One);
-            }
-            _176_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_176_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
-          }
-        } else {
-        }
-        Dafny.ISequence<Dafny.Rune> _181_body;
-        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _182___v9;
-        Dafny.ISequence<Dafny.Rune> _out45;
-        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out46;
-        DCOMP.COMP.GenStmts((m).dtor_body, _165_paramNames, true, _176_earlyReturn, out _out45, out _out46);
-        _181_body = _out45;
-        _182___v9 = _out46;
+        Dafny.ISequence<Dafny.Rune> _187_earlyReturn;
+        _187_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return;");
         DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source11 = (m).dtor_outVars;
         if (_source11.is_Some) {
-          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _183___mcc_h1 = _source11.dtor_Some_a0;
-          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _184_outVars = _183___mcc_h1;
+          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _188___mcc_h0 = _source11.dtor_Some_a0;
+          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _189_outVars = _188___mcc_h0;
           {
-            _181_body = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_181_body, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _176_earlyReturn);
+            _187_earlyReturn = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return (");
+            BigInteger _190_outI;
+            _190_outI = BigInteger.Zero;
+            while ((_190_outI) < (new BigInteger((_189_outVars).Count))) {
+              if ((_190_outI).Sign == 1) {
+                _187_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_187_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+              }
+              Dafny.ISequence<Dafny.Rune> _191_outVar;
+              _191_outVar = (_189_outVars).Select(_190_outI);
+              _187_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_187_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_191_outVar));
+              _190_outI = (_190_outI) + (BigInteger.One);
+            }
+            _187_earlyReturn = Dafny.Sequence<Dafny.Rune>.Concat(_187_earlyReturn, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
           }
         } else {
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _181_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
+        Dafny.ISequence<Dafny.Rune> _192_body;
+        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _193___v12;
+        Dafny.ISequence<Dafny.Rune> _out57;
+        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out58;
+        DCOMP.COMP.GenStmts((m).dtor_body, _176_paramNames, true, _187_earlyReturn, out _out57, out _out58);
+        _192_body = _out57;
+        _193___v12 = _out58;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source12 = (m).dtor_outVars;
+        if (_source12.is_Some) {
+          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _194___mcc_h1 = _source12.dtor_Some_a0;
+          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _195_outVars = _194___mcc_h1;
+          {
+            _192_body = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_192_body, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n")), _187_earlyReturn);
+          }
+        } else {
+        }
+        s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _192_body), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}\n"));
       } else {
         s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n"));
       }
@@ -4721,483 +4937,547 @@ namespace DCOMP {
       readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty;
       generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
       readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-      BigInteger _185_i;
-      _185_i = BigInteger.Zero;
-      while ((_185_i) < (new BigInteger((stmts).Count))) {
-        DAST._IStatement _186_stmt;
-        _186_stmt = (stmts).Select(_185_i);
-        Dafny.ISequence<Dafny.Rune> _187_stmtString;
-        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _188_recIdents;
-        Dafny.ISequence<Dafny.Rune> _out47;
-        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out48;
-        DCOMP.COMP.GenStmt(_186_stmt, @params, (isLast) && ((_185_i) == ((new BigInteger((stmts).Count)) - (BigInteger.One))), earlyReturn, out _out47, out _out48);
-        _187_stmtString = _out47;
-        _188_recIdents = _out48;
-        readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _188_recIdents);
-        if ((_185_i).Sign == 1) {
+      BigInteger _196_i;
+      _196_i = BigInteger.Zero;
+      while ((_196_i) < (new BigInteger((stmts).Count))) {
+        DAST._IStatement _197_stmt;
+        _197_stmt = (stmts).Select(_196_i);
+        Dafny.ISequence<Dafny.Rune> _198_stmtString;
+        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _199_recIdents;
+        Dafny.ISequence<Dafny.Rune> _out59;
+        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out60;
+        DCOMP.COMP.GenStmt(_197_stmt, @params, (isLast) && ((_196_i) == ((new BigInteger((stmts).Count)) - (BigInteger.One))), earlyReturn, out _out59, out _out60);
+        _198_stmtString = _out59;
+        _199_recIdents = _out60;
+        readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _199_recIdents);
+        if ((_196_i).Sign == 1) {
           generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, _187_stmtString);
-        _185_i = (_185_i) + (BigInteger.One);
+        generated = Dafny.Sequence<Dafny.Rune>.Concat(generated, _198_stmtString);
+        _196_i = (_196_i) + (BigInteger.One);
+      }
+    }
+    public static void GenAssignLhs(DAST._IAssignLhs lhs, Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> @params, out Dafny.ISequence<Dafny.Rune> generated, out bool needsIIFE, out Dafny.ISet<Dafny.ISequence<Dafny.Rune>> readIdents) {
+      generated = Dafny.Sequence<Dafny.Rune>.Empty;
+      needsIIFE = false;
+      readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty;
+      DAST._IAssignLhs _source13 = lhs;
+      if (_source13.is_Ident) {
+        Dafny.ISequence<Dafny.Rune> _200___mcc_h0 = _source13.dtor_Ident_a0;
+        Dafny.ISequence<Dafny.Rune> _source14 = _200___mcc_h0;
+        Dafny.ISequence<Dafny.Rune> _201___mcc_h1 = _source14;
+        Dafny.ISequence<Dafny.Rune> _202_id = _201___mcc_h1;
+        {
+          if ((@params).Contains(_202_id)) {
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("*r#"), _202_id);
+          } else {
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _202_id);
+          }
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_202_id);
+          needsIIFE = false;
+        }
+      } else {
+        DAST._IExpression _203___mcc_h2 = _source13.dtor_expr;
+        Dafny.ISequence<Dafny.Rune> _204___mcc_h3 = _source13.dtor_field;
+        Dafny.ISequence<Dafny.Rune> _205_field = _204___mcc_h3;
+        DAST._IExpression _206_on = _203___mcc_h2;
+        {
+          Dafny.ISequence<Dafny.Rune> _207_onExpr;
+          bool _208_onOwned;
+          bool _209_onErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _210_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out61;
+          bool _out62;
+          bool _out63;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out64;
+          DCOMP.COMP.GenExpr(_206_on, @params, false, out _out61, out _out62, out _out63, out _out64);
+          _207_onExpr = _out61;
+          _208_onOwned = _out62;
+          _209_onErased = _out63;
+          _210_recIdents = _out64;
+          if (!(_209_onErased)) {
+            Dafny.ISequence<Dafny.Rune> _211_eraseFn;
+            _211_eraseFn = ((_208_onOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase")));
+            _207_onExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::"), _211_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _207_onExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          }
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("*("), _207_onExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".")), _205_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".borrow_mut())"));
+          readIdents = _210_recIdents;
+          needsIIFE = true;
+        }
       }
     }
     public static void GenStmt(DAST._IStatement stmt, Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> @params, bool isLast, Dafny.ISequence<Dafny.Rune> earlyReturn, out Dafny.ISequence<Dafny.Rune> generated, out Dafny.ISet<Dafny.ISequence<Dafny.Rune>> readIdents) {
       generated = Dafny.Sequence<Dafny.Rune>.Empty;
       readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty;
-      DAST._IStatement _source12 = stmt;
-      if (_source12.is_DeclareVar) {
-        Dafny.ISequence<Dafny.Rune> _189___mcc_h0 = _source12.dtor_name;
-        DAST._IType _190___mcc_h1 = _source12.dtor_typ;
-        DAST._IOptional<DAST._IExpression> _191___mcc_h2 = _source12.dtor_maybeValue;
-        DAST._IOptional<DAST._IExpression> _source13 = _191___mcc_h2;
-        if (_source13.is_Some) {
-          DAST._IExpression _192___mcc_h3 = _source13.dtor_Some_a0;
-          DAST._IExpression _193_expression = _192___mcc_h3;
-          DAST._IType _194_typ = _190___mcc_h1;
-          Dafny.ISequence<Dafny.Rune> _195_name = _189___mcc_h0;
+      DAST._IStatement _source15 = stmt;
+      if (_source15.is_DeclareVar) {
+        Dafny.ISequence<Dafny.Rune> _212___mcc_h0 = _source15.dtor_name;
+        DAST._IType _213___mcc_h1 = _source15.dtor_typ;
+        DAST._IOptional<DAST._IExpression> _214___mcc_h2 = _source15.dtor_maybeValue;
+        DAST._IOptional<DAST._IExpression> _source16 = _214___mcc_h2;
+        if (_source16.is_Some) {
+          DAST._IExpression _215___mcc_h3 = _source16.dtor_Some_a0;
+          DAST._IExpression _216_expression = _215___mcc_h3;
+          DAST._IType _217_typ = _213___mcc_h1;
+          Dafny.ISequence<Dafny.Rune> _218_name = _212___mcc_h0;
           {
-            Dafny.ISequence<Dafny.Rune> _196_expr;
-            bool _197___v10;
-            bool _198_recErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _199_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out49;
-            bool _out50;
-            bool _out51;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out52;
-            DCOMP.COMP.GenExpr(_193_expression, @params, true, out _out49, out _out50, out _out51, out _out52);
-            _196_expr = _out49;
-            _197___v10 = _out50;
-            _198_recErased = _out51;
-            _199_recIdents = _out52;
-            if (_198_recErased) {
-              _196_expr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _196_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _219_expr;
+            bool _220___v13;
+            bool _221_recErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _222_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out65;
+            bool _out66;
+            bool _out67;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out68;
+            DCOMP.COMP.GenExpr(_216_expression, @params, true, out _out65, out _out66, out _out67, out _out68);
+            _219_expr = _out65;
+            _220___v13 = _out66;
+            _221_recErased = _out67;
+            _222_recIdents = _out68;
+            if (_221_recErased) {
+              _219_expr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _219_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            Dafny.ISequence<Dafny.Rune> _200_typeString;
-            Dafny.ISequence<Dafny.Rune> _out53;
-            _out53 = DCOMP.COMP.GenType(_194_typ, true, false);
-            _200_typeString = _out53;
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _195_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _200_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _196_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
-            readIdents = _199_recIdents;
+            Dafny.ISequence<Dafny.Rune> _223_typeString;
+            Dafny.ISequence<Dafny.Rune> _out69;
+            _out69 = DCOMP.COMP.GenType(_217_typ, true, false);
+            _223_typeString = _out69;
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _218_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _223_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _219_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            readIdents = _222_recIdents;
           }
         } else {
-          DAST._IType _201_typ = _190___mcc_h1;
-          Dafny.ISequence<Dafny.Rune> _202_name = _189___mcc_h0;
+          DAST._IType _224_typ = _213___mcc_h1;
+          Dafny.ISequence<Dafny.Rune> _225_name = _212___mcc_h0;
           {
-            Dafny.ISequence<Dafny.Rune> _203_typeString;
-            Dafny.ISequence<Dafny.Rune> _out54;
-            _out54 = DCOMP.COMP.GenType(_201_typ, true, false);
-            _203_typeString = _out54;
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _202_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _203_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            Dafny.ISequence<Dafny.Rune> _226_typeString;
+            Dafny.ISequence<Dafny.Rune> _out70;
+            _out70 = DCOMP.COMP.GenType(_224_typ, true, false);
+            _226_typeString = _out70;
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let mut r#"), _225_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), _226_typeString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
           }
         }
-      } else if (_source12.is_Assign) {
-        Dafny.ISequence<Dafny.Rune> _204___mcc_h4 = _source12.dtor_name;
-        DAST._IExpression _205___mcc_h5 = _source12.dtor_value;
-        DAST._IExpression _206_expression = _205___mcc_h5;
-        Dafny.ISequence<Dafny.Rune> _207_name = _204___mcc_h4;
+      } else if (_source15.is_Assign) {
+        DAST._IAssignLhs _227___mcc_h4 = _source15.dtor_lhs;
+        DAST._IExpression _228___mcc_h5 = _source15.dtor_value;
+        DAST._IExpression _229_expression = _228___mcc_h5;
+        DAST._IAssignLhs _230_lhs = _227___mcc_h4;
         {
-          Dafny.ISequence<Dafny.Rune> _208_expr;
-          bool _209___v11;
-          bool _210_recErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _211_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out55;
-          bool _out56;
-          bool _out57;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out58;
-          DCOMP.COMP.GenExpr(_206_expression, @params, true, out _out55, out _out56, out _out57, out _out58);
-          _208_expr = _out55;
-          _209___v11 = _out56;
-          _210_recErased = _out57;
-          _211_recIdents = _out58;
-          if (_210_recErased) {
-            _208_expr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _208_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-          }
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _207_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _208_expr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
-          readIdents = _211_recIdents;
-        }
-      } else if (_source12.is_If) {
-        DAST._IExpression _212___mcc_h6 = _source12.dtor_cond;
-        Dafny.ISequence<DAST._IStatement> _213___mcc_h7 = _source12.dtor_thn;
-        Dafny.ISequence<DAST._IStatement> _214___mcc_h8 = _source12.dtor_els;
-        Dafny.ISequence<DAST._IStatement> _215_els = _214___mcc_h8;
-        Dafny.ISequence<DAST._IStatement> _216_thn = _213___mcc_h7;
-        DAST._IExpression _217_cond = _212___mcc_h6;
-        {
-          Dafny.ISequence<Dafny.Rune> _218_condString;
-          bool _219___v12;
-          bool _220_condErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _221_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out59;
-          bool _out60;
-          bool _out61;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out62;
-          DCOMP.COMP.GenExpr(_217_cond, @params, true, out _out59, out _out60, out _out61, out _out62);
-          _218_condString = _out59;
-          _219___v12 = _out60;
-          _220_condErased = _out61;
-          _221_recIdents = _out62;
-          if (!(_220_condErased)) {
-            _218_condString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _218_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-          }
-          readIdents = _221_recIdents;
-          Dafny.ISequence<Dafny.Rune> _222_thnString;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _223_thnIdents;
-          Dafny.ISequence<Dafny.Rune> _out63;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out64;
-          DCOMP.COMP.GenStmts(_216_thn, @params, isLast, earlyReturn, out _out63, out _out64);
-          _222_thnString = _out63;
-          _223_thnIdents = _out64;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _223_thnIdents);
-          Dafny.ISequence<Dafny.Rune> _224_elsString;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _225_elsIdents;
-          Dafny.ISequence<Dafny.Rune> _out65;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out66;
-          DCOMP.COMP.GenStmts(_215_els, @params, isLast, earlyReturn, out _out65, out _out66);
-          _224_elsString = _out65;
-          _225_elsIdents = _out66;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _225_elsIdents);
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if "), _218_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _222_thnString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _224_elsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
-        }
-      } else if (_source12.is_While) {
-        DAST._IExpression _226___mcc_h9 = _source12.dtor_cond;
-        Dafny.ISequence<DAST._IStatement> _227___mcc_h10 = _source12.dtor_body;
-        Dafny.ISequence<DAST._IStatement> _228_body = _227___mcc_h10;
-        DAST._IExpression _229_cond = _226___mcc_h9;
-        {
-          Dafny.ISequence<Dafny.Rune> _230_condString;
-          bool _231___v13;
-          bool _232_condErased;
+          Dafny.ISequence<Dafny.Rune> _231_lhsGen;
+          bool _232_needsIIFE;
           Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _233_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out67;
-          bool _out68;
-          bool _out69;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out70;
-          DCOMP.COMP.GenExpr(_229_cond, @params, true, out _out67, out _out68, out _out69, out _out70);
-          _230_condString = _out67;
-          _231___v13 = _out68;
-          _232_condErased = _out69;
-          _233_recIdents = _out70;
-          if (!(_232_condErased)) {
-            _230_condString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase("), _230_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-          }
-          readIdents = _233_recIdents;
-          Dafny.ISequence<Dafny.Rune> _234_bodyString;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _235_bodyIdents;
           Dafny.ISequence<Dafny.Rune> _out71;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out72;
-          DCOMP.COMP.GenStmts(_228_body, @params, false, earlyReturn, out _out71, out _out72);
-          _234_bodyString = _out71;
-          _235_bodyIdents = _out72;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _235_bodyIdents);
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("while "), _230_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _234_bodyString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+          bool _out72;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out73;
+          DCOMP.COMP.GenAssignLhs(_230_lhs, @params, out _out71, out _out72, out _out73);
+          _231_lhsGen = _out71;
+          _232_needsIIFE = _out72;
+          _233_recIdents = _out73;
+          Dafny.ISequence<Dafny.Rune> _234_exprGen;
+          bool _235___v14;
+          bool _236_exprErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _237_exprIdents;
+          Dafny.ISequence<Dafny.Rune> _out74;
+          bool _out75;
+          bool _out76;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out77;
+          DCOMP.COMP.GenExpr(_229_expression, @params, true, out _out74, out _out75, out _out76, out _out77);
+          _234_exprGen = _out74;
+          _235___v14 = _out75;
+          _236_exprErased = _out76;
+          _237_exprIdents = _out77;
+          if (_236_exprErased) {
+            _234_exprGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _234_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          }
+          if (_232_needsIIFE) {
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ let __rhs = "), _234_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("; ")), _231_lhsGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = __rhs; }"));
+          } else {
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_231_lhsGen, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _234_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+          }
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_233_recIdents, _237_exprIdents);
         }
-      } else if (_source12.is_Call) {
-        DAST._IExpression _236___mcc_h11 = _source12.dtor_on;
-        Dafny.ISequence<Dafny.Rune> _237___mcc_h12 = _source12.dtor_name;
-        Dafny.ISequence<DAST._IType> _238___mcc_h13 = _source12.dtor_typeArgs;
-        Dafny.ISequence<DAST._IExpression> _239___mcc_h14 = _source12.dtor_args;
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _240___mcc_h15 = _source12.dtor_outs;
-        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _241_maybeOutVars = _240___mcc_h15;
-        Dafny.ISequence<DAST._IExpression> _242_args = _239___mcc_h14;
-        Dafny.ISequence<DAST._IType> _243_typeArgs = _238___mcc_h13;
-        Dafny.ISequence<Dafny.Rune> _244_name = _237___mcc_h12;
-        DAST._IExpression _245_on = _236___mcc_h11;
+      } else if (_source15.is_If) {
+        DAST._IExpression _238___mcc_h6 = _source15.dtor_cond;
+        Dafny.ISequence<DAST._IStatement> _239___mcc_h7 = _source15.dtor_thn;
+        Dafny.ISequence<DAST._IStatement> _240___mcc_h8 = _source15.dtor_els;
+        Dafny.ISequence<DAST._IStatement> _241_els = _240___mcc_h8;
+        Dafny.ISequence<DAST._IStatement> _242_thn = _239___mcc_h7;
+        DAST._IExpression _243_cond = _238___mcc_h6;
         {
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          Dafny.ISequence<Dafny.Rune> _246_typeArgString;
-          _246_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          if ((new BigInteger((_243_typeArgs).Count)) >= (BigInteger.One)) {
-            BigInteger _247_typeI;
-            _247_typeI = BigInteger.Zero;
-            _246_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
-            while ((_247_typeI) < (new BigInteger((_243_typeArgs).Count))) {
-              if ((_247_typeI).Sign == 1) {
-                _246_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_246_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-              }
-              Dafny.ISequence<Dafny.Rune> _248_typeString;
-              Dafny.ISequence<Dafny.Rune> _out73;
-              _out73 = DCOMP.COMP.GenType((_243_typeArgs).Select(_247_typeI), false, false);
-              _248_typeString = _out73;
-              _246_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_246_typeArgString, _248_typeString);
-              _247_typeI = (_247_typeI) + (BigInteger.One);
-            }
-            _246_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_246_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
-          }
-          Dafny.ISequence<Dafny.Rune> _249_argString;
-          _249_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _250_i;
-          _250_i = BigInteger.Zero;
-          while ((_250_i) < (new BigInteger((_242_args).Count))) {
-            if ((_250_i).Sign == 1) {
-              _249_argString = Dafny.Sequence<Dafny.Rune>.Concat(_249_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-            }
-            Dafny.ISequence<Dafny.Rune> _251_argExpr;
-            bool _252_isOwned;
-            bool _253_argErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _254_argIdents;
-            Dafny.ISequence<Dafny.Rune> _out74;
-            bool _out75;
-            bool _out76;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out77;
-            DCOMP.COMP.GenExpr((_242_args).Select(_250_i), @params, false, out _out74, out _out75, out _out76, out _out77);
-            _251_argExpr = _out74;
-            _252_isOwned = _out75;
-            _253_argErased = _out76;
-            _254_argIdents = _out77;
-            if (_252_isOwned) {
-              _251_argExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), _251_argExpr);
-            }
-            _249_argString = Dafny.Sequence<Dafny.Rune>.Concat(_249_argString, _251_argExpr);
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _254_argIdents);
-            _250_i = (_250_i) + (BigInteger.One);
-          }
-          Dafny.ISequence<Dafny.Rune> _255_enclosingString;
-          bool _256___v14;
-          bool _257___v15;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _258_enclosingIdents;
+          Dafny.ISequence<Dafny.Rune> _244_condString;
+          bool _245___v15;
+          bool _246_condErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _247_recIdents;
           Dafny.ISequence<Dafny.Rune> _out78;
           bool _out79;
           bool _out80;
           Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out81;
-          DCOMP.COMP.GenExpr(_245_on, @params, true, out _out78, out _out79, out _out80, out _out81);
-          _255_enclosingString = _out78;
-          _256___v14 = _out79;
-          _257___v15 = _out80;
-          _258_enclosingIdents = _out81;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _258_enclosingIdents);
-          DAST._IExpression _source14 = _245_on;
-          if (_source14.is_Literal) {
-            DAST._ILiteral _259___mcc_h18 = _source14.dtor_Literal_a0;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Ident) {
-            Dafny.ISequence<Dafny.Rune> _260___mcc_h20 = _source14.dtor_Ident_a0;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Companion) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _261___mcc_h22 = _source14.dtor_Companion_a0;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_255_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
-            }
-          } else if (_source14.is_Tuple) {
-            Dafny.ISequence<DAST._IExpression> _262___mcc_h24 = _source14.dtor_Tuple_a0;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_New) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _263___mcc_h26 = _source14.dtor_path;
-            Dafny.ISequence<DAST._IExpression> _264___mcc_h27 = _source14.dtor_args;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_NewArray) {
-            Dafny.ISequence<DAST._IExpression> _265___mcc_h30 = _source14.dtor_dims;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_DatatypeValue) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _266___mcc_h32 = _source14.dtor_path;
-            Dafny.ISequence<Dafny.Rune> _267___mcc_h33 = _source14.dtor_variant;
-            bool _268___mcc_h34 = _source14.dtor_isCo;
-            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _269___mcc_h35 = _source14.dtor_contents;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_SubsetUpgrade) {
-            DAST._IExpression _270___mcc_h40 = _source14.dtor_value;
-            DAST._IType _271___mcc_h41 = _source14.dtor_typ;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_SubsetDowngrade) {
-            DAST._IExpression _272___mcc_h44 = _source14.dtor_value;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_SeqValue) {
-            Dafny.ISequence<DAST._IExpression> _273___mcc_h46 = _source14.dtor_elements;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_SetValue) {
-            Dafny.ISequence<DAST._IExpression> _274___mcc_h48 = _source14.dtor_elements;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_This) {
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Ite) {
-            DAST._IExpression _275___mcc_h50 = _source14.dtor_cond;
-            DAST._IExpression _276___mcc_h51 = _source14.dtor_thn;
-            DAST._IExpression _277___mcc_h52 = _source14.dtor_els;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_UnOp) {
-            DAST._IUnaryOp _278___mcc_h56 = _source14.dtor_unOp;
-            DAST._IExpression _279___mcc_h57 = _source14.dtor_expr;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_BinOp) {
-            Dafny.ISequence<Dafny.Rune> _280___mcc_h60 = _source14.dtor_op;
-            DAST._IExpression _281___mcc_h61 = _source14.dtor_left;
-            DAST._IExpression _282___mcc_h62 = _source14.dtor_right;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Select) {
-            DAST._IExpression _283___mcc_h66 = _source14.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _284___mcc_h67 = _source14.dtor_field;
-            bool _285___mcc_h68 = _source14.dtor_onDatatype;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_SelectFn) {
-            DAST._IExpression _286___mcc_h72 = _source14.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _287___mcc_h73 = _source14.dtor_field;
-            bool _288___mcc_h74 = _source14.dtor_onDatatype;
-            bool _289___mcc_h75 = _source14.dtor_isStatic;
-            BigInteger _290___mcc_h76 = _source14.dtor_arity;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_TupleSelect) {
-            DAST._IExpression _291___mcc_h82 = _source14.dtor_expr;
-            BigInteger _292___mcc_h83 = _source14.dtor_index;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Call) {
-            DAST._IExpression _293___mcc_h86 = _source14.dtor_on;
-            Dafny.ISequence<Dafny.Rune> _294___mcc_h87 = _source14.dtor_name;
-            Dafny.ISequence<DAST._IType> _295___mcc_h88 = _source14.dtor_typeArgs;
-            Dafny.ISequence<DAST._IExpression> _296___mcc_h89 = _source14.dtor_args;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Lambda) {
-            Dafny.ISequence<DAST._IFormal> _297___mcc_h94 = _source14.dtor_params;
-            DAST._IType _298___mcc_h95 = _source14.dtor_retType;
-            Dafny.ISequence<DAST._IStatement> _299___mcc_h96 = _source14.dtor_body;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_IIFE) {
-            Dafny.ISequence<Dafny.Rune> _300___mcc_h100 = _source14.dtor_name;
-            DAST._IType _301___mcc_h101 = _source14.dtor_typ;
-            DAST._IExpression _302___mcc_h102 = _source14.dtor_value;
-            DAST._IExpression _303___mcc_h103 = _source14.dtor_iifeBody;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_Apply) {
-            DAST._IExpression _304___mcc_h108 = _source14.dtor_expr;
-            Dafny.ISequence<DAST._IExpression> _305___mcc_h109 = _source14.dtor_args;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else if (_source14.is_TypeTest) {
-            DAST._IExpression _306___mcc_h112 = _source14.dtor_on;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _307___mcc_h113 = _source14.dtor_dType;
-            Dafny.ISequence<Dafny.Rune> _308___mcc_h114 = _source14.dtor_variant;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
-          } else {
-            DAST._IType _309___mcc_h118 = _source14.dtor_typ;
-            {
-              _255_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
-            }
+          DCOMP.COMP.GenExpr(_243_cond, @params, true, out _out78, out _out79, out _out80, out _out81);
+          _244_condString = _out78;
+          _245___v15 = _out79;
+          _246_condErased = _out80;
+          _247_recIdents = _out81;
+          if (!(_246_condErased)) {
+            _244_condString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _244_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
-          Dafny.ISequence<Dafny.Rune> _310_receiver;
-          _310_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source15 = _241_maybeOutVars;
-          if (_source15.is_Some) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _311___mcc_h120 = _source15.dtor_Some_a0;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _312_outVars = _311___mcc_h120;
-            {
-              if ((new BigInteger((_312_outVars).Count)) > (BigInteger.One)) {
-                _310_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
-              }
-              BigInteger _313_outI;
-              _313_outI = BigInteger.Zero;
-              while ((_313_outI) < (new BigInteger((_312_outVars).Count))) {
-                if ((_313_outI).Sign == 1) {
-                  _310_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_310_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
-                }
-                Dafny.ISequence<Dafny.Rune> _314_outVar;
-                _314_outVar = (_312_outVars).Select(_313_outI);
-                _310_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_310_receiver, (_314_outVar));
-                _313_outI = (_313_outI) + (BigInteger.One);
-              }
-              if ((new BigInteger((_312_outVars).Count)) > (BigInteger.One)) {
-                _310_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_310_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-              }
-            }
-          } else {
-          }
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(((!(_310_receiver).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))) ? (Dafny.Sequence<Dafny.Rune>.Concat(_310_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = "))) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))), _255_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _244_name), _246_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _249_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
-        }
-      } else if (_source12.is_Return) {
-        DAST._IExpression _315___mcc_h16 = _source12.dtor_expr;
-        DAST._IExpression _316_expr = _315___mcc_h16;
-        {
-          Dafny.ISequence<Dafny.Rune> _317_exprString;
-          bool _318___v18;
-          bool _319_recErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _320_recIdents;
+          readIdents = _247_recIdents;
+          Dafny.ISequence<Dafny.Rune> _248_thnString;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _249_thnIdents;
           Dafny.ISequence<Dafny.Rune> _out82;
-          bool _out83;
-          bool _out84;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out83;
+          DCOMP.COMP.GenStmts(_242_thn, @params, isLast, earlyReturn, out _out82, out _out83);
+          _248_thnString = _out82;
+          _249_thnIdents = _out83;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _249_thnIdents);
+          Dafny.ISequence<Dafny.Rune> _250_elsString;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _251_elsIdents;
+          Dafny.ISequence<Dafny.Rune> _out84;
           Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out85;
-          DCOMP.COMP.GenExpr(_316_expr, @params, true, out _out82, out _out83, out _out84, out _out85);
-          _317_exprString = _out82;
-          _318___v18 = _out83;
-          _319_recErased = _out84;
-          _320_recIdents = _out85;
-          _317_exprString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _317_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-          readIdents = _320_recIdents;
-          if (isLast) {
-            generated = _317_exprString;
+          DCOMP.COMP.GenStmts(_241_els, @params, isLast, earlyReturn, out _out84, out _out85);
+          _250_elsString = _out84;
+          _251_elsIdents = _out85;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _251_elsIdents);
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if "), _244_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _248_thnString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _250_elsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+        }
+      } else if (_source15.is_While) {
+        DAST._IExpression _252___mcc_h9 = _source15.dtor_cond;
+        Dafny.ISequence<DAST._IStatement> _253___mcc_h10 = _source15.dtor_body;
+        Dafny.ISequence<DAST._IStatement> _254_body = _253___mcc_h10;
+        DAST._IExpression _255_cond = _252___mcc_h9;
+        {
+          Dafny.ISequence<Dafny.Rune> _256_condString;
+          bool _257___v16;
+          bool _258_condErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _259_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out86;
+          bool _out87;
+          bool _out88;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out89;
+          DCOMP.COMP.GenExpr(_255_cond, @params, true, out _out86, out _out87, out _out88, out _out89);
+          _256_condString = _out86;
+          _257___v16 = _out87;
+          _258_condErased = _out88;
+          _259_recIdents = _out89;
+          if (!(_258_condErased)) {
+            _256_condString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase("), _256_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          }
+          readIdents = _259_recIdents;
+          Dafny.ISequence<Dafny.Rune> _260_bodyString;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _261_bodyIdents;
+          Dafny.ISequence<Dafny.Rune> _out90;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out91;
+          DCOMP.COMP.GenStmts(_254_body, @params, false, earlyReturn, out _out90, out _out91);
+          _260_bodyString = _out90;
+          _261_bodyIdents = _out91;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _261_bodyIdents);
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("while "), _256_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _260_bodyString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+        }
+      } else if (_source15.is_Call) {
+        DAST._IExpression _262___mcc_h11 = _source15.dtor_on;
+        Dafny.ISequence<Dafny.Rune> _263___mcc_h12 = _source15.dtor_name;
+        Dafny.ISequence<DAST._IType> _264___mcc_h13 = _source15.dtor_typeArgs;
+        Dafny.ISequence<DAST._IExpression> _265___mcc_h14 = _source15.dtor_args;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _266___mcc_h15 = _source15.dtor_outs;
+        DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _267_maybeOutVars = _266___mcc_h15;
+        Dafny.ISequence<DAST._IExpression> _268_args = _265___mcc_h14;
+        Dafny.ISequence<DAST._IType> _269_typeArgs = _264___mcc_h13;
+        Dafny.ISequence<Dafny.Rune> _270_name = _263___mcc_h12;
+        DAST._IExpression _271_on = _262___mcc_h11;
+        {
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+          Dafny.ISequence<Dafny.Rune> _272_typeArgString;
+          _272_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          if ((new BigInteger((_269_typeArgs).Count)) >= (BigInteger.One)) {
+            BigInteger _273_typeI;
+            _273_typeI = BigInteger.Zero;
+            _272_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
+            while ((_273_typeI) < (new BigInteger((_269_typeArgs).Count))) {
+              if ((_273_typeI).Sign == 1) {
+                _272_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_272_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+              }
+              Dafny.ISequence<Dafny.Rune> _274_typeString;
+              Dafny.ISequence<Dafny.Rune> _out92;
+              _out92 = DCOMP.COMP.GenType((_269_typeArgs).Select(_273_typeI), false, false);
+              _274_typeString = _out92;
+              _272_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_272_typeArgString, _274_typeString);
+              _273_typeI = (_273_typeI) + (BigInteger.One);
+            }
+            _272_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_272_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+          }
+          Dafny.ISequence<Dafny.Rune> _275_argString;
+          _275_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _276_i;
+          _276_i = BigInteger.Zero;
+          while ((_276_i) < (new BigInteger((_268_args).Count))) {
+            if ((_276_i).Sign == 1) {
+              _275_argString = Dafny.Sequence<Dafny.Rune>.Concat(_275_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+            }
+            Dafny.ISequence<Dafny.Rune> _277_argExpr;
+            bool _278_isOwned;
+            bool _279_argErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _280_argIdents;
+            Dafny.ISequence<Dafny.Rune> _out93;
+            bool _out94;
+            bool _out95;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out96;
+            DCOMP.COMP.GenExpr((_268_args).Select(_276_i), @params, false, out _out93, out _out94, out _out95, out _out96);
+            _277_argExpr = _out93;
+            _278_isOwned = _out94;
+            _279_argErased = _out95;
+            _280_argIdents = _out96;
+            if (_278_isOwned) {
+              _277_argExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), _277_argExpr);
+            }
+            _275_argString = Dafny.Sequence<Dafny.Rune>.Concat(_275_argString, _277_argExpr);
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _280_argIdents);
+            _276_i = (_276_i) + (BigInteger.One);
+          }
+          Dafny.ISequence<Dafny.Rune> _281_enclosingString;
+          bool _282___v17;
+          bool _283___v18;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _284_enclosingIdents;
+          Dafny.ISequence<Dafny.Rune> _out97;
+          bool _out98;
+          bool _out99;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out100;
+          DCOMP.COMP.GenExpr(_271_on, @params, false, out _out97, out _out98, out _out99, out _out100);
+          _281_enclosingString = _out97;
+          _282___v17 = _out98;
+          _283___v18 = _out99;
+          _284_enclosingIdents = _out100;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _284_enclosingIdents);
+          DAST._IExpression _source17 = _271_on;
+          if (_source17.is_Literal) {
+            DAST._ILiteral _285___mcc_h18 = _source17.dtor_Literal_a0;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Ident) {
+            Dafny.ISequence<Dafny.Rune> _286___mcc_h20 = _source17.dtor_Ident_a0;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Companion) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _287___mcc_h22 = _source17.dtor_Companion_a0;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_281_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+            }
+          } else if (_source17.is_Tuple) {
+            Dafny.ISequence<DAST._IExpression> _288___mcc_h24 = _source17.dtor_Tuple_a0;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_New) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _289___mcc_h26 = _source17.dtor_path;
+            Dafny.ISequence<DAST._IExpression> _290___mcc_h27 = _source17.dtor_args;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_NewArray) {
+            Dafny.ISequence<DAST._IExpression> _291___mcc_h30 = _source17.dtor_dims;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_DatatypeValue) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _292___mcc_h32 = _source17.dtor_path;
+            Dafny.ISequence<Dafny.Rune> _293___mcc_h33 = _source17.dtor_variant;
+            bool _294___mcc_h34 = _source17.dtor_isCo;
+            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _295___mcc_h35 = _source17.dtor_contents;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_SubsetUpgrade) {
+            DAST._IExpression _296___mcc_h40 = _source17.dtor_value;
+            DAST._IType _297___mcc_h41 = _source17.dtor_typ;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_SubsetDowngrade) {
+            DAST._IExpression _298___mcc_h44 = _source17.dtor_value;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_SeqValue) {
+            Dafny.ISequence<DAST._IExpression> _299___mcc_h46 = _source17.dtor_elements;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_SetValue) {
+            Dafny.ISequence<DAST._IExpression> _300___mcc_h48 = _source17.dtor_elements;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_This) {
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Ite) {
+            DAST._IExpression _301___mcc_h50 = _source17.dtor_cond;
+            DAST._IExpression _302___mcc_h51 = _source17.dtor_thn;
+            DAST._IExpression _303___mcc_h52 = _source17.dtor_els;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_UnOp) {
+            DAST._IUnaryOp _304___mcc_h56 = _source17.dtor_unOp;
+            DAST._IExpression _305___mcc_h57 = _source17.dtor_expr;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_BinOp) {
+            Dafny.ISequence<Dafny.Rune> _306___mcc_h60 = _source17.dtor_op;
+            DAST._IExpression _307___mcc_h61 = _source17.dtor_left;
+            DAST._IExpression _308___mcc_h62 = _source17.dtor_right;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Select) {
+            DAST._IExpression _309___mcc_h66 = _source17.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _310___mcc_h67 = _source17.dtor_field;
+            bool _311___mcc_h68 = _source17.dtor_isConstant;
+            bool _312___mcc_h69 = _source17.dtor_onDatatype;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_SelectFn) {
+            DAST._IExpression _313___mcc_h74 = _source17.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _314___mcc_h75 = _source17.dtor_field;
+            bool _315___mcc_h76 = _source17.dtor_onDatatype;
+            bool _316___mcc_h77 = _source17.dtor_isStatic;
+            BigInteger _317___mcc_h78 = _source17.dtor_arity;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_TupleSelect) {
+            DAST._IExpression _318___mcc_h84 = _source17.dtor_expr;
+            BigInteger _319___mcc_h85 = _source17.dtor_index;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Call) {
+            DAST._IExpression _320___mcc_h88 = _source17.dtor_on;
+            Dafny.ISequence<Dafny.Rune> _321___mcc_h89 = _source17.dtor_name;
+            Dafny.ISequence<DAST._IType> _322___mcc_h90 = _source17.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _323___mcc_h91 = _source17.dtor_args;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Lambda) {
+            Dafny.ISequence<DAST._IFormal> _324___mcc_h96 = _source17.dtor_params;
+            DAST._IType _325___mcc_h97 = _source17.dtor_retType;
+            Dafny.ISequence<DAST._IStatement> _326___mcc_h98 = _source17.dtor_body;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_IIFE) {
+            Dafny.ISequence<Dafny.Rune> _327___mcc_h102 = _source17.dtor_name;
+            DAST._IType _328___mcc_h103 = _source17.dtor_typ;
+            DAST._IExpression _329___mcc_h104 = _source17.dtor_value;
+            DAST._IExpression _330___mcc_h105 = _source17.dtor_iifeBody;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_Apply) {
+            DAST._IExpression _331___mcc_h110 = _source17.dtor_expr;
+            Dafny.ISequence<DAST._IExpression> _332___mcc_h111 = _source17.dtor_args;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          } else if (_source17.is_TypeTest) {
+            DAST._IExpression _333___mcc_h114 = _source17.dtor_on;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _334___mcc_h115 = _source17.dtor_dType;
+            Dafny.ISequence<Dafny.Rune> _335___mcc_h116 = _source17.dtor_variant;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
           } else {
-            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return "), _317_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
+            DAST._IType _336___mcc_h120 = _source17.dtor_typ;
+            {
+              _281_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+            }
+          }
+          Dafny.ISequence<Dafny.Rune> _337_receiver;
+          _337_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          DAST._IOptional<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _source18 = _267_maybeOutVars;
+          if (_source18.is_Some) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _338___mcc_h122 = _source18.dtor_Some_a0;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _339_outVars = _338___mcc_h122;
+            {
+              if ((new BigInteger((_339_outVars).Count)) > (BigInteger.One)) {
+                _337_receiver = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
+              }
+              BigInteger _340_outI;
+              _340_outI = BigInteger.Zero;
+              while ((_340_outI) < (new BigInteger((_339_outVars).Count))) {
+                if ((_340_outI).Sign == 1) {
+                  _337_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_337_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+                }
+                Dafny.ISequence<Dafny.Rune> _341_outVar;
+                _341_outVar = (_339_outVars).Select(_340_outI);
+                _337_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_337_receiver, (_341_outVar));
+                _340_outI = (_340_outI) + (BigInteger.One);
+              }
+              if ((new BigInteger((_339_outVars).Count)) > (BigInteger.One)) {
+                _337_receiver = Dafny.Sequence<Dafny.Rune>.Concat(_337_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              }
+            }
+          } else {
+          }
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(((!(_337_receiver).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))) ? (Dafny.Sequence<Dafny.Rune>.Concat(_337_receiver, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = "))) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""))), _281_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _270_name), _272_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _275_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(");"));
+        }
+      } else if (_source15.is_Return) {
+        DAST._IExpression _342___mcc_h16 = _source15.dtor_expr;
+        DAST._IExpression _343_expr = _342___mcc_h16;
+        {
+          Dafny.ISequence<Dafny.Rune> _344_exprString;
+          bool _345___v21;
+          bool _346_recErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _347_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out101;
+          bool _out102;
+          bool _out103;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out104;
+          DCOMP.COMP.GenExpr(_343_expr, @params, true, out _out101, out _out102, out _out103, out _out104);
+          _344_exprString = _out101;
+          _345___v21 = _out102;
+          _346_recErased = _out103;
+          _347_recIdents = _out104;
+          _344_exprString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _344_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          readIdents = _347_recIdents;
+          if (isLast) {
+            generated = _344_exprString;
+          } else {
+            generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return "), _344_exprString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";"));
           }
         }
-      } else if (_source12.is_EarlyReturn) {
+      } else if (_source15.is_EarlyReturn) {
         {
           generated = earlyReturn;
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
         }
-      } else if (_source12.is_Halt) {
+      } else if (_source15.is_Halt) {
         {
           generated = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("panic!(\"Halt\");");
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
         }
       } else {
-        DAST._IExpression _321___mcc_h17 = _source12.dtor_Print_a0;
-        DAST._IExpression _322_e = _321___mcc_h17;
+        DAST._IExpression _348___mcc_h17 = _source15.dtor_Print_a0;
+        DAST._IExpression _349_e = _348___mcc_h17;
         {
-          Dafny.ISequence<Dafny.Rune> _323_printedExpr;
-          bool _324_isOwned;
-          bool _325___v19;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _326_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out86;
-          bool _out87;
-          bool _out88;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out89;
-          DCOMP.COMP.GenExpr(_322_e, @params, false, out _out86, out _out87, out _out88, out _out89);
-          _323_printedExpr = _out86;
-          _324_isOwned = _out87;
-          _325___v19 = _out88;
-          _326_recIdents = _out89;
-          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper("), ((_324_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _323_printedExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("));"));
-          readIdents = _326_recIdents;
+          Dafny.ISequence<Dafny.Rune> _350_printedExpr;
+          bool _351_isOwned;
+          bool _352___v22;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _353_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out105;
+          bool _out106;
+          bool _out107;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out108;
+          DCOMP.COMP.GenExpr(_349_e, @params, false, out _out105, out _out106, out _out107, out _out108);
+          _350_printedExpr = _out105;
+          _351_isOwned = _out106;
+          _352___v22 = _out107;
+          _353_recIdents = _out108;
+          generated = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!(\"{}\", ::dafny_runtime::DafnyPrintWrapper("), ((_351_isOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")))), _350_printedExpr), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("));"));
+          readIdents = _353_recIdents;
         }
       }
     }
@@ -5206,13 +5486,13 @@ namespace DCOMP {
       isOwned = false;
       isErased = false;
       readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty;
-      DAST._IExpression _source16 = e;
-      if (_source16.is_Literal) {
-        DAST._ILiteral _327___mcc_h0 = _source16.dtor_Literal_a0;
-        DAST._ILiteral _source17 = _327___mcc_h0;
-        if (_source17.is_BoolLiteral) {
-          bool _328___mcc_h1 = _source17.dtor_BoolLiteral_a0;
-          if ((_328___mcc_h1) == (false)) {
+      DAST._IExpression _source19 = e;
+      if (_source19.is_Literal) {
+        DAST._ILiteral _354___mcc_h0 = _source19.dtor_Literal_a0;
+        DAST._ILiteral _source20 = _354___mcc_h0;
+        if (_source20.is_BoolLiteral) {
+          bool _355___mcc_h1 = _source20.dtor_BoolLiteral_a0;
+          if ((_355___mcc_h1) == (false)) {
             {
               s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("false");
               isOwned = true;
@@ -5227,42 +5507,42 @@ namespace DCOMP {
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
             }
           }
-        } else if (_source17.is_IntLiteral) {
-          BigInteger _329___mcc_h2 = _source17.dtor_IntLiteral_a0;
-          BigInteger _330_i = _329___mcc_h2;
+        } else if (_source20.is_IntLiteral) {
+          BigInteger _356___mcc_h2 = _source20.dtor_IntLiteral_a0;
+          BigInteger _357_i = _356___mcc_h2;
           {
-            if ((_330_i).Sign == -1) {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("-"), DCOMP.__default.natToString((BigInteger.Zero) - (_330_i)));
+            if ((_357_i).Sign == -1) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("-"), DCOMP.__default.natToString((BigInteger.Zero) - (_357_i)));
             } else {
-              s = DCOMP.__default.natToString(_330_i);
+              s = DCOMP.__default.natToString(_357_i);
             }
             isOwned = true;
             isErased = true;
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
           }
-        } else if (_source17.is_DecLiteral) {
-          Dafny.ISequence<Dafny.Rune> _331___mcc_h3 = _source17.dtor_DecLiteral_a0;
-          Dafny.ISequence<Dafny.Rune> _332_l = _331___mcc_h3;
+        } else if (_source20.is_DecLiteral) {
+          Dafny.ISequence<Dafny.Rune> _358___mcc_h3 = _source20.dtor_DecLiteral_a0;
+          Dafny.ISequence<Dafny.Rune> _359_l = _358___mcc_h3;
           {
-            s = _332_l;
+            s = _359_l;
             isOwned = true;
             isErased = true;
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
           }
-        } else if (_source17.is_StringLiteral) {
-          Dafny.ISequence<Dafny.Rune> _333___mcc_h4 = _source17.dtor_StringLiteral_a0;
-          Dafny.ISequence<Dafny.Rune> _334_l = _333___mcc_h4;
+        } else if (_source20.is_StringLiteral) {
+          Dafny.ISequence<Dafny.Rune> _360___mcc_h4 = _source20.dtor_StringLiteral_a0;
+          Dafny.ISequence<Dafny.Rune> _361_l = _360___mcc_h4;
           {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""), _334_l), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\".chars().collect::<Vec<char>>()"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\""), _361_l), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\".chars().collect::<Vec<char>>()"));
             isOwned = true;
             isErased = true;
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
           }
-        } else if (_source17.is_CharLiteral) {
-          Dafny.Rune _335___mcc_h5 = _source17.dtor_CharLiteral_a0;
-          Dafny.Rune _336_c = _335___mcc_h5;
+        } else if (_source20.is_CharLiteral) {
+          Dafny.Rune _362___mcc_h5 = _source20.dtor_CharLiteral_a0;
+          Dafny.Rune _363_c = _362___mcc_h5;
           {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::primitive::char::from_u32("), DCOMP.__default.natToString(new BigInteger((_336_c).Value))), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").unwrap()"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::primitive::char::from_u32("), DCOMP.__default.natToString(new BigInteger((_363_c).Value))), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").unwrap()"));
             isOwned = true;
             isErased = true;
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
@@ -5275,12 +5555,12 @@ namespace DCOMP {
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
           }
         }
-      } else if (_source16.is_Ident) {
-        Dafny.ISequence<Dafny.Rune> _337___mcc_h6 = _source16.dtor_Ident_a0;
-        Dafny.ISequence<Dafny.Rune> _338_name = _337___mcc_h6;
+      } else if (_source19.is_Ident) {
+        Dafny.ISequence<Dafny.Rune> _364___mcc_h6 = _source19.dtor_Ident_a0;
+        Dafny.ISequence<Dafny.Rune> _365_name = _364___mcc_h6;
         {
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _338_name);
-          if (!((@params).Contains(_338_name))) {
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#"), _365_name);
+          if (!((@params).Contains(_365_name))) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(&"), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
           if (mustOwn) {
@@ -5290,388 +5570,388 @@ namespace DCOMP {
             isOwned = false;
           }
           isErased = false;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_338_name);
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_365_name);
         }
-      } else if (_source16.is_Companion) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _339___mcc_h7 = _source16.dtor_Companion_a0;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _340_path = _339___mcc_h7;
+      } else if (_source19.is_Companion) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _366___mcc_h7 = _source19.dtor_Companion_a0;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _367_path = _366___mcc_h7;
         {
-          Dafny.ISequence<Dafny.Rune> _out90;
-          _out90 = DCOMP.COMP.GenPath(_340_path);
-          s = _out90;
+          Dafny.ISequence<Dafny.Rune> _out109;
+          _out109 = DCOMP.COMP.GenPath(_367_path);
+          s = _out109;
           isOwned = true;
           isErased = true;
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
         }
-      } else if (_source16.is_Tuple) {
-        Dafny.ISequence<DAST._IExpression> _341___mcc_h8 = _source16.dtor_Tuple_a0;
-        Dafny.ISequence<DAST._IExpression> _342_values = _341___mcc_h8;
+      } else if (_source19.is_Tuple) {
+        Dafny.ISequence<DAST._IExpression> _368___mcc_h8 = _source19.dtor_Tuple_a0;
+        Dafny.ISequence<DAST._IExpression> _369_values = _368___mcc_h8;
         {
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(");
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          BigInteger _343_i;
-          _343_i = BigInteger.Zero;
-          bool _344_allErased;
-          _344_allErased = true;
-          while ((_343_i) < (new BigInteger((_342_values).Count))) {
-            Dafny.ISequence<Dafny.Rune> _345___v20;
-            bool _346___v21;
-            bool _347_isErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _348___v22;
-            Dafny.ISequence<Dafny.Rune> _out91;
-            bool _out92;
-            bool _out93;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out94;
-            DCOMP.COMP.GenExpr((_342_values).Select(_343_i), @params, true, out _out91, out _out92, out _out93, out _out94);
-            _345___v20 = _out91;
-            _346___v21 = _out92;
-            _347_isErased = _out93;
-            _348___v22 = _out94;
-            _344_allErased = (_344_allErased) && (_347_isErased);
-            _343_i = (_343_i) + (BigInteger.One);
+          BigInteger _370_i;
+          _370_i = BigInteger.Zero;
+          bool _371_allErased;
+          _371_allErased = true;
+          while ((_370_i) < (new BigInteger((_369_values).Count))) {
+            Dafny.ISequence<Dafny.Rune> _372___v23;
+            bool _373___v24;
+            bool _374_isErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _375___v25;
+            Dafny.ISequence<Dafny.Rune> _out110;
+            bool _out111;
+            bool _out112;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out113;
+            DCOMP.COMP.GenExpr((_369_values).Select(_370_i), @params, true, out _out110, out _out111, out _out112, out _out113);
+            _372___v23 = _out110;
+            _373___v24 = _out111;
+            _374_isErased = _out112;
+            _375___v25 = _out113;
+            _371_allErased = (_371_allErased) && (_374_isErased);
+            _370_i = (_370_i) + (BigInteger.One);
           }
-          _343_i = BigInteger.Zero;
-          while ((_343_i) < (new BigInteger((_342_values).Count))) {
-            if ((_343_i).Sign == 1) {
+          _370_i = BigInteger.Zero;
+          while ((_370_i) < (new BigInteger((_369_values).Count))) {
+            if ((_370_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" "));
             }
-            Dafny.ISequence<Dafny.Rune> _349_recursiveGen;
-            bool _350___v23;
-            bool _351_isErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _352_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out95;
-            bool _out96;
-            bool _out97;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out98;
-            DCOMP.COMP.GenExpr((_342_values).Select(_343_i), @params, true, out _out95, out _out96, out _out97, out _out98);
-            _349_recursiveGen = _out95;
-            _350___v23 = _out96;
-            _351_isErased = _out97;
-            _352_recIdents = _out98;
-            if ((_351_isErased) && (!(_344_allErased))) {
-              _349_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _349_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _376_recursiveGen;
+            bool _377___v26;
+            bool _378_isErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _379_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out114;
+            bool _out115;
+            bool _out116;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out117;
+            DCOMP.COMP.GenExpr((_369_values).Select(_370_i), @params, true, out _out114, out _out115, out _out116, out _out117);
+            _376_recursiveGen = _out114;
+            _377___v26 = _out115;
+            _378_isErased = _out116;
+            _379_recIdents = _out117;
+            if ((_378_isErased) && (!(_371_allErased))) {
+              _376_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _376_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _349_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _352_recIdents);
-            _343_i = (_343_i) + (BigInteger.One);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, _376_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(","));
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _379_recIdents);
+            _370_i = (_370_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
-          isErased = _344_allErased;
+          isErased = _371_allErased;
         }
-      } else if (_source16.is_New) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _353___mcc_h9 = _source16.dtor_path;
-        Dafny.ISequence<DAST._IExpression> _354___mcc_h10 = _source16.dtor_args;
-        Dafny.ISequence<DAST._IExpression> _355_args = _354___mcc_h10;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _356_path = _353___mcc_h9;
+      } else if (_source19.is_New) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _380___mcc_h9 = _source19.dtor_path;
+        Dafny.ISequence<DAST._IExpression> _381___mcc_h10 = _source19.dtor_args;
+        Dafny.ISequence<DAST._IExpression> _382_args = _381___mcc_h10;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _383_path = _380___mcc_h9;
         {
-          Dafny.ISequence<Dafny.Rune> _357_path;
-          Dafny.ISequence<Dafny.Rune> _out99;
-          _out99 = DCOMP.COMP.GenPath(_356_path);
-          _357_path = _out99;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _357_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::new("));
+          Dafny.ISequence<Dafny.Rune> _384_path;
+          Dafny.ISequence<Dafny.Rune> _out118;
+          _out118 = DCOMP.COMP.GenPath(_383_path);
+          _384_path = _out118;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _384_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::new("));
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          BigInteger _358_i;
-          _358_i = BigInteger.Zero;
-          while ((_358_i) < (new BigInteger((_355_args).Count))) {
-            if ((_358_i).Sign == 1) {
+          BigInteger _385_i;
+          _385_i = BigInteger.Zero;
+          while ((_385_i) < (new BigInteger((_382_args).Count))) {
+            if ((_385_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _359_recursiveGen;
-            bool _360___v24;
-            bool _361_isErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _362_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out100;
-            bool _out101;
-            bool _out102;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out103;
-            DCOMP.COMP.GenExpr((_355_args).Select(_358_i), @params, true, out _out100, out _out101, out _out102, out _out103);
-            _359_recursiveGen = _out100;
-            _360___v24 = _out101;
-            _361_isErased = _out102;
-            _362_recIdents = _out103;
-            if (_361_isErased) {
-              _359_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _359_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _386_recursiveGen;
+            bool _387___v27;
+            bool _388_isErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _389_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out119;
+            bool _out120;
+            bool _out121;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out122;
+            DCOMP.COMP.GenExpr((_382_args).Select(_385_i), @params, true, out _out119, out _out120, out _out121, out _out122);
+            _386_recursiveGen = _out119;
+            _387___v27 = _out120;
+            _388_isErased = _out121;
+            _389_recIdents = _out122;
+            if (_388_isErased) {
+              _386_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _386_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(s, _359_recursiveGen);
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _362_recIdents);
-            _358_i = (_358_i) + (BigInteger.One);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(s, _386_recursiveGen);
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _389_recIdents);
+            _385_i = (_385_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("))"));
           isOwned = true;
           isErased = true;
         }
-      } else if (_source16.is_NewArray) {
-        Dafny.ISequence<DAST._IExpression> _363___mcc_h11 = _source16.dtor_dims;
-        Dafny.ISequence<DAST._IExpression> _364_dims = _363___mcc_h11;
+      } else if (_source19.is_NewArray) {
+        Dafny.ISequence<DAST._IExpression> _390___mcc_h11 = _source19.dtor_dims;
+        Dafny.ISequence<DAST._IExpression> _391_dims = _390___mcc_h11;
         {
-          BigInteger _365_i;
-          _365_i = (new BigInteger((_364_dims).Count)) - (BigInteger.One);
+          BigInteger _392_i;
+          _392_i = (new BigInteger((_391_dims).Count)) - (BigInteger.One);
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::default::Default::default()");
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          while ((_365_i).Sign != -1) {
-            Dafny.ISequence<Dafny.Rune> _366_recursiveGen;
-            bool _367___v25;
-            bool _368_isErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _369_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out104;
-            bool _out105;
-            bool _out106;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out107;
-            DCOMP.COMP.GenExpr((_364_dims).Select(_365_i), @params, true, out _out104, out _out105, out _out106, out _out107);
-            _366_recursiveGen = _out104;
-            _367___v25 = _out105;
-            _368_isErased = _out106;
-            _369_recIdents = _out107;
-            if (!(_368_isErased)) {
-              _366_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _366_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          while ((_392_i).Sign != -1) {
+            Dafny.ISequence<Dafny.Rune> _393_recursiveGen;
+            bool _394___v28;
+            bool _395_isErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _396_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out123;
+            bool _out124;
+            bool _out125;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out126;
+            DCOMP.COMP.GenExpr((_391_dims).Select(_392_i), @params, true, out _out123, out _out124, out _out125, out _out126);
+            _393_recursiveGen = _out123;
+            _394___v28 = _out124;
+            _395_isErased = _out125;
+            _396_recIdents = _out126;
+            if (!(_395_isErased)) {
+              _393_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _393_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("vec!["), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("; (")), _366_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") as usize]"));
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _369_recIdents);
-            _365_i = (_365_i) - (BigInteger.One);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("vec!["), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("; (")), _393_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(") as usize]"));
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _396_recIdents);
+            _392_i = (_392_i) - (BigInteger.One);
           }
           isOwned = true;
           isErased = true;
         }
-      } else if (_source16.is_DatatypeValue) {
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _370___mcc_h12 = _source16.dtor_path;
-        Dafny.ISequence<Dafny.Rune> _371___mcc_h13 = _source16.dtor_variant;
-        bool _372___mcc_h14 = _source16.dtor_isCo;
-        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _373___mcc_h15 = _source16.dtor_contents;
-        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _374_values = _373___mcc_h15;
-        bool _375_isCo = _372___mcc_h14;
-        Dafny.ISequence<Dafny.Rune> _376_variant = _371___mcc_h13;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _377_path = _370___mcc_h12;
+      } else if (_source19.is_DatatypeValue) {
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _397___mcc_h12 = _source19.dtor_path;
+        Dafny.ISequence<Dafny.Rune> _398___mcc_h13 = _source19.dtor_variant;
+        bool _399___mcc_h14 = _source19.dtor_isCo;
+        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _400___mcc_h15 = _source19.dtor_contents;
+        Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _401_values = _400___mcc_h15;
+        bool _402_isCo = _399___mcc_h14;
+        Dafny.ISequence<Dafny.Rune> _403_variant = _398___mcc_h13;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _404_path = _397___mcc_h12;
         {
-          Dafny.ISequence<Dafny.Rune> _378_path;
-          Dafny.ISequence<Dafny.Rune> _out108;
-          _out108 = DCOMP.COMP.GenPath(_377_path);
-          _378_path = _out108;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _378_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _376_variant);
+          Dafny.ISequence<Dafny.Rune> _405_path;
+          Dafny.ISequence<Dafny.Rune> _out127;
+          _out127 = DCOMP.COMP.GenPath(_404_path);
+          _405_path = _out127;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::rc::Rc::new("), _405_path), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _403_variant);
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          BigInteger _379_i;
-          _379_i = BigInteger.Zero;
+          BigInteger _406_i;
+          _406_i = BigInteger.Zero;
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {"));
-          while ((_379_i) < (new BigInteger((_374_values).Count))) {
-            _System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression> _let_tmp_rhs0 = (_374_values).Select(_379_i);
-            Dafny.ISequence<Dafny.Rune> _380_name = _let_tmp_rhs0.dtor__0;
-            DAST._IExpression _381_value = _let_tmp_rhs0.dtor__1;
-            if ((_379_i).Sign == 1) {
+          while ((_406_i) < (new BigInteger((_401_values).Count))) {
+            _System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression> _let_tmp_rhs0 = (_401_values).Select(_406_i);
+            Dafny.ISequence<Dafny.Rune> _407_name = _let_tmp_rhs0.dtor__0;
+            DAST._IExpression _408_value = _let_tmp_rhs0.dtor__1;
+            if ((_406_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            if (_375_isCo) {
-              Dafny.ISequence<Dafny.Rune> _382_recursiveGen;
-              bool _383___v26;
-              bool _384_isErased;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _385_recIdents;
-              Dafny.ISequence<Dafny.Rune> _out109;
-              bool _out110;
-              bool _out111;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out112;
-              DCOMP.COMP.GenExpr(_381_value, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), true, out _out109, out _out110, out _out111, out _out112);
-              _382_recursiveGen = _out109;
-              _383___v26 = _out110;
-              _384_isErased = _out111;
-              _385_recIdents = _out112;
-              if (!(_384_isErased)) {
-                _382_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _382_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            if (_402_isCo) {
+              Dafny.ISequence<Dafny.Rune> _409_recursiveGen;
+              bool _410___v29;
+              bool _411_isErased;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _412_recIdents;
+              Dafny.ISequence<Dafny.Rune> _out128;
+              bool _out129;
+              bool _out130;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out131;
+              DCOMP.COMP.GenExpr(_408_value, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), true, out _out128, out _out129, out _out130, out _out131);
+              _409_recursiveGen = _out128;
+              _410___v29 = _out129;
+              _411_isErased = _out130;
+              _412_recIdents = _out131;
+              if (!(_411_isErased)) {
+                _409_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _409_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
               }
-              _382_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _382_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-              readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _385_recIdents);
-              Dafny.ISequence<Dafny.Rune> _386_allReadCloned;
-              _386_allReadCloned = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-              while (!(_385_recIdents).Equals(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements())) {
-                Dafny.ISequence<Dafny.Rune> _387_next;
-                foreach (Dafny.ISequence<Dafny.Rune> _assign_such_that_0 in (_385_recIdents).Elements) {
-                  _387_next = (Dafny.ISequence<Dafny.Rune>)_assign_such_that_0;
-                  if ((_385_recIdents).Contains(_387_next)) {
+              _409_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _409_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _412_recIdents);
+              Dafny.ISequence<Dafny.Rune> _413_allReadCloned;
+              _413_allReadCloned = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+              while (!(_412_recIdents).Equals(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements())) {
+                Dafny.ISequence<Dafny.Rune> _414_next;
+                foreach (Dafny.ISequence<Dafny.Rune> _assign_such_that_0 in (_412_recIdents).Elements) {
+                  _414_next = (Dafny.ISequence<Dafny.Rune>)_assign_such_that_0;
+                  if ((_412_recIdents).Contains(_414_next)) {
                     goto after__ASSIGN_SUCH_THAT_0;
                   }
                 }
-                throw new System.Exception("assign-such-that search produced no value (line 985)");
+                throw new System.Exception("assign-such-that search produced no value (line 1038)");
               after__ASSIGN_SUCH_THAT_0:;
-                _386_allReadCloned = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_386_allReadCloned, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let r#")), _387_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = r#")), _387_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone();\n"));
-                _385_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_385_recIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_387_next));
+                _413_allReadCloned = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_413_allReadCloned, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let r#")), _414_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = r#")), _414_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone();\n"));
+                _412_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_412_recIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_414_next));
               }
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _380_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::LazyFieldWrapper(::dafny_runtime::Lazy::new(::std::boxed::Box::new({\n")), _386_allReadCloned), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("move || (")), _382_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")})))"));
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _407_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ::dafny_runtime::LazyFieldWrapper(::dafny_runtime::Lazy::new(::std::boxed::Box::new({\n")), _413_allReadCloned), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("move || (")), _409_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")})))"));
             } else {
-              Dafny.ISequence<Dafny.Rune> _388_recursiveGen;
-              bool _389___v27;
-              bool _390_isErased;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _391_recIdents;
-              Dafny.ISequence<Dafny.Rune> _out113;
-              bool _out114;
-              bool _out115;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out116;
-              DCOMP.COMP.GenExpr(_381_value, @params, true, out _out113, out _out114, out _out115, out _out116);
-              _388_recursiveGen = _out113;
-              _389___v27 = _out114;
-              _390_isErased = _out115;
-              _391_recIdents = _out116;
-              if (!(_390_isErased)) {
-                _388_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _388_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              Dafny.ISequence<Dafny.Rune> _415_recursiveGen;
+              bool _416___v30;
+              bool _417_isErased;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _418_recIdents;
+              Dafny.ISequence<Dafny.Rune> _out132;
+              bool _out133;
+              bool _out134;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out135;
+              DCOMP.COMP.GenExpr(_408_value, @params, true, out _out132, out _out133, out _out134, out _out135);
+              _415_recursiveGen = _out132;
+              _416___v30 = _out133;
+              _417_isErased = _out134;
+              _418_recIdents = _out135;
+              if (!(_417_isErased)) {
+                _415_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _415_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
               }
-              _388_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _388_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _380_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _388_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-              readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _391_recIdents);
+              _415_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _415_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), _407_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _415_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+              readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _418_recIdents);
             }
-            _379_i = (_379_i) + (BigInteger.One);
+            _406_i = (_406_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" })"));
           isOwned = true;
           isErased = true;
         }
-      } else if (_source16.is_SubsetUpgrade) {
-        DAST._IExpression _392___mcc_h16 = _source16.dtor_value;
-        DAST._IType _393___mcc_h17 = _source16.dtor_typ;
-        DAST._IType _394_tpe = _393___mcc_h17;
-        DAST._IExpression _395_expr = _392___mcc_h16;
+      } else if (_source19.is_SubsetUpgrade) {
+        DAST._IExpression _419___mcc_h16 = _source19.dtor_value;
+        DAST._IType _420___mcc_h17 = _source19.dtor_typ;
+        DAST._IType _421_tpe = _420___mcc_h17;
+        DAST._IExpression _422_expr = _419___mcc_h16;
         {
-          Dafny.ISequence<Dafny.Rune> _396_tpeGen;
-          Dafny.ISequence<Dafny.Rune> _out117;
-          _out117 = DCOMP.COMP.GenType(_394_tpe, true, false);
-          _396_tpeGen = _out117;
-          Dafny.ISequence<Dafny.Rune> _397_recursiveGen;
-          bool _398_recOwned;
-          bool _399_recErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _400_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out118;
-          bool _out119;
-          bool _out120;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out121;
-          DCOMP.COMP.GenExpr(_395_expr, @params, false, out _out118, out _out119, out _out120, out _out121);
-          _397_recursiveGen = _out118;
-          _398_recOwned = _out119;
-          _399_recErased = _out120;
-          _400_recIdents = _out121;
-          Dafny.ISequence<Dafny.Rune> _401_uneraseFn;
-          _401_uneraseFn = ((_398_recOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase")));
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"), _396_tpeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" as ::dafny_runtime::DafnyUnerasable<_>>::")), _401_uneraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _397_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-          isOwned = _398_recOwned;
+          Dafny.ISequence<Dafny.Rune> _423_tpeGen;
+          Dafny.ISequence<Dafny.Rune> _out136;
+          _out136 = DCOMP.COMP.GenType(_421_tpe, true, false);
+          _423_tpeGen = _out136;
+          Dafny.ISequence<Dafny.Rune> _424_recursiveGen;
+          bool _425_recOwned;
+          bool _426_recErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _427_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out137;
+          bool _out138;
+          bool _out139;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out140;
+          DCOMP.COMP.GenExpr(_422_expr, @params, false, out _out137, out _out138, out _out139, out _out140);
+          _424_recursiveGen = _out137;
+          _425_recOwned = _out138;
+          _426_recErased = _out139;
+          _427_recIdents = _out140;
+          Dafny.ISequence<Dafny.Rune> _428_uneraseFn;
+          _428_uneraseFn = ((_425_recOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase")));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"), _423_tpeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" as ::dafny_runtime::DafnyUnerasable<_>>::")), _428_uneraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _424_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          isOwned = _425_recOwned;
           isErased = false;
-          readIdents = _400_recIdents;
+          readIdents = _427_recIdents;
         }
-      } else if (_source16.is_SubsetDowngrade) {
-        DAST._IExpression _402___mcc_h18 = _source16.dtor_value;
-        DAST._IExpression _403_expr = _402___mcc_h18;
+      } else if (_source19.is_SubsetDowngrade) {
+        DAST._IExpression _429___mcc_h18 = _source19.dtor_value;
+        DAST._IExpression _430_expr = _429___mcc_h18;
         {
-          Dafny.ISequence<Dafny.Rune> _404_recursiveGen;
-          bool _405_recOwned;
-          bool _406_recErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _407_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out122;
-          bool _out123;
-          bool _out124;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out125;
-          DCOMP.COMP.GenExpr(_403_expr, @params, false, out _out122, out _out123, out _out124, out _out125);
-          _404_recursiveGen = _out122;
-          _405_recOwned = _out123;
-          _406_recErased = _out124;
-          _407_recIdents = _out125;
-          Dafny.ISequence<Dafny.Rune> _408_eraseFn;
-          _408_eraseFn = ((_405_recOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase")));
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::"), _408_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _404_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
-          isOwned = _405_recOwned;
+          Dafny.ISequence<Dafny.Rune> _431_recursiveGen;
+          bool _432_recOwned;
+          bool _433_recErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _434_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out141;
+          bool _out142;
+          bool _out143;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out144;
+          DCOMP.COMP.GenExpr(_430_expr, @params, false, out _out141, out _out142, out _out143, out _out144);
+          _431_recursiveGen = _out141;
+          _432_recOwned = _out142;
+          _433_recErased = _out143;
+          _434_recIdents = _out144;
+          Dafny.ISequence<Dafny.Rune> _435_eraseFn;
+          _435_eraseFn = ((_432_recOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase")));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::"), _435_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _431_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          isOwned = _432_recOwned;
           isErased = true;
-          readIdents = _407_recIdents;
+          readIdents = _434_recIdents;
         }
-      } else if (_source16.is_SeqValue) {
-        Dafny.ISequence<DAST._IExpression> _409___mcc_h19 = _source16.dtor_elements;
-        Dafny.ISequence<DAST._IExpression> _410_exprs = _409___mcc_h19;
+      } else if (_source19.is_SeqValue) {
+        Dafny.ISequence<DAST._IExpression> _436___mcc_h19 = _source19.dtor_elements;
+        Dafny.ISequence<DAST._IExpression> _437_exprs = _436___mcc_h19;
         {
-          Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>> _411_generatedValues;
-          _411_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements();
+          Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>> _438_generatedValues;
+          _438_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements();
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          BigInteger _412_i;
-          _412_i = BigInteger.Zero;
-          bool _413_allErased;
-          _413_allErased = true;
-          while ((_412_i) < (new BigInteger((_410_exprs).Count))) {
-            Dafny.ISequence<Dafny.Rune> _414_recursiveGen;
-            bool _415___v28;
-            bool _416_isErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _417_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out126;
-            bool _out127;
-            bool _out128;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out129;
-            DCOMP.COMP.GenExpr((_410_exprs).Select(_412_i), @params, true, out _out126, out _out127, out _out128, out _out129);
-            _414_recursiveGen = _out126;
-            _415___v28 = _out127;
-            _416_isErased = _out128;
-            _417_recIdents = _out129;
-            _413_allErased = (_413_allErased) && (_416_isErased);
-            _411_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.Concat(_411_generatedValues, Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements(_System.Tuple2<Dafny.ISequence<Dafny.Rune>, bool>.create(_414_recursiveGen, _416_isErased)));
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _417_recIdents);
-            _412_i = (_412_i) + (BigInteger.One);
+          BigInteger _439_i;
+          _439_i = BigInteger.Zero;
+          bool _440_allErased;
+          _440_allErased = true;
+          while ((_439_i) < (new BigInteger((_437_exprs).Count))) {
+            Dafny.ISequence<Dafny.Rune> _441_recursiveGen;
+            bool _442___v31;
+            bool _443_isErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _444_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out145;
+            bool _out146;
+            bool _out147;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out148;
+            DCOMP.COMP.GenExpr((_437_exprs).Select(_439_i), @params, true, out _out145, out _out146, out _out147, out _out148);
+            _441_recursiveGen = _out145;
+            _442___v31 = _out146;
+            _443_isErased = _out147;
+            _444_recIdents = _out148;
+            _440_allErased = (_440_allErased) && (_443_isErased);
+            _438_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.Concat(_438_generatedValues, Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements(_System.Tuple2<Dafny.ISequence<Dafny.Rune>, bool>.create(_441_recursiveGen, _443_isErased)));
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _444_recIdents);
+            _439_i = (_439_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("vec![");
-          _412_i = BigInteger.Zero;
-          while ((_412_i) < (new BigInteger((_411_generatedValues).Count))) {
-            if ((_412_i).Sign == 1) {
+          _439_i = BigInteger.Zero;
+          while ((_439_i) < (new BigInteger((_438_generatedValues).Count))) {
+            if ((_439_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _418_gen;
-            _418_gen = ((_411_generatedValues).Select(_412_i)).dtor__0;
-            if ((((_411_generatedValues).Select(_412_i)).dtor__1) && (!(_413_allErased))) {
-              _418_gen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _418_gen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _445_gen;
+            _445_gen = ((_438_generatedValues).Select(_439_i)).dtor__0;
+            if ((((_438_generatedValues).Select(_439_i)).dtor__1) && (!(_440_allErased))) {
+              _445_gen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _445_gen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(s, _418_gen);
-            _412_i = (_412_i) + (BigInteger.One);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(s, _445_gen);
+            _439_i = (_439_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("]"));
           isOwned = true;
-          isErased = _413_allErased;
+          isErased = _440_allErased;
         }
-      } else if (_source16.is_SetValue) {
-        Dafny.ISequence<DAST._IExpression> _419___mcc_h20 = _source16.dtor_elements;
-        Dafny.ISequence<DAST._IExpression> _420_exprs = _419___mcc_h20;
+      } else if (_source19.is_SetValue) {
+        Dafny.ISequence<DAST._IExpression> _446___mcc_h20 = _source19.dtor_elements;
+        Dafny.ISequence<DAST._IExpression> _447_exprs = _446___mcc_h20;
         {
-          Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>> _421_generatedValues;
-          _421_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements();
+          Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>> _448_generatedValues;
+          _448_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements();
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          BigInteger _422_i;
-          _422_i = BigInteger.Zero;
-          bool _423_allErased;
-          _423_allErased = true;
-          while ((_422_i) < (new BigInteger((_420_exprs).Count))) {
-            Dafny.ISequence<Dafny.Rune> _424_recursiveGen;
-            bool _425___v29;
-            bool _426_isErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _427_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out130;
-            bool _out131;
-            bool _out132;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out133;
-            DCOMP.COMP.GenExpr((_420_exprs).Select(_422_i), @params, true, out _out130, out _out131, out _out132, out _out133);
-            _424_recursiveGen = _out130;
-            _425___v29 = _out131;
-            _426_isErased = _out132;
-            _427_recIdents = _out133;
-            _423_allErased = (_423_allErased) && (_426_isErased);
-            _421_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.Concat(_421_generatedValues, Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements(_System.Tuple2<Dafny.ISequence<Dafny.Rune>, bool>.create(_424_recursiveGen, _426_isErased)));
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _427_recIdents);
-            _422_i = (_422_i) + (BigInteger.One);
+          BigInteger _449_i;
+          _449_i = BigInteger.Zero;
+          bool _450_allErased;
+          _450_allErased = true;
+          while ((_449_i) < (new BigInteger((_447_exprs).Count))) {
+            Dafny.ISequence<Dafny.Rune> _451_recursiveGen;
+            bool _452___v32;
+            bool _453_isErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _454_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out149;
+            bool _out150;
+            bool _out151;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out152;
+            DCOMP.COMP.GenExpr((_447_exprs).Select(_449_i), @params, true, out _out149, out _out150, out _out151, out _out152);
+            _451_recursiveGen = _out149;
+            _452___v32 = _out150;
+            _453_isErased = _out151;
+            _454_recIdents = _out152;
+            _450_allErased = (_450_allErased) && (_453_isErased);
+            _448_generatedValues = Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.Concat(_448_generatedValues, Dafny.Sequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, bool>>.FromElements(_System.Tuple2<Dafny.ISequence<Dafny.Rune>, bool>.create(_451_recursiveGen, _453_isErased)));
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _454_recIdents);
+            _449_i = (_449_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("vec![");
-          _422_i = BigInteger.Zero;
-          while ((_422_i) < (new BigInteger((_421_generatedValues).Count))) {
-            if ((_422_i).Sign == 1) {
+          _449_i = BigInteger.Zero;
+          while ((_449_i) < (new BigInteger((_448_generatedValues).Count))) {
+            if ((_449_i).Sign == 1) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _428_gen;
-            _428_gen = ((_421_generatedValues).Select(_422_i)).dtor__0;
-            if ((((_421_generatedValues).Select(_422_i)).dtor__1) && (!(_423_allErased))) {
-              _428_gen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _428_gen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _455_gen;
+            _455_gen = ((_448_generatedValues).Select(_449_i)).dtor__0;
+            if ((((_448_generatedValues).Select(_449_i)).dtor__1) && (!(_450_allErased))) {
+              _455_gen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::unerase_owned("), _455_gen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(s, _428_gen);
-            _422_i = (_422_i) + (BigInteger.One);
+            s = Dafny.Sequence<Dafny.Rune>.Concat(s, _455_gen);
+            _449_i = (_449_i) + (BigInteger.One);
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("].into_iter().collect::<std::collections::HashSet<_>>()"));
           isOwned = true;
           isErased = true;
         }
-      } else if (_source16.is_This) {
+      } else if (_source19.is_This) {
         {
           if (mustOwn) {
             s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self.clone()");
@@ -5683,232 +5963,237 @@ namespace DCOMP {
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self"));
           isErased = false;
         }
-      } else if (_source16.is_Ite) {
-        DAST._IExpression _429___mcc_h21 = _source16.dtor_cond;
-        DAST._IExpression _430___mcc_h22 = _source16.dtor_thn;
-        DAST._IExpression _431___mcc_h23 = _source16.dtor_els;
-        DAST._IExpression _432_f = _431___mcc_h23;
-        DAST._IExpression _433_t = _430___mcc_h22;
-        DAST._IExpression _434_cond = _429___mcc_h21;
+      } else if (_source19.is_Ite) {
+        DAST._IExpression _456___mcc_h21 = _source19.dtor_cond;
+        DAST._IExpression _457___mcc_h22 = _source19.dtor_thn;
+        DAST._IExpression _458___mcc_h23 = _source19.dtor_els;
+        DAST._IExpression _459_f = _458___mcc_h23;
+        DAST._IExpression _460_t = _457___mcc_h22;
+        DAST._IExpression _461_cond = _456___mcc_h21;
         {
-          Dafny.ISequence<Dafny.Rune> _435_condString;
-          bool _436___v30;
-          bool _437_condErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _438_recIdentsCond;
-          Dafny.ISequence<Dafny.Rune> _out134;
-          bool _out135;
-          bool _out136;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out137;
-          DCOMP.COMP.GenExpr(_434_cond, @params, true, out _out134, out _out135, out _out136, out _out137);
-          _435_condString = _out134;
-          _436___v30 = _out135;
-          _437_condErased = _out136;
-          _438_recIdentsCond = _out137;
-          if (!(_437_condErased)) {
-            _435_condString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _435_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          Dafny.ISequence<Dafny.Rune> _462_condString;
+          bool _463___v33;
+          bool _464_condErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _465_recIdentsCond;
+          Dafny.ISequence<Dafny.Rune> _out153;
+          bool _out154;
+          bool _out155;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out156;
+          DCOMP.COMP.GenExpr(_461_cond, @params, true, out _out153, out _out154, out _out155, out _out156);
+          _462_condString = _out153;
+          _463___v33 = _out154;
+          _464_condErased = _out155;
+          _465_recIdentsCond = _out156;
+          if (!(_464_condErased)) {
+            _462_condString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _462_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
-          Dafny.ISequence<Dafny.Rune> _439___v31;
-          bool _440_tHasToBeOwned;
-          bool _441___v32;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _442___v33;
-          Dafny.ISequence<Dafny.Rune> _out138;
-          bool _out139;
-          bool _out140;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out141;
-          DCOMP.COMP.GenExpr(_433_t, @params, mustOwn, out _out138, out _out139, out _out140, out _out141);
-          _439___v31 = _out138;
-          _440_tHasToBeOwned = _out139;
-          _441___v32 = _out140;
-          _442___v33 = _out141;
-          Dafny.ISequence<Dafny.Rune> _443_fString;
-          bool _444_fOwned;
-          bool _445_fErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _446_recIdentsF;
-          Dafny.ISequence<Dafny.Rune> _out142;
-          bool _out143;
-          bool _out144;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out145;
-          DCOMP.COMP.GenExpr(_432_f, @params, _440_tHasToBeOwned, out _out142, out _out143, out _out144, out _out145);
-          _443_fString = _out142;
-          _444_fOwned = _out143;
-          _445_fErased = _out144;
-          _446_recIdentsF = _out145;
-          Dafny.ISequence<Dafny.Rune> _447_tString;
-          bool _448___v34;
-          bool _449_tErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _450_recIdentsT;
-          Dafny.ISequence<Dafny.Rune> _out146;
-          bool _out147;
-          bool _out148;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out149;
-          DCOMP.COMP.GenExpr(_433_t, @params, _444_fOwned, out _out146, out _out147, out _out148, out _out149);
-          _447_tString = _out146;
-          _448___v34 = _out147;
-          _449_tErased = _out148;
-          _450_recIdentsT = _out149;
-          if ((!(_445_fErased)) || (!(_449_tErased))) {
-            if (_445_fErased) {
-              _443_fString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _443_fString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          Dafny.ISequence<Dafny.Rune> _466___v34;
+          bool _467_tHasToBeOwned;
+          bool _468___v35;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _469___v36;
+          Dafny.ISequence<Dafny.Rune> _out157;
+          bool _out158;
+          bool _out159;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out160;
+          DCOMP.COMP.GenExpr(_460_t, @params, mustOwn, out _out157, out _out158, out _out159, out _out160);
+          _466___v34 = _out157;
+          _467_tHasToBeOwned = _out158;
+          _468___v35 = _out159;
+          _469___v36 = _out160;
+          Dafny.ISequence<Dafny.Rune> _470_fString;
+          bool _471_fOwned;
+          bool _472_fErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _473_recIdentsF;
+          Dafny.ISequence<Dafny.Rune> _out161;
+          bool _out162;
+          bool _out163;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out164;
+          DCOMP.COMP.GenExpr(_459_f, @params, _467_tHasToBeOwned, out _out161, out _out162, out _out163, out _out164);
+          _470_fString = _out161;
+          _471_fOwned = _out162;
+          _472_fErased = _out163;
+          _473_recIdentsF = _out164;
+          Dafny.ISequence<Dafny.Rune> _474_tString;
+          bool _475___v37;
+          bool _476_tErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _477_recIdentsT;
+          Dafny.ISequence<Dafny.Rune> _out165;
+          bool _out166;
+          bool _out167;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out168;
+          DCOMP.COMP.GenExpr(_460_t, @params, _471_fOwned, out _out165, out _out166, out _out167, out _out168);
+          _474_tString = _out165;
+          _475___v37 = _out166;
+          _476_tErased = _out167;
+          _477_recIdentsT = _out168;
+          if ((!(_472_fErased)) || (!(_476_tErased))) {
+            if (_472_fErased) {
+              _470_fString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _470_fString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            if (_449_tErased) {
-              _447_tString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _447_tString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            if (_476_tErased) {
+              _474_tString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _474_tString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(if "), _435_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _447_tString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _443_fString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n})"));
-          isOwned = _444_fOwned;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_438_recIdentsCond, _450_recIdentsT), _446_recIdentsF);
-          isErased = (_445_fErased) || (_449_tErased);
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(if "), _462_condString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _474_tString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n} else {\n")), _470_fString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n})"));
+          isOwned = _471_fOwned;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_465_recIdentsCond, _477_recIdentsT), _473_recIdentsF);
+          isErased = (_472_fErased) || (_476_tErased);
         }
-      } else if (_source16.is_UnOp) {
-        DAST._IUnaryOp _451___mcc_h24 = _source16.dtor_unOp;
-        DAST._IExpression _452___mcc_h25 = _source16.dtor_expr;
-        DAST._IUnaryOp _source18 = _451___mcc_h24;
-        if (_source18.is_Not) {
-          DAST._IExpression _453_e = _452___mcc_h25;
+      } else if (_source19.is_UnOp) {
+        DAST._IUnaryOp _478___mcc_h24 = _source19.dtor_unOp;
+        DAST._IExpression _479___mcc_h25 = _source19.dtor_expr;
+        DAST._IUnaryOp _source21 = _478___mcc_h24;
+        if (_source21.is_Not) {
+          DAST._IExpression _480_e = _479___mcc_h25;
           {
-            Dafny.ISequence<Dafny.Rune> _454_recursiveGen;
-            bool _455___v35;
-            bool _456_recErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _457_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out150;
-            bool _out151;
-            bool _out152;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out153;
-            DCOMP.COMP.GenExpr(_453_e, @params, true, out _out150, out _out151, out _out152, out _out153);
-            _454_recursiveGen = _out150;
-            _455___v35 = _out151;
-            _456_recErased = _out152;
-            _457_recIdents = _out153;
-            if (!(_456_recErased)) {
-              _454_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _454_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _481_recursiveGen;
+            bool _482___v38;
+            bool _483_recErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _484_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out169;
+            bool _out170;
+            bool _out171;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out172;
+            DCOMP.COMP.GenExpr(_480_e, @params, true, out _out169, out _out170, out _out171, out _out172);
+            _481_recursiveGen = _out169;
+            _482___v38 = _out170;
+            _483_recErased = _out171;
+            _484_recIdents = _out172;
+            if (!(_483_recErased)) {
+              _481_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _481_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("!("), _454_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("!("), _481_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             isOwned = true;
-            readIdents = _457_recIdents;
+            readIdents = _484_recIdents;
             isErased = true;
           }
-        } else if (_source18.is_BitwiseNot) {
-          DAST._IExpression _458_e = _452___mcc_h25;
+        } else if (_source21.is_BitwiseNot) {
+          DAST._IExpression _485_e = _479___mcc_h25;
           {
-            Dafny.ISequence<Dafny.Rune> _459_recursiveGen;
-            bool _460___v36;
-            bool _461_recErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _462_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out154;
-            bool _out155;
-            bool _out156;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out157;
-            DCOMP.COMP.GenExpr(_458_e, @params, true, out _out154, out _out155, out _out156, out _out157);
-            _459_recursiveGen = _out154;
-            _460___v36 = _out155;
-            _461_recErased = _out156;
-            _462_recIdents = _out157;
-            if (!(_461_recErased)) {
-              _459_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _459_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _486_recursiveGen;
+            bool _487___v39;
+            bool _488_recErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _489_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out173;
+            bool _out174;
+            bool _out175;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out176;
+            DCOMP.COMP.GenExpr(_485_e, @params, true, out _out173, out _out174, out _out175, out _out176);
+            _486_recursiveGen = _out173;
+            _487___v39 = _out174;
+            _488_recErased = _out175;
+            _489_recIdents = _out176;
+            if (!(_488_recErased)) {
+              _486_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _486_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("~("), _459_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("~("), _486_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             isOwned = true;
-            readIdents = _462_recIdents;
+            readIdents = _489_recIdents;
             isErased = true;
           }
         } else {
-          DAST._IExpression _463_e = _452___mcc_h25;
+          DAST._IExpression _490_e = _479___mcc_h25;
           {
-            Dafny.ISequence<Dafny.Rune> _464_recursiveGen;
-            bool _465___v37;
-            bool _466_recErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _467_recIdents;
-            Dafny.ISequence<Dafny.Rune> _out158;
-            bool _out159;
-            bool _out160;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out161;
-            DCOMP.COMP.GenExpr(_463_e, @params, false, out _out158, out _out159, out _out160, out _out161);
-            _464_recursiveGen = _out158;
-            _465___v37 = _out159;
-            _466_recErased = _out160;
-            _467_recIdents = _out161;
-            if (!(_466_recErased)) {
-              _464_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _464_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+            Dafny.ISequence<Dafny.Rune> _491_recursiveGen;
+            bool _492___v40;
+            bool _493_recErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _494_recIdents;
+            Dafny.ISequence<Dafny.Rune> _out177;
+            bool _out178;
+            bool _out179;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out180;
+            DCOMP.COMP.GenExpr(_490_e, @params, false, out _out177, out _out178, out _out179, out _out180);
+            _491_recursiveGen = _out177;
+            _492___v40 = _out178;
+            _493_recErased = _out179;
+            _494_recIdents = _out180;
+            if (!(_493_recErased)) {
+              _491_recursiveGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _491_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _464_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").len()"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _491_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").len()"));
             isOwned = true;
-            readIdents = _467_recIdents;
+            readIdents = _494_recIdents;
             isErased = true;
           }
         }
-      } else if (_source16.is_BinOp) {
-        Dafny.ISequence<Dafny.Rune> _468___mcc_h26 = _source16.dtor_op;
-        DAST._IExpression _469___mcc_h27 = _source16.dtor_left;
-        DAST._IExpression _470___mcc_h28 = _source16.dtor_right;
-        DAST._IExpression _471_r = _470___mcc_h28;
-        DAST._IExpression _472_l = _469___mcc_h27;
-        Dafny.ISequence<Dafny.Rune> _473_op = _468___mcc_h26;
+      } else if (_source19.is_BinOp) {
+        Dafny.ISequence<Dafny.Rune> _495___mcc_h26 = _source19.dtor_op;
+        DAST._IExpression _496___mcc_h27 = _source19.dtor_left;
+        DAST._IExpression _497___mcc_h28 = _source19.dtor_right;
+        DAST._IExpression _498_r = _497___mcc_h28;
+        DAST._IExpression _499_l = _496___mcc_h27;
+        Dafny.ISequence<Dafny.Rune> _500_op = _495___mcc_h26;
         {
-          Dafny.ISequence<Dafny.Rune> _474_left;
-          bool _475___v38;
-          bool _476_leftErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _477_recIdentsL;
-          Dafny.ISequence<Dafny.Rune> _out162;
-          bool _out163;
-          bool _out164;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out165;
-          DCOMP.COMP.GenExpr(_472_l, @params, true, out _out162, out _out163, out _out164, out _out165);
-          _474_left = _out162;
-          _475___v38 = _out163;
-          _476_leftErased = _out164;
-          _477_recIdentsL = _out165;
-          Dafny.ISequence<Dafny.Rune> _478_right;
-          bool _479___v39;
-          bool _480_rightErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _481_recIdentsR;
-          Dafny.ISequence<Dafny.Rune> _out166;
-          bool _out167;
-          bool _out168;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out169;
-          DCOMP.COMP.GenExpr(_471_r, @params, true, out _out166, out _out167, out _out168, out _out169);
-          _478_right = _out166;
-          _479___v39 = _out167;
-          _480_rightErased = _out168;
-          _481_recIdentsR = _out169;
-          if (!(_476_leftErased)) {
-            _474_left = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _474_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          Dafny.ISequence<Dafny.Rune> _501_left;
+          bool _502___v41;
+          bool _503_leftErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _504_recIdentsL;
+          Dafny.ISequence<Dafny.Rune> _out181;
+          bool _out182;
+          bool _out183;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out184;
+          DCOMP.COMP.GenExpr(_499_l, @params, true, out _out181, out _out182, out _out183, out _out184);
+          _501_left = _out181;
+          _502___v41 = _out182;
+          _503_leftErased = _out183;
+          _504_recIdentsL = _out184;
+          Dafny.ISequence<Dafny.Rune> _505_right;
+          bool _506___v42;
+          bool _507_rightErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _508_recIdentsR;
+          Dafny.ISequence<Dafny.Rune> _out185;
+          bool _out186;
+          bool _out187;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out188;
+          DCOMP.COMP.GenExpr(_498_r, @params, true, out _out185, out _out186, out _out187, out _out188);
+          _505_right = _out185;
+          _506___v42 = _out186;
+          _507_rightErased = _out187;
+          _508_recIdentsR = _out188;
+          if (!(_503_leftErased)) {
+            _501_left = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _501_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
-          if (!(_480_rightErased)) {
-            _478_right = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _478_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          if (!(_507_rightErased)) {
+            _505_right = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::erase_owned("), _505_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _474_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _473_op), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _478_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _501_left), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _500_op), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" ")), _505_right), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_477_recIdentsL, _481_recIdentsR);
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_504_recIdentsL, _508_recIdentsR);
           isErased = true;
         }
-      } else if (_source16.is_Select) {
-        DAST._IExpression _482___mcc_h29 = _source16.dtor_expr;
-        Dafny.ISequence<Dafny.Rune> _483___mcc_h30 = _source16.dtor_field;
-        bool _484___mcc_h31 = _source16.dtor_onDatatype;
-        bool _485_isDatatype = _484___mcc_h31;
-        Dafny.ISequence<Dafny.Rune> _486_field = _483___mcc_h30;
-        DAST._IExpression _487_on = _482___mcc_h29;
+      } else if (_source19.is_Select) {
+        DAST._IExpression _509___mcc_h29 = _source19.dtor_expr;
+        Dafny.ISequence<Dafny.Rune> _510___mcc_h30 = _source19.dtor_field;
+        bool _511___mcc_h31 = _source19.dtor_isConstant;
+        bool _512___mcc_h32 = _source19.dtor_onDatatype;
+        bool _513_isDatatype = _512___mcc_h32;
+        bool _514_isConstant = _511___mcc_h31;
+        Dafny.ISequence<Dafny.Rune> _515_field = _510___mcc_h30;
+        DAST._IExpression _516_on = _509___mcc_h29;
         {
-          Dafny.ISequence<Dafny.Rune> _488_onString;
-          bool _489_onOwned;
-          bool _490_onErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _491_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out170;
-          bool _out171;
-          bool _out172;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out173;
-          DCOMP.COMP.GenExpr(_487_on, @params, false, out _out170, out _out171, out _out172, out _out173);
-          _488_onString = _out170;
-          _489_onOwned = _out171;
-          _490_onErased = _out172;
-          _491_recIdents = _out173;
-          if (!(_490_onErased)) {
-            Dafny.ISequence<Dafny.Rune> _492_eraseFn;
-            _492_eraseFn = ((_489_onOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase")));
-            _488_onString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::"), _492_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _488_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          Dafny.ISequence<Dafny.Rune> _517_onString;
+          bool _518_onOwned;
+          bool _519_onErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _520_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out189;
+          bool _out190;
+          bool _out191;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out192;
+          DCOMP.COMP.GenExpr(_516_on, @params, false, out _out189, out _out190, out _out191, out _out192);
+          _517_onString = _out189;
+          _518_onOwned = _out190;
+          _519_onErased = _out191;
+          _520_recIdents = _out192;
+          if (!(_519_onErased)) {
+            Dafny.ISequence<Dafny.Rune> _521_eraseFn;
+            _521_eraseFn = ((_518_onOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("erase")));
+            _517_onString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyErasable::"), _521_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _517_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
-          if (_485_isDatatype) {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _488_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _486_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("()"));
+          if ((_513_isDatatype) || (_514_isConstant)) {
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _517_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _515_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("()"));
+            if (_514_isConstant) {
+              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), s);
+            }
             if (mustOwn) {
               s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
               isOwned = true;
@@ -5916,88 +6201,84 @@ namespace DCOMP {
               isOwned = false;
             }
           } else {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _488_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _486_field);
-            if (mustOwn) {
-              s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
-              isOwned = true;
-            } else {
-              isOwned = false;
-            }
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::ops::Deref::deref(&(("), _517_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".r#")), _515_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".borrow()))"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()"));
+            isOwned = true;
           }
           isErased = false;
-          readIdents = _491_recIdents;
+          readIdents = _520_recIdents;
         }
-      } else if (_source16.is_SelectFn) {
-        DAST._IExpression _493___mcc_h32 = _source16.dtor_expr;
-        Dafny.ISequence<Dafny.Rune> _494___mcc_h33 = _source16.dtor_field;
-        bool _495___mcc_h34 = _source16.dtor_onDatatype;
-        bool _496___mcc_h35 = _source16.dtor_isStatic;
-        BigInteger _497___mcc_h36 = _source16.dtor_arity;
-        BigInteger _498_arity = _497___mcc_h36;
-        bool _499_isStatic = _496___mcc_h35;
-        bool _500_isDatatype = _495___mcc_h34;
-        Dafny.ISequence<Dafny.Rune> _501_field = _494___mcc_h33;
-        DAST._IExpression _502_on = _493___mcc_h32;
+      } else if (_source19.is_SelectFn) {
+        DAST._IExpression _522___mcc_h33 = _source19.dtor_expr;
+        Dafny.ISequence<Dafny.Rune> _523___mcc_h34 = _source19.dtor_field;
+        bool _524___mcc_h35 = _source19.dtor_onDatatype;
+        bool _525___mcc_h36 = _source19.dtor_isStatic;
+        BigInteger _526___mcc_h37 = _source19.dtor_arity;
+        BigInteger _527_arity = _526___mcc_h37;
+        bool _528_isStatic = _525___mcc_h36;
+        bool _529_isDatatype = _524___mcc_h35;
+        Dafny.ISequence<Dafny.Rune> _530_field = _523___mcc_h34;
+        DAST._IExpression _531_on = _522___mcc_h33;
         {
-          Dafny.ISequence<Dafny.Rune> _503_onString;
-          bool _504_onOwned;
-          bool _505___v40;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _506_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out174;
-          bool _out175;
-          bool _out176;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out177;
-          DCOMP.COMP.GenExpr(_502_on, @params, false, out _out174, out _out175, out _out176, out _out177);
-          _503_onString = _out174;
-          _504_onOwned = _out175;
-          _505___v40 = _out176;
-          _506_recIdents = _out177;
-          if (_499_isStatic) {
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_503_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), _501_field);
+          Dafny.ISequence<Dafny.Rune> _532_onString;
+          bool _533_onOwned;
+          bool _534___v43;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _535_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out193;
+          bool _out194;
+          bool _out195;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out196;
+          DCOMP.COMP.GenExpr(_531_on, @params, false, out _out193, out _out194, out _out195, out _out196);
+          _532_onString = _out193;
+          _533_onOwned = _out194;
+          _534___v43 = _out195;
+          _535_recIdents = _out196;
+          if (_528_isStatic) {
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_532_onString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::")), _530_field);
           } else {
             s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{\n");
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let callTarget = (")), _503_onString), ((_504_onOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()")))), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n"));
-            Dafny.ISequence<Dafny.Rune> _507_args;
-            _507_args = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-            BigInteger _508_i;
-            _508_i = BigInteger.Zero;
-            while ((_508_i) < (_498_arity)) {
-              if ((_508_i).Sign == 1) {
-                _507_args = Dafny.Sequence<Dafny.Rune>.Concat(_507_args, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let callTarget = (")), _532_onString), ((_533_onOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").clone()")))), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n"));
+            Dafny.ISequence<Dafny.Rune> _536_args;
+            _536_args = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+            BigInteger _537_i;
+            _537_i = BigInteger.Zero;
+            while ((_537_i) < (_527_arity)) {
+              if ((_537_i).Sign == 1) {
+                _536_args = Dafny.Sequence<Dafny.Rune>.Concat(_536_args, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
               }
-              _507_args = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_507_args, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("arg")), DCOMP.__default.natToString(_508_i));
-              _508_i = (_508_i) + (BigInteger.One);
+              _536_args = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_536_args, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("arg")), DCOMP.__default.natToString(_537_i));
+              _537_i = (_537_i) + (BigInteger.One);
             }
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("move |")), _507_args), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("| {\n"));
-            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("callTarget.")), _501_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _507_args), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")\n"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("move |")), _536_args), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("| {\n"));
+            s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("callTarget.")), _530_field), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _536_args), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")\n"));
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}\n"));
             s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("}"));
           }
           s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::FunctionWrapper("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
           isErased = true;
-          readIdents = _506_recIdents;
+          readIdents = _535_recIdents;
         }
-      } else if (_source16.is_TupleSelect) {
-        DAST._IExpression _509___mcc_h37 = _source16.dtor_expr;
-        BigInteger _510___mcc_h38 = _source16.dtor_index;
-        BigInteger _511_idx = _510___mcc_h38;
-        DAST._IExpression _512_on = _509___mcc_h37;
+      } else if (_source19.is_TupleSelect) {
+        DAST._IExpression _538___mcc_h38 = _source19.dtor_expr;
+        BigInteger _539___mcc_h39 = _source19.dtor_index;
+        BigInteger _540_idx = _539___mcc_h39;
+        DAST._IExpression _541_on = _538___mcc_h38;
         {
-          Dafny.ISequence<Dafny.Rune> _513_onString;
-          bool _514___v41;
-          bool _515_tupErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _516_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out178;
-          bool _out179;
-          bool _out180;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out181;
-          DCOMP.COMP.GenExpr(_512_on, @params, false, out _out178, out _out179, out _out180, out _out181);
-          _513_onString = _out178;
-          _514___v41 = _out179;
-          _515_tupErased = _out180;
-          _516_recIdents = _out181;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _513_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").")), DCOMP.__default.natToString(_511_idx));
+          Dafny.ISequence<Dafny.Rune> _542_onString;
+          bool _543___v44;
+          bool _544_tupErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _545_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out197;
+          bool _out198;
+          bool _out199;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out200;
+          DCOMP.COMP.GenExpr(_541_on, @params, false, out _out197, out _out198, out _out199, out _out200);
+          _542_onString = _out197;
+          _543___v44 = _out198;
+          _544_tupErased = _out199;
+          _545_recIdents = _out200;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _542_onString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").")), DCOMP.__default.natToString(_540_idx));
           if (mustOwn) {
             s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), s), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone()"));
             isOwned = true;
@@ -6005,442 +6286,443 @@ namespace DCOMP {
             s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), s);
             isOwned = false;
           }
-          isErased = _515_tupErased;
-          readIdents = _516_recIdents;
+          isErased = _544_tupErased;
+          readIdents = _545_recIdents;
         }
-      } else if (_source16.is_Call) {
-        DAST._IExpression _517___mcc_h39 = _source16.dtor_on;
-        Dafny.ISequence<Dafny.Rune> _518___mcc_h40 = _source16.dtor_name;
-        Dafny.ISequence<DAST._IType> _519___mcc_h41 = _source16.dtor_typeArgs;
-        Dafny.ISequence<DAST._IExpression> _520___mcc_h42 = _source16.dtor_args;
-        Dafny.ISequence<DAST._IExpression> _521_args = _520___mcc_h42;
-        Dafny.ISequence<DAST._IType> _522_typeArgs = _519___mcc_h41;
-        Dafny.ISequence<Dafny.Rune> _523_name = _518___mcc_h40;
-        DAST._IExpression _524_on = _517___mcc_h39;
+      } else if (_source19.is_Call) {
+        DAST._IExpression _546___mcc_h40 = _source19.dtor_on;
+        Dafny.ISequence<Dafny.Rune> _547___mcc_h41 = _source19.dtor_name;
+        Dafny.ISequence<DAST._IType> _548___mcc_h42 = _source19.dtor_typeArgs;
+        Dafny.ISequence<DAST._IExpression> _549___mcc_h43 = _source19.dtor_args;
+        Dafny.ISequence<DAST._IExpression> _550_args = _549___mcc_h43;
+        Dafny.ISequence<DAST._IType> _551_typeArgs = _548___mcc_h42;
+        Dafny.ISequence<Dafny.Rune> _552_name = _547___mcc_h41;
+        DAST._IExpression _553_on = _546___mcc_h40;
         {
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          Dafny.ISequence<Dafny.Rune> _525_typeArgString;
-          _525_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          if ((new BigInteger((_522_typeArgs).Count)) >= (BigInteger.One)) {
-            BigInteger _526_typeI;
-            _526_typeI = BigInteger.Zero;
-            _525_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
-            while ((_526_typeI) < (new BigInteger((_522_typeArgs).Count))) {
-              if ((_526_typeI).Sign == 1) {
-                _525_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_525_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _554_typeArgString;
+          _554_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          if ((new BigInteger((_551_typeArgs).Count)) >= (BigInteger.One)) {
+            BigInteger _555_typeI;
+            _555_typeI = BigInteger.Zero;
+            _554_typeArgString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::<");
+            while ((_555_typeI) < (new BigInteger((_551_typeArgs).Count))) {
+              if ((_555_typeI).Sign == 1) {
+                _554_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_554_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
               }
-              Dafny.ISequence<Dafny.Rune> _527_typeString;
-              Dafny.ISequence<Dafny.Rune> _out182;
-              _out182 = DCOMP.COMP.GenType((_522_typeArgs).Select(_526_typeI), false, false);
-              _527_typeString = _out182;
-              _525_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_525_typeArgString, _527_typeString);
-              _526_typeI = (_526_typeI) + (BigInteger.One);
+              Dafny.ISequence<Dafny.Rune> _556_typeString;
+              Dafny.ISequence<Dafny.Rune> _out201;
+              _out201 = DCOMP.COMP.GenType((_551_typeArgs).Select(_555_typeI), false, false);
+              _556_typeString = _out201;
+              _554_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_554_typeArgString, _556_typeString);
+              _555_typeI = (_555_typeI) + (BigInteger.One);
             }
-            _525_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_525_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
+            _554_typeArgString = Dafny.Sequence<Dafny.Rune>.Concat(_554_typeArgString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(">"));
           }
-          Dafny.ISequence<Dafny.Rune> _528_argString;
-          _528_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _529_i;
-          _529_i = BigInteger.Zero;
-          while ((_529_i) < (new BigInteger((_521_args).Count))) {
-            if ((_529_i).Sign == 1) {
-              _528_argString = Dafny.Sequence<Dafny.Rune>.Concat(_528_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _557_argString;
+          _557_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _558_i;
+          _558_i = BigInteger.Zero;
+          while ((_558_i) < (new BigInteger((_550_args).Count))) {
+            if ((_558_i).Sign == 1) {
+              _557_argString = Dafny.Sequence<Dafny.Rune>.Concat(_557_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _530_argExpr;
-            bool _531_isOwned;
-            bool _532_argErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _533_argIdents;
-            Dafny.ISequence<Dafny.Rune> _out183;
-            bool _out184;
-            bool _out185;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out186;
-            DCOMP.COMP.GenExpr((_521_args).Select(_529_i), @params, false, out _out183, out _out184, out _out185, out _out186);
-            _530_argExpr = _out183;
-            _531_isOwned = _out184;
-            _532_argErased = _out185;
-            _533_argIdents = _out186;
-            if (_531_isOwned) {
-              _530_argExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), _530_argExpr);
+            Dafny.ISequence<Dafny.Rune> _559_argExpr;
+            bool _560_isOwned;
+            bool _561_argErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _562_argIdents;
+            Dafny.ISequence<Dafny.Rune> _out202;
+            bool _out203;
+            bool _out204;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out205;
+            DCOMP.COMP.GenExpr((_550_args).Select(_558_i), @params, false, out _out202, out _out203, out _out204, out _out205);
+            _559_argExpr = _out202;
+            _560_isOwned = _out203;
+            _561_argErased = _out204;
+            _562_argIdents = _out205;
+            if (_560_isOwned) {
+              _559_argExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), _559_argExpr);
             }
-            _528_argString = Dafny.Sequence<Dafny.Rune>.Concat(_528_argString, _530_argExpr);
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _533_argIdents);
-            _529_i = (_529_i) + (BigInteger.One);
+            _557_argString = Dafny.Sequence<Dafny.Rune>.Concat(_557_argString, _559_argExpr);
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _562_argIdents);
+            _558_i = (_558_i) + (BigInteger.One);
           }
-          Dafny.ISequence<Dafny.Rune> _534_enclosingString;
-          bool _535___v42;
-          bool _536___v43;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _537_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out187;
-          bool _out188;
-          bool _out189;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out190;
-          DCOMP.COMP.GenExpr(_524_on, @params, false, out _out187, out _out188, out _out189, out _out190);
-          _534_enclosingString = _out187;
-          _535___v42 = _out188;
-          _536___v43 = _out189;
-          _537_recIdents = _out190;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _537_recIdents);
-          DAST._IExpression _source19 = _524_on;
-          if (_source19.is_Literal) {
-            DAST._ILiteral _538___mcc_h56 = _source19.dtor_Literal_a0;
+          Dafny.ISequence<Dafny.Rune> _563_enclosingString;
+          bool _564___v45;
+          bool _565___v46;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _566_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out206;
+          bool _out207;
+          bool _out208;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out209;
+          DCOMP.COMP.GenExpr(_553_on, @params, false, out _out206, out _out207, out _out208, out _out209);
+          _563_enclosingString = _out206;
+          _564___v45 = _out207;
+          _565___v46 = _out208;
+          _566_recIdents = _out209;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _566_recIdents);
+          DAST._IExpression _source22 = _553_on;
+          if (_source22.is_Literal) {
+            DAST._ILiteral _567___mcc_h57 = _source22.dtor_Literal_a0;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Ident) {
-            Dafny.ISequence<Dafny.Rune> _539___mcc_h58 = _source19.dtor_Ident_a0;
+          } else if (_source22.is_Ident) {
+            Dafny.ISequence<Dafny.Rune> _568___mcc_h59 = _source22.dtor_Ident_a0;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Companion) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _540___mcc_h60 = _source19.dtor_Companion_a0;
+          } else if (_source22.is_Companion) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _569___mcc_h61 = _source22.dtor_Companion_a0;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_534_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(_563_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
             }
-          } else if (_source19.is_Tuple) {
-            Dafny.ISequence<DAST._IExpression> _541___mcc_h62 = _source19.dtor_Tuple_a0;
+          } else if (_source22.is_Tuple) {
+            Dafny.ISequence<DAST._IExpression> _570___mcc_h63 = _source22.dtor_Tuple_a0;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_New) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _542___mcc_h64 = _source19.dtor_path;
-            Dafny.ISequence<DAST._IExpression> _543___mcc_h65 = _source19.dtor_args;
+          } else if (_source22.is_New) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _571___mcc_h65 = _source22.dtor_path;
+            Dafny.ISequence<DAST._IExpression> _572___mcc_h66 = _source22.dtor_args;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_NewArray) {
-            Dafny.ISequence<DAST._IExpression> _544___mcc_h68 = _source19.dtor_dims;
+          } else if (_source22.is_NewArray) {
+            Dafny.ISequence<DAST._IExpression> _573___mcc_h69 = _source22.dtor_dims;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_DatatypeValue) {
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _545___mcc_h70 = _source19.dtor_path;
-            Dafny.ISequence<Dafny.Rune> _546___mcc_h71 = _source19.dtor_variant;
-            bool _547___mcc_h72 = _source19.dtor_isCo;
-            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _548___mcc_h73 = _source19.dtor_contents;
+          } else if (_source22.is_DatatypeValue) {
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _574___mcc_h71 = _source22.dtor_path;
+            Dafny.ISequence<Dafny.Rune> _575___mcc_h72 = _source22.dtor_variant;
+            bool _576___mcc_h73 = _source22.dtor_isCo;
+            Dafny.ISequence<_System._ITuple2<Dafny.ISequence<Dafny.Rune>, DAST._IExpression>> _577___mcc_h74 = _source22.dtor_contents;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_SubsetUpgrade) {
-            DAST._IExpression _549___mcc_h78 = _source19.dtor_value;
-            DAST._IType _550___mcc_h79 = _source19.dtor_typ;
+          } else if (_source22.is_SubsetUpgrade) {
+            DAST._IExpression _578___mcc_h79 = _source22.dtor_value;
+            DAST._IType _579___mcc_h80 = _source22.dtor_typ;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_SubsetDowngrade) {
-            DAST._IExpression _551___mcc_h82 = _source19.dtor_value;
+          } else if (_source22.is_SubsetDowngrade) {
+            DAST._IExpression _580___mcc_h83 = _source22.dtor_value;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_SeqValue) {
-            Dafny.ISequence<DAST._IExpression> _552___mcc_h84 = _source19.dtor_elements;
+          } else if (_source22.is_SeqValue) {
+            Dafny.ISequence<DAST._IExpression> _581___mcc_h85 = _source22.dtor_elements;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_SetValue) {
-            Dafny.ISequence<DAST._IExpression> _553___mcc_h86 = _source19.dtor_elements;
+          } else if (_source22.is_SetValue) {
+            Dafny.ISequence<DAST._IExpression> _582___mcc_h87 = _source22.dtor_elements;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_This) {
+          } else if (_source22.is_This) {
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Ite) {
-            DAST._IExpression _554___mcc_h88 = _source19.dtor_cond;
-            DAST._IExpression _555___mcc_h89 = _source19.dtor_thn;
-            DAST._IExpression _556___mcc_h90 = _source19.dtor_els;
+          } else if (_source22.is_Ite) {
+            DAST._IExpression _583___mcc_h89 = _source22.dtor_cond;
+            DAST._IExpression _584___mcc_h90 = _source22.dtor_thn;
+            DAST._IExpression _585___mcc_h91 = _source22.dtor_els;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_UnOp) {
-            DAST._IUnaryOp _557___mcc_h94 = _source19.dtor_unOp;
-            DAST._IExpression _558___mcc_h95 = _source19.dtor_expr;
+          } else if (_source22.is_UnOp) {
+            DAST._IUnaryOp _586___mcc_h95 = _source22.dtor_unOp;
+            DAST._IExpression _587___mcc_h96 = _source22.dtor_expr;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_BinOp) {
-            Dafny.ISequence<Dafny.Rune> _559___mcc_h98 = _source19.dtor_op;
-            DAST._IExpression _560___mcc_h99 = _source19.dtor_left;
-            DAST._IExpression _561___mcc_h100 = _source19.dtor_right;
+          } else if (_source22.is_BinOp) {
+            Dafny.ISequence<Dafny.Rune> _588___mcc_h99 = _source22.dtor_op;
+            DAST._IExpression _589___mcc_h100 = _source22.dtor_left;
+            DAST._IExpression _590___mcc_h101 = _source22.dtor_right;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Select) {
-            DAST._IExpression _562___mcc_h104 = _source19.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _563___mcc_h105 = _source19.dtor_field;
-            bool _564___mcc_h106 = _source19.dtor_onDatatype;
+          } else if (_source22.is_Select) {
+            DAST._IExpression _591___mcc_h105 = _source22.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _592___mcc_h106 = _source22.dtor_field;
+            bool _593___mcc_h107 = _source22.dtor_isConstant;
+            bool _594___mcc_h108 = _source22.dtor_onDatatype;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_SelectFn) {
-            DAST._IExpression _565___mcc_h110 = _source19.dtor_expr;
-            Dafny.ISequence<Dafny.Rune> _566___mcc_h111 = _source19.dtor_field;
-            bool _567___mcc_h112 = _source19.dtor_onDatatype;
-            bool _568___mcc_h113 = _source19.dtor_isStatic;
-            BigInteger _569___mcc_h114 = _source19.dtor_arity;
+          } else if (_source22.is_SelectFn) {
+            DAST._IExpression _595___mcc_h113 = _source22.dtor_expr;
+            Dafny.ISequence<Dafny.Rune> _596___mcc_h114 = _source22.dtor_field;
+            bool _597___mcc_h115 = _source22.dtor_onDatatype;
+            bool _598___mcc_h116 = _source22.dtor_isStatic;
+            BigInteger _599___mcc_h117 = _source22.dtor_arity;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_TupleSelect) {
-            DAST._IExpression _570___mcc_h120 = _source19.dtor_expr;
-            BigInteger _571___mcc_h121 = _source19.dtor_index;
+          } else if (_source22.is_TupleSelect) {
+            DAST._IExpression _600___mcc_h123 = _source22.dtor_expr;
+            BigInteger _601___mcc_h124 = _source22.dtor_index;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Call) {
-            DAST._IExpression _572___mcc_h124 = _source19.dtor_on;
-            Dafny.ISequence<Dafny.Rune> _573___mcc_h125 = _source19.dtor_name;
-            Dafny.ISequence<DAST._IType> _574___mcc_h126 = _source19.dtor_typeArgs;
-            Dafny.ISequence<DAST._IExpression> _575___mcc_h127 = _source19.dtor_args;
+          } else if (_source22.is_Call) {
+            DAST._IExpression _602___mcc_h127 = _source22.dtor_on;
+            Dafny.ISequence<Dafny.Rune> _603___mcc_h128 = _source22.dtor_name;
+            Dafny.ISequence<DAST._IType> _604___mcc_h129 = _source22.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _605___mcc_h130 = _source22.dtor_args;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Lambda) {
-            Dafny.ISequence<DAST._IFormal> _576___mcc_h132 = _source19.dtor_params;
-            DAST._IType _577___mcc_h133 = _source19.dtor_retType;
-            Dafny.ISequence<DAST._IStatement> _578___mcc_h134 = _source19.dtor_body;
+          } else if (_source22.is_Lambda) {
+            Dafny.ISequence<DAST._IFormal> _606___mcc_h135 = _source22.dtor_params;
+            DAST._IType _607___mcc_h136 = _source22.dtor_retType;
+            Dafny.ISequence<DAST._IStatement> _608___mcc_h137 = _source22.dtor_body;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_IIFE) {
-            Dafny.ISequence<Dafny.Rune> _579___mcc_h138 = _source19.dtor_name;
-            DAST._IType _580___mcc_h139 = _source19.dtor_typ;
-            DAST._IExpression _581___mcc_h140 = _source19.dtor_value;
-            DAST._IExpression _582___mcc_h141 = _source19.dtor_iifeBody;
+          } else if (_source22.is_IIFE) {
+            Dafny.ISequence<Dafny.Rune> _609___mcc_h141 = _source22.dtor_name;
+            DAST._IType _610___mcc_h142 = _source22.dtor_typ;
+            DAST._IExpression _611___mcc_h143 = _source22.dtor_value;
+            DAST._IExpression _612___mcc_h144 = _source22.dtor_iifeBody;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_Apply) {
-            DAST._IExpression _583___mcc_h146 = _source19.dtor_expr;
-            Dafny.ISequence<DAST._IExpression> _584___mcc_h147 = _source19.dtor_args;
+          } else if (_source22.is_Apply) {
+            DAST._IExpression _613___mcc_h149 = _source22.dtor_expr;
+            Dafny.ISequence<DAST._IExpression> _614___mcc_h150 = _source22.dtor_args;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
-          } else if (_source19.is_TypeTest) {
-            DAST._IExpression _585___mcc_h150 = _source19.dtor_on;
-            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _586___mcc_h151 = _source19.dtor_dType;
-            Dafny.ISequence<Dafny.Rune> _587___mcc_h152 = _source19.dtor_variant;
+          } else if (_source22.is_TypeTest) {
+            DAST._IExpression _615___mcc_h153 = _source22.dtor_on;
+            Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _616___mcc_h154 = _source22.dtor_dType;
+            Dafny.ISequence<Dafny.Rune> _617___mcc_h155 = _source22.dtor_variant;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           } else {
-            DAST._IType _588___mcc_h156 = _source19.dtor_typ;
+            DAST._IType _618___mcc_h159 = _source22.dtor_typ;
             {
-              _534_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _534_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
+              _563_enclosingString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("("), _563_enclosingString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")."));
             }
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_534_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_523_name)), _525_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _528_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_563_enclosingString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("r#")), (_552_name)), _554_typeArgString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _557_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           isOwned = true;
           isErased = false;
         }
-      } else if (_source16.is_Lambda) {
-        Dafny.ISequence<DAST._IFormal> _589___mcc_h43 = _source16.dtor_params;
-        DAST._IType _590___mcc_h44 = _source16.dtor_retType;
-        Dafny.ISequence<DAST._IStatement> _591___mcc_h45 = _source16.dtor_body;
-        Dafny.ISequence<DAST._IStatement> _592_body = _591___mcc_h45;
-        DAST._IType _593_retType = _590___mcc_h44;
-        Dafny.ISequence<DAST._IFormal> _594_params = _589___mcc_h43;
+      } else if (_source19.is_Lambda) {
+        Dafny.ISequence<DAST._IFormal> _619___mcc_h44 = _source19.dtor_params;
+        DAST._IType _620___mcc_h45 = _source19.dtor_retType;
+        Dafny.ISequence<DAST._IStatement> _621___mcc_h46 = _source19.dtor_body;
+        Dafny.ISequence<DAST._IStatement> _622_body = _621___mcc_h46;
+        DAST._IType _623_retType = _620___mcc_h45;
+        Dafny.ISequence<DAST._IFormal> _624_params = _619___mcc_h44;
         {
-          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _595_paramNames;
-          _595_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          BigInteger _596_i;
-          _596_i = BigInteger.Zero;
-          while ((_596_i) < (new BigInteger((_594_params).Count))) {
-            _595_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(_595_paramNames, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(((_594_params).Select(_596_i)).dtor_name));
-            _596_i = (_596_i) + (BigInteger.One);
+          Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _625_paramNames;
+          _625_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements();
+          BigInteger _626_i;
+          _626_i = BigInteger.Zero;
+          while ((_626_i) < (new BigInteger((_624_params).Count))) {
+            _625_paramNames = Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(_625_paramNames, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(((_624_params).Select(_626_i)).dtor_name));
+            _626_i = (_626_i) + (BigInteger.One);
           }
-          Dafny.ISequence<Dafny.Rune> _597_recursiveGen;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _598_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out191;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out192;
-          DCOMP.COMP.GenStmts(_592_body, _595_paramNames, true, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""), out _out191, out _out192);
-          _597_recursiveGen = _out191;
-          _598_recIdents = _out192;
+          Dafny.ISequence<Dafny.Rune> _627_recursiveGen;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _628_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out210;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out211;
+          DCOMP.COMP.GenStmts(_622_body, _625_paramNames, true, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""), out _out210, out _out211);
+          _627_recursiveGen = _out210;
+          _628_recIdents = _out211;
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-          Dafny.ISequence<Dafny.Rune> _599_allReadCloned;
-          _599_allReadCloned = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          while (!(_598_recIdents).Equals(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements())) {
-            Dafny.ISequence<Dafny.Rune> _600_next;
-            foreach (Dafny.ISequence<Dafny.Rune> _assign_such_that_1 in (_598_recIdents).Elements) {
-              _600_next = (Dafny.ISequence<Dafny.Rune>)_assign_such_that_1;
-              if ((_598_recIdents).Contains(_600_next)) {
+          Dafny.ISequence<Dafny.Rune> _629_allReadCloned;
+          _629_allReadCloned = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          while (!(_628_recIdents).Equals(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements())) {
+            Dafny.ISequence<Dafny.Rune> _630_next;
+            foreach (Dafny.ISequence<Dafny.Rune> _assign_such_that_1 in (_628_recIdents).Elements) {
+              _630_next = (Dafny.ISequence<Dafny.Rune>)_assign_such_that_1;
+              if ((_628_recIdents).Contains(_630_next)) {
                 goto after__ASSIGN_SUCH_THAT_1;
               }
             }
-            throw new System.Exception("assign-such-that search produced no value (line 1313)");
+            throw new System.Exception("assign-such-that search produced no value (line 1366)");
           after__ASSIGN_SUCH_THAT_1:;
-            if (!((_595_paramNames).Contains(_600_next))) {
-              _599_allReadCloned = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_599_allReadCloned, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let r#")), _600_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = r#")), _600_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone();\n"));
-              readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_600_next));
+            if (!((_625_paramNames).Contains(_630_next))) {
+              _629_allReadCloned = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_629_allReadCloned, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let r#")), _630_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = r#")), _630_next), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".clone();\n"));
+              readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_630_next));
             }
-            _598_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_598_recIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_600_next));
+            _628_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_628_recIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_630_next));
           }
-          Dafny.ISequence<Dafny.Rune> _601_paramsString;
-          _601_paramsString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          _596_i = BigInteger.Zero;
-          while ((_596_i) < (new BigInteger((_594_params).Count))) {
-            if ((_596_i).Sign == 1) {
-              _601_paramsString = Dafny.Sequence<Dafny.Rune>.Concat(_601_paramsString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _631_paramsString;
+          _631_paramsString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          _626_i = BigInteger.Zero;
+          while ((_626_i) < (new BigInteger((_624_params).Count))) {
+            if ((_626_i).Sign == 1) {
+              _631_paramsString = Dafny.Sequence<Dafny.Rune>.Concat(_631_paramsString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _602_typStr;
-            Dafny.ISequence<Dafny.Rune> _out193;
-            _out193 = DCOMP.COMP.GenType(((_594_params).Select(_596_i)).dtor_typ, false, true);
-            _602_typStr = _out193;
-            _601_paramsString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_601_paramsString, ((_594_params).Select(_596_i)).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _602_typStr);
-            _596_i = (_596_i) + (BigInteger.One);
+            Dafny.ISequence<Dafny.Rune> _632_typStr;
+            Dafny.ISequence<Dafny.Rune> _out212;
+            _out212 = DCOMP.COMP.GenType(((_624_params).Select(_626_i)).dtor_typ, false, true);
+            _632_typStr = _out212;
+            _631_paramsString = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(_631_paramsString, ((_624_params).Select(_626_i)).dtor_name), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": &")), _632_typStr);
+            _626_i = (_626_i) + (BigInteger.One);
           }
-          Dafny.ISequence<Dafny.Rune> _603_retTypeGen;
-          Dafny.ISequence<Dafny.Rune> _out194;
-          _out194 = DCOMP.COMP.GenType(_593_retType, false, true);
-          _603_retTypeGen = _out194;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::FunctionWrapper({\n"), _599_allReadCloned), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::boxed::Box::new(move |")), _601_paramsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("| -> ")), _603_retTypeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _597_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n})})"));
+          Dafny.ISequence<Dafny.Rune> _633_retTypeGen;
+          Dafny.ISequence<Dafny.Rune> _out213;
+          _out213 = DCOMP.COMP.GenType(_623_retType, false, true);
+          _633_retTypeGen = _out213;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::FunctionWrapper({\n"), _629_allReadCloned), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::std::boxed::Box::new(move |")), _631_paramsString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("| -> ")), _633_retTypeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" {\n")), _627_recursiveGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n})})"));
           isOwned = true;
           isErased = true;
         }
-      } else if (_source16.is_IIFE) {
-        Dafny.ISequence<Dafny.Rune> _604___mcc_h46 = _source16.dtor_name;
-        DAST._IType _605___mcc_h47 = _source16.dtor_typ;
-        DAST._IExpression _606___mcc_h48 = _source16.dtor_value;
-        DAST._IExpression _607___mcc_h49 = _source16.dtor_iifeBody;
-        DAST._IExpression _608_iifeBody = _607___mcc_h49;
-        DAST._IExpression _609_value = _606___mcc_h48;
-        DAST._IType _610_tpe = _605___mcc_h47;
-        Dafny.ISequence<Dafny.Rune> _611_name = _604___mcc_h46;
+      } else if (_source19.is_IIFE) {
+        Dafny.ISequence<Dafny.Rune> _634___mcc_h47 = _source19.dtor_name;
+        DAST._IType _635___mcc_h48 = _source19.dtor_typ;
+        DAST._IExpression _636___mcc_h49 = _source19.dtor_value;
+        DAST._IExpression _637___mcc_h50 = _source19.dtor_iifeBody;
+        DAST._IExpression _638_iifeBody = _637___mcc_h50;
+        DAST._IExpression _639_value = _636___mcc_h49;
+        DAST._IType _640_tpe = _635___mcc_h48;
+        Dafny.ISequence<Dafny.Rune> _641_name = _634___mcc_h47;
         {
-          Dafny.ISequence<Dafny.Rune> _612_valueGen;
-          bool _613_valueOwned;
-          bool _614_valueErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _615_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out195;
-          bool _out196;
-          bool _out197;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out198;
-          DCOMP.COMP.GenExpr(_609_value, @params, false, out _out195, out _out196, out _out197, out _out198);
-          _612_valueGen = _out195;
-          _613_valueOwned = _out196;
-          _614_valueErased = _out197;
-          _615_recIdents = _out198;
-          if (_614_valueErased) {
-            Dafny.ISequence<Dafny.Rune> _616_eraseFn;
-            _616_eraseFn = ((_613_valueOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase")));
-            _612_valueGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::"), _616_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _612_valueGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
+          Dafny.ISequence<Dafny.Rune> _642_valueGen;
+          bool _643_valueOwned;
+          bool _644_valueErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _645_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out214;
+          bool _out215;
+          bool _out216;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out217;
+          DCOMP.COMP.GenExpr(_639_value, @params, false, out _out214, out _out215, out _out216, out _out217);
+          _642_valueGen = _out214;
+          _643_valueOwned = _out215;
+          _644_valueErased = _out216;
+          _645_recIdents = _out217;
+          if (_644_valueErased) {
+            Dafny.ISequence<Dafny.Rune> _646_eraseFn;
+            _646_eraseFn = ((_643_valueOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase")));
+            _642_valueGen = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::dafny_runtime::DafnyUnerasable::<_>::"), _646_eraseFn), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _642_valueGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(")"));
           }
-          readIdents = _615_recIdents;
-          Dafny.ISequence<Dafny.Rune> _617_valueTypeGen;
-          Dafny.ISequence<Dafny.Rune> _out199;
-          _out199 = DCOMP.COMP.GenType(_610_tpe, false, true);
-          _617_valueTypeGen = _out199;
-          Dafny.ISequence<Dafny.Rune> _618_bodyGen;
-          bool _619_bodyOwned;
-          bool _620_bodyErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _621_bodyIdents;
-          Dafny.ISequence<Dafny.Rune> _out200;
-          bool _out201;
-          bool _out202;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out203;
-          DCOMP.COMP.GenExpr(_608_iifeBody, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(@params, ((_613_valueOwned) ? (Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements()) : (Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((_611_name))))), mustOwn, out _out200, out _out201, out _out202, out _out203);
-          _618_bodyGen = _out200;
-          _619_bodyOwned = _out201;
-          _620_bodyErased = _out202;
-          _621_bodyIdents = _out203;
-          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _621_bodyIdents);
-          Dafny.ISequence<Dafny.Rune> _622_eraseFn;
-          _622_eraseFn = ((_613_valueOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase")));
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{\nlet r#"), (_611_name)), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), ((_613_valueOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")))), _617_valueTypeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _612_valueGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n")), _618_bodyGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
-          isOwned = _619_bodyOwned;
-          isErased = _620_bodyErased;
+          readIdents = _645_recIdents;
+          Dafny.ISequence<Dafny.Rune> _647_valueTypeGen;
+          Dafny.ISequence<Dafny.Rune> _out218;
+          _out218 = DCOMP.COMP.GenType(_640_tpe, false, true);
+          _647_valueTypeGen = _out218;
+          Dafny.ISequence<Dafny.Rune> _648_bodyGen;
+          bool _649_bodyOwned;
+          bool _650_bodyErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _651_bodyIdents;
+          Dafny.ISequence<Dafny.Rune> _out219;
+          bool _out220;
+          bool _out221;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out222;
+          DCOMP.COMP.GenExpr(_638_iifeBody, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(@params, ((_643_valueOwned) ? (Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements()) : (Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements((_641_name))))), mustOwn, out _out219, out _out220, out _out221, out _out222);
+          _648_bodyGen = _out219;
+          _649_bodyOwned = _out220;
+          _650_bodyErased = _out221;
+          _651_bodyIdents = _out222;
+          readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _651_bodyIdents);
+          Dafny.ISequence<Dafny.Rune> _652_eraseFn;
+          _652_eraseFn = ((_643_valueOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase_owned")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unerase")));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{\nlet r#"), (_641_name)), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(": ")), ((_643_valueOwned) ? (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("")) : (Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&")))), _647_valueTypeGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" = ")), _642_valueGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(";\n")), _648_bodyGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n}"));
+          isOwned = _649_bodyOwned;
+          isErased = _650_bodyErased;
         }
-      } else if (_source16.is_Apply) {
-        DAST._IExpression _623___mcc_h50 = _source16.dtor_expr;
-        Dafny.ISequence<DAST._IExpression> _624___mcc_h51 = _source16.dtor_args;
-        Dafny.ISequence<DAST._IExpression> _625_args = _624___mcc_h51;
-        DAST._IExpression _626_func = _623___mcc_h50;
+      } else if (_source19.is_Apply) {
+        DAST._IExpression _653___mcc_h51 = _source19.dtor_expr;
+        Dafny.ISequence<DAST._IExpression> _654___mcc_h52 = _source19.dtor_args;
+        Dafny.ISequence<DAST._IExpression> _655_args = _654___mcc_h52;
+        DAST._IExpression _656_func = _653___mcc_h51;
         {
-          Dafny.ISequence<Dafny.Rune> _627_funcString;
-          bool _628___v46;
-          bool _629_funcErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _630_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out204;
-          bool _out205;
-          bool _out206;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out207;
-          DCOMP.COMP.GenExpr(_626_func, @params, false, out _out204, out _out205, out _out206, out _out207);
-          _627_funcString = _out204;
-          _628___v46 = _out205;
-          _629_funcErased = _out206;
-          _630_recIdents = _out207;
-          readIdents = _630_recIdents;
-          Dafny.ISequence<Dafny.Rune> _631_argString;
-          _631_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
-          BigInteger _632_i;
-          _632_i = BigInteger.Zero;
-          while ((_632_i) < (new BigInteger((_625_args).Count))) {
-            if ((_632_i).Sign == 1) {
-              _631_argString = Dafny.Sequence<Dafny.Rune>.Concat(_631_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
+          Dafny.ISequence<Dafny.Rune> _657_funcString;
+          bool _658___v49;
+          bool _659_funcErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _660_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out223;
+          bool _out224;
+          bool _out225;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out226;
+          DCOMP.COMP.GenExpr(_656_func, @params, false, out _out223, out _out224, out _out225, out _out226);
+          _657_funcString = _out223;
+          _658___v49 = _out224;
+          _659_funcErased = _out225;
+          _660_recIdents = _out226;
+          readIdents = _660_recIdents;
+          Dafny.ISequence<Dafny.Rune> _661_argString;
+          _661_argString = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("");
+          BigInteger _662_i;
+          _662_i = BigInteger.Zero;
+          while ((_662_i) < (new BigInteger((_655_args).Count))) {
+            if ((_662_i).Sign == 1) {
+              _661_argString = Dafny.Sequence<Dafny.Rune>.Concat(_661_argString, Dafny.Sequence<Dafny.Rune>.UnicodeFromString(", "));
             }
-            Dafny.ISequence<Dafny.Rune> _633_argExpr;
-            bool _634_isOwned;
-            bool _635_argErased;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _636_argIdents;
-            Dafny.ISequence<Dafny.Rune> _out208;
-            bool _out209;
-            bool _out210;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out211;
-            DCOMP.COMP.GenExpr((_625_args).Select(_632_i), @params, false, out _out208, out _out209, out _out210, out _out211);
-            _633_argExpr = _out208;
-            _634_isOwned = _out209;
-            _635_argErased = _out210;
-            _636_argIdents = _out211;
-            if (_634_isOwned) {
-              _633_argExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), _633_argExpr);
+            Dafny.ISequence<Dafny.Rune> _663_argExpr;
+            bool _664_isOwned;
+            bool _665_argErased;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _666_argIdents;
+            Dafny.ISequence<Dafny.Rune> _out227;
+            bool _out228;
+            bool _out229;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out230;
+            DCOMP.COMP.GenExpr((_655_args).Select(_662_i), @params, false, out _out227, out _out228, out _out229, out _out230);
+            _663_argExpr = _out227;
+            _664_isOwned = _out228;
+            _665_argErased = _out229;
+            _666_argIdents = _out230;
+            if (_664_isOwned) {
+              _663_argExpr = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("&"), _663_argExpr);
             }
-            _631_argString = Dafny.Sequence<Dafny.Rune>.Concat(_631_argString, _633_argExpr);
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _636_argIdents);
-            _632_i = (_632_i) + (BigInteger.One);
+            _661_argString = Dafny.Sequence<Dafny.Rune>.Concat(_661_argString, _663_argExpr);
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _666_argIdents);
+            _662_i = (_662_i) + (BigInteger.One);
           }
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(("), _627_funcString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").0")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _631_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("))"));
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(("), _657_funcString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(").0")), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("(")), _661_argString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("))"));
           isOwned = true;
           isErased = false;
         }
-      } else if (_source16.is_TypeTest) {
-        DAST._IExpression _637___mcc_h52 = _source16.dtor_on;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _638___mcc_h53 = _source16.dtor_dType;
-        Dafny.ISequence<Dafny.Rune> _639___mcc_h54 = _source16.dtor_variant;
-        Dafny.ISequence<Dafny.Rune> _640_variant = _639___mcc_h54;
-        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _641_dType = _638___mcc_h53;
-        DAST._IExpression _642_on = _637___mcc_h52;
+      } else if (_source19.is_TypeTest) {
+        DAST._IExpression _667___mcc_h53 = _source19.dtor_on;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _668___mcc_h54 = _source19.dtor_dType;
+        Dafny.ISequence<Dafny.Rune> _669___mcc_h55 = _source19.dtor_variant;
+        Dafny.ISequence<Dafny.Rune> _670_variant = _669___mcc_h55;
+        Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _671_dType = _668___mcc_h54;
+        DAST._IExpression _672_on = _667___mcc_h53;
         {
-          Dafny.ISequence<Dafny.Rune> _643_exprGen;
-          bool _644___v47;
-          bool _645_exprErased;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _646_recIdents;
-          Dafny.ISequence<Dafny.Rune> _out212;
-          bool _out213;
-          bool _out214;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out215;
-          DCOMP.COMP.GenExpr(_642_on, @params, false, out _out212, out _out213, out _out214, out _out215);
-          _643_exprGen = _out212;
-          _644___v47 = _out213;
-          _645_exprErased = _out214;
-          _646_recIdents = _out215;
-          Dafny.ISequence<Dafny.Rune> _647_dTypePath;
-          Dafny.ISequence<Dafny.Rune> _out216;
-          _out216 = DCOMP.COMP.GenPath(_641_dType);
-          _647_dTypePath = _out216;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("matches!("), _643_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".as_ref(), ")), _647_dTypePath), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _640_variant), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ .. })"));
+          Dafny.ISequence<Dafny.Rune> _673_exprGen;
+          bool _674___v50;
+          bool _675_exprErased;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _676_recIdents;
+          Dafny.ISequence<Dafny.Rune> _out231;
+          bool _out232;
+          bool _out233;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out234;
+          DCOMP.COMP.GenExpr(_672_on, @params, false, out _out231, out _out232, out _out233, out _out234);
+          _673_exprGen = _out231;
+          _674___v50 = _out232;
+          _675_exprErased = _out233;
+          _676_recIdents = _out234;
+          Dafny.ISequence<Dafny.Rune> _677_dTypePath;
+          Dafny.ISequence<Dafny.Rune> _out235;
+          _out235 = DCOMP.COMP.GenPath(_671_dType);
+          _677_dTypePath = _out235;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("matches!("), _673_exprGen), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(".as_ref(), ")), _677_dTypePath), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::r#")), _670_variant), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{ .. })"));
           isOwned = true;
           isErased = true;
-          readIdents = _646_recIdents;
+          readIdents = _676_recIdents;
         }
       } else {
-        DAST._IType _648___mcc_h55 = _source16.dtor_typ;
-        DAST._IType _649_typ = _648___mcc_h55;
+        DAST._IType _678___mcc_h56 = _source19.dtor_typ;
+        DAST._IType _679_typ = _678___mcc_h56;
         {
-          Dafny.ISequence<Dafny.Rune> _650_typString;
-          Dafny.ISequence<Dafny.Rune> _out217;
-          _out217 = DCOMP.COMP.GenType(_649_typ, false, false);
-          _650_typString = _out217;
-          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"), _650_typString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" as std::default::Default>::default()"));
+          Dafny.ISequence<Dafny.Rune> _680_typString;
+          Dafny.ISequence<Dafny.Rune> _out236;
+          _out236 = DCOMP.COMP.GenType(_679_typ, false, false);
+          _680_typString = _out236;
+          s = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"), _680_typString), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(" as std::default::Default>::default()"));
           isOwned = true;
           isErased = false;
           readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
@@ -6451,32 +6733,32 @@ namespace DCOMP {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("#![allow(warnings, unconditional_panic)]\n");
       s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("extern crate dafny_runtime;\n"));
-      BigInteger _651_i;
-      _651_i = BigInteger.Zero;
-      while ((_651_i) < (new BigInteger((p).Count))) {
-        Dafny.ISequence<Dafny.Rune> _652_generated = Dafny.Sequence<Dafny.Rune>.Empty;
-        Dafny.ISequence<Dafny.Rune> _out218;
-        _out218 = DCOMP.COMP.GenModule((p).Select(_651_i), Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements());
-        _652_generated = _out218;
-        if ((_651_i).Sign == 1) {
+      BigInteger _681_i;
+      _681_i = BigInteger.Zero;
+      while ((_681_i) < (new BigInteger((p).Count))) {
+        Dafny.ISequence<Dafny.Rune> _682_generated = Dafny.Sequence<Dafny.Rune>.Empty;
+        Dafny.ISequence<Dafny.Rune> _out237;
+        _out237 = DCOMP.COMP.GenModule((p).Select(_681_i), Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements());
+        _682_generated = _out237;
+        if ((_681_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\n"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _652_generated);
-        _651_i = (_651_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, _682_generated);
+        _681_i = (_681_i) + (BigInteger.One);
       }
       return s;
     }
     public static Dafny.ISequence<Dafny.Rune> EmitCallToMain(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> fullName) {
       Dafny.ISequence<Dafny.Rune> s = Dafny.Sequence<Dafny.Rune>.Empty;
       s = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("\nfn main() {\n");
-      BigInteger _653_i;
-      _653_i = BigInteger.Zero;
-      while ((_653_i) < (new BigInteger((fullName).Count))) {
-        if ((_653_i).Sign == 1) {
+      BigInteger _683_i;
+      _683_i = BigInteger.Zero;
+      while ((_683_i) < (new BigInteger((fullName).Count))) {
+        if ((_683_i).Sign == 1) {
           s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("::"));
         }
-        s = Dafny.Sequence<Dafny.Rune>.Concat(s, (fullName).Select(_653_i));
-        _653_i = (_653_i) + (BigInteger.One);
+        s = Dafny.Sequence<Dafny.Rune>.Concat(s, (fullName).Select(_683_i));
+        _683_i = (_683_i) + (BigInteger.One);
       }
       s = Dafny.Sequence<Dafny.Rune>.Concat(s, Dafny.Sequence<Dafny.Rune>.UnicodeFromString("();\n}"));
       return s;


### PR DESCRIPTION
Support class fields in the Rust backend



Right now, we still use reference counted pointers, which means that cycles will result in memory leaks. I plan to address this with cycle collection in a later PR.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT
license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/dafny-lang/dafny/pull/4429).
* #4438
* __->__ #4429