### PR TITLE
Add flows for binary operators

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/AdjustableType.cs
+++ b/Source/DafnyCore/Resolver/PreType/AdjustableType.cs
@@ -135,18 +135,3 @@ public class BottomTypePlaceholder : TypeProxy {
     }
   }
 }
-
-public class ExactTypePlaceholder : TypeProxy {
-  public ExactTypePlaceholder(Type baseType) {
-    T = baseType;
-  }
-
-  public override string TypeName(DafnyOptions options, ModuleDefinition context, bool parseAble) {
-    var baseName = base.TypeName(options, context, parseAble);
-    if (options.Get(CommonOptionBag.NewTypeInferenceDebug)) {
-      return $"/*exact*/{baseName}";
-    } else {
-      return baseName;
-    }
-  }
-}

--- a/Source/DafnyCore/Resolver/PreType/Flows.cs
+++ b/Source/DafnyCore/Resolver/PreType/Flows.cs
@@ -386,12 +386,10 @@ abstract class FlowIntoExpr : Flow {
   }
 
   public override void DebugPrint(TextWriter output) {
-    if (sink is AdjustableType adjustableType) {
-      var sourceType = GetSourceType();
-      var bound = PreTypeConstraints.Pad($"{AdjustableType.ToStringAsAdjustableType(adjustableType)} :> {AdjustableType.ToStringAsAdjustableType(sourceType)}", 27);
-      var value = PreTypeConstraints.Pad(AdjustableType.ToStringAsBottom(adjustableType), 20);
-      output.WriteLine($"    {bound}  {value}    {TokDescription()}");
-    }
+    var sourceType = GetSourceType();
+    var bound = PreTypeConstraints.Pad($"{AdjustableType.ToStringAsAdjustableType(sink)} :> {AdjustableType.ToStringAsAdjustableType(sourceType)}", 27);
+    var value = PreTypeConstraints.Pad(AdjustableType.ToStringAsBottom(sink), 20);
+    output.WriteLine($"    {bound}  {value}    {TokDescription()}");
   }
 }
 

--- a/Source/DafnyCore/Resolver/PreType/PreType2TypeUtil.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreType2TypeUtil.cs
@@ -30,10 +30,7 @@ public static class PreType2TypeUtil {
       case TypeParameter.TPVariance.Co:
         ty = new BottomTypePlaceholder(ty);
         break;
-      case TypeParameter.TPVariance.Non:
-        ty = new ExactTypePlaceholder(ty);
-        break;
-      case TypeParameter.TPVariance.Contra:
+      default:
         break;
     }
 
