### PR TITLE
Add unused dependencies to text logger

### DIFF
--- a/Source/DafnyCore/ProofDependencyWarnings.cs
+++ b/Source/DafnyCore/ProofDependencyWarnings.cs
@@ -107,7 +107,10 @@ public class ProofDependencyWarnings {
 
     // Ensures clauses are often proven vacuously during well-formedness checks.
     // There's unfortunately no way to identify these checks once Dafny has
-    // been translated to Boogie other than looking at the name.
+    // been translated to Boogie other than looking at the name. This is a significant
+    // limitation, because it means that function ensures clauses that are satisfied
+    // only vacuously won't be reported. It would great if we could change the Boogie
+    // encoding so that these unreachable-by-construction checks don't exist.
     if (verboseName.Contains("well-formedness") && dep is EnsuresDependency) {
       return false;
     }

--- a/Test/logger/NoProofDependenciesOnError.dfy
+++ b/Test/logger/NoProofDependenciesOnError.dfy
@@ -1,0 +1,9 @@
+// RUN: %exits-with 4 %baredafny verify --log-format:text --boogie -trackVerificationCoverage "%s" > "%t"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// CHECK-NOT:     Proof dependencies:
+// CHECK-NOT:     Unused by proof:
+
+lemma NotTrue(x: int)
+  requires x > 0
+  ensures x + 1 < 0
+{}

--- a/Test/logger/ProofDependencyLogging.dfy
+++ b/Test/logger/ProofDependencyLogging.dfy
@@ -167,7 +167,7 @@
 // CHECK:       ProofDependencyLogging.dfy\(417,13\)-\(417,17\): ensures clause
 // CHECK:       ProofDependencyLogging.dfy\(420,7\)-\(420,15\): assignment \(or return\)
 // CHECK:     Unused by proof:
-// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(428,5\): assumption that divisor is always non-zero.
+// CHECK:       ProofDependencyLogging.dfy\(428,7\)-\(428,7\): assumption that divisor is always non-zero.
 // CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(429,13\): calc statement result
 module M {
 method {:testEntry} RedundantAssumeMethod(n: int)

--- a/Test/logger/ProofDependencyLogging.dfy
+++ b/Test/logger/ProofDependencyLogging.dfy
@@ -166,9 +166,9 @@
 // CHECK:       ProofDependencyLogging.dfy\(416,12\)-\(416,17\): requires clause
 // CHECK:       ProofDependencyLogging.dfy\(417,13\)-\(417,17\): ensures clause
 // CHECK:       ProofDependencyLogging.dfy\(420,7\)-\(420,15\): assignment \(or return\)
-
-
-
+// CHECK:     Unused by proof:
+// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(428,5\): assumption that divisor is always non-zero.
+// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(429,13\): calc statement result
 
 method RedundantAssumeMethod(n: int)
 {

--- a/Test/logger/ProofDependencyLogging.dfy_combined.html.expect
+++ b/Test/logger/ProofDependencyLogging.dfy_combined.html.expect
@@ -183,10 +183,10 @@
 // CHECK:       ProofDependencyLogging.dfy\(416,12\)-\(416,17\): requires clause
 // CHECK:       ProofDependencyLogging.dfy\(417,13\)-\(417,17\): ensures clause
 // CHECK:       ProofDependencyLogging.dfy\(420,7\)-\(420,15\): assignment \(or return\)
-
-
+// CHECK:     Unused by proof:
+// CHECK:       ProofDependencyLogging.dfy\(428,7\)-\(428,7\): assumption that divisor is always non-zero.
+// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(429,13\): calc statement result
 module M {
-
 method {:testEntry} RedundantAssumeMethod(n: int)
 {
     // either one or the other assumption shouldn't be covered

--- a/Test/logger/ProofDependencyLogging.dfy_combined_limited.html.expect
+++ b/Test/logger/ProofDependencyLogging.dfy_combined_limited.html.expect
@@ -183,10 +183,10 @@
 // CHECK:       ProofDependencyLogging.dfy\(416,12\)-\(416,17\): requires clause
 // CHECK:       ProofDependencyLogging.dfy\(417,13\)-\(417,17\): ensures clause
 // CHECK:       ProofDependencyLogging.dfy\(420,7\)-\(420,15\): assignment \(or return\)
-
-
+// CHECK:     Unused by proof:
+// CHECK:       ProofDependencyLogging.dfy\(428,7\)-\(428,7\): assumption that divisor is always non-zero.
+// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(429,13\): calc statement result
 module M {
-
 method {:testEntry} RedundantAssumeMethod(n: int)
 {
     // either one or the other assumption shouldn't be covered

--- a/Test/logger/ProofDependencyLogging.dfy_tests_expected.html.expect
+++ b/Test/logger/ProofDependencyLogging.dfy_tests_expected.html.expect
@@ -183,10 +183,10 @@
 // CHECK:       ProofDependencyLogging.dfy\(416,12\)-\(416,17\): requires clause
 // CHECK:       ProofDependencyLogging.dfy\(417,13\)-\(417,17\): ensures clause
 // CHECK:       ProofDependencyLogging.dfy\(420,7\)-\(420,15\): assignment \(or return\)
-
-
+// CHECK:     Unused by proof:
+// CHECK:       ProofDependencyLogging.dfy\(428,7\)-\(428,7\): assumption that divisor is always non-zero.
+// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(429,13\): calc statement result
 module M {
-
 method {:testEntry} RedundantAssumeMethod(n: int)
 </span><span class="fc" id="174:1">{
 </span><span class="na" id="175:1">    // either one or the other assumption shouldn't be covered

--- a/Test/logger/ProofDependencyLogging.dfy_verification.html.expect
+++ b/Test/logger/ProofDependencyLogging.dfy_verification.html.expect
@@ -183,10 +183,10 @@
 // CHECK:       ProofDependencyLogging.dfy\(416,12\)-\(416,17\): requires clause
 // CHECK:       ProofDependencyLogging.dfy\(417,13\)-\(417,17\): ensures clause
 // CHECK:       ProofDependencyLogging.dfy\(420,7\)-\(420,15\): assignment \(or return\)
-
-
+// CHECK:     Unused by proof:
+// CHECK:       ProofDependencyLogging.dfy\(428,7\)-\(428,7\): assumption that divisor is always non-zero.
+// CHECK:       ProofDependencyLogging.dfy\(428,5\)-\(429,13\): calc statement result
 module M {
-
 method {:testEntry} RedundantAssumeMethod(n: int)
 {
     // either one or the other assumption shouldn't be covered


### PR DESCRIPTION
Make `--log-format text` output program elements unused in a proof, in addition to the existing proof dependencies.

These can be useful for deep dives into understanding how a proof was completed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
