### PR TITLE
Fix newtype of alias crash

### DIFF
--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Dafny {
         AddXConstraint(newtypeDecl.tok, "NumericType", newtypeDecl.BaseType, "newtypes must be based on some numeric type (got {0})");
         // type check the constraint, if any
         if (newtypeDecl.Var != null) {
-          Contract.Assert(object.ReferenceEquals(newtypeDecl.Var.Type, newtypeDecl.BaseType.NormalizeExpand(true)));  // follows from NewtypeDecl invariant
+          Contract.Assert(object.ReferenceEquals(newtypeDecl.Var.Type.NormalizeExpand(true), newtypeDecl.BaseType.NormalizeExpand(true)));  // follows from NewtypeDecl invariant
           Contract.Assert(newtypeDecl.Constraint != null);  // follows from NewtypeDecl invariant
 
           scope.PushMarker();

--- a/Test/newtype/aliases.dfy
+++ b/Test/newtype/aliases.dfy
@@ -1,0 +1,16 @@
+// RUN: %baredafny resolve --use-basename-for-filename %s > %t
+// RUN: %diff "%s.expect" %t
+
+module A {
+  import B
+  newtype VerySpecificInt = x : B.SpecificIntAlias | x == 1 witness 1
+}
+
+module B {
+  import C
+  type SpecificIntAlias = C.SpecificInt
+}
+
+module C {
+  newtype SpecificInt = x : int | 0 <= x <= 10
+}

--- a/Test/newtype/aliases.dfy
+++ b/Test/newtype/aliases.dfy
@@ -1,16 +1,6 @@
 // RUN: %baredafny resolve --use-basename-for-filename %s > %t
 // RUN: %diff "%s.expect" %t
 
-module A {
-  import B
-  newtype VerySpecificInt = x : B.SpecificIntAlias | x == 1 witness 1
-}
-
-module B {
-  import C
-  type SpecificIntAlias = C.SpecificInt
-}
-
-module C {
-  newtype SpecificInt = x : int | 0 <= x <= 10
-}
+newtype VerySpecificInt = x : SpecificIntAlias | x == 1 witness 1
+type SpecificIntAlias = SpecificInt
+newtype SpecificInt = x : int | 0 <= x <= 10

--- a/Test/newtype/aliases.dfy.expect
+++ b/Test/newtype/aliases.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier did not attempt verification


### PR DESCRIPTION
### Changes
- Prevent crash from occurring when a newtype refers to an alias of a newtype

### Testing
- Add test that reproduces the crash

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
