### PR TITLE
fix: Fix reusable workflow secrets declarations

### DIFF
--- a/.github/workflows/nightly-build-manual.yml
+++ b/.github/workflows/nightly-build-manual.yml
@@ -23,4 +23,4 @@ jobs:
       ref: ${{ inputs.ref }}
       publish-prerelease: ${{ inputs.publish-prerelease }}
     secrets:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      # Required if publish-prerelease is true
+      nuget_api_key:
+        required: false
 
 jobs:
   deep-integration-tests:
@@ -54,4 +58,4 @@ jobs:
       release_notes: "This is an automatically published nightly release. This release may not be as stable as versioned releases and does not contain release notes."
       prerelease: true
     secrets:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      nuget_api_key: ${{ secrets.nuget_api_key }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       ref: master
     secrets:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
 
   nightly-build-for-4-3:
     if: github.repository_owner == 'dafny-lang'
@@ -38,4 +38,4 @@ jobs:
       ref: 4.3
       publish-prerelease: true
     secrets:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,4 +37,4 @@ jobs:
       # We can probably automate pulling this out of RELEASE_NOTES.md in the future
       release_notes: ""
     secrets:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
Broken by #4573. Tested on my fork this time (skipped because of the `if: github.repository_owner == 'dafny-lang'` guard, but at least verified the syntax is valid): https://github.com/robin-aws/dafny/actions/runs/6276358103/job/17045852984

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Is this a bug fix for an issue introduced in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<!-- Are you moving a large amount of code? Read CONTRIBUTING.md to learn how to do that while maintaining git history -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
