### PR TITLE
(WIP) Only test both resolvers in nightly

### DIFF
--- a/Source/IntegrationTests/LitTests.cs
+++ b/Source/IntegrationTests/LitTests.cs
@@ -49,9 +49,17 @@ namespace IntegrationTests {
       // useful for capturing prover logs.
       var extraDafnyArguments =
         Environment.GetEnvironmentVariable("DAFNY_EXTRA_TEST_ARGUMENTS");
-
+      
       IEnumerable<string> AddExtraArgs(IEnumerable<string> args, IEnumerable<string> local) {
         return (extraDafnyArguments is null ? args : args.Append(extraDafnyArguments)).Concat(local);
+      }
+
+      // Allow extra arguments to the TestDafny tool.
+      var extraTestDafnyArguments =
+        Environment.GetEnvironmentVariable("TEST_DAFNY_EXTRA_ARGUMENTS");
+
+      IEnumerable<string> AddExtraTestDafnyArgs(IEnumerable<string> args, IEnumerable<string> local) {
+        return (extraTestDafnyArguments is null ? args : args.Append(extraTestDafnyArguments)).Concat(local);
       }
 
       string[] defaultResolveArgs = new[] { "resolve", "--use-basename-for-filename", "--show-snippets:false" };

--- a/Source/TestDafny/MultiBackendTest.cs
+++ b/Source/TestDafny/MultiBackendTest.cs
@@ -132,16 +132,16 @@ public class MultiBackendTest {
         0,
         NoVerify: false)
     };
-    if (options.RefreshExitCode != null) {
-      resolutionOptions.Add(
-        new ResolutionSetting(
-          "refresh",
-          new string[] { "--type-system-refresh" },
-          new string[] { ".refresh.expect", ".verifier.expect" },
-          (int)options.RefreshExitCode,
-          NoVerify: false)
-      );
-    }
+    // if (options.RefreshExitCode != null) {
+    //   resolutionOptions.Add(
+    //     new ResolutionSetting(
+    //       "refresh",
+    //       new string[] { "--type-system-refresh" },
+    //       new string[] { ".refresh.expect", ".verifier.expect" },
+    //       (int)options.RefreshExitCode,
+    //       NoVerify: false)
+    //   );
+    // }
     foreach (var resolutionOption in resolutionOptions) {
       var (exitCode, outputString, error) = RunDafny(options.DafnyCliPath, dafnyArgs.Concat(resolutionOption.AdditionalOptions));
 
@@ -237,8 +237,8 @@ public class MultiBackendTest {
     var resolutionOptions = new List<ResolutionSetting>() {
       new ResolutionSetting("legacy", new string[] { }, new string[] { ".expect" },
         options.ExpectExitCode ?? 0, NoVerify: false),
-      new ResolutionSetting("refresh", new string[] { "--type-system-refresh" }, new string[] { ".refresh.expect", ".expect" },
-        options.RefreshExitCode ?? options.ExpectExitCode ?? 0, NoVerify: options.RefreshNoVerify)
+      // new ResolutionSetting("refresh", new string[] { "--type-system-refresh" }, new string[] { ".refresh.expect", ".expect" },
+      //   options.RefreshExitCode ?? options.ExpectExitCode ?? 0, NoVerify: options.RefreshNoVerify)
     };
 
     foreach (var resolutionOption in resolutionOptions) {


### PR DESCRIPTION
Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