@@ -50,7 +47,7 @@ public static class PreType2TypeUtil {
     }
 
     Type ArgumentAsCo(int i) {
-      return PreType2Type(pt.Arguments[i], allowFutureAdjustments, futureAdjustments);
+      return PreType2Type(pt.Arguments[i], true, futureAdjustments);
     }
 
     switch (pt.Decl.Name) {
@@ -79,7 +76,7 @@ public static class PreType2TypeUtil {
       default:
         break;
     }
-    // TODO: the following line should look at variance and adjust the parameters to PreType2Type accordingly
+
     var arguments = pt.Arguments.ConvertAll(preType => PreType2AdjustableType(preType, futureAdjustments));
     if (pt.Decl is ArrowTypeDecl arrowTypeDecl) {
       return new ArrowType(pt.Decl.tok, arrowTypeDecl, arguments);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -2028,9 +2028,6 @@ namespace Microsoft.Dafny {
         dtv.Bindings.AcceptArgumentExpressionsAsExactParameterList();
       }
 
-      if (CodeContextWrapper.Unwrap(resolutionContext.CodeContext) is ICallable caller && caller.EnclosingModule == datatypeDecl.EnclosingModuleDefinition) {
-        caller.EnclosingModule.CallGraph.AddEdge(caller, datatypeDecl);
-      }
       return ok && ctor.Formals.Count == dtv.Arguments.Count;
     }
 

--- a/Source/DafnyCore/Resolver/PreType/TypeAdjustor.cs
+++ b/Source/DafnyCore/Resolver/PreType/TypeAdjustor.cs
@@ -179,24 +179,86 @@ public class TypeAdjustorVisitor : ASTVisitor<IASTVisitorContext> {
 
     } else if (expr is BinaryExpr binaryExpr) {
       switch (binaryExpr.ResolvedOp) {
+        case BinaryExpr.ResolvedOpcode.Iff:
+        case BinaryExpr.ResolvedOpcode.Imp:
+        case BinaryExpr.ResolvedOpcode.And:
+        case BinaryExpr.ResolvedOpcode.Or:
+        case BinaryExpr.ResolvedOpcode.Add:
+        case BinaryExpr.ResolvedOpcode.Sub:
+        case BinaryExpr.ResolvedOpcode.Mul:
+        case BinaryExpr.ResolvedOpcode.Div:
+        case BinaryExpr.ResolvedOpcode.Mod:
+        case BinaryExpr.ResolvedOpcode.BitwiseAnd:
+        case BinaryExpr.ResolvedOpcode.BitwiseOr:
+        case BinaryExpr.ResolvedOpcode.BitwiseXor:
         case BinaryExpr.ResolvedOpcode.Union:
+        case BinaryExpr.ResolvedOpcode.Intersection:
         case BinaryExpr.ResolvedOpcode.MultiSetUnion:
+        case BinaryExpr.ResolvedOpcode.MultiSetIntersection:
         case BinaryExpr.ResolvedOpcode.Concat:
         case BinaryExpr.ResolvedOpcode.MapMerge:
-        case BinaryExpr.ResolvedOpcode.Intersection:
-        case BinaryExpr.ResolvedOpcode.MultiSetIntersection:
+          // For these operators, the result type is the same as that of E0 and E1.
+          //
           // Note about intersection: In general, let set<C> be the result of combining the operands set<A> and set<B>
           // of intersection. To be precise, we would need C to be a type that conjoins the constraints of A and B.
           // We don't have such a time, so we instead (approximate the other direction and) let C be the join of A and B.
           flows.Add(new FlowBetweenExpressions(expr, binaryExpr.E0, BinaryExpr.OpcodeString(binaryExpr.Op)));
           flows.Add(new FlowBetweenExpressions(expr, binaryExpr.E1, BinaryExpr.OpcodeString(binaryExpr.Op)));
           break;
+        case BinaryExpr.ResolvedOpcode.LeftShift:
+        case BinaryExpr.ResolvedOpcode.RightShift:
         case BinaryExpr.ResolvedOpcode.SetDifference:
         case BinaryExpr.ResolvedOpcode.MultiSetDifference:
         case BinaryExpr.ResolvedOpcode.MapSubtraction:
+          // For these operators, the result type is determined by E0.
           flows.Add(new FlowBetweenExpressions(expr, binaryExpr.E0, BinaryExpr.OpcodeString(binaryExpr.Op)));
           break;
+        case BinaryExpr.ResolvedOpcode.EqCommon:
+        case BinaryExpr.ResolvedOpcode.NeqCommon:
+        case BinaryExpr.ResolvedOpcode.Lt:
+        case BinaryExpr.ResolvedOpcode.Le:
+        case BinaryExpr.ResolvedOpcode.Ge:
+        case BinaryExpr.ResolvedOpcode.Gt:
+        case BinaryExpr.ResolvedOpcode.LtChar:
+        case BinaryExpr.ResolvedOpcode.LeChar:
+        case BinaryExpr.ResolvedOpcode.GeChar:
+        case BinaryExpr.ResolvedOpcode.GtChar:
+        case BinaryExpr.ResolvedOpcode.SetEq:
+        case BinaryExpr.ResolvedOpcode.SetNeq:
+        case BinaryExpr.ResolvedOpcode.ProperSubset:
+        case BinaryExpr.ResolvedOpcode.Subset:
+        case BinaryExpr.ResolvedOpcode.Superset:
+        case BinaryExpr.ResolvedOpcode.ProperSuperset:
+        case BinaryExpr.ResolvedOpcode.Disjoint:
+        case BinaryExpr.ResolvedOpcode.InSet:
+        case BinaryExpr.ResolvedOpcode.NotInSet:
+        case BinaryExpr.ResolvedOpcode.MultiSetEq:
+        case BinaryExpr.ResolvedOpcode.MultiSetNeq:
+        case BinaryExpr.ResolvedOpcode.MultiSubset:
+        case BinaryExpr.ResolvedOpcode.MultiSuperset:
+        case BinaryExpr.ResolvedOpcode.ProperMultiSubset:
+        case BinaryExpr.ResolvedOpcode.ProperMultiSuperset:
+        case BinaryExpr.ResolvedOpcode.MultiSetDisjoint:
+        case BinaryExpr.ResolvedOpcode.InMultiSet:
+        case BinaryExpr.ResolvedOpcode.NotInMultiSet:
+        case BinaryExpr.ResolvedOpcode.SeqEq:
+        case BinaryExpr.ResolvedOpcode.SeqNeq:
+        case BinaryExpr.ResolvedOpcode.ProperPrefix:
+        case BinaryExpr.ResolvedOpcode.Prefix:
+        case BinaryExpr.ResolvedOpcode.InSeq:
+        case BinaryExpr.ResolvedOpcode.NotInSeq:
+        case BinaryExpr.ResolvedOpcode.MapEq:
+        case BinaryExpr.ResolvedOpcode.MapNeq:
+        case BinaryExpr.ResolvedOpcode.InMap:
+        case BinaryExpr.ResolvedOpcode.NotInMap:
+        case BinaryExpr.ResolvedOpcode.RankLt:
+        case BinaryExpr.ResolvedOpcode.RankGt:
+          // For these operators, the result type is fixed (to be bool), so there is no flow.
+          break;
+        case BinaryExpr.ResolvedOpcode.YetUndetermined:
+        case BinaryExpr.ResolvedOpcode.LessThanLimit:
         default:
+          Contract.Assert(false); // unexpected operator
           break;
       }
 

--- a/Test/dafny0/Termination.dfy
+++ b/Test/dafny0/Termination.dfy
@@ -903,6 +903,32 @@ method Negation1(S: set) {
 // ------------------ multiple conjuncts in the guard -----------------------
 
 method MultipleGuardConjuncts0(N: nat) {
+  // The old resolver (/typeSystemRefresh:0) infers the type of `s` to be `nat`. That doesn't
+  // seem justifiable in general, but happens to work for this example. In fact, it's helpful
+  // for this example, because this type then provides the loop invariant `0 <= s`, which is
+  // needed to prove termination.
+  //
+  // The new resolver (/typeSystemRefresh:1) infers the type of `s` to be `int`. That is more
+  // justifiable in general. Unfortunately, this means that the type of `s` does not contribute
+  // the loop invariant that's necessary to prove termination of this loop. Fortunately, Dafny
+  // asks Boogie to do a little abstract interpretation (/infer:j). From the fact that `N`
+  // satisfies `0 <= N` on entry and the assignment `s := s - 1;` is guarded by `s != 0, one
+  // can infer `0 <= s`. Unfortunately, the condition `0 <= N` is encoded in a `where` clause
+  // and Boogie's abstract interpretation doesn't look at `where` clauses (https://github.com/boogie-org/boogie/issues/786).
+  //
+  // For this reason, /typeSystemRefresh:1 causes a cannot-prove-termination complaint for this
+  // method. The nearly identical method MultipleGuardConjuncts0' uses a Dafny precondition for
+  // the condition `0 <= N`, which Boogie's abstract interpreter does pick up. So, it verifies.
+  var s, b := N, *;
+  while b && s != 0 {
+    s, b := s - 1, *;
+  }
+}
+
+method MultipleGuardConjuncts0'(N: int)
+  requires 0 <= N
+{
+  // See comment in MultipleGuardConjuncts0 above.
   var s, b := N, *;
   while b && s != 0 {
     s, b := s - 1, *;

--- a/Test/dafny0/Termination.dfy.refresh.expect
+++ b/Test/dafny0/Termination.dfy.refresh.expect
@@ -18,9 +18,10 @@ Termination.dfy(714,2): Error: cannot prove termination; try supplying a decreas
 Termination.dfy(722,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(730,2): Error: decreases expression might not decrease
 Termination.dfy(806,2): Error: cannot prove termination; try supplying a decreases clause for the loop
+Termination.dfy(923,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(1178,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(1194,2): Error: cannot prove termination; try supplying a decreases clause for the loop
 Termination.dfy(361,46): Error: decreases clause might not decrease
 Termination.dfy(577,5): Error: cannot find witness that shows type is inhabited; try giving a hint through a 'witness' or 'ghost witness' clause, or use 'witness *' to treat as a possibly empty type
 
-Dafny program verifier finished with 96 verified, 23 errors
+Dafny program verifier finished with 95 verified, 24 errors


### PR DESCRIPTION
This PR makes some fixes and improvements to the new type system:

* Fix some of the pre-type to type conversions, including the building of flows for binary expressions
* Remove code that distinguished all 3 kinds of variance, where only co-variance mattered
* As part of the previous bullet, remove the `ExactTypePlaceholder` type that is not used
* Improve debug printing
* Remove a call-graph edge addition from type inference (this statement must have been oversight from when the migration of call-graph building was moved to a later phase of the Resolver pipeline)
* Adjust one affected test file

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
