### PR TITLE
Map eq range

### DIFF
--- a/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
+++ b/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
@@ -22,7 +22,6 @@ class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
     return astVisitorContext;
   }
 
-
   protected override bool VisitOneExpression(Expression expr, IASTVisitorContext context) {
 
     if (expr is ExprDotName) {
@@ -38,7 +37,6 @@ class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
         }
       }
     }
-
     return base.VisitOneExpression(expr, context);
   }
 }

--- a/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
+++ b/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
@@ -1,0 +1,36 @@
+//-----------------------------------------------------------------------------
+//
+// Copyright by the contributors to the Dafny Project
+// SPDX-License-Identifier: MIT
+//
+//-----------------------------------------------------------------------------
+
+namespace Microsoft.Dafny;
+
+class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
+  private readonly ErrorReporter reporter;
+
+  public CheckMapRangeSupportsEquality(ErrorReporter reporter) {
+    this.reporter = reporter;
+  }
+
+  public override IASTVisitorContext GetContext(IASTVisitorContext astVisitorContext, bool inFunctionPostcondition) {
+    return astVisitorContext;
+  }
+
+
+  protected override bool VisitOneExpression(Expression expr, IASTVisitorContext context) {
+
+    if (expr is ExprDotName) {
+      var e = (ExprDotName) expr;
+      if (e.Lhs.Type.IsMapType && (e.SuffixName == "Values" || e.SuffixName == "Items")) {
+        if (!e.Lhs.Type.AsMapType.Range.SupportsEquality) {
+          reporter.Error(MessageSource.Resolver, expr,
+            "NO NO NO");  
+        }
+      }
+    }
+
+    return base.VisitOneExpression(expr, context);
+  }
+}

