### PR TITLE
ci: Disable test reporter auto-discovery to speed up integration tests

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -155,7 +155,7 @@ jobs:
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
       run: |
         ${{ inputs.all_platforms }} && export DAFNY_RELEASE="${{ github.workspace }}/unzippedRelease/dafny"
-        dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" dafny/Source/IntegrationTests
+        dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" --settings dafny/Source/IntegrationTests/coverlet.runsettings dafny/Source/IntegrationTests
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/Source/IntegrationTests/IntegrationTests.csproj
+++ b/Source/IntegrationTests/IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Source/IntegrationTests/coverlet.runsettings
+++ b/Source/IntegrationTests/coverlet.runsettings
@@ -9,4 +9,14 @@
       </DataCollector>
     </DataCollectors>
   </DataCollectionRunSettings>
+  <xUnit>
+    <!-- 
+    Important to disable the reporter auto-discovery
+    because we have a ton of classes in this project,
+    especially those generated from Dafny,
+    which can cause close to an hour delay before starting any tests!
+    See https://github.com/xunit/xunit/issues/2549.
+    -->
+    <NoAutoReporters>true</NoAutoReporters>
+  </xUnit>
 </RunSettings>


### PR DESCRIPTION
Addresses https://github.com/xunit/xunit/issues/2549 to reduce our integration test shard execution time from almost 90 mins in the worst case to under 30 mins.

The TL;DR is that xUnit has an extension mechanism that attempts to load every class in every available DLL to see if it extends a given interface. This manifests in a huge delay on startup before any tests begin to run, e.g. 52 mins in this case: https://github.com/dafny-lang/dafny/actions/runs/6241813664/job/16944685069#step:22:146 (make sure you turn on Show Timestamps!) This was steadily getting worse as we added more classes, especially https://github.com/dafny-lang/dafny/pull/4438 as it added a bunch of Dafny-generated code.

Fortunately xUnit 2.5.1 added a knob to switch off this discovery, which we're definitely not using.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
