### PR TITLE
Fix help message for the --cores option

### DIFF
--- a/Source/DafnyCore/Options/BoogieOptionBag.cs
+++ b/Source/DafnyCore/Options/BoogieOptionBag.cs
@@ -89,7 +89,7 @@ public static class BoogieOptionBag {
 
 
   static BoogieOptionBag() {
-    Cores.SetDefaultValue((uint)((Environment.ProcessorCount + 1) / 2));
+    Cores.SetDefaultValue("50%");
 
     DafnyOptions.RegisterLegacyBinding(BoogieFilter, (o, f) => o.ProcsToCheck.AddRange(f));
     DafnyOptions.RegisterLegacyBinding(BoogieArguments, (o, boogieOptions) => {


### PR DESCRIPTION
This option accepts both an absolute number and a percentage. The default is based on a percentage, so that should be made obvious.

This only changes what is shown when using `dafny verify --help`, nothing else is affected.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
