### PR TITLE
Chore: Keep core token for reporting.

### DIFF
--- a/Source/DafnyCore/AST/Tokens.cs
+++ b/Source/DafnyCore/AST/Tokens.cs
@@ -296,7 +296,7 @@ public class RangeToken : TokenWrapper {
   }
 
   public BoogieRangeToken ToToken(IToken uniquelyIdentifyingToken = null) {
-    return new BoogieRangeToken(StartToken, EndToken, uniquelyIdentifyingToken);
+    return new BoogieRangeToken(StartToken, EndToken, null, uniquelyIdentifyingToken);
   }
 
   public bool Contains(int position) {
@@ -314,15 +314,17 @@ public class BoogieRangeToken : TokenWrapper {
   public IToken StartToken { get; }
   public IToken EndToken { get; }
   public IToken NameToken { get; }
+  public IToken UniquelyIdentifyingToken { get; }
 
   // Used for range reporting
   public override string val => new(' ', Math.Max(EndToken.pos + EndToken.val.Length - pos, 1));
 
-  public BoogieRangeToken(IToken startTok, IToken endTok, IToken nameToken) : base(
+  public BoogieRangeToken(IToken startTok, IToken endTok, IToken nameToken, IToken uniquelyIdentifyingToken) : base(
     nameToken ?? startTok) {
     StartToken = startTok;
     EndToken = endTok;
     NameToken = nameToken;
+    UniquelyIdentifyingToken = uniquelyIdentifyingToken;
   }
 
   public override IToken WithVal(string newVal) {

--- a/Source/DafnyCore/AST/Tokens.cs
+++ b/Source/DafnyCore/AST/Tokens.cs
@@ -295,8 +295,8 @@ public class RangeToken : TokenWrapper {
     throw new NotImplementedException();
   }
 
-  public BoogieRangeToken ToToken() {
-    return new BoogieRangeToken(StartToken, EndToken, null);
+  public BoogieRangeToken ToToken(IToken uniquelyIdentifyingToken = null) {
+    return new BoogieRangeToken(StartToken, EndToken, uniquelyIdentifyingToken);
   }
 
   public bool Contains(int position) {

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -3469,7 +3469,7 @@ namespace Microsoft.Dafny {
       if (flags.ReportRanges) {
         // Filter against IHasUsages to only select declarations, not usages.
         if (node is IDeclarationOrUsage declarationOrUsage && node is not IHasUsages) {
-          return new BoogieRangeToken(node.StartToken, node.EndToken, declarationOrUsage.NameToken);
+          return new BoogieRangeToken(node.StartToken, node.EndToken, declarationOrUsage.NameToken, null);
         }
         return node.RangeToken.ToToken(node.Tok);
       } else {

--- a/Source/DafnyCore/Verifier/Translator.cs
+++ b/Source/DafnyCore/Verifier/Translator.cs
@@ -3471,7 +3471,7 @@ namespace Microsoft.Dafny {
         if (node is IDeclarationOrUsage declarationOrUsage && node is not IHasUsages) {
           return new BoogieRangeToken(node.StartToken, node.EndToken, declarationOrUsage.NameToken);
         }
-        return node.RangeToken.ToToken();
+        return node.RangeToken.ToToken(node.Tok);
       } else {
         return node.Tok;
       }


### PR DESCRIPTION
This PR does not modify the existing behavior but for reporting, will enable access not just to the start and end token of a node, but also to the representative `Tok` that was used in the past, so that hints reported on a single token still use it in an unambiguous way. There is nothing to test normally, this is an internal change only for now.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
