### PR TITLE
Clone reads for decreases

### DIFF
--- a/Source/DafnyCore/AST/SystemModuleManager.cs
+++ b/Source/DafnyCore/AST/SystemModuleManager.cs
@@ -80,6 +80,12 @@ public class SystemModuleManager {
     Contract.Assume(ObjectDecl != null);
     return new UserDefinedType(Token.NoToken, "object?", null) { ResolvedClass = ObjectDecl };
   }
+  /// <summary>
+  /// Return a resolved type for "set<object?>".
+  /// </summary>
+  public Type ObjectSetType() {
+    return new SetType(true, ObjectQ());
+  }
 
   public SystemModuleManager(DafnyOptions options) {
     this.Options = options;

--- a/Source/DafnyCore/AST/SystemModuleManager.cs
+++ b/Source/DafnyCore/AST/SystemModuleManager.cs
@@ -285,7 +285,7 @@ public class SystemModuleManager {
       var argExprs = args.ConvertAll(a =>
         (Expression)new IdentifierExpr(tok, a.Name) { Var = a, Type = a.Type });
       var readsIS = new FunctionCallExpr(tok, "reads", new ImplicitThisExpr(tok), tok, tok, argExprs) {
-        Type = new SetType(true, ObjectQ()),
+        Type = ObjectSetType(),
       };
       var readsFrame = new List<FrameExpression> { new FrameExpression(tok, readsIS, null) };
       var function = new Function(RangeToken.NoToken, new Name(name), false, true, false,
@@ -299,7 +299,7 @@ public class SystemModuleManager {
       return function;
     }
 
-    var reads = CreateMember("reads", new SetType(true, ObjectQ()), null);
+    var reads = CreateMember("reads", ObjectSetType(), null);
     var req = CreateMember("requires", Type.Bool, reads);
 
     var arrowDecl = new ArrowTypeDecl(tps, req, reads, SystemModule, DontCompile());

--- a/Source/DafnyCore/AST/TypeDeclarations/IteratorDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/IteratorDecl.cs
@@ -399,11 +399,11 @@ public class IteratorDecl : ClassDecl, IMethodCodeContext, ICanVerify {
     });
     // add the additional special variables as fields
     Member_Reads = new SpecialField(RangeToken, "_reads", SpecialField.ID.Reads, null, true, false, false,
-      new SetType(true, resolver.SystemModuleManager.ObjectQ()), null);
+      resolver.SystemModuleManager.ObjectSetType(), null);
     Member_Modifies = new SpecialField(RangeToken, "_modifies", SpecialField.ID.Modifies, null, true, false,
-      false, new SetType(true, resolver.SystemModuleManager.ObjectQ()), null);
+      false, resolver.SystemModuleManager.ObjectSetType(), null);
     Member_New = new SpecialField(RangeToken, "_new", SpecialField.ID.New, null, true, true, true,
-      new SetType(true, resolver.SystemModuleManager.ObjectQ()), null);
+      resolver.SystemModuleManager.ObjectSetType(), null);
     foreach (var field in new List<Field>() { Member_Reads, Member_Modifies, Member_New }) {
       field.EnclosingClass = this; // resolve here
       field.InheritVisibility(this);

--- a/Source/DafnyCore/Resolver/InferDecreasesClause.cs
+++ b/Source/DafnyCore/Resolver/InferDecreasesClause.cs
@@ -152,7 +152,7 @@ public class InferDecreasesClause {
       if (fe.E is WildcardExpr) {
         // drop wildcards altogether
       } else {
-        Expression e = fe.E; // keep only fe.E, drop any fe.Field designation
+        Expression e = new Cloner(false, true).CloneExpr(fe.E); // keep only fe.E, drop any fe.Field designation
         Contract.Assert(e.Type != null); // should have been resolved already
         var eType = e.Type.NormalizeExpand();
         if (eType.IsRefType) {

--- a/Source/DafnyCore/Resolver/InferDecreasesClause.cs
+++ b/Source/DafnyCore/Resolver/InferDecreasesClause.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 
 namespace Microsoft.Dafny;
 
@@ -147,68 +148,68 @@ public class InferDecreasesClause {
     List<Expression> sets = new List<Expression>();
     List<Expression> singletons = null;
     var idGen = new FreshIdGenerator();
-    foreach (FrameExpression fe in fexprs) {
+    // drop wildcards altogether in the following iterations
+    foreach (FrameExpression fe in fexprs.Where(fe => fe.E is not WildcardExpr)) {
       Contract.Assert(fe != null);
-      if (fe.E is WildcardExpr) {
-        // drop wildcards altogether
-      } else {
-        Expression e = new Cloner(false, true).CloneExpr(fe.E); // keep only fe.E, drop any fe.Field designation
-        Contract.Assert(e.Type != null); // should have been resolved already
-        var eType = e.Type.NormalizeExpand();
-        if (eType.IsRefType) {
-          // e represents a singleton set
-          if (singletons == null) {
-            singletons = new List<Expression>();
-          }
-
-          singletons.Add(e);
-        } else if (eType is SeqType || eType is MultiSetType || LiteralExpr.IsEmptySet(e)) {
-          // e represents a sequence or multiset
-          var collectionType = (CollectionType)eType;
-          var resolvedOpcode = collectionType.ResolvedOpcodeForIn;
-          var boundedPool = collectionType.GetBoundedPool(e);
-
-          // Add:  set x :: x in e
-          var bv = new BoundVar(e.tok, idGen.FreshId("_s2s_"),
-            collectionType.Arg.NormalizeExpand());
-          var bvIE = new IdentifierExpr(e.tok, bv.Name) {
-            Var = bv,
-            Type = bv.Type
-          };
-          var sInE = new BinaryExpr(e.tok, BinaryExpr.Opcode.In, bvIE, e) {
-            ResolvedOp = resolvedOpcode,
-            Type = Type.Bool
-          };
-          var s = new SetComprehension(e.tok, e.RangeToken, true, new List<BoundVar>() { bv }, sInE, bvIE,
-            new Attributes("trigger", new List<Expression> { sInE }, null)) {
-            Type = new SetType(true, resolver.SystemModuleManager.ObjectQ()),
-            Bounds = new List<ComprehensionExpr.BoundedPool>() { boundedPool }
-          };
-          sets.Add(s);
-        } else {
-          // e is already a set
-          Contract.Assert(eType is SetType);
-          sets.Add(e);
+      Expression e = new Cloner(false, true).CloneExpr(fe.E); // keep only fe.E, drop any fe.Field designation
+      Contract.Assert(e.Type != null); // fe.E should have been resolved already, and the clone should still have that type
+      var eType = e.Type.NormalizeExpand();
+      if (eType.IsRefType) {
+        // e represents a singleton set
+        if (singletons == null) {
+          singletons = new List<Expression>();
         }
+        singletons.Add(e);
+
+      } else if (eType is SeqType || eType is MultiSetType || LiteralExpr.IsEmptySet(e)) {
+        // e represents a sequence or multiset
+        var collectionType = (CollectionType)eType;
+        var resolvedOpcode = collectionType.ResolvedOpcodeForIn;
+        var boundedPool = collectionType.GetBoundedPool(e);
+
+        // Add:  set x :: x in e
+        var bvDecl = new BoundVar(e.tok, idGen.FreshId("_s2s_"), collectionType.Arg.NormalizeExpand());
+        var bv = new IdentifierExpr(e.tok, bvDecl.Name) {
+          Var = bvDecl,
+          Type = bvDecl.Type
+        };
+        var bvInE = new BinaryExpr(e.tok, BinaryExpr.Opcode.In, bv, e) {
+          ResolvedOp = resolvedOpcode,
+          Type = Type.Bool
+        };
+        var s = new SetComprehension(e.tok, e.RangeToken, true, new List<BoundVar>() { bvDecl }, bvInE, bv,
+          new Attributes("trigger", new List<Expression> { bvInE }, null)) {
+          Type = resolver.SystemModuleManager.ObjectSetType(),
+          Bounds = new List<ComprehensionExpr.BoundedPool>() { boundedPool }
+        };
+        sets.Add(s);
+
+      } else {
+        // e is already a set
+        Contract.Assert(eType is SetType);
+        sets.Add(e);
       }
     }
 
     if (singletons != null) {
-      Expression display = new SetDisplayExpr(singletons[0].tok, true, singletons);
-      display.Type = new SetType(true, resolver.SystemModuleManager.ObjectQ()); // resolve here
+      Expression display = new SetDisplayExpr(singletons[0].tok, true, singletons) {
+        Type = resolver.SystemModuleManager.ObjectSetType()
+      };
       sets.Add(display);
     }
 
     if (sets.Count == 0) {
-      Expression emptyset = new SetDisplayExpr(Token.NoToken, true, new List<Expression>());
-      emptyset.Type = new SetType(true, resolver.SystemModuleManager.ObjectQ()); // resolve here
-      return emptyset;
+      var emptySet = new SetDisplayExpr(Token.NoToken, true, new List<Expression>()) {
+        Type = resolver.SystemModuleManager.ObjectSetType()
+      };
+      return emptySet;
     } else {
       Expression s = sets[0];
-      for (int i = 1; i < sets.Count; i++) {
-        BinaryExpr union = new BinaryExpr(s.tok, BinaryExpr.Opcode.Add, s, sets[i]);
-        union.ResolvedOp = BinaryExpr.ResolvedOpcode.Union; // resolve here
-        union.Type = new SetType(true, resolver.SystemModuleManager.ObjectQ()); // resolve here
+      for (var i = 1; i < sets.Count; i++) {
+        var union = new BinaryExpr(s.tok, BinaryExpr.Opcode.Add, s, sets[i]) {
+          ResolvedOp = BinaryExpr.ResolvedOpcode.Union,
+          Type = resolver.SystemModuleManager.ObjectSetType()
+        };
         s = union;
       }
 

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.Dafny {
         scope.PopMarker();
         expr.Type = SelectAppropriateArrowType(e.tok, e.BoundVars.ConvertAll(v => v.Type), e.Body.Type, e.Reads.Expressions.Count != 0, e.Range != null, SystemModuleManager);
       } else if (expr is WildcardExpr) {
-        expr.Type = new SetType(true, SystemModuleManager.ObjectQ());
+        expr.Type = SystemModuleManager.ObjectSetType();
       } else if (expr is StmtExpr) {
         var e = (StmtExpr)expr;
         int prevErrorCount = reporter.Count(ErrorLevel.Error);

--- a/Source/DafnyCore/Rewriters/AutoContractsRewriter.cs
+++ b/Source/DafnyCore/Rewriters/AutoContractsRewriter.cs
@@ -79,7 +79,7 @@ public class AutoContractsRewriter : IRewriter {
     // Add:  ghost var Repr: set<object>
     // ...unless a field with that name is already present
     if (!cl.Members.Exists(member => member is Field && member.Name == "Repr")) {
-      Type ty = new SetType(true, systemModuleManager.ObjectQ());
+      Type ty = systemModuleManager.ObjectSetType();
       var repr = new Field(range, new Name(range, "Repr"), true, ty, null);
       cl.Members.Add(repr);
       AddHoverText(cl.tok, "{0}", Printer.FieldToString(Reporter.Options, repr));
@@ -283,7 +283,7 @@ public class AutoContractsRewriter : IRewriter {
           if (ctor.RefinementBase == null) {
             // Repr := {this};
             var e = new SetDisplayExpr(tok, true, new List<Expression>() { self });
-            e.Type = new SetType(true, systemModuleManager.ObjectQ());
+            e.Type = systemModuleManager.ObjectSetType();
             Statement s = new AssignStmt(member.RangeToken, Repr, new ExprRhs(e));
             s.IsGhost = true;
             sbs.AppendStmt(s);
@@ -355,7 +355,7 @@ public class AutoContractsRewriter : IRewriter {
     foreach (var ff in subobjects) {
       var F = CreateResolvedFieldSelect(tok, implicitSelf, ff.Item1);  // create a resolved MemberSelectExpr
       Expression e = new SetDisplayExpr(tok, true, new List<Expression>() { F }) {
-        Type = new SetType(true, systemModuleManager.ObjectQ())  // resolve here
+        Type = systemModuleManager.ObjectSetType()
       };
       var rhs = new BinaryExpr(tok, BinaryExpr.Opcode.Add, Repr, e) {
         ResolvedOp = BinaryExpr.ResolvedOpcode.Union,

--- a/Source/DafnyCore/Verifier/Translator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/Translator.ExpressionWellformed.cs
@@ -588,7 +588,7 @@ namespace Microsoft.Dafny {
 
             if (wfOptions.DoReadsChecks && !fnCoreType.IsArrowTypeWithoutReadEffects) {
               // check read effects
-              Type objset = new SetType(true, program.SystemModuleManager.ObjectQ());
+              Type objset = program.SystemModuleManager.ObjectSetType();
               Expression wrap = new BoogieWrapper(
                 FunctionCall(e.tok, Reads(arity), TrType(objset), args),
                 objset);
@@ -721,7 +721,7 @@ namespace Microsoft.Dafny {
 
                 if (wfOptions.DoReadsChecks) {
                   // check that the callee reads only what the caller is already allowed to read
-                  Type objset = new SetType(true, program.SystemModuleManager.ObjectQ());
+                  Type objset = program.SystemModuleManager.ObjectSetType();
                   Expression wrap = new BoogieWrapper(
                     FunctionCall(expr.tok, Reads(e.Args.Count()), TrType(objset), arguments),
                     objset);

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -5997,7 +5997,7 @@ namespace Microsoft.Dafny {
           // be referred to.
 
           var fhandle = FunctionCall(f.tok, name, predef.HandleType, SnocSelf(SnocPrevH(args)));
-          Bpl.Expr lhs_inner = FunctionCall(f.tok, Reads(arity), TrType(new SetType(true, program.SystemModuleManager.ObjectQ())), Concat(tyargs, Cons(h, Cons(fhandle, lhs_args))));
+          Bpl.Expr lhs_inner = FunctionCall(f.tok, Reads(arity), TrType(program.SystemModuleManager.ObjectSetType()), Concat(tyargs, Cons(h, Cons(fhandle, lhs_args))));
 
           Bpl.Expr bx; var bxVar = BplBoundVar("$bx", predef.BoxType, out bx);
           Bpl.Expr unboxBx = FunctionCall(f.tok, BuiltinFunction.Unbox, predef.RefType, bx);
@@ -6120,7 +6120,7 @@ namespace Microsoft.Dafny {
       // [Heap, Box, ..., Box] Bool
       var requires_ty = new Bpl.MapType(tok, new List<Bpl.TypeVariable>(), map_args, Bpl.Type.Bool);
       // Set Box
-      var objset_ty = TrType(new SetType(true, program.SystemModuleManager.ObjectQ()));
+      var objset_ty = TrType(program.SystemModuleManager.ObjectSetType());
       // [Heap, Box, ..., Box] (Set Box)
       var reads_ty = new Bpl.MapType(tok, new List<Bpl.TypeVariable>(), map_args, objset_ty);
 
@@ -9246,7 +9246,7 @@ namespace Microsoft.Dafny {
       builder.Add(AssertNS(tok, q, desc));
       if (!forArray && options.DoReadsChecks) {
         // check read effects
-        Type objset = new SetType(true, program.SystemModuleManager.ObjectQ());
+        Type objset = program.SystemModuleManager.ObjectSetType();
         Expression wrap = new BoogieWrapper(
           FunctionCall(tok, Reads(1), TrType(objset), args),
           objset);


### PR DESCRIPTION
This PR does 3 things. The primary thing is to change

``` c#
Expression e = fe.E;
```

to

``` c#
Expression e = new Cloner(false, true).CloneExpr(fe.E);
```

in `InferDecreasesExpr.cs`. This prevents the given `reads` expression AST nodes from being shared in the generated `decreases` clause. (This is good, because it lets the new type inference assume that it will come across each variable declaration just once.)

The PR also introduces a method `SystemModuleManager.ObjectSetType()`, which returns the type `set<object?>`. This type was constructed in many places in the Dafny implementation, including in the code surrounding the primary change of this PR.

Finally, the PR rewrites some code surrounding the primary change to use more modern C#.



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
