### PR TITLE
Chore: Updated check deep tests to account for workflow refactoring, run deep tests inline with release process

### DIFF
--- a/.github/workflows/check-deep-tests-reusable.yml
+++ b/.github/workflows/check-deep-tests-reusable.yml
@@ -2,11 +2,6 @@ name: Check Deep Tests (Reusable Workflow)
 
 on:
   workflow_call:
-    inputs:
-      sha:
-        type: string
-      branch:
-        type: string
 
 jobs:
   check-deep-tests:
@@ -20,9 +15,11 @@ jobs:
     - uses: actions/github-script@v6
       if: github.repository_owner == 'dafny-lang'
       with:
+        # Since nightly-build.yml always targets fixed branches now, rather than being parameterized by
+        # branch, we can't effectively check "for a specific branch".
+        # That means we have to be less precise for now and block all branches if any branch fails the deep nightly tests.
         script: |
           const script = require('${{ github.workspace }}/dafny/.github/workflows/check-for-workflow-run.js')
           console.log(script({github, context, core,
                               workflow_id: 'nightly-build.yml',
-                              ...('${{ inputs.sha }}' ? {sha: '${{ inputs.sha }}'} : {}),
-                              ...('${{ inputs.branch }}' ? {branch: '${{ inputs.branch }}'} : {})}))
+                              branch: 'master'}))

--- a/.github/workflows/check-deep-tests-reusable.yml
+++ b/.github/workflows/check-deep-tests-reusable.yml
@@ -23,6 +23,6 @@ jobs:
         script: |
           const script = require('${{ github.workspace }}/dafny/.github/workflows/check-for-workflow-run.js')
           console.log(script({github, context, core,
-                              workflow_id: 'nightly-build-reusable.yml',
+                              workflow_id: 'nightly-build.yml',
                               ...('${{ inputs.sha }}' ? {sha: '${{ inputs.sha }}'} : {}),
                               ...('${{ inputs.branch }}' ? {branch: '${{ inputs.branch }}'} : {})}))

--- a/.github/workflows/check-deep-tests-reusable.yml
+++ b/.github/workflows/check-deep-tests-reusable.yml
@@ -23,6 +23,6 @@ jobs:
         script: |
           const script = require('${{ github.workspace }}/dafny/.github/workflows/check-for-workflow-run.js')
           console.log(script({github, context, core,
-                              workflow_id: 'deep-tests.yml',
+                              workflow_id: 'nightly-build-reusable.yml',
                               ...('${{ inputs.sha }}' ? {sha: '${{ inputs.sha }}'} : {}),
                               ...('${{ inputs.branch }}' ? {branch: '${{ inputs.branch }}'} : {})}))

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -18,8 +18,6 @@ concurrency:
 jobs:
   check-deep-tests:
      uses: ./.github/workflows/check-deep-tests-reusable.yml
-     with:
-       branch: ${{ github.base_ref }}
 
   doctests:
     needs: check-deep-tests

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -16,8 +16,6 @@ env:
 jobs:
   check-deep-tests:
     uses: ./.github/workflows/check-deep-tests-reusable.yml
-    with:
-      branch: ${{ github.base_ref }}
 
   singletons:
     needs: check-deep-tests

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,6 +10,14 @@ env:
   dotnet-version: 6.0.x # SDK Version for building Dafny
 
 jobs:
+  deep-integration-tests:
+    if: github.repository_owner == 'dafny-lang'
+    uses: ./.github/workflows/integration-tests-reusable.yml
+    with:
+      ref: ${{ github.ref }}
+      all_platforms: true
+      num_shards: 5
+
   get-version:
     runs-on: ubuntu-22.04
     steps:
@@ -21,7 +29,7 @@ jobs:
       version: ${{ steps.get-version.outputs.version-without-v }}
 
   publish-release:
-    needs: [check-deep-tests, get-version]
+    needs: [deep-integration-tests, get-version]
     uses: ./.github/workflows/publish-release-reusable.yml
     with:
       name: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,11 +10,6 @@ env:
   dotnet-version: 6.0.x # SDK Version for building Dafny
 
 jobs:
