### PR TITLE
Fix caching of export declarations

### DIFF
--- a/Source/DafnyCore/AST/Modules/ModuleExportDecl.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleExportDecl.cs
@@ -12,8 +12,7 @@ public class ModuleExportDecl : ModuleDecl, ICanFormat {
   public readonly bool IsDefault;
   public List<ExportSignature> Exports; // list of TopLevelDecl that are included in the export
   public List<IToken> Extends; // list of exports that are extended
-  [FilledInDuringResolution] public readonly List<ModuleExportDecl> ExtendDecls = new List<ModuleExportDecl>();
-  [FilledInDuringResolution] public readonly HashSet<Tuple<Declaration, bool>> ExportDecls = new HashSet<Tuple<Declaration, bool>>();
+  [FilledInDuringResolution] public readonly List<ModuleExportDecl> ExtendDecls = new();
   public bool RevealAll; // only kept for initial rewriting, then discarded
   public bool ProvideAll;
   public override IEnumerable<INode> Children => Exports;

--- a/Source/DafnyCore/AST/Modules/ModuleExportDecl.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleExportDecl.cs
@@ -31,6 +31,7 @@ public class ModuleExportDecl : ModuleDecl, ICanFormat {
     IsRefining = original.IsRefining;
     IsDefault = original.IsDefault;
     ThisScope = new VisibilityScope(FullSanitizedName);
+    SetupDefaultSignature();
   }
 
   public ModuleExportDecl(RangeToken rangeToken, Name name, ModuleDefinition parent,
@@ -44,6 +45,7 @@ public class ModuleExportDecl : ModuleDecl, ICanFormat {
     ProvideAll = provideAll;
     RevealAll = revealAll;
     ThisScope = new VisibilityScope(this.FullSanitizedName);
+    SetupDefaultSignature();
   }
 
   public void SetupDefaultSignature() {

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -198,11 +198,7 @@ namespace Microsoft.Dafny {
         } else {
           abs.Signature = new ModuleSignature(); // there was an error, give it a valid but empty signature
         }
-      } else if (decl is ModuleExportDecl exportDecl) {
-        exportDecl.SetupDefaultSignature();
-
-        Contract.Assert(exportDecl.Signature != null);
-        Contract.Assert(exportDecl.Signature.VisibilityScope != null);
+      } else if (decl is ModuleExportDecl) {
       } else {
         Contract.Assert(false); // Unknown kind of ModuleDecl
       }

--- a/Source/DafnyCore/Resolver/ProgramResolver.cs
+++ b/Source/DafnyCore/Resolver/ProgramResolver.cs
@@ -259,7 +259,12 @@ public class ProgramResolver {
         continue;
       }
 
-      dependencies.AddEdge(literalDecl, moduleDecl);
+      if (toplevel is ModuleExportDecl) {
+        dependencies.AddEdge(moduleDecl, literalDecl);
+      } else {
+        dependencies.AddEdge(literalDecl, moduleDecl);
+      }
+
       var subBindings = bindings.SubBindings(moduleDecl.Name);
       ProcessDependencies(moduleDecl, subBindings ?? bindings, declarationPointers);
       if (!module.IsAbstract && moduleDecl is AbstractModuleDecl && ((AbstractModuleDecl)moduleDecl).QId.Root != null) {

--- a/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CompilationStatusNotificationTest.cs
@@ -47,7 +47,7 @@ method Bar() {
       var a6 = await compilationStatusReceiver.AwaitNextNotificationAsync(CancellationToken);
       Assert.Equal(somethingElse.Uri, a6.Uri);
     }
-    
+
     [Fact]
     public async Task MultipleDocumentsFailedResolution() {
       var source = @"


### PR DESCRIPTION
### Changes
- Change the direction of the dependency between a module and its export declarations, so that the exports depends on the module instead of the other way around. The containing module already depends on the import declarations it contains, and now the export declaration indirectly depend on those imports as well. So if the imported modules change, the export declaration is recreated and resolved.

### Testing
- Added XUnit test that reproduces the problem
- Manually testing that this particular caching issue no longer occurs

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
