### PR TITLE
chore: Mark FuelTrigger wish as now passing

### DIFF
--- a/Test/wishlist/FuelTriggers.dfy
+++ b/Test/wishlist/FuelTriggers.dfy
@@ -1,12 +1,15 @@
 // RUN: %dafny /compile:0 /print:"%t.print" /dprint:"%t.dprint" "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-// XFAIL: *
 
-// With the default version of opaque + fuel, the following fails to verify
-// because the quantifier in the requires used a trigger that included
-// StartFuel_P, while the assert used StartFuelAssert_P.  Since P is
-// opaque, we can't tell that those fuels are the same, and hence the
-// trigger never fires. A wish would be to fix this.
+// THIS USED TO BE THE CASE:
+//
+//     With the default version of opaque + fuel, the following fails to verify
+//     because the quantifier in the requires used a trigger that included
+//     StartFuel_P, while the assert used StartFuelAssert_P.  Since P is
+//     opaque, we can't tell that those fuels are the same, and hence the
+//     trigger never fires. A wish would be to fix this.
+//
+// This has been fixed, so the test assertion is now passing.
 
 ghost predicate {:opaque} P(x:int)
 

--- a/Test/wishlist/FuelTriggers.dfy.expect
+++ b/Test/wishlist/FuelTriggers.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION

Evidently, this was fixed by https://github.com/dafny-lang/dafny/pull/4180


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
