### PR TITLE
Skip VerificationCoverageReport.dfy on Windows

### DIFF
--- a/Test/logger/VerificationCoverageReport.dfy
+++ b/Test/logger/VerificationCoverageReport.dfy
@@ -1,4 +1,5 @@
 // NONUNIFORM: Not a compiler test
+// UNSUPPORTED: windows
 // RUN: rm -rf "%t"/coverage
 // RUN: %baredafny verify --use-basename-for-filename --show-snippets false --verify-included-files --coverage-report "%t/coverage" %s
 // RUN: %sed 's/<h1 hidden.*//' "%t"/coverage/*/ProofDependencyLogging.dfy_verification.html > "%t"/coverage_actual.html


### PR DESCRIPTION
The different line endings on Windows mean that the coverage report positions are different. Everything should still work fine on Windows, but the static .expect file is only valid for systems that use Unix-style newlines.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
