### PR TITLE
ci: Split off reusable nightly build workflow, run it for master and 4.3

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -19,7 +19,7 @@ jobs:
   check-deep-tests:
      uses: ./.github/workflows/check-deep-tests-reusable.yml
      with:
-       branch: master
+       branch: ${{ github.base_ref }}
 
   doctests:
     needs: check-deep-tests

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -9,6 +9,9 @@ on:
       num_shards:
         required: true
         type: number
+      ref:
+        required: true
+        type: string
 
 env:
   dotnet-version: 6.0.x # SDK Version for building Dafny
@@ -98,6 +101,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: dafny
+        ref: ${{ inputs.ref }}
         submodules: true # Until the libraries work again
     - name: Install Java runtime locally (non-Windows)
       if: runner.os != 'Windows'

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -17,7 +17,7 @@ jobs:
   check-deep-tests:
     uses: ./.github/workflows/check-deep-tests-reusable.yml
     with:
-      branch: master
+      branch: ${{ github.base_ref }}
 
   singletons:
     needs: check-deep-tests
@@ -71,6 +71,7 @@ jobs:
     if: always() && (( github.event_name == 'pull_request' && (needs.check-deep-tests.result == 'success' || contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))) || ( github.event_name == 'push' && ( github.ref_name == 'master' || vars.TEST_ON_FORK == 'true' )))
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
+      ref: ${{ github.ref }}
       # By default run only on one platform, but run on all platforms if the PR has the "run-deep-tests"
       # label, and skip checking the nightly build above.
       # This is the best way to fix an issue in master that was only caught by the nightly build.

--- a/.github/workflows/nightly-build-manual.yml
+++ b/.github/workflows/nightly-build-manual.yml
@@ -1,0 +1,26 @@
+
+# Manual trigger for the nightly build on a given branch.
+
+name: Nightly test and release workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The git ref to run on'
+        required: true
+        type: string
+      publish-prerelease:
+        description: 'Whether to publish a prerelease'
+        required: false
+        type: boolean
+        default: false
+      
+jobs:
+  nightly-build:
+    uses: ./.github/workflows/nightly-build-reusable.yml
+    with:
+      ref: ${{ inputs.ref }}
+      publish-prerelease: ${{ inputs.publish-prerelease }}
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/nightly-build-manual.yml
+++ b/.github/workflows/nightly-build-manual.yml
@@ -1,7 +1,7 @@
 
 # Manual trigger for the nightly build on a given branch.
 
-name: Nightly test and release workflow
+name: Nightly test and release workflow (Manual trigger)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -1,37 +1,36 @@
-
 # This workflow includes more expensive tests than what is run on every PR, that are unlikely to break on most changes.
-# It also publishes a nightly release.
-#
-# The if at the beginning of each job terminates the workflow immediately on any repo (like a fork) that is not the main
-# dafny-lang/dafny repo. This stops such forks from running this workflow and failing (for lack of a secret) the attempt to
-# publish a nightly build themselves.
+# It also optionally publishes a nightly prerelease.
 
-name: Nightly test and release workflow
+name: Nightly test and release workflow (Reusable Workflow)
 
 on:
-  schedule:
-    # Chosen to be hopefully outside of business hours for most contributors'
-    # time zones, and not on the hour to avoid heavy scheduled-job times:
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron: "30 14 * * *"
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      publish-prerelease:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   deep-integration-tests:
     if: github.repository_owner == 'dafny-lang'
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
+      ref: ${{ inputs.ref }}
       all_platforms: true
       num_shards: 5
 
   determine-vars:
-    if: github.repository_owner == 'dafny-lang' && github.ref == 'refs/heads/master'
+    if: github.repository_owner == 'dafny-lang' && inputs.publish-prerelease
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Dafny
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ inputs.ref }}
           submodules: recursive
 
       - name: Get short sha
@@ -48,11 +47,11 @@ jobs:
     needs: [deep-integration-tests, determine-vars]
     with:
       name: ${{ needs.determine-vars.outputs.name }}
