### PR TITLE
Enable passing project files to 'dafny run'

### DIFF
--- a/Source/DafnyCore/Compilers/CSharp/CsharpBackend.cs
+++ b/Source/DafnyCore/Compilers/CSharp/CsharpBackend.cs
@@ -92,6 +92,7 @@ public class CsharpBackend : ExecutableBackend {
       compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile)));
     }
     var outputDir = targetFilename == null ? Directory.GetCurrentDirectory() : Path.GetDirectoryName(Path.GetFullPath(targetFilename));
+    Directory.CreateDirectory(outputDir);
     var outputPath = Path.Join(outputDir, Path.GetFileNameWithoutExtension(Path.GetFileName(dafnyProgramName)) + ".dll");
     var outputJson = Path.Join(outputDir, Path.GetFileNameWithoutExtension(Path.GetFileName(dafnyProgramName)) + ".runtimeconfig.json");
     var emitResult = compilation.Emit(outputPath);

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -76,6 +76,12 @@ This option is useful in a diamond dependency situation,
 to prevent code from the bottom dependency from being generated more than once.
 The value may be a comma-separated list of files and folders.".TrimStart());
 
+  public static readonly Option<FileInfo> BuildFile = new(new[] { "--build", "-b" },
+    "Specify the filepath that determines where to place and how to name build files.") {
+    ArgumentHelpName = "file",
+    IsHidden = true
+  };
+
   public static readonly Option<FileInfo> Output = new(new[] { "--output", "-o" },
     "Specify the filename and location for the generated target language files.") {
     ArgumentHelpName = "file",
@@ -297,6 +303,9 @@ Change the default opacity of functions.
       options.ExpandFilename(options.DafnyPrelude, x => options.DafnyPrelude = x, options.LogPrefix,
         options.FileTimestamp);
     });
+
+    DafnyOptions.RegisterLegacyBinding(BuildFile, (options, value) => { options.DafnyPrintCompiledFile = value?.FullName; });
+
     DafnyOptions.RegisterLegacyBinding(Libraries,
       (options, value) => { options.LibraryFiles = value.Select(fi => fi.FullName).ToHashSet(); });
     DafnyOptions.RegisterLegacyBinding(Output, (options, value) => { options.DafnyPrintCompiledFile = value?.FullName; });

--- a/Source/DafnyCore/Plugins/IExecutableBackend.cs
+++ b/Source/DafnyCore/Plugins/IExecutableBackend.cs
@@ -149,7 +149,7 @@ public abstract class IExecutableBackend {
   /// Returns <c>true</c> on success. Then, <c>compilationResult</c> is a value that can be passed in to
   /// the instance's <c>RunTargetProgram</c> method.
   /// </summary>
-  public abstract bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string pathsFilename,
+  public abstract bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string targetFilename,
     ReadOnlyCollection<string> otherFileNames, bool runAfterCompile, TextWriter outputWriter, out object compilationResult);
 
   /// <summary>

--- a/Source/DafnyDriver/Commands/RunCommand.cs
+++ b/Source/DafnyDriver/Commands/RunCommand.cs
@@ -23,13 +23,15 @@ class RunCommand : ICommandSpec {
     });
 
     DooFile.RegisterNoChecksNeeded(
-      Inputs
+      Inputs,
+      CommonOptionBag.BuildFile
     );
   }
 
   public IEnumerable<Option> Options =>
     new Option[] {
       Inputs,
+      CommonOptionBag.BuildFile,
     }.Concat(ICommandSpec.ExecutionOptions).
       Concat(ICommandSpec.ConsoleOutputOptions).
       Concat(ICommandSpec.ResolverOptions);
