### PR TITLE
chore: publish nightly prereleases from master instead of 4.3

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,14 +28,6 @@ jobs:
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
-    secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
-
-  nightly-build-for-4-3:
-    if: github.repository_owner == 'dafny-lang'
-    uses: ./.github/workflows/nightly-build-reusable.yml
-    with:
-      ref: 4.3
       publish-prerelease: true
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
### Description

Now that 4.3.0 has been released, we should revert to publishing pre-releases from the master branch instead of the 4.3.0 branch.

This also removes the nightly builds for the 4.3.0 branch entirely, to save CI resources and since it's no longer needed.

### How has this been tested?

No manual test run, but can do so as described in https://github.com/dafny-lang/dafny/pull/4573.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