-  check-deep-tests:
-    uses: ./.github/workflows/check-deep-tests-reusable.yml
-    with:
-      sha: ${{ github.sha }}
-
   get-version:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -12,8 +12,6 @@ concurrency:
 jobs:
   check-deep-tests:
      uses: ./.github/workflows/check-deep-tests-reusable.yml
-     with:
-       branch: ${{ github.base_ref }}
 
   build-refman:
     needs: check-deep-tests

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -12,8 +12,6 @@ concurrency:
 jobs:
   check-deep-tests:
      uses: ./.github/workflows/check-deep-tests-reusable.yml
-     with:
-       branch: ${{ github.base_ref }}
 
   build:
     needs: check-deep-tests

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -21,13 +21,14 @@
    and push it.
 
 1. Kick off the deep test suite by navigating to
-   <https://github.com/dafny-lang/dafny/actions/workflows/deep-tests.yml>,
-   clicking the "Run workflow" dropdown, selecting the newly created branch, and
-   clicking the "Run workflow" button. The automation for releasing below will
-   check for a run of this workflow on the exact commit to release.  (TODO:
-   Run this automatically as part of the prepare-release script.)
+   <https://github.com/dafny-lang/dafny/actions/workflows/nightly-build.yml>,
+   clicking the "Run workflow" dropdown, selecting the newly created branch,
+   and clicking the "Run workflow" button. The automation for releasing below will
+   NOT ANYMORE check for a run of this workflow on the exact commit to release,
+   so you will have to check it yourself.
+   (TODO: Make it possible to check it again)
 
-1. Once the the tests complete, run `Scripts/prepare_release.py $VER
+1. Once the the tests complete, run `./Scripts/prepare_release.py $VER
    release` from the root of the repository. The script will tag the
    current commit and push it. (TODO: Merge with the two steps above.) A
    GitHub action will automatically run in reaction to the tag being

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -13,6 +13,7 @@
    incremented since the last release, so they do not necessarily need
    to be updated. However, you may want to increment them further
    depending the types of changes that are in the release.
+
 1. Run `Scripts/prepare_release.py $VER prepare --source-branch <this branch>`
    (`--source-branch` is optional and defaults to 'master')
    from the root of the repository. The script will check that the repository is in a good
@@ -20,19 +21,13 @@
    `Source/Directory.Build.props` and `RELEASE_NOTES.md`, prepare a release commit,
    and push it.
 
-1. Kick off the deep test suite by navigating to
-   <https://github.com/dafny-lang/dafny/actions/workflows/nightly-build.yml>,
-   clicking the "Run workflow" dropdown, selecting the newly created branch,
-   and clicking the "Run workflow" button. The automation for releasing below will
-   NOT ANYMORE check for a run of this workflow on the exact commit to release,
-   so you will have to check it yourself.
-   (TODO: Make it possible to check it again)
-
-1. Once the the tests complete, run `./Scripts/prepare_release.py $VER
+1. Run `./Scripts/prepare_release.py $VER
    release` from the root of the repository. The script will tag the
-   current commit and push it. (TODO: Merge with the two steps above.) A
+   current commit and push it. A
    GitHub action will automatically run in reaction to the tag being
-   pushed, which will build the artifacts and reference manual and then
+   pushed, which will run the deep integration test suite,
+   build the artifacts and reference manual,
+   publish artifacts to nuget.org, and then
    create a draft GitHub release. You can find and watch the progress of
    this workflow at <https://github.com/dafny-lang/dafny/actions>.
 


### PR DESCRIPTION
Until this PR, for the last 5 days, check-deep-tests was checking a result that was 5 days old.
Releases are impossible because deep-tests.yml has been renamed.

This PR tweaks check-deep-tests to check the right workflow and not attempt to check on a per-branch basis (since `nightly-build.yml` checks the same branches no matter what branch it is launched on) - this means development on any protected branch will be blocked by failures on any such branch, but this is at least safe for now.

Also changed the `publish-release.yml` workflow to run the deep tests directly instead of checking for a previous run, since this avoids the issue above and is more efficient anyway.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
