### PR TITLE
feat: Non-reference traits

### DIFF
--- a/Source/DafnyCore/AST/Grammar/ParseErrors.cs
+++ b/Source/DafnyCore/AST/Grammar/ParseErrors.cs
@@ -155,7 +155,7 @@ Only modules may be declared abstract.
 
     Add(ErrorId.p_general_traits_beta,
       @"
-Use of traits as non-reference types is a beta feature. To engage, use /generalTraits:1.
+Use of traits as non-reference types is a beta feature. To engage, use /generalTraits:datatype.
 ", Remove(true));
 
     Add(ErrorId.p_no_ghost_for_by_method,

--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -989,7 +989,7 @@ public class ModuleDefinition : RangeNode, IAttributeBearingDeclaration, IClonea
           }
         }
 
-        traitDecl.SetUpAsReferenceType(resolver.Options.Get(CommonOptionBag.GeneralTraits) ? inheritsFromObject : true);
+        traitDecl.SetUpAsReferenceType(resolver.Options.Get(CommonOptionBag.GeneralTraits) == CommonOptionBag.GeneralTraitsOptions.Legacy || inheritsFromObject);
         traitsProgress[traitDecl] = true; // indicate that traitDecl.IsReferenceTypeDecl can now be called
         return inheritsFromObject;
       }

