### PR TITLE
Revisit reads checking

### DIFF
--- a/Source/DafnyCore/Verifier/Translator.ClassMembers.cs
+++ b/Source/DafnyCore/Verifier/Translator.ClassMembers.cs
@@ -668,7 +668,7 @@ namespace Microsoft.Dafny {
         // check well-formedness of any default-value expressions (before assuming preconditions)
         foreach (var formal in m.Ins.Where(formal => formal.DefaultValue != null)) {
           var e = formal.DefaultValue;
-          CheckWellformed(e, new WFOptions(null, false, false, true), localVariables, builder, etran);
+          CheckWellformed(e, WFOptions.ForDefaultParameterExpressions(false), localVariables, builder, etran);
           builder.Add(new Boogie.AssumeCmd(e.tok, CanCallAssumption(e, etran)));
           CheckSubrange(e.tok, etran.TrExpr(e), e.Type, formal.Type, builder);
 

--- a/Source/DafnyCore/Verifier/Translator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/Translator.ExpressionWellformed.cs
@@ -55,6 +55,10 @@ namespace Microsoft.Dafny {
         }
       }
 
+      public static WFOptions ForDefaultParameterExpressions(bool doReadsChecks) {
+        return new WFOptions(null, doReadsChecks, doReadsChecks, true);
+      }
+
       public WFOptions(Bpl.QKeyValue kv) {
         AssertKv = kv;
       }

--- a/Source/DafnyCore/Verifier/Translator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/Translator.TrStatement.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Dafny {
         var r = new Bpl.LocalVariable(pat.tok, new Bpl.TypedIdent(pat.tok, nm, TrType(rhs.Type)));
         locals.Add(r);
         var rIe = new Bpl.IdentifierExpr(rhs.tok, r);
-        CheckWellformedWithResult(rhs, new WFOptions(null, false, false), rIe, pat.Expr.Type, locals, builder, etran);
+        CheckWellformedWithResult(rhs, new WFOptions(null, false), rIe, pat.Expr.Type, locals, builder, etran);
         CheckCasePatternShape(pat, rIe, rhs.tok, pat.Expr.Type, builder);
         builder.Add(TrAssumeCmd(pat.tok, Bpl.Expr.Eq(etran.TrExpr(pat.Expr), rIe)));
       } else if (stmt is TryRecoverStatement haltRecoveryStatement) {

--- a/Test/dafny0/MoreReads.dfy
+++ b/Test/dafny0/MoreReads.dfy
@@ -90,3 +90,95 @@ ghost function R3(obj: object): int
 {
   100
 }
+
+// lambda expressions
+
+method Lambda0() {
+  var f :=
+    (x: int)
+    requires x < 100
+    reads if x == 202 then var u := 10/0; {} else {} // no problem, because of precondition
+    =>
+    2;
+  var g :=
+    (x: int)
+    reads if x == 202 then var u := 10/0; {} else {} // no problem, because of precondition
+    requires x < 100
+    =>
+    2;
+}
+
+method Lambda1() {
+  var p :=
+    ()
+    requires exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100
+    =>
+    var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; // error: precondition on .reads
+    var cc := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100;
+    var f: int ~> int :| f.requires(10) && f.reads(10) == {} && f(10) == 100;
+    var g: int ~> int :| g.reads(10) == {} && g.requires(10) && g(10) == 100; // error: precondition on .reads
+    f(10) + g(10);
+
+  var r0 :=
+    ()
+    requires exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100
+    reads
+      var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; // error: precondition on .reads
+      var cc := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100;
+      {}
+    =>
+    100;
+
+  var r1 :=
+    ()
+    reads
+      var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {obj} && f(10) == 100; // error: precondition on .reads
+      var cc := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; // error: insufficient reads clause on .reads
+      {}
+    =>
+    100;
+
+  var r2 :=
+    ()
+    reads
+      var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {obj} && f(10) == 100; // error: precondition on .reads
+      var cc := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; // error: insufficient reads clause on .reads
+      {obj}
+    =>
+    100;
+
+  var r3 :=
+    ()
+    reads
+      var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {obj} && f(10) == 100; // error: precondition on .reads
+      var cc := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; // error: insufficient reads clause on .reads
+      {}
+    reads obj
+    =>
+    100;
+}
+
+// lambda expressions are not subject to enclosing reads clause
+
+class Cell {
+  var data: int
+}
+
+function LambdaInsideLambda0(cell: Cell): int
+{
+  var f := () reads cell => cell.data; // fine
+  2
+}
+
+function LambdaInsideLambda1(cell: Cell): int
+{
+  var f := () reads cell => cell.data;
+  f() // error: LambdaInsideLambda1 has insufficient reads clause for this call
+}
+
+function LambdaInsideLambda2(cell: Cell): int
+  reads cell
+{
+  var f := () reads cell => cell.data;
+  f() // fine, since LambdaInsideLambda2 is allowed to read c
+}

--- a/Test/dafny0/MoreReads.dfy
+++ b/Test/dafny0/MoreReads.dfy
@@ -1,0 +1,92 @@
+// RUN: %exits-with 4 %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// reads checks for default-value expressions
+
+ghost function F0(x: int := var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; 100): int {
+  2
+}
+
+ghost function F1(x: int := var bb := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100; 100): int { // error: precondition on .reads
+  2
+}
+
+ghost function F2(obj: object,
+  x: int := var bb := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; 100 // error: insufficient reads on .reads
+  ) : int
+{
+  2
+}
+
+ghost function F3(obj: object,
+  x: int := var bb := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; 100
+  ) : int
+  reads obj
+{
+  2
+}
+
+datatype Dt =
+  | Ctor0(ghost x: int := var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; 100)
+  | Ctor1(ghost x: int := var bb := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100; 100) // error: precondition on .reads
+  | Ctor2(obj: object,
+          ghost x: int := var bb := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; 100) // error: insufficient reads on .reads
+
+method M0(ghost x: int := var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; 100) {
+}
+
+method M1(ghost x: int := var bb := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100; 100) {
+}
+
+iterator Iter(ghost x: int := var bb := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100; 100) {
+}
+
+// delayed reads checks in reads clauses and functon bodies
+
+ghost function P(): int
+  requires exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100
+{
+  var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; // error: precondition on .reads
+  var cc := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100;
+  var f: int ~> int :| f.requires(10) && f.reads(10) == {} && f(10) == 100;
+  var g: int ~> int :| g.reads(10) == {} && g.requires(10) && g(10) == 100; // error: precondition on .reads
+  f(10) + g(10)
+}
+
+ghost function R0(): int
+  requires exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100
+  reads
+    var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {} && f(10) == 100; // error: precondition on .reads
+    var cc := exists f: int ~> int :: f.reads(10) == {} && f.requires(10) && f(10) == 100;
+    {}
+{
+  100
+}
+
+ghost function R1(obj: object): int
+  reads
+    var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {obj} && f(10) == 100; // error: precondition on .reads
+    var cc := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; // error: insufficient reads clause on .reads
+    {}
+{
+  100
+}
+
+ghost function R2(obj: object): int
+  reads
+    var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {obj} && f(10) == 100; // error: precondition on .reads
+    var cc := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; // error: insufficient reads clause on .reads
+    {obj}
+{
+  100
+}
+
+ghost function R3(obj: object): int
+  reads
+    var bb := exists f: int ~> int :: f.requires(10) && f.reads(10) == {obj} && f(10) == 100; // error: precondition on .reads
+    var cc := exists f: int ~> int :: f.reads(10) == {obj} && f.requires(10) && f(10) == 100; // error: insufficient reads clause on .reads
+    {}
+  reads obj
+{
+  100
+}


### PR DESCRIPTION
With some upcoming changes to `reads` checking (fixing soundness bugs in the encoding of function values, and adding opt-in `reads` clauses for methods), several issues were brought to the surface. These can broadly be placed in two groups:

* Eager versus delayed reads checking
* Reads checking for lambda expressions

For the former, one idea is to delay reads checking only when checking the well-formedness of preconditions. However, there are expressions (like quantifiers over function values where the quantifier's body restricts the function values to ones with a certain reads clause) that need delayed reads checking. So, it seems that a function's requires/reads/body should all do delayed reads checking. I think that's what's currently done, but it would be good to revisit this design point and to check that the implementation really does that.

Also for the former, default-value expressions that are subject to reads checking should do delayed reads checking. The reason is the same as above, namely that some expressions (like those quantifiers) need delayed checking. The general design for checking default-value expressions is that they should live up to the reads clause of the enclosing declaration--this way, it is never a surprise to a caller who implicitly uses the default-value expressions for the parameters.

For the second bullet above, the implementation seems to have two problems. One is that the lambda expression's precondition does not get assumed when the lambda expression's `reads` clause is checked. The other is that the reads checks for a lambda expression should be guided only by the `reads` clause of the lambda expression itself, not the enclosing context. Furthermore, when applying a function, reads checking should be done.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