@@ -48,8 +50,6 @@ class RunCommand : ICommandSpec {
 
   public void PostProcess(DafnyOptions dafnyOptions, Options options, InvocationContext context) {
     dafnyOptions.MainArgs = context.ParseResult.GetValueForArgument(userProgramArguments).ToList();
-    var inputFile = context.ParseResult.GetValueForArgument(CommandRegistry.FileArgument);
-    dafnyOptions.CliRootSourceUris.Add(new Uri(Path.GetFullPath(inputFile.FullName)));
     dafnyOptions.Compile = true;
     dafnyOptions.RunAfterCompile = true;
     dafnyOptions.ForceCompile = dafnyOptions.Get(BoogieOptionBag.NoVerify);

--- a/Source/DafnyDriver/DafnyDriver.cs
+++ b/Source/DafnyDriver/DafnyDriver.cs
@@ -951,11 +951,11 @@ namespace Microsoft.Dafny {
       compiler.OnPostCompile();
 
       // blurt out the code to a file, if requested, or if other target-language files were specified on the command line.
-      var paths = GenerateTargetPaths(options, dafnyProgramName);
+      var targetPaths = GenerateTargetPaths(options, dafnyProgramName);
       if (options.SpillTargetCode > 0 || otherFileNames.Count > 0 || (invokeCompiler && !compiler.SupportsInMemoryCompilation) ||
           (invokeCompiler && compiler.TextualTargetIsExecutable && !options.RunAfterCompile)) {
-        compiler.CleanSourceDirectory(paths.SourceDirectory);
-        WriteDafnyProgramToFiles(options, paths, targetProgramHasErrors, targetProgramText, callToMain, otherFiles, outputWriter);
+        compiler.CleanSourceDirectory(targetPaths.SourceDirectory);
+        WriteDafnyProgramToFiles(options, targetPaths, targetProgramHasErrors, targetProgramText, callToMain, otherFiles, outputWriter);
       }
 
       if (targetProgramHasErrors) {
@@ -967,7 +967,7 @@ namespace Microsoft.Dafny {
       }
 
       // compile the program into an assembly
-      var compiledCorrectly = compiler.CompileTargetProgram(dafnyProgramName, targetProgramText, callToMain, paths.Filename, otherFileNames,
+      var compiledCorrectly = compiler.CompileTargetProgram(dafnyProgramName, targetProgramText, callToMain, targetPaths.Filename, otherFileNames,
         hasMain && options.RunAfterCompile, outputWriter, out var compilationResult);
       if (compiledCorrectly && options.RunAfterCompile) {
         if (hasMain) {
@@ -977,7 +977,7 @@ namespace Microsoft.Dafny {
           }
 
           compiledCorrectly = compiler.RunTargetProgram(dafnyProgramName, targetProgramText, callToMain,
-            paths.Filename, otherFileNames, compilationResult, outputWriter, errorWriter);
+            targetPaths.Filename, otherFileNames, compilationResult, outputWriter, errorWriter);
         } else {
           // make sure to give some feedback to the user
           if (options.Verbose) {
@@ -1015,7 +1015,7 @@ namespace Microsoft.Dafny {
       throw new NotSupportedException();
     }
 
-    public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string pathsFilename,
+    public override bool CompileTargetProgram(string dafnyProgramName, string targetProgramText, string callToMain, string targetFilename,
       ReadOnlyCollection<string> otherFileNames, bool runAfterCompile, TextWriter outputWriter, out object compilationResult) {
       throw new NotSupportedException();
     }

--- a/Test/cli/projectFile/projectFileRun.dfy
+++ b/Test/cli/projectFile/projectFileRun.dfy
@@ -1,0 +1,4 @@
+// Run works with project files
+// RUN: %baredafny run --show-snippets:false --build=Build/temp --warn-shadowing=false --use-basename-for-filename "%S/dfyconfig.toml" > "%t"
+
+// RUN: %diff "%s.expect" "%t"

--- a/Test/cli/projectFile/projectFileRun.dfy
+++ b/Test/cli/projectFile/projectFileRun.dfy
@@ -1,3 +1,4 @@
+// NONUNIFORM: we're not testing the execution behavior
 // Run works with project files
 // RUN: %baredafny run --show-snippets:false --build=Build/temp --warn-shadowing=false --use-basename-for-filename "%S/dfyconfig.toml" > "%t"
 

--- a/Test/cli/projectFile/projectFileRun.dfy.expect
+++ b/Test/cli/projectFile/projectFileRun.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+hello

--- a/Test/cli/projectFile/src/input.dfy
+++ b/Test/cli/projectFile/src/input.dfy
@@ -10,3 +10,7 @@ method Foo() {
 ghost function Bar(): int {
   3
 } 
+
+method Main() {
+  print "hello";
+}


### PR DESCRIPTION
Fixes #4622

### Description
- Enable passing project files to 'dafny run'
- Add a hidden `--build` option to configure where intermediate build files are placed when using `dafny run`

### How has this been tested?
Added a littish test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