--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -2809,7 +2809,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override ConcreteSyntaxTree EmitDowncast(Type from, Type to, IToken tok, ConcreteSyntaxTree wr) {
       from = from.NormalizeExpand();
       to = to.NormalizeExpand();
-      Contract.Assert(Options.Get(CommonOptionBag.GeneralTraits) || from.IsRefType == to.IsRefType);
+      Contract.Assert(Options.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Legacy || from.IsRefType == to.IsRefType);
 
       var w = new ConcreteSyntaxTree();
       if (from.IsTraitType && to.AsNewtype != null) {

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -5208,7 +5208,7 @@ namespace Microsoft.Dafny.Compilers {
         EmitUnaryExpr(UnaryOpCodeMap[e.ResolvedOp], e.E, inLetExprBody, wr, wStmts);
       } else if (expr is ConversionExpr) {
         var e = (ConversionExpr)expr;
-        Contract.Assert(Options.Get(CommonOptionBag.GeneralTraits) || e.ToType.IsRefType == e.E.Type.IsRefType);
+        Contract.Assert(Options.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Legacy || e.ToType.IsRefType == e.E.Type.IsRefType);
         if (e.ToType.IsRefType || e.ToType.IsTraitType || e.E.Type.IsTraitType) {
           var w = EmitCoercionIfNecessary(e.E.Type, e.ToType, e.tok, wr);
           w = EmitDowncastIfNecessary(e.E.Type, e.ToType, e.tok, w);

--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -1264,9 +1264,12 @@ ClassDecl<DeclModifierData dmodClass, ModuleDefinition/*!*/ module, out TopLevel
 ExtendsClause<. List<Type> parentTraits, out IToken tokenWithTrailingDocString, string requiresNonReferenceTraitsFor .>
 = (. Type parentTrait;
   .)
-  "extends"                   (. if (requiresNonReferenceTraitsFor != null && !theOptions.Get(CommonOptionBag.GeneralTraits)) {
+  "extends"                   (. if (requiresNonReferenceTraitsFor == "newtype" && theOptions.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Full) {
                                    SemErr(ErrorId.p_general_traits_beta, t,
-                                     $"{requiresNonReferenceTraitsFor} extending traits is a beta feature; use /generalTraits:1 to engage");
+                                     $"{requiresNonReferenceTraitsFor} extending traits is a beta feature; use /generalTraits:full to engage");
+                                 } else if (requiresNonReferenceTraitsFor != null && theOptions.Get(CommonOptionBag.GeneralTraits) == CommonOptionBag.GeneralTraitsOptions.Legacy) {
+                                   SemErr(ErrorId.p_general_traits_beta, t,
+                                     $"{requiresNonReferenceTraitsFor} extending traits is a beta feature; use /generalTraits:datatype to engage");
                                  }
                               .)
   Type<out parentTrait>       (. parentTraits.Add(parentTrait); tokenWithTrailingDocString = t; .)

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -77,7 +77,7 @@ features like traits or co-inductive types.".TrimStart(), "cs");
       RegisterLegacyUi(CommonOptionBag.GeneralTraits, ParseGeneralTraitsOption, "Language feature selection", "generalTraits", @"
 legacy (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
 datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any non-'newtype' type with members can extend traits.
-full - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart(),
+full - (don't use; not yet completely supported) A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart(),
         CommonOptionBag.GeneralTraitsOptions.Legacy);
       RegisterLegacyUi(CommonOptionBag.TypeInferenceDebug, ParseBoolean, "Language feature selection", "titrace", @"
 0 (default) - Don't print type-inference debug information.

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -75,8 +75,10 @@ features like traits or co-inductive types.".TrimStart(), "cs");
 0 (default) - The type-inference engine and supported types are those of Dafny 4.0.
 1 - Use an updated type-inference engine. Warning: This mode is under construction and probably won't work at this time.".TrimStart(), defaultValue: false);
       RegisterLegacyUi(CommonOptionBag.GeneralTraits, ParseGeneralTraitsOption, "Language feature selection", "generalTraits", @"
-0 (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and classes can extend traits.
-1 - A trait is a reference type iff it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart(), CommonOptionBag.GeneralTraitsOptions.Legacy);
+legacy (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
+datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any non-'newtype' type with members can extend traits.
+full - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart(),
+        CommonOptionBag.GeneralTraitsOptions.Legacy);
       RegisterLegacyUi(CommonOptionBag.TypeInferenceDebug, ParseBoolean, "Language feature selection", "titrace", @"
 0 (default) - Don't print type-inference debug information.
 1 - Print type-inference debug information.".TrimStart(), defaultValue: false);

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -74,9 +74,9 @@ features like traits or co-inductive types.".TrimStart(), "cs");
       RegisterLegacyUi(CommonOptionBag.TypeSystemRefresh, ParseBoolean, "Language feature selection", "typeSystemRefresh", @"
 0 (default) - The type-inference engine and supported types are those of Dafny 4.0.
 1 - Use an updated type-inference engine. Warning: This mode is under construction and probably won't work at this time.".TrimStart(), defaultValue: false);
-      RegisterLegacyUi(CommonOptionBag.GeneralTraits, ParseBoolean, "Language feature selection", "generalTraits", @"
+      RegisterLegacyUi(CommonOptionBag.GeneralTraits, ParseGeneralTraitsOption, "Language feature selection", "generalTraits", @"
 0 (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and classes can extend traits.
-1 - A trait is a reference type iff it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart(), false);
+1 - A trait is a reference type iff it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart(), CommonOptionBag.GeneralTraitsOptions.Legacy);
       RegisterLegacyUi(CommonOptionBag.TypeInferenceDebug, ParseBoolean, "Language feature selection", "titrace", @"
 0 (default) - Don't print type-inference debug information.
 1 - Print type-inference debug information.".TrimStart(), defaultValue: false);
@@ -214,6 +214,25 @@ NoGhost - disable printing of functions, ghost methods, and proof
       int result = 0;
       if (ps.GetIntArgument(ref result, 2)) {
         options.Set(option, result == 1);
+      }
+    }
+
+    private static void ParseGeneralTraitsOption(Option<CommonOptionBag.GeneralTraitsOptions> option, Bpl.CommandLineParseState ps, DafnyOptions options) {
+      if (ps.ConfirmArgumentCount(1)) {
+        switch (ps.args[ps.i]) {
+          case "legacy":
+            options.Set(option, CommonOptionBag.GeneralTraitsOptions.Legacy);
+            break;
+          case "datatype":
+            options.Set(option, CommonOptionBag.GeneralTraitsOptions.Datatype);
+            break;
+          case "full":
+            options.Set(option, CommonOptionBag.GeneralTraitsOptions.Full);
+            break;
+          default:
+            InvalidArgumentError(option.Name, ps);
+            break;
+        }
       }
     }
 

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -160,7 +160,7 @@ true - Use an updated type-inference engine. Warning: This mode is under constru
     @"
 legacy - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
 datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any non-'newtype' type with members can extend traits.
-full - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart()) {
+full - (don't use; not yet completely supported) A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart()) {
     IsHidden = true
   };
 

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -150,10 +150,17 @@ true - Use an updated type-inference engine. Warning: This mode is under constru
     IsHidden = true
   };
 
-  public static readonly Option<bool> GeneralTraits = new("--general-traits", () => false,
+  public enum GeneralTraitsOptions {
+    Legacy,
+    Datatype,
+    Full
+  }
+
+  public static readonly Option<GeneralTraitsOptions> GeneralTraits = new("--general-traits", () => GeneralTraitsOptions.Legacy,
     @"
-false - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
-true - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart()) {
+legacy - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
+datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any non-'newtype' type with members can extend traits.
+full - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.".TrimStart()) {
     IsHidden = true
   };
 

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/CheckTypeInferenceVisitor.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/CheckTypeInferenceVisitor.cs
@@ -211,7 +211,7 @@ class CheckTypeInferenceVisitor : ASTVisitor<TypeInferenceCheckingContext> {
       var e = (ConversionExpr)expr;
       if (e.ToType.IsRefType) {
         var fromType = e.E.Type;
-        Contract.Assert(resolver.Options.Get(CommonOptionBag.GeneralTraits) || fromType.IsRefType);
+        Contract.Assert(resolver.Options.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Legacy || fromType.IsRefType);
         if (fromType.IsSubtypeOf(e.ToType, false, true) || e.ToType.IsSubtypeOf(fromType, false, true)) {
           // looks good
         } else {
@@ -228,7 +228,7 @@ class CheckTypeInferenceVisitor : ASTVisitor<TypeInferenceCheckingContext> {
       } else if (!e.ToType.IsSubtypeOf(fromType, false, true)) {
         resolver.ReportError(ResolutionErrors.ErrorId.r_never_succeeding_type_test, e.tok,
           "a type test to '{0}' must be from a compatible type (got '{1}')", e.ToType, fromType);
-      } else if (resolver.Options.Get(CommonOptionBag.GeneralTraits) && (fromType.IsTraitType || fromType.Equals(e.ToType))) {
+      } else if (resolver.Options.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Legacy && (fromType.IsTraitType || fromType.Equals(e.ToType))) {
         // it's fine
       } else if (!e.ToType.IsRefType) {
         resolver.ReportError(ResolutionErrors.ErrorId.r_unsupported_type_test, e.tok,

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -5606,7 +5606,7 @@ namespace Microsoft.Dafny {
         var hint0 = "(did you forget to qualify a name or declare a module import 'opened'?)";
         var hint1 = " (note that names in outer modules are not visible in contained modules)";
         var hint2 = "";
-        if (Options.Get(CommonOptionBag.GeneralTraits) && expr.Name.EndsWith("?")) {
+        if (Options.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Legacy && expr.Name.EndsWith("?")) {
           var nameWithoutQuestionMark = expr.Name[..^1];
           if (nameWithoutQuestionMark.Length != 0 &&
               moduleInfo.TopLevels.TryGetValue(nameWithoutQuestionMark, out decl) && decl is TraitDecl) {

--- a/Source/DafnyCore/Resolver/PreType/PreType2TypeUtil.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreType2TypeUtil.cs
@@ -30,7 +30,10 @@ public static class PreType2TypeUtil {
       case TypeParameter.TPVariance.Co:
         ty = new BottomTypePlaceholder(ty);
         break;
-      default:
+      case TypeParameter.TPVariance.Non:
+        ty = new ExactTypePlaceholder(ty);
+        break;
+      case TypeParameter.TPVariance.Contra:
         break;
     }
 

--- a/Source/DafnyCore/Resolver/PreType/PreType2TypeUtil.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreType2TypeUtil.cs
@@ -30,10 +30,7 @@ public static class PreType2TypeUtil {
       case TypeParameter.TPVariance.Co:
         ty = new BottomTypePlaceholder(ty);
         break;
-      case TypeParameter.TPVariance.Non:
-        ty = new ExactTypePlaceholder(ty);
-        break;
-      case TypeParameter.TPVariance.Contra:
+      default:
         break;
     }
 

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -5620,7 +5620,7 @@ namespace Microsoft.Dafny {
         }
       }
 
-      Contract.Assert(options.Get(CommonOptionBag.GeneralTraits) || expr.Type.IsRefType == toType.IsRefType);
+      Contract.Assert(options.Get(CommonOptionBag.GeneralTraits) != CommonOptionBag.GeneralTraitsOptions.Legacy || expr.Type.IsRefType == toType.IsRefType);
       if (toType.IsRefType) {
         PutSourceIntoLocal();
         CheckSubrange(tok, o, expr.Type, toType, builder, errorMsgPrefix);

--- a/Test/traits/GeneralTraits.dfy
+++ b/Test/traits/GeneralTraits.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 2 %dafny /typeSystemRefresh:1 /generalTraits:1 "%s" > "%t"
+// RUN: %exits-with 2 %dafny /typeSystemRefresh:1 /generalTraits:full "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Tests {

--- a/Test/traits/GeneralTraitsCompile.dfy
+++ b/Test/traits/GeneralTraitsCompile.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachCompiler "%s" --refresh-exit-code=0 -- --general-traits --type-system-refresh
+// RUN: %testDafnyForEachCompiler "%s" --refresh-exit-code=0 -- --general-traits:full --type-system-refresh
 
 method Main() {
   Tests.Test();

--- a/Test/traits/GeneralTraitsVerify.dfy
+++ b/Test/traits/GeneralTraitsVerify.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %dafny /typeSystemRefresh:1 /generalTraits:1 "%s" > "%t"
+// RUN: %exits-with 4 %dafny /typeSystemRefresh:1 /generalTraits:full "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Tests {

--- a/Test/traits/NonReferenceTraits.dfy
+++ b/Test/traits/NonReferenceTraits.dfy
@@ -1,5 +1,5 @@
-// RUN: %exits-with 2 %dafny /generalTraits:0 "%s" > "%t"
-// RUN: %exits-with 2 %dafny /generalTraits:1 "%s" >> "%t"
+// RUN: %exits-with 2 %dafny /generalTraits:legacy "%s" > "%t"
+// RUN: %exits-with 2 %dafny /generalTraits:datatype "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Tests {

--- a/Test/traits/NonReferenceTraitsCompile.dfy
+++ b/Test/traits/NonReferenceTraitsCompile.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachCompiler "%s" --refresh-exit-code=0 -- --general-traits
+// RUN: %testDafnyForEachCompiler "%s" --refresh-exit-code=0 -- --general-traits:full
 
 method Main() {
   BoxingConcerns.Test();

--- a/Test/traits/NonReferenceTraitsVerify.dfy
+++ b/Test/traits/NonReferenceTraitsVerify.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %dafny /generalTraits:1 "%s" > "%t"
+// RUN: %exits-with 4 %dafny /generalTraits:datatype "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module ChildIsNonRefTrait {

--- a/Test/traits/TraitVariance.dfy
+++ b/Test/traits/TraitVariance.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 2 %dafny /generalTraits:1 "%s" > "%t"
+// RUN: %exits-with 2 %dafny /generalTraits:full "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module NoVariance {

--- a/docs/DafnyRef/Options.txt
+++ b/docs/DafnyRef/Options.txt
@@ -106,8 +106,9 @@ Usage: dafny [ option ... ] [ filename ... ]
       `opaque` means functions are always opaque so the opaque keyword is not needed, and functions must be revealed everywhere needed for a proof.
 
   /generalTraits:<value>
-      0 (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and classes can extend traits.
-      1 - A trait is a reference type iff it or one of its ancestor traits is 'object'. Any type with members can extend traits.
+      legacy (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
+      datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any non-'newtype' type with members can extend traits.
+      full - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.
 
   /ntitrace:<value>
       0 (default) - Don't print debug information for the new type system.

--- a/docs/DafnyRef/Options.txt
+++ b/docs/DafnyRef/Options.txt
@@ -108,7 +108,7 @@ Usage: dafny [ option ... ] [ filename ... ]
   /generalTraits:<value>
       legacy (default) - Every trait implicitly extends 'object', and thus is a reference type. Only traits and reference types can extend traits.
       datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any non-'newtype' type with members can extend traits.
-      full - A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.
+      full - (don't use; not yet completely supported) A trait is a reference type only if it or one of its ancestor traits is 'object'. Any type with members can extend traits.
 
   /ntitrace:<value>
       0 (default) - Don't print debug information for the new type system.

--- a/docs/HowToFAQ/Errors-Parser.md
+++ b/docs/HowToFAQ/Errors-Parser.md
@@ -255,7 +255,7 @@ trait Trait { }
 datatype D extends Trait = A | B
 ```
 
-Use of traits as non-reference types is a beta feature. To engage, use /generalTraits:1.
+Use of traits as non-reference types is a beta feature. To engage, use /generalTraits:datatype.
 
 ## **Warning: module-level const declarations are always non-instance, so the 'static' keyword is not allowed here {#p_module_level_const_always_static}
 

--- a/docs/HowToFAQ/Errors-Parser.md
+++ b/docs/HowToFAQ/Errors-Parser.md
@@ -248,7 +248,7 @@ module N refines M { datatype D = ... Y | Z }
 There are limitations on refining a datatype, namely that the set of constructors cannot be changed.
 It is only allowed to add members to the body of the datatype.
 
-## **Error: datatype extending traits is a beta feature; use /generalTraits:1 to engage** {#p_general_traits_beta}
+## **Error: datatype extending traits is a beta feature; use /generalTraits:datatype to engage** {#p_general_traits_beta}
 
 ```dafny
 trait Trait { }

--- a/docs/HowToFAQ/Errors-Parser.template
+++ b/docs/HowToFAQ/Errors-Parser.template
@@ -204,7 +204,7 @@ module N refines M { datatype D = ... Y | Z }
 
 <!-- INSERT-TEXT -->
 
-## **Error: datatype extending traits is a beta feature; use /generalTraits:1 to engage** {#p_general_traits_beta}
+## **Error: datatype extending traits is a beta feature; use /generalTraits:datatype to engage** {#p_general_traits_beta}
 
 ```dafny
 trait Trait { }


### PR DESCRIPTION
The Dafny language is extending its `trait` types to make them available not just as abstract supertypes for `class` types, but also as abstract supertypes for other types. Over time (probably in Dafny 5), the new traits will be the default. This PR provides a command-line option that allows program to opt-in to using the new traits now:

```
--general-traits=<value>
    legacy (default) - Every trait implicitly extends 'object', and thus is a reference type.
                       Only traits and reference types can extend traits.
    datatype - A trait is a reference type only if it or one of its ancestor traits is 'object'.
               Any non-'newtype' type with members can extend traits.
```

## Traits as reference types or not

Under the `--general-traits=datatype` option, a `trait` is a reference type iff:

* the trait is declared to explicitly extend `object` (using `extends object`) or extends some other reference-type trait.

Note that, with the `--general-traits=legacy` option, `extends object` on a trait is allowed but redundant. Thus, a program that is partially upgraded with various `extends object` clauses is still a valid program with Dafny's old traits.

If a trait is a reference type, then:

* A declaration `trait A` gives rise to two types, the possibly-null type `A?` and the non-null type `A`. Values of these types can be compared with `null`.
* The trait can declare mutable fields (using `var` member declarations).

On the flip side, a _non_-reference trait:

* can be extended (not only by `class` and other `trait` declarations, but also) by `datatype`, `codatatype`, and abstract type (keyword `type` without a following `=`) declarations.

## New subtype relations

Dafny's existing type system does not understand the new subtype relations that non-reference traits give rise to. So, by itself, `--general-traits=datatype` will allow a `datatype` to extend a `trait`, but a value of such a datatype cannot be assigned to a variable whose type is the trait. Luckily, Dafny has a new type system that does understand these subtype relations. The new type system can be used with (the orthogonal option) `--type-system-refresh`. The combination

```
--general-traits=datatype --type-system-refresh
```

allows full use of traits over datatypes. (The new type system does a few things differently. A description of those details is out of scope here.)

## Looking ahead

The plan for Dafny's non-reference traits is to support them as abstract supertypes for any type that can have members. In addition to the types listed above, this means also letting a `newtype` declaration extend traits. This PR gives a way to opt in to `newtype`s extending `trait`s, with a third value for `--general-traits`:

```
    full - (don't use; not yet completely supported) A trait is a reference type only if
           it or one of its ancestor traits is 'object'. Any type with members can extend traits.
```

Under `--general-traits=full`, a `newtype` can be declared to extend traits. And when that option is used together with `--type-system-refresh`, then type checking and verification are supported. However, compilation of such `newtype`s is not yet completely implemented. (In particular, what's missing at this time is the runtime "boxing" and "unboxing" to convert between a `newtype`'s standard representation to its "fat pointer" representation.)

## A previous `--general-traits` option

The `--general-traits` option was introduced as a beta feature in the last few months. It then had two options, `false` and `true`. Essentially, this PR breaks up the `=true` option into the `=datatype` and `=full` options. That is, the old `--general-traits=false` is now `--general-traits=legacy`, and the old `--general-traits=true` is now `--general-traits=full`.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
