### PR TITLE
Feature: Gentoo tweaks

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -108,7 +108,7 @@ testDafnyExecutableResolver = 'dotnet run --no-build --project ' + quotePath(os.
 defaultServerExecutable = 'dotnet run --no-build --project ' + quotePath(os.path.join(sourceDirectory, 'DafnyServer', 'DafnyServer.csproj'))
 serverExecutable = lit_config.params.get('serverExecutable', defaultServerExecutable)
 
-boogieExecutable = 'dotnet tool run boogie'
+boogieExecutable = shutil.which('boogie') or 'dotnet tool run boogie'
 
 config.suffixes.append('.transcript')
 

--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -127,7 +127,7 @@ dafnyArgs = [
     # Set a default time limit, to catch cases where verification time runs off the rails
     'timeLimit:300'
 ]
-    
+
 boogieArgs = [
     'infer:j',
     'proverOpt:O:auto_config=false',
@@ -153,7 +153,7 @@ def buildCmd(cmd, args):
         return f'{cmd} /{argStr}'
     else:
         return args
-        
+
 dafny = addParams(buildCmd(dafnyExecutable, dafnyArgs))
 boogie = buildCmd(boogieExecutable, boogieArgs)
 
@@ -209,7 +209,8 @@ def find(name, rooot):
 
 solverPath = \
     find("z3-4.12.1", binaryDir) or \
-    find("cvc4", binaryDir)
+    find("cvc4", binaryDir) or \
+    shutil.which("z3")
 
 if not solverPath:
     lit_config.fatal('Could not find solver')


### PR DESCRIPTION
Hello! 

In Gentoo we perform a from-source build of Dafny.

I would like to propose 2 changes right now:
1. if z3 is not found in binaryDir use system z3
2. first pick boogie binary found in path, than fall-back to boogie as a .NET tool

Those correspond to following patches:
* https://github.com/gentoo/gentoo/blob/master/dev-lang/dafny/files/dafny-4.1.0-lit.patch
* https://github.com/gentoo/gentoo/blob/master/dev-lang/dafny/files/dafny-4.2.0-lit-use-system-boogie.patch