### PR TITLE
Use Module Name in identifying a let-such-that expression

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Dafny {
               ComputeFreeTypeVariables(bv.Type, FTVs);
             }
             ComputeFreeTypeVariables(e.RHSs[0], FTVs);
-            info = new LetSuchThatExprInfo(e.tok, letSuchThatExprInfo.Count, FVs.ToList(), FTVs.ToList(), usesHeap, usesOldHeap, FVsHeapAt, usesThis, currentDeclaration);
+            info = new LetSuchThatExprInfo(e.tok, $"{currentModule.SanitizedName}_{letSuchThatExprInfo.Count}", FVs.ToList(), FTVs.ToList(), usesHeap, usesOldHeap, FVsHeapAt, usesThis, currentDeclaration);
             letSuchThatExprInfo.Add(e, info);
           }
 
@@ -183,7 +183,7 @@ namespace Microsoft.Dafny {
 
     class LetSuchThatExprInfo {
       public readonly IToken Tok;
-      public readonly int LetId;
+      public readonly string LetId;
       public readonly List<IVariable> FVs;
       public readonly List<Expression> FV_Exprs;  // these are what initially were the free variables, but they may have undergone substitution so they are here Expression's.
       public readonly List<TypeParameter> FTVs;
@@ -192,7 +192,7 @@ namespace Microsoft.Dafny {
       public readonly bool UsesOldHeap;
       public readonly List<Label> UsesHeapAt;
       public readonly Type ThisType;  // null if 'this' is not used
-      public LetSuchThatExprInfo(IToken tok, int uniqueLetId,
+      public LetSuchThatExprInfo(IToken tok, string uniqueLetId,
       List<IVariable> freeVariables, List<TypeParameter> freeTypeVars,
       bool usesHeap, bool usesOldHeap, ISet<Label> usesHeapAt, Type thisType, Declaration currentDeclaration) {
         Tok = tok;


### PR DESCRIPTION
WIP Fixes #4717

### Description
Let-such-that expressions are currently assigned an id during translation to Boogie which is unique within the Dafny module being translated. However, this id is not unique in the entire translated Dafny program, since a Dafny program with multiple modules is translated to multiple Boogie files. This means that several Boogie files might contain `#canCall` functions that are identically named but express different functionality. This PR proposes to extend the unique id with the module name to make disambiguating between such functions easier. 

To be clear, the existing implementation does not lead to any issues during verification. However, it makes it much more difficult to manipulate Boogie code produced from Dafny and, in particular, leads to a bug in test generation when several Boogie files are merged together into one. The proposed change maintains the properties that ids have right now (unique per module and consistent when translating the same file multiple times) while also making it easier to interpret and modify the resulting Boogie code.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
