### PR TITLE
Fix: Unresolved abstract imports no longer crash the resolver

### DIFF
--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -390,7 +390,7 @@ public class ModuleDefinition : RangeNode, IDeclarationOrUsage, IAttributeBearin
           importSig = ((AbstractModuleDecl)d).OriginalSignature;
         }
 
-        if (importSig.ModuleDef is not { SuccessfullyResolved: true }) {
+        if (importSig is not {ModuleDef: { SuccessfullyResolved: true }}) {
           return false;
         }
       } else if (d is LiteralModuleDecl) {

--- a/Test/git-issues/git-issue-4298.dfy
+++ b/Test/git-issues/git-issue-4298.dfy
@@ -1,0 +1,13 @@
+// RUN: %exits-with 2 %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module A {
+  export E
+    provides f
+
+  function f() : bool { true }
+}
+
+abstract module B {
+  import A0: A
+}

--- a/Test/git-issues/git-issue-4298.dfy.expect
+++ b/Test/git-issues/git-issue-4298.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Test/git-issues/git-issue-4298.dfy.expect
+++ b/Test/git-issues/git-issue-4298.dfy.expect
@@ -1,2 +1,2 @@
-
-Dafny program verifier finished with TODO verified, TODO errors
+git-issue-4298.dfy(12,13): Error: no default export set declared in module: A
+1 resolution/type errors detected in git-issue-4298.dfy

--- a/docs/dev/news/4298.fix
+++ b/docs/dev/news/4298.fix
@@ -1,0 +1,1 @@
+Unresolved abstract imports no longer crash the resolver


### PR DESCRIPTION
This PR fixes #4298
A conditional was missing a null check.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>