### PR TITLE
Multi-file support for  legacy symbol table

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/DeclarationLocationMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DeclarationLocationMigrationTest.cs
@@ -335,7 +335,7 @@ class A {
       await ApplyChangeAndWaitCompletionAsync(ref documentItem, null, "; include \"foreign.dfy\"\nclass Y {}");
       document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem);
       Assert.NotNull(document);
-      Assert.True(TryFindSymbolDeclarationByName(document, "A", out var _, uri));
+      Assert.True(TryFindSymbolDeclarationByName(document, "A", out var _, new Uri(includePath)));
 
       // Finally we drop the reference to `foreign.dfy` and confirm that `A` is not accessible any more.
       await ApplyChangeAndWaitCompletionAsync(ref documentItem, null, "class Y {}");

--- a/Source/DafnyLanguageServer.Test/Synchronization/DeclarationLocationMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DeclarationLocationMigrationTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
     //      does not incorporate the closing braces.
 
     protected bool TryFindSymbolDeclarationByName(IdeState state, string symbolName, out SymbolLocation location, Uri uri = null) {
-      location = state.SignatureAndCompletionTable.Locations[uri ?? state.SignatureAndCompletionTable.Locations.First().Key]
+      location = state.SignatureAndCompletionTable.LocationsPerUri[uri ?? state.SignatureAndCompletionTable.LocationsPerUri.First().Key]
         .WithCancellation(CancellationToken)
         .Where(entry => entry.Key.Name == symbolName)
         .Select(entry => entry.Value)

--- a/Source/DafnyLanguageServer.Test/Synchronization/DeclarationLocationMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/DeclarationLocationMigrationTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Dafny.LanguageServer.Workspace;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
 
@@ -22,8 +24,8 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
     // TODO The "BodyEndToken" used by the CreateDeclarationDictionary.CreateDeclarationDictionary()
     //      does not incorporate the closing braces.
 
-    protected bool TryFindSymbolDeclarationByName(IdeState state, string symbolName, out SymbolLocation location) {
-      location = state.SignatureAndCompletionTable.Locations
+    protected bool TryFindSymbolDeclarationByName(IdeState state, string symbolName, out SymbolLocation location, Uri uri = null) {
+      location = state.SignatureAndCompletionTable.Locations[uri ?? state.SignatureAndCompletionTable.Locations.First().Key]
         .WithCancellation(CancellationToken)
         .Where(entry => entry.Key.Name == symbolName)
         .Select(entry => entry.Value)
@@ -318,25 +320,28 @@ class A {
 
     [Fact]
     public async Task PassingANullChangeRangePreservesForeignSymbols() {
+      var directory = Path.Combine(Directory.GetCurrentDirectory(), "Lookup/TestFiles");
       var source = "include \"foreign.dfy\"\nclass X {}";
-      var documentItem = CreateTestDocument(source, Path.Combine(Directory.GetCurrentDirectory(), "Lookup/TestFiles/test.dfy"));
+      var documentItem = CreateTestDocument(source, Path.Combine(directory, "test.dfy"));
+      var includePath = Path.Combine(directory, "foreign.dfy");
 
       await Client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
-      Assert.True(TryFindSymbolDeclarationByName(document, "A", out var _));
+      var uri = documentItem.Uri.ToUri();
+      Assert.True(TryFindSymbolDeclarationByName(document, "A", out var _, new Uri(includePath)));
 
       // Try a change that breaks resolution.  Symbols for `foreign.dfy` are kept.
       await ApplyChangeAndWaitCompletionAsync(ref documentItem, null, "; include \"foreign.dfy\"\nclass Y {}");
       document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem);
       Assert.NotNull(document);
-      Assert.True(TryFindSymbolDeclarationByName(document, "A", out var _));
+      Assert.True(TryFindSymbolDeclarationByName(document, "A", out var _, uri));
 
       // Finally we drop the reference to `foreign.dfy` and confirm that `A` is not accessible any more.
       await ApplyChangeAndWaitCompletionAsync(ref documentItem, null, "class Y {}");
       document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem);
       Assert.NotNull(document);
-      Assert.False(TryFindSymbolDeclarationByName(document, "A", out var _));
+      Assert.False(TryFindSymbolDeclarationByName(document, "A", out var _, uri));
     }
 
     public DeclarationLocationMigrationTest(ITestOutputHelper output) : this(output, LogLevel.Information) {

--- a/Source/DafnyLanguageServer.Test/Synchronization/LookupMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/LookupMigrationTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Threading.Tasks;
@@ -276,7 +277,7 @@ class Test {
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
       Assert.False(document.SignatureAndCompletionTable.TryGetSymbolAt((6, 9), out var _));
-      Assert.Equal(lookupCountBefore - 1, document.SignatureAndCompletionTable.LookupTree.Count);
+      Assert.Equal(lookupCountBefore - 1, document.SignatureAndCompletionTable.LookupTree.First().Value.Count);
     }
 
     [Fact]

--- a/Source/DafnyLanguageServer.Test/Synchronization/LookupMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/LookupMigrationTest.cs
@@ -267,7 +267,7 @@ class Test {
       await Client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
       var originalDocument = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(originalDocument);
-      var lookupCountBefore = originalDocument.SignatureAndCompletionTable.LookupTree.Count;
+      var lookupCountBefore = originalDocument.SignatureAndCompletionTable.LookupTreePerUri.First().Value.Count;
 
       await ApplyChangeAndWaitCompletionAsync(
         ref documentItem,
@@ -277,7 +277,7 @@ class Test {
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
       Assert.False(document.SignatureAndCompletionTable.TryGetSymbolAt((6, 9), out var _));
-      Assert.Equal(lookupCountBefore - 1, document.SignatureAndCompletionTable.LookupTree.First().Value.Count);
+      Assert.Equal(lookupCountBefore - 1, document.SignatureAndCompletionTable.LookupTreePerUri.First().Value.Count);
     }
 
     [Fact]

--- a/Source/DafnyLanguageServer.Test/Synchronization/SymbolMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/SymbolMigrationTest.cs
@@ -30,7 +30,7 @@ function GetConstant2(): int {
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
       Assert.True(document.SignatureAndCompletionTable.Resolved);
-      Assert.Equal(2, document.SignatureAndCompletionTable.Locations.Keys.OfType<FunctionSymbol>().Count());
+      Assert.Equal(2, document.SignatureAndCompletionTable.Locations.First().Value.Keys.OfType<FunctionSymbol>().Count());
     }
 
     [Fact]
@@ -98,7 +98,7 @@ method GetIt(x: int) returns (y: int) {
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
       Assert.True(document.SignatureAndCompletionTable.Resolved);
-      Assert.Single(document.SignatureAndCompletionTable.Locations.Keys.OfType<MethodSymbol>());
+      Assert.Single(document.SignatureAndCompletionTable.Locations.First().Value.Keys.OfType<MethodSymbol>());
     }
 
     public SymbolMigrationTest(ITestOutputHelper output) : base(output) {

--- a/Source/DafnyLanguageServer.Test/Synchronization/SymbolMigrationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/SymbolMigrationTest.cs
@@ -30,7 +30,7 @@ function GetConstant2(): int {
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
       Assert.True(document.SignatureAndCompletionTable.Resolved);
-      Assert.Equal(2, document.SignatureAndCompletionTable.Locations.First().Value.Keys.OfType<FunctionSymbol>().Count());
+      Assert.Equal(2, document.SignatureAndCompletionTable.LocationsPerUri.First().Value.Keys.OfType<FunctionSymbol>().Count());
     }
 
     [Fact]
@@ -98,7 +98,7 @@ method GetIt(x: int) returns (y: int) {
       var document = await Projects.GetResolvedDocumentAsyncNormalizeUri(documentItem.Uri);
       Assert.NotNull(document);
       Assert.True(document.SignatureAndCompletionTable.Resolved);
-      Assert.Single(document.SignatureAndCompletionTable.Locations.First().Value.Keys.OfType<MethodSymbol>());
+      Assert.Single(document.SignatureAndCompletionTable.LocationsPerUri.First().Value.Keys.OfType<MethodSymbol>());
     }
 
     public SymbolMigrationTest(ITestOutputHelper output) : base(output) {

--- a/Source/DafnyLanguageServer.Test/Unit/GhostStateDiagnosticCollectorTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/GhostStateDiagnosticCollectorTest.cs
@@ -69,7 +69,7 @@ public class GhostStateDiagnosticCollectorTest {
     var source = new CancellationTokenSource();
     source.CancelAfter(TimeSpan.FromSeconds(50));
     var ghostDiagnostics = ghostStateDiagnosticCollector.GetGhostStateDiagnostics(
-      new SignatureAndCompletionTable(null!, new CompilationUnit(rootUri, program),
+      new LegacySignatureAndCompletionTable(null!, new CompilationUnit(rootUri, program),
         null!, null!, new IntervalTree<Position, ILocalizableSymbol>(), true)
       , source.Token);
     Assert.Empty(ghostDiagnostics);

--- a/Source/DafnyLanguageServer.Test/Unit/GhostStateDiagnosticCollectorTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/GhostStateDiagnosticCollectorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -70,7 +71,7 @@ public class GhostStateDiagnosticCollectorTest {
     source.CancelAfter(TimeSpan.FromSeconds(50));
     var ghostDiagnostics = ghostStateDiagnosticCollector.GetGhostStateDiagnostics(
       new LegacySignatureAndCompletionTable(null!, new CompilationUnit(rootUri, program),
-        null!, null!, new IntervalTree<Position, ILocalizableSymbol>(), true)
+        null!, null!, ImmutableDictionary<Uri, IIntervalTree<Position, ILocalizableSymbol>>.Empty, true)
       , source.Token);
     Assert.Empty(ghostDiagnostics);
   }

--- a/Source/DafnyLanguageServer/Language/GhostStateDiagnosticCollector.cs
+++ b/Source/DafnyLanguageServer/Language/GhostStateDiagnosticCollector.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     }
 
     public IReadOnlyDictionary<Uri, IReadOnlyList<Range>> GetGhostStateDiagnostics(
-      SignatureAndCompletionTable signatureAndCompletionTable, CancellationToken cancellationToken) {
+      LegacySignatureAndCompletionTable signatureAndCompletionTable, CancellationToken cancellationToken) {
       if (!options.Get(ServerCommand.GhostIndicators)) {
         return ImmutableDictionary<Uri, IReadOnlyList<Range>>.Empty;
       }

--- a/Source/DafnyLanguageServer/Language/IGhostStateDiagnosticCollector.cs
+++ b/Source/DafnyLanguageServer/Language/IGhostStateDiagnosticCollector.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// <exception cref="System.OperationCanceledException">Thrown when the cancellation was requested before completion.</exception>
     /// <exception cref="System.ObjectDisposedException">Thrown if the cancellation token was disposed before the completion.</exception>
     IReadOnlyDictionary<Uri, IReadOnlyList<Range>> GetGhostStateDiagnostics(
-      SignatureAndCompletionTable signatureAndCompletionTable, CancellationToken cancellationToken);
+      LegacySignatureAndCompletionTable signatureAndCompletionTable, CancellationToken cancellationToken);
   }
 }

--- a/Source/DafnyLanguageServer/Language/Symbols/ISymbolTableFactory.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/ISymbolTableFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
     /// <returns>A symbol table representing the provided compilation unit.</returns>
     /// <exception cref="System.OperationCanceledException">Thrown when the cancellation was requested before completion.</exception>
     /// <exception cref="System.ObjectDisposedException">Thrown if the cancellation token was disposed before the completion.</exception>
-    SignatureAndCompletionTable CreateFrom(CompilationUnit compilationUnit, CancellationToken cancellationToken);
+    LegacySignatureAndCompletionTable CreateFrom(CompilationUnit compilationUnit, CancellationToken cancellationToken);
     SymbolTable CreateFrom(Dafny.Program program, Compilation compilation, CancellationToken cancellationToken);
   }
 }

--- a/Source/DafnyLanguageServer/Language/Symbols/LegacySignatureAndCompletionTable.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/LegacySignatureAndCompletionTable.cs
@@ -2,7 +2,9 @@
 using IntervalTree;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -27,12 +29,12 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
     /// <summary>
     /// Gets the dictionary allowing to resolve the location of a specified symbol. Do not modify this instance.
     /// </summary>
-    public IDictionary<ILegacySymbol, SymbolLocation> Locations { get; }
+    public ImmutableDictionary<Uri, IDictionary<ILegacySymbol, SymbolLocation>> Locations { get; }
 
     /// <summary>
     /// Gets the interval tree backing this symbol table. Do not modify this instance.
     /// </summary>
-    public IIntervalTree<Position, ILocalizableSymbol> LookupTree { get; }
+    public ImmutableDictionary<Uri, IIntervalTree<Position, ILocalizableSymbol>> LookupTree { get; }
 
     /// <summary>
     /// <c>true</c> if the symbol table results from a successful resolution by the dafny resolver.
@@ -47,8 +49,8 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
         NullLogger<LegacySignatureAndCompletionTable>.Instance,
         new CompilationUnit(project.Uri, emptyProgram),
         new Dictionary<object, ILocalizableSymbol>(),
-        new Dictionary<ILegacySymbol, SymbolLocation>(),
-        new IntervalTree<Position, ILocalizableSymbol>(),
+        ImmutableDictionary<Uri, IDictionary<ILegacySymbol, SymbolLocation>>.Empty,
+        ImmutableDictionary<Uri, IIntervalTree<Position, ILocalizableSymbol>>.Empty,
         symbolsResolved: false);
     }
 
@@ -71,8 +73,8 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
         ILogger<LegacySignatureAndCompletionTable> iLogger,
         CompilationUnit compilationUnit,
         IDictionary<AstElement, ILocalizableSymbol> declarations,
-        IDictionary<ILegacySymbol, SymbolLocation> locations,
-        IIntervalTree<Position, ILocalizableSymbol> lookupTree,
+        ImmutableDictionary<Uri, IDictionary<ILegacySymbol, SymbolLocation>> locations,
+        ImmutableDictionary<Uri, IIntervalTree<Position, ILocalizableSymbol>> lookupTree,
         bool symbolsResolved
     ) {
       CompilationUnit = compilationUnit;
@@ -82,20 +84,16 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
       Resolved = symbolsResolved;
       typeResolver = new DafnyLangTypeResolver(declarations);
       logger = iLogger;
-
-      // TODO IntervalTree goes out of sync after any change and "fixes" its state upon the first query. Replace it with another implementation that can be queried without potential side-effects.
-      LookupTree.Query(new Position(0, 0));
     }
 
     /// <summary>
     /// Tries to get a symbol at the specified location.
