### PR TITLE
chore: Hide Rust backend in reference manual

### DIFF
--- a/Source/DafnyCore/Compilers/Rust/RustBackend.cs
+++ b/Source/DafnyCore/Compilers/Rust/RustBackend.cs
@@ -15,6 +15,7 @@ public class RustBackend : DafnyExecutableBackend {
   public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { ".rs" };
   public override string TargetName => "Rust";
   public override bool IsStable => false;
+  public override bool IsInternal => true;
   public override string TargetExtension => "rs";
   public override int TargetIndentSize => 4;
   public override bool SupportsInMemoryCompilation => false;

--- a/docs/DafnyRef/Features.md
+++ b/docs/DafnyRef/Features.md
@@ -1,47 +1,47 @@
-| Feature | C# | JavaScript | Go | Java | Python | C++ | Dafny Library (.doo) | Rust |
-|-|-|-|-|-|-|-|-|-|
-| [Unbounded integers](#sec-numeric-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Real numbers](#sec-numeric-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Ordinals](#sec-ordinals) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Function values](#sec-arrow-subset-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Iterators](#sec-iterator-types) |  X  |  X  |  X  |  |  X  |  |  X  |  |
-| [Collections with trait element types](#sec-collection-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [External module names with only underscores](#sec-extern-decls) |  X  |  X  |  |  X  |  X  |  X  |  X  |  X  |
-| [Co-inductive datatypes](#sec-coinductive-datatypes) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Multisets](#sec-multisets) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Runtime type descriptors](#) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Multi-dimensional arrays](#sec-multi-dimensional-arrays) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Map comprehensions](#sec-map-comprehension-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Traits](#sec-trait-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Let-such-that expressions](#sec-let-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Non-native numeric newtypes](#sec-newtypes) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Method synthesis](#sec-synthesize-attr) |  X  |  |  |  |  |  |  X  |  |
-| [External classes](#sec-extern-decls) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Instantiating the `object` type](#sec-object-type) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [`forall` statements that cannot be sequentialized](#sec-forall-statement)[^compiler-feature-forall-note] |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Taking an array's length](#sec-array-type) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [`m.Items` when `m` is a map](#sec-maps) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [The /runAllTests option](#sec-test-attribute) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Integer range constraints in quantifiers (e.g. `a <= x <= b`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| [Exact value constraints in quantifiers (`x == C`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Sequence displays of characters](#sec-sequence-displays)[^compiler-sequence-display-of-characters-note] |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Type test expressions (`x is T`)](#sec-as-is-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [Type test expressions on subset types](#sec-as-is-expression) |  |  |  |  |  |  |  X  |  |
-| [Quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Bitvector RotateLeft/RotateRight functions](#sec-bit-vector-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |  |
-| [`for` loops](#sec-for-statement) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| [`continue` statements](#sec-break-continue-statement) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| [Assign-such-that statements with potentially infinite bounds](#sec-update-and-call-statement)[^compiler-infinite-assign-such-that-note] |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  |
-| [Sequence update expressions](#sec-other-sequence-expressions) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  |
-| [Sequence constructions with non-lambda initializers](#sec-sequence-displays)[^compiler-sequence-display-nolambda-note] |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  |
-| [Externally-implemented constructors](#sec-extern-decls) |  X  |  |  |  X  |  X  |  X  |  X  |  |
-| [Auto-initialization of tuple variables](#sec-tuple-types) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| [Subtype constraints in quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  |
-| [Tuples with more than 20 arguments](#sec-tuple-types) |  |  X  |  X  |  |  X  |  X  |  X  |  |
-| [Unicode chars](##sec-characters) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Converting values to strings](#sec-print-statement) |  X  |  X  |  X  |  X  |  X  |  |  X  |  X  |
-| [Legacy CLI without commands](#sec-dafny-commands) |  X  |  X  |  X  |  X  |  X  |  X  |  |  X  |
-| [Separate compilation](#sec-compilation) |  X  |  |  X  |  X  |  X  |  X  |  X  |  X  |
+| Feature | C# | JavaScript | Go | Java | Python | C++ | Dafny Library (.doo) |
+|-|-|-|-|-|-|-|-|
+| [Unbounded integers](#sec-numeric-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Real numbers](#sec-numeric-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Ordinals](#sec-ordinals) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Function values](#sec-arrow-subset-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Iterators](#sec-iterator-types) |  X  |  X  |  X  |  |  X  |  |  X  |
+| [Collections with trait element types](#sec-collection-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [External module names with only underscores](#sec-extern-decls) |  X  |  X  |  |  X  |  X  |  X  |  X  |
+| [Co-inductive datatypes](#sec-coinductive-datatypes) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Multisets](#sec-multisets) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Runtime type descriptors](#) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Multi-dimensional arrays](#sec-multi-dimensional-arrays) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Map comprehensions](#sec-map-comprehension-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Traits](#sec-trait-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Let-such-that expressions](#sec-let-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Non-native numeric newtypes](#sec-newtypes) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Method synthesis](#sec-synthesize-attr) |  X  |  |  |  |  |  |  X  |
+| [External classes](#sec-extern-decls) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Instantiating the `object` type](#sec-object-type) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [`forall` statements that cannot be sequentialized](#sec-forall-statement)[^compiler-feature-forall-note] |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Taking an array's length](#sec-array-type) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [`m.Items` when `m` is a map](#sec-maps) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [The /runAllTests option](#sec-test-attribute) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Integer range constraints in quantifiers (e.g. `a <= x <= b`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Exact value constraints in quantifiers (`x == C`)](#sec-quantifier-domains) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Sequence displays of characters](#sec-sequence-displays)[^compiler-sequence-display-of-characters-note] |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Type test expressions (`x is T`)](#sec-as-is-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Type test expressions on subset types](#sec-as-is-expression) |  |  |  |  |  |  |  X  |
+| [Quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Bitvector RotateLeft/RotateRight functions](#sec-bit-vector-types) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [`for` loops](#sec-for-statement) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [`continue` statements](#sec-break-continue-statement) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Assign-such-that statements with potentially infinite bounds](#sec-update-and-call-statement)[^compiler-infinite-assign-such-that-note] |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Sequence update expressions](#sec-other-sequence-expressions) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Sequence constructions with non-lambda initializers](#sec-sequence-displays)[^compiler-sequence-display-nolambda-note] |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Externally-implemented constructors](#sec-extern-decls) |  X  |  |  |  X  |  X  |  X  |  X  |
+| [Auto-initialization of tuple variables](#sec-tuple-types) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Subtype constraints in quantifiers](#sec-quantifier-expression) |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| [Tuples with more than 20 arguments](#sec-tuple-types) |  |  X  |  X  |  |  X  |  X  |  X  |
+| [Unicode chars](##sec-characters) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Converting values to strings](#sec-print-statement) |  X  |  X  |  X  |  X  |  X  |  |  X  |
+| [Legacy CLI without commands](#sec-dafny-commands) |  X  |  X  |  X  |  X  |  X  |  X  |  |
+| [Separate compilation](#sec-compilation) |  X  |  |  X  |  X  |  X  |  X  |  X  |
 
 [^compiler-feature-forall-note]: 'Sequentializing' a `forall` statement refers to compiling it directly to a series of nested loops
     with the statement's body directly inside. The alternative, default compilation strategy


### PR DESCRIPTION
This is still experimental and not meant to be advertised in any way just yet.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
