### PR TITLE
Parser cancellation

### DIFF
--- a/Source/DafnyCore/AST/Grammar/ProgramParser.cs
+++ b/Source/DafnyCore/AST/Grammar/ProgramParser.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using static Microsoft.Dafny.ParseErrors;
@@ -58,33 +57,20 @@ public class ProgramParser {
         options.XmlSink.WriteFileFragment(dafnyFile.Uri.LocalPath);
       }
 
-      try {
-        var parseResult = ParseFile(
-          options,
-          dafnyFile.GetContent,
-          dafnyFile.Uri,
-          cancellationToken
-        );
-        if (parseResult.ErrorReporter.ErrorCount != 0) {
-          logger.LogDebug($"encountered {parseResult.ErrorReporter.ErrorCount} errors while parsing {dafnyFile.Uri}");
-        }
+      var parseResult = ParseFileWithErrorHandling(
+        errorReporter.Options,
+        dafnyFile.GetContent,
+        dafnyFile.Origin,
+        dafnyFile.Uri,
+        cancellationToken
+      );
+      if (parseResult.ErrorReporter.ErrorCount != 0) {
+        logger.LogDebug($"encountered {parseResult.ErrorReporter.ErrorCount} errors while parsing {dafnyFile.Uri}");
+      }
 
-        AddParseResultToProgram(parseResult, program);
-        if (defaultModule.RangeToken.StartToken.Uri == null) {
-          defaultModule.RangeToken = parseResult.Module.RangeToken;
-        }
-
-      } catch (Exception e) {
-        logger.LogDebug(e, $"encountered an exception while parsing {dafnyFile.Uri}");
-        var internalErrorDummyToken = new Token {
-          Uri = dafnyFile.Uri,
-          line = 1,
-          col = 1,
-          pos = 0,
-          val = string.Empty
-        };
-        errorReporter.Error(MessageSource.Parser, internalErrorDummyToken,
-          "[internal error] Parser exception: " + e.Message);
+      AddParseResultToProgram(parseResult, program);
+      if (defaultModule.RangeToken.StartToken.Uri == null) {
+        defaultModule.RangeToken = parseResult.Module.RangeToken;
       }
     }
 
