### PR TITLE
Always have project mode on

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/LinearVerificationGutterStatusTester.cs
@@ -25,7 +25,6 @@ public abstract class LinearVerificationGutterStatusTester : ClientBasedLanguage
 
     void ModifyOptions(DafnyOptions options) {
       options.Set(ServerCommand.LineVerificationStatus, true);
-      options.Set(ServerCommand.ProjectMode, true);
       modifyOptions?.Invoke(options);
     }
     await base.SetUp(ModifyOptions);

--- a/Source/DafnyLanguageServer.Test/Lookup/GoToDefinitionTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/GoToDefinitionTest.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
 
     [Fact]
     public async Task ExplicitProjectToGoDefinitionWorks() {
-      await SetUp(o => o.Set(ServerCommand.ProjectMode, true));
       var sourceA = @"
 const a := 3;
 ".TrimStart();

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverTest.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
     protected override async Task SetUp(Action<DafnyOptions> modifyOptions = null) {
       void ModifyOptions(DafnyOptions options) {
         options.ProverOptions.Add("SOLVER=noop");
-        options.Set(ServerCommand.ProjectMode, true);
         modifyOptions?.Invoke(options);
       }
 

--- a/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
@@ -21,13 +21,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
   [Collection("Sequential Collection")] // Let slow tests run sequentially
   public class HoverVerificationTest : ClientBasedLanguageServerTest {
 
-    protected override Task SetUp(Action<DafnyOptions> modifyOptions) {
-      return base.SetUp(o => {
-        o.Set(ServerCommand.ProjectMode, true);
-        modifyOptions?.Invoke(o);
-      });
-    }
-
     private const int MaxTestExecutionTimeMs = 30000;
 
     [Fact(Timeout = MaxTestExecutionTimeMs)]

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/CompetingProjectFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/CompetingProjectFilesTest.cs
@@ -12,13 +12,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.ProjectFiles;
 
 public class CompetingProjectFilesTest : ClientBasedLanguageServerTest {
 
-  protected override Task SetUp(Action<DafnyOptions> modifyOptions) {
-    return base.SetUp(o => {
-      o.Set(ServerCommand.ProjectMode, true);
-      modifyOptions?.Invoke(o);
-    });
-  }
-
 
   /// <summary>
   /// A project should only publish diagnostics for uris which it owns,

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/MultipleFilesProjectTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/MultipleFilesProjectTest.cs
@@ -13,43 +13,6 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.ProjectFiles;
 
 public class MultipleFilesProjectTest : ClientBasedLanguageServerTest {
-  protected override Task SetUp(Action<DafnyOptions> modifyOptions) {
-    return base.SetUp(o => {
-      o.Set(ServerCommand.ProjectMode, true);
-      modifyOptions?.Invoke(o);
-    });
-  }
-
-  [Fact]
-  public async Task NoProjectModeWithProjectFileAndMultipleFiles() {
-    await SetUp(o => {
-      o.Set(ServerCommand.ProjectMode, false);
-    });
-    var producerSource = @"
-method Foo(x: int) { 
-  var y: char := 3.0;
-}
-".TrimStart();
-
-    var consumerSource = @"
-include ""A.dfy""
-method Bar() {
-  Foo(true); 
-}
-";
-
-    var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-    Directory.CreateDirectory(directory);
-    await File.WriteAllTextAsync(Path.Combine(directory, DafnyProject.FileName), "");
-    // The names A and B are important, because A must be alphabetically before B to trigger a particular cache without cloning bug 
-    await File.WriteAllTextAsync(Path.Combine(directory, "A.dfy"), producerSource);
-    await CreateAndOpenTestDocument(consumerSource, Path.Combine(directory, "B.dfy"));
-
-    var consumerDiagnostics = await diagnosticsReceiver.AwaitNextNotificationAsync(CancellationToken);
-    Assert.Equal(2, consumerDiagnostics.Diagnostics.Count());
-    Assert.Contains(consumerDiagnostics.Diagnostics, diagnostic => diagnostic.Message.Contains("bool"));
-    await AssertNoDiagnosticsAreComing(CancellationToken);
-  }
 
   [Fact]
   public async Task OnDiskProducerResolutionErrors() {

--- a/Source/DafnyLanguageServer.Test/Refactoring/RenameTest.cs
+++ b/Source/DafnyLanguageServer.Test/Refactoring/RenameTest.cs
@@ -118,13 +118,6 @@ abstract module B { import [>><A<] }
       return tempDir;
     }
 
-    protected override Task SetUp(Action<DafnyOptions> modifyOptions) {
-      return base.SetUp(o => {
-        o.Set(ServerCommand.ProjectMode, true);
-        modifyOptions?.Invoke(o);
-      });
-    }
-
     /// <summary>
     /// Assert that after requesting a rename to <paramref name="newName"/>
     /// at the markup position in <paramref name="source"/>

--- a/Source/DafnyLanguageServer.Test/Synchronization/VerificationOrderTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/VerificationOrderTest.cs
@@ -16,7 +16,6 @@ public class VerificationOrderTest : ClientBasedLanguageServerTest {
   public async Task VerificationPriorityBasedOnChangesWorksWithMultipleFiles() {
     await SetUp(options => {
       options.Set(BoogieOptionBag.Cores, 1U);
-      options.Set(ServerCommand.ProjectMode, true);
       options.Set(ServerCommand.Verification, VerifyOnMode.ChangeProject);
     });
 

--- a/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
@@ -23,7 +23,6 @@ method Foo() returns (x: int) ensures x / 2 == 1; {
 }".TrimStart();
     await SetUp(options => {
       options.Set(ServerCommand.Verification, VerifyOnMode.Never);
-      options.Set(ServerCommand.ProjectMode, true);
     });
     var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     await CreateAndOpenTestDocument("", Path.Combine(directory, DafnyProject.FileName));

--- a/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
@@ -24,9 +24,6 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
 method Foo() returns (x: int) ensures x / 2 == 1; {
   return 2;
 }".TrimStart();
-      await SetUp(options => {
-        options.Set(ServerCommand.ProjectMode, true);
-      });
       var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
       Directory.CreateDirectory(directory);
       await CreateAndOpenTestDocument("", Path.Combine(directory, DafnyProject.FileName));

--- a/Source/DafnyLanguageServer/ServerCommand.cs
+++ b/Source/DafnyLanguageServer/ServerCommand.cs
@@ -16,7 +16,6 @@ public class ServerCommand : ICommandSpec {
     DafnyOptions.RegisterLegacyBinding(VerifySnapshots, (options, u) => options.VerifySnapshots = (int)u);
 
     DooFile.RegisterNoChecksNeeded(
-      ProjectMode,
       Verification,
       GhostIndicators,
       LineVerificationStatus,
@@ -46,11 +45,6 @@ Determine when to automatically verify the program. Choose from: Never, OnChange
 Send notifications about the verification status of each line in the program.
 ".TrimStart());
 
-  public static readonly Option<bool> ProjectMode = new("--project-mode", () => false,
-    "New mode with working with project files. Will become the default") {
-    IsHidden = true
-  };
-
   public static readonly Option<uint> VerifySnapshots = new("--cache-verification", @"
 (experimental)
 0 - do not use any verification result caching (default)
@@ -64,7 +58,6 @@ Send notifications about the verification status of each line in the program.
   };
 
   public IEnumerable<Option> Options => new Option[] {
-    ProjectMode,
     BoogieOptionBag.NoVerify,
     Verification,
     GhostIndicators,

--- a/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
@@ -198,12 +198,6 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         folder = Path.GetDirectoryName(folder);
       }
 
-      if (projectFile != null && projectFile.Uri != sourceUri && !serverOptions.Get(ServerCommand.ProjectMode)) {
-        logger.LogDebug("Project file at {} will be ignored because project mode is disabled", projectFile.Uri);
-        projectFile.Uri = sourceUri;
-        projectFile.Includes = new[] { sourceUri.LocalPath };
-      }
-
       return projectFile;
     }
 


### PR DESCRIPTION
### Changes
- The Dafny language server will now always run in project mode when it finds a `dfyconfig.toml` related to an open file
- Fixed test `ProjectFileOverridesOptions` since it had issues.

### Testing
- Existing tests still pass with this change in default

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