--- a/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
+++ b/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
@@ -23,7 +23,7 @@ class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
 
     if (expr is ExprDotName) {
       var e = (ExprDotName)expr;
-      if (e.Lhs.Type.IsMapType && (e.SuffixName == "Values" || e.SuffixName == "Items")) {
+      if (e.Lhs.Type != null && e.Lhs.Type.IsMapType && (e.SuffixName == "Values" || e.SuffixName == "Items")) {
         if (!e.Lhs.Type.AsMapType.Range.SupportsEquality) {
           reporter.Error(MessageSource.Resolver, expr, "NO NO NO");
         }

--- a/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
+++ b/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
@@ -7,6 +7,10 @@
 
 namespace Microsoft.Dafny;
 
+/// <summary>
+/// This checker ensures that if the set of values or the set of items
+/// of a map is used, then its range type supports equality.
+/// </summary>
 class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
   private readonly ErrorReporter reporter;
 
@@ -23,9 +27,14 @@ class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
 
     if (expr is ExprDotName) {
       var e = (ExprDotName)expr;
+      // Condition 1: the left-hand side is not a module and has a type
+      // Condition 2: the left-hand side is a map
+      // Condition 3: the expression produces a set that contains values from the range
       if (e.Lhs.Type != null && e.Lhs.Type.IsMapType && (e.SuffixName == "Values" || e.SuffixName == "Items")) {
+        // The type of the range must support equality
         if (!e.Lhs.Type.AsMapType.Range.SupportsEquality) {
-          reporter.Error(MessageSource.Resolver, expr, "NO NO NO");
+          reporter.Error(MessageSource.Resolver, expr,
+            $"Cannot compute the set of {e.SuffixName} of map '{e.Lhs}' because the type of its range ({e.Lhs.Type.AsMapType.Range}) does not support equality.");
         }
       }
     }

--- a/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
+++ b/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
@@ -22,11 +22,10 @@ class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
   protected override bool VisitOneExpression(Expression expr, IASTVisitorContext context) {
 
     if (expr is ExprDotName) {
-      var e = (ExprDotName) expr;
+      var e = (ExprDotName)expr;
       if (e.Lhs.Type.IsMapType && (e.SuffixName == "Values" || e.SuffixName == "Items")) {
         if (!e.Lhs.Type.AsMapType.Range.SupportsEquality) {
-          reporter.Error(MessageSource.Resolver, expr,
-            "NO NO NO");  
+          reporter.Error(MessageSource.Resolver, expr, "NO NO NO");
         }
       }
     }

--- a/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
+++ b/Source/DafnyCore/Resolver/CheckMapRangeSupportsEquality.cs
@@ -5,6 +5,8 @@
 //
 //-----------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Dafny;
 
 /// <summary>
@@ -33,7 +35,7 @@ class CheckMapRangeSupportsEquality : ASTVisitor<IASTVisitorContext> {
         // The type of the range must support equality
         if (!e.Lhs.Type.AsMapType.Range.SupportsEquality) {
           reporter.Error(MessageSource.Resolver, expr,
-            $"Cannot compute the set of {e.SuffixName} of map '{e.Lhs}' because the type of its range ({e.Lhs.Type.AsMapType.Range}) does not support equality.");
+            $"Cannot compute the set of {e.SuffixName} because the type the of the range of the map ({e.Lhs.Type.AsMapType.Range}) does not support equality.");
         }
       }
     }

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1531,6 +1531,10 @@ namespace Microsoft.Dafny {
       if (reporter.Count(ErrorLevel.Error) == prevErrorCount) {
         new HigherOrderHeapAllocationCheckerConstructor(reporter).VisitDeclarations(declarations);
       }
+      
+      if (reporter.Count(ErrorLevel.Error) == prevErrorCount) {
+        new CheckMapRangeSupportsEquality(reporter).VisitDeclarations(declarations);
+      }
 
       if (reporter.Count(ErrorLevel.Error) == prevErrorCount) {
         // Check that usage of "this" is restricted before "new;" in constructor bodies,

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1531,7 +1531,7 @@ namespace Microsoft.Dafny {
       if (reporter.Count(ErrorLevel.Error) == prevErrorCount) {
         new HigherOrderHeapAllocationCheckerConstructor(reporter).VisitDeclarations(declarations);
       }
-      
+
       if (reporter.Count(ErrorLevel.Error) == prevErrorCount) {
         new CheckMapRangeSupportsEquality(reporter).VisitDeclarations(declarations);
       }

--- a/Test/git-issues/git-issue-1373.dfy
+++ b/Test/git-issues/git-issue-1373.dfy
@@ -1,0 +1,8 @@
+// RUN: %exits-with 2 %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Main() {
+  var x := map[1 := () => 1];
+  print x.Values; // error: map range type must support equality
+  print x.Items; // error: map range type must support equality
+}

--- a/Test/git-issues/git-issue-1373.dfy.expect
+++ b/Test/git-issues/git-issue-1373.dfy.expect
@@ -1,3 +1,3 @@
-git-issue-1373.dfy(6,10): Error: NO NO NO
-git-issue-1373.dfy(7,10): Error: NO NO NO
+git-issue-1373.dfy(6,10): Error: Cannot compute the set of Values of map 'x' because the type of its range (() ~> int) does not support equality.
+git-issue-1373.dfy(7,10): Error: Cannot compute the set of Items of map 'x' because the type of its range (() ~> int) does not support equality.
 2 resolution/type errors detected in git-issue-1373.dfy

--- a/Test/git-issues/git-issue-1373.dfy.expect
+++ b/Test/git-issues/git-issue-1373.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-1373.dfy(6,10): Error: NO NO NO
+git-issue-1373.dfy(7,10): Error: NO NO NO
+2 resolution/type errors detected in git-issue-1373.dfy

--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -1262,7 +1262,8 @@ the domain, the range, and the 2-tuples holding the key-value
 associations in the map. Note that `m.Values` will have a different
 cardinality than `m.Keys` and `m.Items` if different keys are
 associated with the same value. If `m` is an `imap`, then these
-expressions return `iset` values.
+expressions return `iset` values. If `m` is a map, `m.Values` and `m.Items`
+require the type of the range `U` to support equality.
 
 [^fn-map-membership]: This is likely to change in the future as
     follows:  The `in` and `!in` operations will no longer be

--- a/docs/dev/news/1373.fix
+++ b/docs/dev/news/1373.fix
@@ -1,0 +1,1 @@
+Ensures that computing the set of values or items of map can only be done if the type of the range supports equality.


### PR DESCRIPTION
Fixes formatting of error messages for restrictions on using .Values or .Items

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