@@ -110,6 +96,41 @@ public class ProgramParser {
     ShowWarningsForIncludeCycles(program);
 
     return program;
+  }
+
+  private DfyParseResult ParseFileWithErrorHandling(DafnyOptions options,
+    Func<TextReader> getContent,
+    IToken origin,
+    Uri uri,
+    CancellationToken cancellationToken) {
+    try {
+      return ParseFile(options, getContent, uri, cancellationToken);
+    } catch (IOException e) {
+      if (origin == null) {
+        throw;
+      }
+
+      var reporter = new BatchErrorReporter(options);
+      reporter.Error(MessageSource.Parser, origin,
+        $"Unable to open the file {uri} because {e.Message}.");
+      return new DfyParseResult(reporter, new FileModuleDefinition(Token.NoToken), new Action<SystemModuleManager>[] { });
+    } catch (OperationCanceledException) {
+      throw;
+    } catch (Exception e) {
+      var internalErrorDummyToken = new Token {
+        Uri = uri,
+        line = 1,
+        col = 1,
+        pos = 0,
+        val = string.Empty
+      };
+
+      var reporter = new BatchErrorReporter(options);
+      reporter.Error(MessageSource.Parser, ErrorId.p_internal_exception, internalErrorDummyToken,
+        "[internal error] Parser exception: " + e.Message + (!options.Verbose ? "" :
+          "\n" + e.StackTrace));
+      return new DfyParseResult(reporter, new FileModuleDefinition(Token.NoToken), new Action<SystemModuleManager>[] { });
+    }
   }
 
   private void ShowWarningsForIncludeCycles(Program program) {
@@ -200,25 +221,20 @@ public class ProgramParser {
       }
 
       cancellationToken.ThrowIfCancellationRequested();
-      try {
-        var parseIncludeResult = ParseFile(
-          errorReporter.Options,
-          top.GetContent,
-          top.Uri,
-          cancellationToken
-        );
-        result.Add(parseIncludeResult);
+      var parseIncludeResult = ParseFileWithErrorHandling(
+        errorReporter.Options,
+        top.GetContent,
+        top.Origin,
+        top.Uri,
+        cancellationToken
+      );
+      result.Add(parseIncludeResult);
 
-        foreach (var include in parseIncludeResult.Module.Includes) {
-          var dafnyFile = IncludeToDafnyFile(systemModuleManager, errorReporter, include);
-          if (dafnyFile != null) {
-            stack.Push(dafnyFile);
-          }
+      foreach (var include in parseIncludeResult.Module.Includes) {
+        var dafnyFile = IncludeToDafnyFile(systemModuleManager, errorReporter, include);
+        if (dafnyFile != null) {
+          stack.Push(dafnyFile);
         }
-      } catch (OperationCanceledException) {
-        throw;
-      } catch (Exception) {
-        // ignored
       }
     }
 
@@ -227,12 +243,8 @@ public class ProgramParser {
 
   private DafnyFile IncludeToDafnyFile(SystemModuleManager systemModuleManager, ErrorReporter errorReporter, Include include) {
     try {
-      return new DafnyFile(systemModuleManager.Options, include.IncludedFilename,
+      return new DafnyFile(systemModuleManager.Options, include.IncludedFilename, include.tok,
         () => fileSystem.ReadFile(include.IncludedFilename));
-    } catch (IOException e) {
-      errorReporter.Error(MessageSource.Parser, include.tok,
-        $"Unable to open the include {include.IncludedFilename} because {e.Message}.");
-      return null;
     } catch (IllegalDafnyFile) {
       errorReporter.Error(MessageSource.Parser, include.tok,
         $"Unable to open the include {include.IncludedFilename}.");
@@ -246,28 +258,12 @@ public class ProgramParser {
   /// Returns the number of parsing errors encountered.
   /// Note: first initialize the Scanner.
   ///</summary>
-  protected virtual DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader, Uri uri, CancellationToken cancellationToken) /* throws System.IO.IOException */ {
+  protected virtual DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader,
+    Uri uri, CancellationToken cancellationToken) /* throws System.IO.IOException */ {
     Contract.Requires(uri != null);
     using var reader = getReader();
     var text = SourcePreprocessor.ProcessDirectives(reader, new List<string>());
-    try {
-      return ParseFile(options, text, uri, cancellationToken);
-    } catch (OperationCanceledException) {
-      throw;
-    } catch (Exception e) {
-      var internalErrorDummyToken = new Token {
-        Uri = uri,
-        line = 1,
-        col = 1,
-        pos = 0,
-        val = string.Empty
-      };
-      var reporter = new BatchErrorReporter(options);
-      reporter.Error(MessageSource.Parser, ErrorId.p_internal_exception, internalErrorDummyToken,
-        "[internal error] Parser exception: " + e.Message + (!options.Verbose ? "" :
-            "\n" + e.StackTrace));
-      return new DfyParseResult(reporter, null, new Action<SystemModuleManager>[] { });
-    }
+    return ParseFile(options, text, uri, cancellationToken);
   }
 
   ///<summary>
@@ -307,7 +303,7 @@ public class ProgramParser {
   }
 
   public Program Parse(string source, Uri uri, ErrorReporter reporter) {
-    var files = new[] { new DafnyFile(reporter.Options, uri, () => new StringReader(source)) };
+    var files = new[] { new DafnyFile(reporter.Options, uri, null, () => new StringReader(source)) };
     return ParseFiles(uri.ToString(), files, reporter, CancellationToken.None);
   }
 }

--- a/Source/DafnyCore/AST/Grammar/ProgramParser.cs
+++ b/Source/DafnyCore/AST/Grammar/ProgramParser.cs
@@ -254,7 +254,7 @@ public class ProgramParser {
       return ParseFile(options, text, uri, cancellationToken);
     } catch (OperationCanceledException) {
       throw;
-    }catch (Exception e) {
+    } catch (Exception e) {
       var internalErrorDummyToken = new Token {
         Uri = uri,
         line = 1,

--- a/Source/DafnyCore/Coco/Parser.frame
+++ b/Source/DafnyCore/Coco/Parser.frame
@@ -33,6 +33,7 @@ Coco/R itself) does not fall under the GNU General Public License.
 
 using System;
 using System.Diagnostics.Contracts;
+using System.Threading;
 
 -->namespace
 
@@ -44,6 +45,7 @@ public class Parser {
 
   public Scanner scanner;
   public Errors  errors;
+  CancellationToken cancellationToken;
 
   public IToken t;    // last recognized token
   public IToken la;   // lookahead token
@@ -51,9 +53,10 @@ public class Parser {
 
 -->declarations
 
-  public Parser(Scanner scanner, Errors errors) {
+  public Parser(Scanner scanner, Errors errors, CancellationToken cancellationToken) {
     this.scanner = scanner;
     this.errors = errors;
+    this.cancellationToken = cancellationToken;
     this.la = scanner.FirstToken;
     this.t = scanner.FirstToken; // just to satisfy its non-null constraint
   }
@@ -72,6 +75,7 @@ public class Parser {
   }
 
   void Get() {
+    cancellationToken.ThrowIfCancellationRequested();
     for (; ; ) {
       var tmp = la;
       la = scanner.Scan();

--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -178,8 +178,8 @@ public void ApplyOptionsFromAttributes(Attributes attrs) {
   }
 }
 
-public Parser(DafnyOptions options, Scanner/*!*/ scanner, Errors/*!*/ errors)
-  : this(scanner, errors)  // the real work
+public Parser(DafnyOptions options, Scanner/*!*/ scanner, Errors/*!*/ errors, CancellationToken cancellationToken)
+  : this(scanner, errors, cancellationToken)  // the real work
 {
   // initialize readonly fields
   dummyExpr = new LiteralExpr(Token.NoToken);

--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DafnyCore;
+using JetBrains.Annotations;
 
 namespace Microsoft.Dafny;
 
@@ -16,9 +17,11 @@ public class DafnyFile {
   public bool IsPrecompiled { get; set; }
   public Func<TextReader> GetContent { get; set; }
   public Uri Uri { get; }
+  [CanBeNull] public IToken Origin { get; }
 
-  public DafnyFile(DafnyOptions options, Uri uri, Func<TextReader> getContentOverride = null) {
+  public DafnyFile(DafnyOptions options, Uri uri, [CanBeNull] IToken origin = null, Func<TextReader> getContentOverride = null) {
     Uri = uri;
+    Origin = origin;
     var filePath = uri.LocalPath;
 
     var extension = ".dfy";

--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -14,10 +14,10 @@ public class DafnyFile {
   public string BaseName { get; private set; }
   public bool IsPreverified { get; set; }
   public bool IsPrecompiled { get; set; }
-  public TextReader Content { get; set; }
+  public Func<TextReader> GetContent { get; set; }
   public Uri Uri { get; }
 
-  public DafnyFile(DafnyOptions options, Uri uri, TextReader contentOverride = null) {
+  public DafnyFile(DafnyOptions options, Uri uri, Func<TextReader> getContentOverride = null) {
     Uri = uri;
     var filePath = uri.LocalPath;
 
@@ -27,7 +27,7 @@ public class DafnyFile {
       BaseName = Path.GetFileName(uri.LocalPath);
     }
     if (uri.Scheme == "stdin") {
-      contentOverride = options.Input;
+      getContentOverride = () => options.Input;
       BaseName = "<stdin>";
     }
 
@@ -35,14 +35,14 @@ public class DafnyFile {
     // supported in .Net APIs, because it is very difficult in general
     // So we will just use the absolute path, lowercased for all file systems.
     // cf. IncludeComparer.CompareTo
-    CanonicalPath = contentOverride == null ? Canonicalize(filePath).LocalPath : "<stdin>";
+    CanonicalPath = getContentOverride == null ? Canonicalize(filePath).LocalPath : "<stdin>";
     FilePath = CanonicalPath;
 
     var filePathForErrors = options.UseBaseNameForFileName ? Path.GetFileName(filePath) : filePath;
-    if (contentOverride != null) {
+    if (getContentOverride != null) {
       IsPreverified = false;
       IsPrecompiled = false;
-      Content = contentOverride;
+      GetContent = getContentOverride;
     } else if (extension == ".dfy" || extension == ".dfyi") {
       IsPreverified = false;
       IsPrecompiled = false;
@@ -57,7 +57,7 @@ public class DafnyFile {
         options.Printer.ErrorWriteLine(options.OutputWriter, $"*** Error: file {filePathForErrors} not found");
         throw new IllegalDafnyFile(true);
       } else {
-        Content = new StreamReader(filePath);
+        GetContent = () => new StreamReader(filePath);
       }
     } else if (extension == ".doo") {
       IsPreverified = true;
@@ -78,7 +78,7 @@ public class DafnyFile {
       // more efficiently inside a .doo file, at which point
       // the DooFile class should encapsulate the serialization logic better
       // and expose a Program instead of the program text.
-      Content = new StringReader(dooFile.ProgramText);
+      GetContent = () => new StringReader(dooFile.ProgramText);
     } else if (extension == ".dll") {
       IsPreverified = true;
       // Technically only for C#, this is for backwards compatability
@@ -86,7 +86,7 @@ public class DafnyFile {
 
       var sourceText = GetDafnySourceAttributeText(filePath);
       if (sourceText == null) { throw new IllegalDafnyFile(); }
-      Content = new StringReader(sourceText);
+      GetContent = () => new StringReader(sourceText);
     } else {
       throw new IllegalDafnyFile();
     }

--- a/Source/DafnyDriver/DafnyDoc.cs
+++ b/Source/DafnyDriver/DafnyDoc.cs
@@ -50,6 +50,8 @@ class DafnyDoc {
       outputdir = DefaultOutputDir;
     }
 
+
+
     // Collect all the dafny files; dafnyFiles already includes files from a .toml project file
     var exitValue = DafnyDriver.ExitValue.SUCCESS;
     dafnyFiles = dafnyFiles.Concat(dafnyFolders.SelectMany(folderPath => {

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -516,8 +516,9 @@ namespace Microsoft.Dafny {
           dafnyFile = new DafnyFile(options, new Uri(tempFileName));
         }
 
-        var originalText = dafnyFile.Content.ReadToEnd();
-        dafnyFile.Content = new StringReader(originalText);
+        using var content = dafnyFile.GetContent();
+        var originalText = content.ReadToEnd();
+        dafnyFile.GetContent = () => new StringReader(originalText);
         // Might not be totally optimized but let's do that for now
         var err = DafnyMain.Parse(new List<DafnyFile> { dafnyFile }, programName, options, out var dafnyProgram);
         if (err != null) {

--- a/Source/DafnyLanguageServer/Language/CachingParser.cs
+++ b/Source/DafnyLanguageServer/Language/CachingParser.cs
@@ -26,12 +26,12 @@ public class CachingParser : ProgramParser {
       telemetryPublisher, programName, "parsing");
   }
 
-  protected override DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader, Uri uri) {
+  protected override DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader, Uri uri, CancellationToken cancellationToken) {
     using var reader = getReader();
     var (newReader, hash) = ComputeHashFromReader(uri, reader, HashAlgorithm.Create("SHA256")!);
     if (!parseCache.TryGet(hash, out var result)) {
       logger.LogDebug($"Parse cache miss for {uri}");
-      result = base.ParseFile(options, () => newReader, uri);
+      result = base.ParseFile(options, () => newReader, uri, cancellationToken);
       parseCache.Set(hash, result);
     } else {
       logger.LogDebug($"Parse cache hit for {uri}");

--- a/Source/DafnyLanguageServer/Language/CachingParser.cs
+++ b/Source/DafnyLanguageServer/Language/CachingParser.cs
@@ -26,11 +26,12 @@ public class CachingParser : ProgramParser {
       telemetryPublisher, programName, "parsing");
   }
 
-  protected override DfyParseResult ParseFile(DafnyOptions options, TextReader reader, Uri uri) {
+  protected override DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader, Uri uri) {
+    using var reader = getReader();
     var (newReader, hash) = ComputeHashFromReader(uri, reader, HashAlgorithm.Create("SHA256")!);
     if (!parseCache.TryGet(hash, out var result)) {
       logger.LogDebug($"Parse cache miss for {uri}");
-      result = base.ParseFile(options, newReader, uri);
+      result = base.ParseFile(options, () => newReader, uri);
       parseCache.Set(hash, result);
     } else {
       logger.LogDebug($"Parse cache hit for {uri}");

--- a/Source/DafnyLanguageServer/Language/CachingParser.cs
+++ b/Source/DafnyLanguageServer/Language/CachingParser.cs
@@ -26,7 +26,9 @@ public class CachingParser : ProgramParser {
       telemetryPublisher, programName, "parsing");
   }
 
-  protected override DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader, Uri uri, CancellationToken cancellationToken) {
+  protected override DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader,
+    Uri uri, CancellationToken cancellationToken) {
+
     using var reader = getReader();
     var (newReader, hash) = ComputeHashFromReader(uri, reader, HashAlgorithm.Create("SHA256")!);
     if (!parseCache.TryGet(hash, out var result)) {

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         List<DafnyFile> dafnyFiles = new();
         foreach (var rootSourceUri in rootSourceUris) {
           try {
-            dafnyFiles.Add(new DafnyFile(reporter.Options, rootSourceUri, () => fileSystem.ReadFile(rootSourceUri)));
+            dafnyFiles.Add(new DafnyFile(reporter.Options, rootSourceUri, null, () => fileSystem.ReadFile(rootSourceUri)));
             if (logger.IsEnabled(LogLevel.Trace)) {
               logger.LogTrace($"Parsing file with uri {rootSourceUri} and content\n{fileSystem.ReadFile(rootSourceUri).ReadToEnd()}");
             }

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Dafny.LanguageServer.Workspace;
 
 namespace Microsoft.Dafny.LanguageServer.Language {

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         List<DafnyFile> dafnyFiles = new();
         foreach (var rootSourceUri in rootSourceUris) {
           try {
-            dafnyFiles.Add(new DafnyFile(reporter.Options, rootSourceUri, fileSystem.ReadFile(rootSourceUri)));
+            dafnyFiles.Add(new DafnyFile(reporter.Options, rootSourceUri, () => fileSystem.ReadFile(rootSourceUri)));
             if (logger.IsEnabled(LogLevel.Trace)) {
               logger.LogTrace($"Parsing file with uri {rootSourceUri} and content\n{fileSystem.ReadFile(rootSourceUri).ReadToEnd()}");
             }

--- a/Source/DafnyServer/DafnyHelper.cs
+++ b/Source/DafnyServer/DafnyHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Dafny {
     private bool Parse() {
       var uri = new Uri("transcript:///" + fname);
       reporter = new ConsoleErrorReporter(options);
-      var program = new ProgramParser().ParseFiles(fname, new DafnyFile[] { new(reporter.Options, uri, () => new StringReader(source)) },
+      var program = new ProgramParser().ParseFiles(fname, new DafnyFile[] { new(reporter.Options, uri, null, () => new StringReader(source)) },
         reporter, CancellationToken.None);
 
       var success = reporter.ErrorCount == 0;

--- a/Source/DafnyServer/DafnyHelper.cs
+++ b/Source/DafnyServer/DafnyHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Dafny {
     private bool Parse() {
       var uri = new Uri("transcript:///" + fname);
       reporter = new ConsoleErrorReporter(options);
-      var program = new ProgramParser().ParseFiles(fname, new DafnyFile[] { new(reporter.Options, uri, new StringReader(source)) },
+      var program = new ProgramParser().ParseFiles(fname, new DafnyFile[] { new(reporter.Options, uri, () => new StringReader(source)) },
         reporter, CancellationToken.None);
 
       var success = reporter.ErrorCount == 0;

--- a/Source/DafnyTestGeneration/Utils.cs
+++ b/Source/DafnyTestGeneration/Utils.cs
@@ -86,7 +86,7 @@ namespace DafnyTestGeneration {
       uri ??= new Uri(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
       var reporter = new BatchErrorReporter(options);
 
-      var program = new ProgramParser().ParseFiles(uri.LocalPath, new DafnyFile[] { new(reporter.Options, uri, () => new StringReader(source)) },
+      var program = new ProgramParser().ParseFiles(uri.LocalPath, new DafnyFile[] { new(reporter.Options, uri, null, () => new StringReader(source)) },
         reporter, CancellationToken.None);
 
       if (!resolve) {

--- a/Source/DafnyTestGeneration/Utils.cs
+++ b/Source/DafnyTestGeneration/Utils.cs
@@ -86,7 +86,7 @@ namespace DafnyTestGeneration {
       uri ??= new Uri(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
       var reporter = new BatchErrorReporter(options);
 
-      var program = new ProgramParser().ParseFiles(uri.LocalPath, new DafnyFile[] { new(reporter.Options, uri, new StringReader(source)) },
+      var program = new ProgramParser().ParseFiles(uri.LocalPath, new DafnyFile[] { new(reporter.Options, uri, () => new StringReader(source)) },
         reporter, CancellationToken.None);
 
       if (!resolve) {


### PR DESCRIPTION
### Changes
- Enable cancelling of parsing at the token granularity level, instead of only at the file level
- Do not open file streams used for parsing until actually parsing

### Testing
We don't have a good way of automatically testing such a performance change right now, but in one manual test run I saw runtime go down from 35 to 9s.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
