### PR TITLE
Fix spurious warning about vacuous proof

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -3419,14 +3419,15 @@ namespace Microsoft.Dafny {
           (RefinementToken.IsInherited(refinesTok, currentModule) && (codeContext == null || !codeContext.MustReverify))) {
         // produce a "skip" instead
         cmd = TrAssumeCmd(tok, Bpl.Expr.True, kv);
+        proofDependencies?.AddProofDependencyId(cmd, tok, new AssumedProofObligationDependency(tok, desc));
       } else {
         tok = ForceCheckToken.Unwrap(tok);
         var args = new List<object>();
         args.Add(Bpl.Expr.Literal(0));
         cmd = TrAssertCmdDesc(tok, condition, desc, new Bpl.QKeyValue(tok, "subsumption", args, kv));
+        proofDependencies?.AddProofDependencyId(cmd, tok, new ProofObligationDependency(tok, desc));
       }
 
-      proofDependencies?.AddProofDependencyId(cmd, tok, new ProofObligationDependency(tok, desc));
       return cmd;
     }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/PR4715Test.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/PR4715Test.dfy
@@ -1,0 +1,27 @@
+// RUN: %verify --warn-contradictory-assumptions "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+abstract module PR4715Test {
+  opaque function Pow(b: int, e: nat): int
+    decreases e
+  {
+    if e == 0 then
+      1
+    else
+      b * Pow(b, e - 1)
+  }
+
+  function WeirdIdentity(x: int): (r: int)
+    ensures r == x
+  {
+    if x < 0 then
+      assert Pow(1, 2) == 1 by { reveal Pow(); }
+      x
+    else
+      x
+  }
+
+}
+
+module PR4715Test2 refines PR4715Test {
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/PR4715Test.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/PR4715Test.dfy
@@ -1,4 +1,5 @@
 // RUN: %verify --warn-contradictory-assumptions "%s" > "%t"
+// Check that the output contains no warnings about contradictory assumptions
 // RUN: %diff "%s.expect" "%t"
 
 abstract module PR4715Test {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/PR4715Test.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/PR4715Test.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 3 verified, 0 errors


### PR DESCRIPTION
There were two utility methods to translate the predicate associated with an assert statement. Both could translate it into an assumption in Boogie under certain circumstances. One avoided recording it as a proof obligation in this case, but the other didn’t. Now it does.

### How has this been tested?

The new test case, `git-issues/PR4715Test.dfy`, generates no warnings. (It did generate a warning prior to this PR.)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