+    /// Only used for testing.
     /// </summary>
-    /// <param name="position">The requested position.</param>
-    /// <param name="symbol">The symbol that could be identified at the given position, or <c>null</c> if no symbol could be identified.</param>
-    /// <returns><c>true</c> if a symbol was found, otherwise <c>false</c>.</returns>
-    /// <exception cref="System.InvalidOperationException">Thrown if there was one more symbol at the specified position. This should never happen, unless there was an error.</exception>
     public bool TryGetSymbolAt(Position position, [NotNullWhen(true)] out ILocalizableSymbol? symbol) {
-      var symbolsAtPosition = LookupTree.Query(position);
+      var intervalTree = LookupTree.First().Value;
+
+      var symbolsAtPosition = intervalTree.Query(position);
       symbol = null;
       // Use case: function f(a: int) {}, and hover over a.
       foreach (var potentialSymbol in symbolsAtPosition) {
@@ -110,28 +108,19 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
     }
 
     /// <summary>
-    /// Tries to get the location of the given symbol.
-    /// </summary>
-    /// <param name="symbol">The symbol to get the location of.</param>
-    /// <param name="location">The current location of the specified symbol, or <c>null</c> if no location of the given symbol is known.</param>
-    /// <returns><c>true</c> if a location was found, otherwise <c>false</c>.</returns>
-    public bool TryGetLocationOf(ILegacySymbol symbol, [NotNullWhen(true)] out SymbolLocation? location) {
-      return Locations.TryGetValue(symbol, out location);
-    }
-
-    /// <summary>
     /// Resolves the innermost symbol that encloses the given position.
     /// </summary>
+    /// <param name="uri"></param>
     /// <param name="position">The position to get the innermost symbol of.</param>
     /// <param name="cancellationToken">A token to cancel the update operation before its completion.</param>
     /// <returns>The innermost symbol at the specified position.</returns>
     /// <exception cref="System.OperationCanceledException">Thrown when the cancellation was requested before completion.</exception>
     /// <exception cref="System.ObjectDisposedException">Thrown if the cancellation token was disposed before the completion.</exception>
-    public ILegacySymbol GetEnclosingSymbol(Position position, CancellationToken cancellationToken) {
+    public ILegacySymbol GetEnclosingSymbol(Uri uri, Position position, CancellationToken cancellationToken) {
       // TODO use a suitable data-structure to resolve the locations efficiently.
       ILegacySymbol innerMostSymbol = CompilationUnit;
       var innerMostRange = new Range(new Position(0, 0), new Position(int.MaxValue, int.MaxValue));
-      foreach (var (symbol, location) in Locations) {
+      foreach (var (symbol, location) in Locations.GetValueOrDefault(uri) ?? ImmutableDictionary<ILegacySymbol, SymbolLocation>.Empty) {
         cancellationToken.ThrowIfCancellationRequested();
         var range = location.Declaration;
         if (IsEnclosedBy(innerMostRange, range) && IsInside(range, position)) {

--- a/Source/DafnyLanguageServer/Language/Symbols/LegacySignatureAndCompletionTable.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/LegacySignatureAndCompletionTable.cs
@@ -4,7 +4,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
-using Microsoft.Dafny.LanguageServer.Workspace;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using AstElement = System.Object;
@@ -14,8 +13,8 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   /// <summary>
   /// Represents the symbol table
   /// </summary>
-  public class SignatureAndCompletionTable {
-    private readonly ILogger<SignatureAndCompletionTable> logger;
+  public class LegacySignatureAndCompletionTable {
+    private readonly ILogger<LegacySignatureAndCompletionTable> logger;
 
     // TODO Guard the properties from changes
     public CompilationUnit CompilationUnit { get; }
@@ -42,10 +41,10 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
 
     private readonly DafnyLangTypeResolver typeResolver;
 
-    public static SignatureAndCompletionTable Empty(DafnyOptions options, DafnyProject project) {
+    public static LegacySignatureAndCompletionTable Empty(DafnyOptions options, DafnyProject project) {
       var emptyProgram = GetEmptyProgram(options, project.Uri);
-      return new SignatureAndCompletionTable(
-        NullLogger<SignatureAndCompletionTable>.Instance,
+      return new LegacySignatureAndCompletionTable(
+        NullLogger<LegacySignatureAndCompletionTable>.Instance,
         new CompilationUnit(project.Uri, emptyProgram),
         new Dictionary<object, ILocalizableSymbol>(),
         new Dictionary<ILegacySymbol, SymbolLocation>(),
@@ -68,8 +67,8 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
       return emptyProgram;
     }
 
-    public SignatureAndCompletionTable(
-        ILogger<SignatureAndCompletionTable> iLogger,
+    public LegacySignatureAndCompletionTable(
+        ILogger<LegacySignatureAndCompletionTable> iLogger,
         CompilationUnit compilationUnit,
         IDictionary<AstElement, ILocalizableSymbol> declarations,
         IDictionary<ILegacySymbol, SymbolLocation> locations,

--- a/Source/DafnyLanguageServer/Language/Symbols/SymbolTableFactory.cs
+++ b/Source/DafnyLanguageServer/Language/Symbols/SymbolTableFactory.cs
@@ -15,15 +15,15 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
   public class SymbolTableFactory : ISymbolTableFactory {
     private readonly ILogger logger;
-    private readonly ILogger<SignatureAndCompletionTable> loggerSymbolTable;
+    private readonly ILogger<LegacySignatureAndCompletionTable> loggerSymbolTable;
 
-    public SymbolTableFactory(ILogger<SymbolTableFactory> logger, ILogger<SignatureAndCompletionTable> loggerSymbolTable) {
+    public SymbolTableFactory(ILogger<SymbolTableFactory> logger, ILogger<LegacySignatureAndCompletionTable> loggerSymbolTable) {
       this.logger = logger;
       this.loggerSymbolTable = loggerSymbolTable;
     }
 
 
-    public SignatureAndCompletionTable CreateFrom(CompilationUnit compilationUnit, CancellationToken cancellationToken) {
+    public LegacySignatureAndCompletionTable CreateFrom(CompilationUnit compilationUnit, CancellationToken cancellationToken) {
       var program = compilationUnit.Program;
       var declarations = CreateDeclarationDictionary(compilationUnit, cancellationToken);
       var designatorVisitor = new DesignatorVisitor(logger, compilationUnit, declarations, compilationUnit, cancellationToken);
@@ -40,7 +40,7 @@ namespace Microsoft.Dafny.LanguageServer.Language.Symbols {
         //      prohibiting it to be null).
         logger.LogDebug("cannot create symbol table from a program with errors");
       }
-      return new SignatureAndCompletionTable(
+      return new LegacySignatureAndCompletionTable(
         loggerSymbolTable,
         compilationUnit,
         declarations,

--- a/Source/DafnyLanguageServer/Workspace/Documents/Compilation.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/Compilation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       var program = new EmptyNode();
       return ToIdeState(new IdeState(initialCompilation.Version, initialCompilation, program,
         ImmutableDictionary<Uri, IReadOnlyList<Diagnostic>>.Empty,
-        SymbolTable.Empty(), SignatureAndCompletionTable.Empty(options, initialCompilation.Project), new(),
+        SymbolTable.Empty(), LegacySignatureAndCompletionTable.Empty(options, initialCompilation.Project), new(),
         Array.Empty<Counterexample>(),
         ImmutableDictionary<Uri, IReadOnlyList<Range>>.Empty,
         initialCompilation.RootUris.ToDictionary(uri => uri, uri => (VerificationTree)new DocumentVerificationTree(program, uri))

--- a/Source/DafnyLanguageServer/Workspace/Documents/CompilationAfterResolution.cs
+++ b/Source/DafnyLanguageServer/Workspace/Documents/CompilationAfterResolution.cs
@@ -17,7 +17,7 @@ public class CompilationAfterResolution : CompilationAfterParsing {
   public CompilationAfterResolution(CompilationAfterParsing compilationAfterParsing,
     IReadOnlyDictionary<Uri, List<DafnyDiagnostic>> diagnostics,
     SymbolTable? symbolTable,
-    SignatureAndCompletionTable signatureAndCompletionTable,
+    LegacySignatureAndCompletionTable signatureAndCompletionTable,
     IReadOnlyDictionary<Uri, IReadOnlyList<Range>> ghostDiagnostics,
     IReadOnlyList<ICanVerify> verifiables,
     ConcurrentDictionary<ModuleDefinition, Task<IReadOnlyDictionary<FilePosition, IReadOnlyList<IImplementationTask>>>> translatedModules,
@@ -33,7 +33,7 @@ public class CompilationAfterResolution : CompilationAfterParsing {
   }
   public List<Counterexample> Counterexamples { get; set; }
   public SymbolTable? SymbolTable { get; }
-  public SignatureAndCompletionTable SignatureAndCompletionTable { get; }
+  public LegacySignatureAndCompletionTable SignatureAndCompletionTable { get; }
   public IReadOnlyDictionary<Uri, IReadOnlyList<Range>> GhostDiagnostics { get; }
   public IReadOnlyList<ICanVerify> Verifiables { get; }
   public ConcurrentDictionary<ICanVerify, Dictionary<string, ImplementationView>> ImplementationsPerVerifiable { get; } = new();

--- a/Source/DafnyLanguageServer/Workspace/IdeState.cs
+++ b/Source/DafnyLanguageServer/Workspace/IdeState.cs
@@ -28,7 +28,7 @@ public record IdeState(
   Node Program,
   IReadOnlyDictionary<Uri, IReadOnlyList<Diagnostic>> ResolutionDiagnostics,
   SymbolTable SymbolTable,
-  SignatureAndCompletionTable SignatureAndCompletionTable,
+  LegacySignatureAndCompletionTable SignatureAndCompletionTable,
   Dictionary<Location, IdeVerificationResult> VerificationResults,
   IReadOnlyList<Counterexample> Counterexamples,
   IReadOnlyDictionary<Uri, IReadOnlyList<Range>> GhostRanges,

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         .AddSingleton<INotificationPublisher, NotificationPublisher>()
         .AddSingleton<CreateMigrator>(provider => (changes, cancellationToken) => new Migrator(
           provider.GetRequiredService<ILogger<Migrator>>(),
-          provider.GetRequiredService<ILogger<SignatureAndCompletionTable>>(),
+          provider.GetRequiredService<ILogger<LegacySignatureAndCompletionTable>>(),
           changes, cancellationToken))
         .AddSingleton<ISymbolGuesser, SymbolGuesser>()
         .AddSingleton<ICompilationStatusNotificationPublisher, CompilationStatusNotificationPublisher>()

--- a/Source/DafnyLanguageServer/Workspace/Migrator.cs
+++ b/Source/DafnyLanguageServer/Workspace/Migrator.cs
@@ -18,13 +18,13 @@ public class Migrator {
   private readonly ILogger<Migrator> logger;
   private readonly DidChangeTextDocumentParams changeParams;
   private readonly CancellationToken cancellationToken;
-  private readonly ILogger<SignatureAndCompletionTable> loggerSymbolTable;
+  private readonly ILogger<LegacySignatureAndCompletionTable> loggerSymbolTable;
 
   private readonly Dictionary<TextDocumentContentChangeEvent, Position> getPositionAtEndOfAppliedChangeCache = new();
 
   public Migrator(
     ILogger<Migrator> logger,
-    ILogger<SignatureAndCompletionTable> loggerSymbolTable,
+    ILogger<LegacySignatureAndCompletionTable> loggerSymbolTable,
     DidChangeTextDocumentParams changeParams,
     CancellationToken cancellationToken
   ) {
@@ -112,7 +112,7 @@ public class Migrator {
     };
   }
 
-  public SignatureAndCompletionTable MigrateSymbolTable(SignatureAndCompletionTable originalSymbolTable) {
+  public LegacySignatureAndCompletionTable MigrateSymbolTable(LegacySignatureAndCompletionTable originalSymbolTable) {
     var migratedLookupTree = originalSymbolTable.LookupTree;
     var migratedDeclarations = originalSymbolTable.Locations;
     foreach (var change in changeParams.ContentChanges) {
@@ -126,7 +126,7 @@ public class Migrator {
     }
     logger.LogTrace("migrated the lookup tree, lookup before={SymbolsBefore}, after={SymbolsAfter}",
       originalSymbolTable.LookupTree.Count, migratedLookupTree.Count);
-    return new SignatureAndCompletionTable(
+    return new LegacySignatureAndCompletionTable(
       loggerSymbolTable,
       originalSymbolTable.CompilationUnit,
       originalSymbolTable.Declarations,
@@ -259,7 +259,7 @@ public class Migrator {
   }
 
   private IDictionary<ILegacySymbol, SymbolLocation> ApplyDeclarationsChange(
-    SignatureAndCompletionTable originalSymbolTable,
+    LegacySignatureAndCompletionTable originalSymbolTable,
     IDictionary<ILegacySymbol, SymbolLocation> previousDeclarations,
     TextDocumentContentChangeEvent changeRange,
     Position? afterChangeEndOffset

--- a/Source/DafnyLanguageServer/Workspace/Migrator.cs
+++ b/Source/DafnyLanguageServer/Workspace/Migrator.cs
@@ -141,7 +141,7 @@ public class Migrator {
       originalSymbolTable.CompilationUnit,
       originalSymbolTable.Declarations,
       originalSymbolTable.Locations.SetItem(uri, migratedDeclarations!),
-      originalSymbolTable.LookupTree.SetItem(uri, migratedLookupTree),
+      originalSymbolTable.LookupTree.SetItem(uri, migratedLookupTree!),
       false
     );
   }

--- a/Source/DafnyLanguageServer/Workspace/SymbolGuesser.cs
+++ b/Source/DafnyLanguageServer/Workspace/SymbolGuesser.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
           }
           return (null, null);
         }
-        return GetSymbolAndTypeOfLastMember(position, memberAccesses);
+        return GetSymbolAndTypeOfLastMember(uri, position, memberAccesses);
       }
 
       private static Position? GetLinePositionBefore(Position requestPosition) {
@@ -67,8 +67,9 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         return new Position(position.Line, position.Character - 1);
       }
 
-      private (ILegacySymbol? Designator, ILegacySymbol? Type) GetSymbolAndTypeOfLastMember(Position position, IReadOnlyList<string> memberAccessChain) {
-        var enclosingSymbol = state.SignatureAndCompletionTable.GetEnclosingSymbol(position, cancellationToken);
+      private (ILegacySymbol? Designator, ILegacySymbol? Type) GetSymbolAndTypeOfLastMember(Uri uri, Position position,
+        IReadOnlyList<string> memberAccessChain) {
+        var enclosingSymbol = state.SignatureAndCompletionTable.GetEnclosingSymbol(uri, position, cancellationToken);
         ILegacySymbol? currentDesignator = null;
         ILegacySymbol? currentDesignatorType = null;
         for (int currentMemberAccess = 0; currentMemberAccess < memberAccessChain.Count; currentMemberAccess++) {

--- a/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
+++ b/Source/DafnyLanguageServer/Workspace/TextDocumentLoader.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         program,
         resolutionDiagnostics,
         SymbolTable.Empty(),
-        SignatureAndCompletionTable.Empty(dafnyOptions, compilation.Project),
+        LegacySignatureAndCompletionTable.Empty(dafnyOptions, compilation.Project),
         new(),
         Array.Empty<Counterexample>(),
         ImmutableDictionary<Uri, IReadOnlyList<Range>>.Empty,

--- a/Source/DafnyServer/DafnyHelper.cs
+++ b/Source/DafnyServer/DafnyHelper.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Dafny {
     public void Symbols() {
       ServerUtils.ApplyArgs(args, options);
       if (Parse() && Resolve()) {
-        var symbolTable = new LegacySymbolTable(dafnyProgram);
+        var symbolTable = new SuperLegacySymbolTable(dafnyProgram);
         var symbols = symbolTable.CalculateSymbols();
         Console.WriteLine("SYMBOLS_START " + ConvertToJson(symbols) + " SYMBOLS_END");
       } else {

--- a/Source/DafnyServer/SuperLegacySymbolTable.cs
+++ b/Source/DafnyServer/SuperLegacySymbolTable.cs
@@ -11,11 +11,11 @@ using Function = Microsoft.Dafny.Function;
 using Program = Microsoft.Dafny.Program;
 
 namespace DafnyServer {
-  public class LegacySymbolTable {
+  public class SuperLegacySymbolTable {
     private readonly Program _dafnyProgram;
     private readonly List<SymbolInformation> _information = new();
 
-    public LegacySymbolTable(Program dafnyProgram) {
+    public SuperLegacySymbolTable(Program dafnyProgram) {
       _dafnyProgram = dafnyProgram;
     }
 


### PR DESCRIPTION
### Changes

1. Rename `LegacySymbolTable`, which is part of the non-LSP Dafny server, to `SuperLegacySymbolTable`
1. Rename `SignatureAndCompletionTable` to `LegacySignatureAndCompletionTable`
1. Let `SignatureAndCompletionTable` differentiate between positions in different files, so it doesn't get confused between symbols in different files when they have similar positions or ranges.
1. Only migrate state in `SignatureAndCompletionTable` that relates to the changed file

### Testing
- There could be a test added for 3 but I didn't add it.
- Merging this PR into this other PR (https://github.com/dafny-lang/dafny/pull/4419), reduces the time of the test `ManyFastEditsUsingLargeFilesAndIncludes` from 47 seconds to 8 seconds

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
