### PR TITLE
Adjust repositoryRoot, now that lit tests have moved

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/lit.site.cfg
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/lit.site.cfg
@@ -90,7 +90,7 @@ def quotePath(path):
 
 # Find Dafny.exe
 up = os.path.dirname
-repositoryRoot = up(up(up(up( os.path.abspath(__file__) ))))
+repositoryRoot = up(up(up(up(up(up( os.path.abspath(__file__) ))))))
 lit_config.note('Repository root is {}'.format(repositoryRoot))
 
 binaryDir = os.path.join(repositoryRoot, 'Binaries')


### PR DESCRIPTION
Recently (https://github.com/dafny-lang/dafny/pull/4615), the Dafny test suite moved from `Test/` to `Source/IntegrationTests/TestFiles/LitTests/LitTest/`. This PR makes a corresponding change in the `respositoryRoot` definition in `lit.site.cfg`. This allows `lit` to be run in the new location.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
