### PR TITLE
Use resolved syntax expressions for triggers

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Expression.cs
+++ b/Source/DafnyCore/AST/Expressions/Expression.cs
@@ -774,6 +774,18 @@ public abstract class Expression : TokenNode {
   }
 
   /// <summary>
+  /// If "expr" is an expression that exists only as a resolved expression, then wrap it in the usual unresolved structure.
+  /// </summary>
+  public static Expression WrapAsParsedStructureIfNecessary(Expression expr, SystemModuleManager systemModuleManager) {
+    if (expr is FunctionCallExpr functionCallExpr) {
+      return WrapResolvedCall(functionCallExpr, systemModuleManager);
+    } else if (expr is MemberSelectExpr memberSelectExpr) {
+      return WrapResolvedMemberSelect(memberSelectExpr);
+    }
+    return expr;
+  }
+
+  /// <summary>
   /// Create a resolved case expression for a match expression
   /// </summary>
   public static MatchCaseExpr CreateMatchCase(MatchCaseExpr old_case, Expression new_body) {

--- a/Source/DafnyCore/Rewriters/RewriterCollection.cs
+++ b/Source/DafnyCore/Rewriters/RewriterCollection.cs
@@ -22,7 +22,7 @@ public static class RewriterCollection {
 
     if (reporter.Options.AutoTriggers) {
       result.Add(new QuantifierSplittingRewriter(reporter));
-      result.Add(new TriggerGeneratingRewriter(reporter));
+      result.Add(new TriggerGeneratingRewriter(reporter, program.SystemModuleManager));
     }
 
     if (reporter.Options.TestContracts != DafnyOptions.ContractTestingMode.None) {

--- a/Source/DafnyCore/Rewriters/TriggerGeneratingRewriter.cs
+++ b/Source/DafnyCore/Rewriters/TriggerGeneratingRewriter.cs
@@ -3,8 +3,10 @@ using System.Diagnostics.Contracts;
 namespace Microsoft.Dafny;
 
 public class TriggerGeneratingRewriter : IRewriter {
-  internal TriggerGeneratingRewriter(ErrorReporter reporter) : base(reporter) {
+  private readonly SystemModuleManager systemModuleManager;
+  internal TriggerGeneratingRewriter(ErrorReporter reporter, SystemModuleManager systemModuleManager) : base(reporter) {
     Contract.Requires(reporter != null);
+    this.systemModuleManager = systemModuleManager;
   }
 
   internal override void PostCyclicityResolve(ModuleDefinition definition, ErrorReporter reporter) {
@@ -17,7 +19,7 @@ public class TriggerGeneratingRewriter : IRewriter {
     var triggersCollector = new Triggers.TriggersCollector(finder.exprsInOldContext, Reporter.Options);
     foreach (var quantifierCollection in finder.quantifierCollections) {
       quantifierCollection.ComputeTriggers(triggersCollector);
-      quantifierCollection.CommitTriggers(Reporter.Options);
+      quantifierCollection.CommitTriggers(Reporter.Options, systemModuleManager);
     }
   }
 }

--- a/Source/DafnyCore/Triggers/QuantifiersCollection.cs
+++ b/Source/DafnyCore/Triggers/QuantifiersCollection.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Dafny.Triggers {
       return expr;
     }
 
-    private void CommitOne(DafnyOptions options, QuantifierWithTriggers q, bool addHeader) {
+    private void CommitOne(DafnyOptions options, QuantifierWithTriggers q, bool addHeader, SystemModuleManager systemModuleManager) {
       var errorLevel = ErrorLevel.Info;
       var msg = new StringBuilder();
       var indent = addHeader ? "  " : "";
@@ -313,7 +313,9 @@ namespace Microsoft.Dafny.Triggers {
         }
 
         foreach (var candidate in q.Candidates) {
-          q.quantifier.Attributes = new Attributes("trigger", candidate.Terms.Select(t => t.Expr).ToList(), q.quantifier.Attributes);
+          q.quantifier.Attributes = new Attributes("trigger",
+            candidate.Terms.ConvertAll(t => Expression.WrapAsParsedStructureIfNecessary(t.Expr, systemModuleManager)),
+            q.quantifier.Attributes);
         }
 
         AddTriggersToMessage("Selected triggers:", q.Candidates, msg, indent);
@@ -363,9 +365,9 @@ namespace Microsoft.Dafny.Triggers {
       }
     }
 
-    internal void CommitTriggers(DafnyOptions options) {
+    internal void CommitTriggers(DafnyOptions options, SystemModuleManager systemModuleManager) {
       foreach (var q in quantifiers) {
-        CommitOne(options, q, quantifiers.Count > 1);
+        CommitOne(options, q, quantifiers.Count > 1, systemModuleManager);
       }
     }
   }

--- a/Test/dafny0/PrefixTypeSubst.dfy
+++ b/Test/dafny0/PrefixTypeSubst.dfy
@@ -1,5 +1,5 @@
-// RUN: %exits-with 4 %dafny /env:0 /rprint:- "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
+// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s" -- --rprint:-
+
 
 class MyClass<A,B> {
   greatest predicate P<X,Y>(x: X, y: Y)

--- a/Test/dafny0/PrefixTypeSubst.dfy.expect
+++ b/Test/dafny0/PrefixTypeSubst.dfy.expect
@@ -228,7 +228,7 @@ lemma /*{:_induction _k}*/ N#<D0, D1, D2>[_k: ORDINAL](o: MyClass<D0, D1>)
   if 0 < _k.Offset {
     N#<D0, D1, D2>[_k - 1](o);
   } else {
-    forall _k': ORDINAL, o: MyClass<D0, D1> /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger o.R#[_k']()} | _k' < _k
+    forall _k': ORDINAL, o: MyClass<D0, D1> /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger o.R#<D2>[_k']()} | _k' < _k
       ensures o.R#[_k']()
     {
       N#[_k'](o)
@@ -250,7 +250,7 @@ lemma /*{:_induction _k}*/ O#<D0, D1, D2>[_k: ORDINAL]()
   if 0 < _k.Offset {
     O#<D0, D1, D2>[_k - 1]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<D0, D1>.S#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<D0, D1>.S#<D2>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<D0, D1>.S#[_k']()
     {
       O#[_k']()
@@ -272,7 +272,7 @@ lemma {:induction false} RstRst0#<alpha, gamma>[_k: ORDINAL]()
   if 0 < _k.Offset {
     RstRst0#<int, gamma>[_k - 1]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, char>.RST#[_k']()
     {
       RstRst0#[_k']()
@@ -294,7 +294,7 @@ lemma {:induction false} RstRst1#<alpha, gamma>[_k: ORDINAL]()
   if 0 < _k.Offset {
     RstRst1#<int, int>[_k - 1]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, char>.RST#[_k']()
     {
       RstRst1#[_k']()
@@ -316,7 +316,7 @@ lemma {:induction false} RstRst2#<alpha, gamma>[_k: ORDINAL]()
   if 0 < _k.Offset {
     RstRst2#<alpha, gamma>[_k - 1]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, char>.RST#[_k']()
     {
       RstRst2#[_k']()
@@ -338,7 +338,7 @@ lemma {:induction false} RstRst3#<alpha, beta, gamma>[_k: ORDINAL]()
   if 0 < _k.Offset {
     RstRst3#<alpha, beta, gamma>[_k - 1]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, beta>.RST#[_k']()
     {
       RstRst3#[_k']()
@@ -360,7 +360,7 @@ lemma {:induction false} RstRst4#<alpha, beta, gamma>[_k: ORDINAL]()
   if 0 < _k.Offset {
     RstRst4#<beta, alpha, gamma>[_k - 1]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, beta>.RST#[_k']()
     {
       RstRst4#[_k']()
@@ -390,7 +390,7 @@ lemma {:induction false} RstRst5#<alpha, gamma>[_k: ORDINAL]()
       assert _k.Offset == 1;
     }
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, char>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, char>.RST#[_k']()
     {
       RstRst5#[_k']()
@@ -420,7 +420,7 @@ lemma {:induction false} RstRst6#<alpha, beta, gamma>[_k: ORDINAL]()
     case 2 <= _k.Offset =>
       RstRst6#<alpha, beta, gamma>[_k - 2]();
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, beta>.RST#[_k']()
     {
       RstRst6#[_k']()
@@ -448,7 +448,7 @@ lemma /*{:_induction _k}*/ RstRst7#<alpha, beta, gamma>[_k: ORDINAL]()
     } else {
     }
   } else {
-    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#[_k']()} {:trigger _k' < _k} | _k' < _k
+    forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger MyClass<alpha, beta>.RST#<gamma>[_k']()} {:trigger _k' < _k} | _k' < _k
       ensures MyClass<alpha, beta>.RST#[_k']()
     {
       RstRst7#[_k']()
@@ -585,7 +585,7 @@ class MyClass<A, B> {
     if 0 < _k.Offset {
       L#[_k - 1](u, v);
     } else {
-      forall _k': ORDINAL, u: U, v: V /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger this.P#[_k'](u, v)} | _k' < _k
+      forall _k': ORDINAL, u: U, v: V /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger this.P#<U, V>[_k'](u, v)} | _k' < _k
         ensures this.P#[_k'](u, v)
       {
         L#[_k'](u, v)
@@ -609,7 +609,7 @@ class MyClass<A, B> {
       M#<W>[_k - 1]();
       assert R#<char>[_k - 1]();
     } else {
-      forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger this.R#[_k']()} {:trigger _k' < _k} | _k' < _k
+      forall _k': ORDINAL /*{:_autorequires}*/ /*{:_trustWellformed}*/ {:auto_generated} {:trigger this.R#<char>[_k']()} {:trigger _k' < _k} | _k' < _k
         ensures this.R#[_k']()
       {
         M#[_k']()

--- a/Test/dafny4/UnionFind.dfy
+++ b/Test/dafny4/UnionFind.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachCompiler "%s" -- --relax-definite-assignment
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment
 // Rustan Leino, Nov 2015
 
 // Module M0 gives the high-level specification of the UnionFind data structure


### PR DESCRIPTION
This PR makes sure that any automatically selected trigger expressions are of AST forms that can be resolved (by the new type system).

## More detail

The AST nodes `FunctionCallExpr` and `MemberSelectExpr` (henceforth referred to as "those two cases") are never produced by the parser. Instead, these are created during resolution, from some `ConcreteSyntaxExpression` after such a `ConcreteSyntaxExpression` has been resolved. This means that name-resolution/type-inference doesn't need to handle those two cases. In the old type system, there is nevertheless code for resolving these two AST nodes, which seems like dead code or at best redundant. The new type-system implementation instead asserts out if it's asked to resolve one of those two expressions. So, the new type system expects to never be asked to resolve these two kinds of AST nodes.

Indeed, most of the Dafny pipeline uses the more specific AST nodes (by looking up the `.Resolved` field of whatever AST node they see, which has the effect of going from any `ConcreteSyntaxExpression` to its resolved counterpart). So, most parts of the Dafny pipeline will use those two cases (and will always bypass any `ConcreteSyntaxExpression`). However, if, _after resolution_, Dafny extends the AST in any way, then the resulting AST may be cloned for any refinement module, in which case they will go through the resolver again for the refinement module.

This is the reason that the old type-system implementation is still willing to resolve a `FunctionCallExpr` or `MemberSelectExpr`. Something needs to be done for the new type-system implementation--should it also be willing to resolve those two AST nodes or should we hold the AST to a higher standard where those two cases are never used as input to the resolver? The design of the type-system implementation chooses the latter.

One place where expressions of those two kinds were being generated is in the auto-trigger machinery. This PR makes sure that any trigger that is generated and incorporated into the AST is not of those two kinds, but rather is a `ConcreteSyntaxExpression` (that the resolver will then turn into an expression of those two kinds).

## A detail

Evidently, the pretty printer includes any type parameters when asked to do an `/rprint`. For this reason, one of the `.expect` files in this PR changed to reflect that these parameters are shown in triggers.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
