### PR TITLE
Prevent the IDE from locking up when certain parse error occur

### DIFF
--- a/Source/DafnyCore/Generic/Node.cs
+++ b/Source/DafnyCore/Generic/Node.cs
@@ -66,7 +66,10 @@ public abstract class Node : INode {
       var childrenFiltered = GetConcreteChildren(this).ToList();
 
       // If we parse a resolved document, some children sometimes have the same token because they are auto-generated
-      var startToEndTokenNotOwned = childrenFiltered.Where(c => c.StartToken.pos <= c.EndToken.pos).
+      var startToEndTokenNotOwned = childrenFiltered.
+        // Because RangeToken.EndToken is inclusive, a token with an empty range has an EndToken that occurs before the StartToken
+        // We need to filter these out to prevent an infinite loop
+        Where(c => c.StartToken.pos <= c.EndToken.pos).
         GroupBy(child => child.StartToken.pos).
         ToDictionary(g => g.Key, g => g.MaxBy(child => child.EndToken.pos).EndToken
       );

--- a/Source/DafnyCore/Generic/Node.cs
+++ b/Source/DafnyCore/Generic/Node.cs
@@ -66,7 +66,8 @@ public abstract class Node : INode {
       var childrenFiltered = GetConcreteChildren(this).ToList();
 
       // If we parse a resolved document, some children sometimes have the same token because they are auto-generated
-      var startToEndTokenNotOwned = childrenFiltered.GroupBy(child => child.StartToken.pos).
+      var startToEndTokenNotOwned = childrenFiltered.Where(c => c.StartToken.pos <= c.EndToken.pos).
+        GroupBy(child => child.StartToken.pos).
         ToDictionary(g => g.Key, g => g.MaxBy(child => child.EndToken.pos).EndToken
       );
 

--- a/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
@@ -46,6 +46,17 @@ module A.B.C {
     }
 
     [Fact]
+    public async Task DoubleComma() {
+      var source = @"
+  method Foo(a: int,, b: int) returns (x: int) {
+  }".TrimStart();
+      var documentItem = CreateTestDocument(source);
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var allSymbols = await RequestDocumentSymbol(documentItem);
+      Assert.Single(allSymbols);
+    }
+
+    [Fact]
     public async Task LoadCorrectDocumentCreatesTopLevelSymbols() {
       var source = @"
   method DoIt() returns (x: int) {


### PR DESCRIPTION
### Changes

Previously the IDE server would become completely unresponsive when a repeated comma occurred in a parameter, now it does not.

### Testing

Added test to ensure the behavior does not occur

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