-      sha: ${{ github.sha }}
+      ref: ${{ inputs.ref }}
       tag_name: nightly
       release_nuget: true
       draft: false
       release_notes: "This is an automatically published nightly release. This release may not be as stable as versioned releases and does not contain release notes."
       prerelease: true
     secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,6 +1,12 @@
 
-# This workflow includes more expensive tests than what is run on every PR, that are unlikely to break on most changes.
-# It also publishes a nightly release.
+# Scheduled nightly build
+#
+# Scheduled workflows only ever trigger for the default branch,
+# but we need to run nightly jobs on multiple branches.
+# This workflow therefore triggers a reusable workflow
+# on every branch that needs to be protected with the nightly deep-test mechanism,
+# and ensures which ever branch contains the next planned release
+# publishes the nightly prerelease.
 #
 # The if at the beginning of each job terminates the workflow immediately on any repo (like a fork) that is not the main
 # dafny-lang/dafny repo. This stops such forks from running this workflow and failing (for lack of a secret) the attempt to

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,35 @@
+
+# This workflow includes more expensive tests than what is run on every PR, that are unlikely to break on most changes.
+# It also publishes a nightly release.
+#
+# The if at the beginning of each job terminates the workflow immediately on any repo (like a fork) that is not the main
+# dafny-lang/dafny repo. This stops such forks from running this workflow and failing (for lack of a secret) the attempt to
+# publish a nightly build themselves.
+
+name: Nightly test and release workflow
+
+on:
+  schedule:
+    # Chosen to be hopefully outside of business hours for most contributors'
+    # time zones, and not on the hour to avoid heavy scheduled-job times:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+    - cron: "30 14 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly-build-for-master:
+    if: github.repository_owner == 'dafny-lang'
+    uses: ./.github/workflows/nightly-build-reusable.yml
+    with:
+      ref: master
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  nightly-build-for-4-3:
+    if: github.repository_owner == 'dafny-lang'
+    uses: ./.github/workflows/nightly-build-reusable.yml
+    with:
+      ref: 4.3
+      publish-prerelease: true
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -9,7 +9,7 @@ on:
       prerelease:
         required: false
         type: boolean
-      sha:
+      ref:
         required: true
         type: string
       draft:
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: dafny
-        ref: ${{ inputs.sha }}
+        ref: ${{ inputs.ref }}
     - name: Ensure tag exists
       if: ${{ inputs.prerelease }}
       run: |
@@ -96,7 +96,7 @@ jobs:
       # Need --skip-duplicate for cases where we release a new Dafny
       # version but the runtime hasn't changed and is still the old
       # version.
-      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.nuget_api_key }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Install latex pandoc
       run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,11 +30,11 @@ jobs:
     uses: ./.github/workflows/publish-release-reusable.yml
     with:
       name: ${{ needs.get-version.outputs.version }}
-      sha: ${{ github.sha }}
+      ref: ${{ github.sha }}
       tag_name: ${{ github.ref }}
       draft: true
       release_nuget: true
       # We can probably automate pulling this out of RELEASE_NOTES.md in the future
       release_notes: ""
     secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -13,7 +13,7 @@ jobs:
   check-deep-tests:
      uses: ./.github/workflows/check-deep-tests-reusable.yml
      with:
-       branch: master
+       branch: ${{ github.base_ref }}
 
   build-refman:
     needs: check-deep-tests

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -13,7 +13,7 @@ jobs:
   check-deep-tests:
      uses: ./.github/workflows/check-deep-tests-reusable.yml
      with:
-       branch: master
+       branch: ${{ github.base_ref }}
 
   build:
     needs: check-deep-tests


### PR DESCRIPTION
This addresses the fact that the nightly build only publishes prereleases out of `master`, even when we have a different branch containing the content of the next planned release. See comment on the top of `nightly-build.tml` for details.

Also addressed a couple of incidental issues, renaming `sha` to `ref` in a few places to clarify use, and passing the correct branch to `check-deep-tests-reusable.yml`.

Since these changes are notoriously difficult to test properly before merging, I'd recommend only merging this well ahead of the scheduled trigger time (14:30 UTC) and triggering it manually with the `nightly-build-manual.yml` workflow.

Feel free to update the target branch from `4.3` to `main-4.3` if that renaming happens before this is merged.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
