### PR TITLE
Fix client side crash for document symbol because of empty name 

### DIFF
--- a/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -12,13 +13,54 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
   public class DocumentSymbolTest : ClientBasedLanguageServerTest {
 
     [Fact]
-    public async Task NoCrashOnJustFunction() {
-      var source = "function";
+    public async Task NamelessClass() {
+      var source = @"class {
+  function Foo(): int
+  function Bar(): int
+}";
       var documentItem = CreateAndOpenTestDocument(source);
 
       var symbols = (await RequestDocumentSymbol(documentItem)).ToList();
       Assert.True(symbols.All(s => s.Range.Start.Line >= 0));
       Assert.True(symbols.All(s => s.SelectionRange.Start.Line >= 0));
+      Assert.True(symbols.All(s => !string.IsNullOrEmpty(s.Name)));
+    }
+
+    [Fact]
+    public async Task NamelessModule() {
+      var source = @"module {
+  function Foo(): int
+  function Bar(): int
+}";
+      var documentItem = CreateAndOpenTestDocument(source);
+
+      var symbols = (await RequestDocumentSymbol(documentItem)).ToList();
+      SymbolsAreValid(symbols);
+    }
+
+    [Fact]
+    public async Task NoCrashOnJustFunction() {
+      var source = "function";
+      var documentItem = CreateAndOpenTestDocument(source);
+
+      var symbols = (await RequestDocumentSymbol(documentItem)).ToList();
+      SymbolsAreValid(symbols);
+    }
+
+    private static void SymbolsAreValid(List<DocumentSymbol> symbols)
+    {
+      Assert.True(symbols.All(s => s.Range.Start.Line >= 0));
+      Assert.True(symbols.All(s => s.SelectionRange.Start.Line >= 0));
+      Assert.True(symbols.All(s => !string.IsNullOrEmpty(s.Name)));
+    }
+
+    [Fact]
+    public async Task NamelessFunction() {
+      var source = "function(): int";
+      var documentItem = CreateAndOpenTestDocument(source);
+
+      var symbols = (await RequestDocumentSymbol(documentItem)).ToList();
+      SymbolsAreValid(symbols);
     }
 
     [Fact]

--- a/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
       SymbolsAreValid(symbols);
     }
 
-    private static void SymbolsAreValid(List<DocumentSymbol> symbols)
-    {
+    private static void SymbolsAreValid(List<DocumentSymbol> symbols) {
       Assert.True(symbols.All(s => s.Range.Start.Line >= 0));
       Assert.True(symbols.All(s => s.SelectionRange.Start.Line >= 0));
       Assert.True(symbols.All(s => !string.IsNullOrEmpty(s.Name)));

--- a/Source/DafnyLanguageServer/Handlers/DafnyDocumentSymbolHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyDocumentSymbolHandler.cs
@@ -42,27 +42,33 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
       }
 
       var fileNodes = state.Program.FindNodesInUris(request.TextDocument.Uri.ToUri()).OfType<ISymbol>();
-      return fileNodes.Select(topLevel => new SymbolInformationOrDocumentSymbol(FromSymbol(topLevel))).ToList();
+      return fileNodes.SelectMany(FromSymbol).Select(s => new SymbolInformationOrDocumentSymbol(s)).ToList();
     }
 
-    private DocumentSymbol FromSymbol(ISymbol symbol) {
+    private IEnumerable<DocumentSymbol> FromSymbol(ISymbol symbol) {
       var documentation = (symbol as IHasDocstring)?.GetDocstring(serverOptions) ?? "";
       var children = new List<DocumentSymbol>();
       if (symbol is IHasSymbolChildren hasSymbolChildren) {
         foreach (var child in hasSymbolChildren.ChildSymbols) {
-          var childDocumentSymbol = FromSymbol(child);
-          children.Add(childDocumentSymbol);
+          var childDocumentSymbols = FromSymbol(child);
+          children.AddRange(childDocumentSymbols);
         }
       }
 
+      if (string.IsNullOrEmpty(symbol.NameToken.val)) {
+        return children;
+      }
+
       var range = symbol.RangeToken.ToLspRange();
-      return new DocumentSymbol {
-        Children = children,
-        Name = symbol.NameToken.val,
-        Detail = documentation,
-        Range = range,
-        Kind = (SymbolKind)symbol.Kind,
-        SelectionRange = symbol.NameToken == Token.NoToken ? range : symbol.NameToken.ToRange().ToLspRange()
+      return new DocumentSymbol[] {
+        new() {
+          Children = children,
+          Name = symbol.NameToken.val,
+          Detail = documentation,
+          Range = range,
+          Kind = (SymbolKind)symbol.Kind,
+          SelectionRange = symbol.NameToken == Token.NoToken ? range : symbol.NameToken.ToRange().ToLspRange()
+        }
       };
     }
   }


### PR DESCRIPTION
### Description
- Prevent a client side crash on our malformed document symbol results, that would occur when code has `function` with a name.

### How has this been tested?
- Added a few XUnit tests

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
