### PR TITLE
Don't warn about `assume true` being unused

### DIFF
--- a/Source/DafnyCore/ProofDependencyWarnings.cs
+++ b/Source/DafnyCore/ProofDependencyWarnings.cs
@@ -59,7 +59,9 @@ public class ProofDependencyWarnings {
       }
 
       foreach (var dep in unusedAssumeStatements) {
-        reporter.Warning(MessageSource.Verifier, "", dep.Range, $"unnecessary assumption");
+        if (ShouldWarnUnused(dep)) {
+          reporter.Warning(MessageSource.Verifier, "", dep.Range, $"unnecessary assumption");
+        }
       }
     }
   }
@@ -110,6 +112,27 @@ public class ProofDependencyWarnings {
     // Ensures clauses are often proven vacuously during well-formedness checks.
     if (verboseName.Contains("well-formedness") && dep is EnsuresDependency) {
       return false;
+    }
+
+    return true;
+  }
+
+  /// <summary>
+  /// Some assumptions that don't show up in the dependency list
+  /// are innocuous. In particular, `assume true` is often used
+  /// as a place to attach attributes such as `{:split_here}`.
+  /// Don't warn about such assumptions.
+  /// </summary>
+  /// <param name="dep">the dependency to examine</param>
+  /// <returns>false to skip warning about the absence of this
+  /// dependency, true otherwise</returns>
+  private static bool ShouldWarnUnused(ProofDependency dep) {
+    if (dep is AssumptionDependency assumeDep) {
+      if (assumeDep.Expr is not null &&
+          Expression.IsBoolLiteral(assumeDep.Expr, out var lit) &&
+          lit == true) {
+        return false;
+      }
     }
 
     return true;

--- a/Source/DafnyCore/Verifier/ProofDependency.cs
+++ b/Source/DafnyCore/Verifier/ProofDependency.cs
@@ -164,20 +164,21 @@ public class CallDependency : ProofDependency {
 
 // Represents the assumption of a predicate in an `assume` statement.
 public class AssumptionDependency : ProofDependency {
-  private readonly Expression expr;
-
   public override RangeToken Range =>
-    expr.RangeToken;
+    Expr.RangeToken;
 
   public override string Description =>
     comment ?? $"assume {OriginalString()}";
 
   private readonly string comment;
+
+  public Expression Expr { get; }
+
   public bool IsAssumeStatement { get; }
 
   public AssumptionDependency(bool isAssumeStatement, string comment, Expression expr) {
     this.comment = comment;
-    this.expr = expr;
+    this.Expr = expr;
     this.IsAssumeStatement = isAssumeStatement;
   }
 }

--- a/Test/logger/ProofDependencyLogging.dfy
+++ b/Test/logger/ProofDependencyLogging.dfy
@@ -434,3 +434,8 @@ method DontWarnAboutVacuousAssertFalse(x: int) {
   assume x == x + 1;
   assert false;
 }
+
+method DontWarnAboutUnusedAssumeTrue(x: int) {
+  assume true;
+  assert 1 + x == x + 1;
+}

--- a/Test/logger/ProofDependencyWarnings.dfy.expect
+++ b/Test/logger/ProofDependencyWarnings.dfy.expect
@@ -17,4 +17,4 @@ ProofDependencyLogging.dfy(346,10): Warning: ensures clause proved using contrad
 ProofDependencyLogging.dfy(354,11): Warning: unnecessary requires clause
 ProofDependencyLogging.dfy(363,9): Warning: unnecessary assumption
 
-Dafny program verifier finished with 30 verified, 0 errors
+Dafny program verifier finished with 31 verified, 0 errors


### PR DESCRIPTION
Previously, `--warn-redundant-assumptions` would warn about instances of `assume true`. These are almost always intentionally included, and used as a place to hang attributes related to the proof process (like `{:split_here}`), so it doesn't make sense to warn about them.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
