### PR TITLE
Hide the plugin option

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -90,7 +90,8 @@ receive arguments. More information about what plugins do and how
 to define them:
 
 https://github.com/dafny-lang/dafny/blob/master/Source/DafnyLanguageServer/README.md#about-plugins") {
-    ArgumentHelpName = "path-to-one-assembly[,argument]*"
+    ArgumentHelpName = "path-to-one-assembly[,argument]*",
+    IsHidden = true
   };
 
   public static readonly Option<FileInfo> Prelude = new("--prelude", "Choose the Dafny prelude file.") {


### PR DESCRIPTION
### Description
Hides the plugin option from the regular help. 

The plugin option was already marked experimental to indicate that the API is expected to change, and that without special circumstances, no system should depend on this option. Hiding the option means it won't show up when using `--help`, to make it extra clear that users should not depend on this option. Users who work with the Dafny maintainers to develop this feature can still use it, and the option is still shown when using `--help-internal`.

### How has this been tested?
Manually

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
