### PR TITLE
Publish gutter icons based on events coming from CompilationManager

### DIFF
--- a/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
+++ b/Source/DafnyLanguageServer.Test/GutterStatus/SimpleLinearVerificationGutterStatusTester.cs
@@ -14,7 +14,15 @@ public class SimpleLinearVerificationGutterStatusTester : LinearVerificationGutt
   // To add a new test, just call VerifyTrace on a given program,
   // the test will fail and give the correct output that can be use for the test
   // Add '//Replace<n>:' to edit a line multiple times
-
+  
+  [Fact]
+  public async Task GitIssue4656GutterIconsResolutionError() {
+    await VerifyTrace(@"
+   :method Test() {
+/!\:  assert x == 1;
+   :}", false, intermediates: false);
+  }
+  
   [Fact]
   public async Task GitIssue4432GutterIconsOnly() {
     await VerifyTrace(@"

--- a/Source/DafnyLanguageServer/Language/IGutterIconAndHoverVerificationDetailsManager.cs
+++ b/Source/DafnyLanguageServer/Language/IGutterIconAndHoverVerificationDetailsManager.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Dafny.LanguageServer.Language {
   /// </summary>
   public interface IGutterIconAndHoverVerificationDetailsManager {
     void RecomputeVerificationTrees(CompilationAfterParsing compilation);
-    void PublishGutterIcons(CompilationAfterParsing compilation, Uri uri, bool verificationStarted);
 
     void ReportImplementationsBeforeVerification(CompilationAfterResolution compilation, ICanVerify canVerify, Implementation[] implementations);
     void ReportVerifyImplementationRunning(CompilationAfterResolution compilation, Implementation implToken);

--- a/Source/DafnyLanguageServer/Workspace/CompilationManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/CompilationManager.cs
@@ -99,10 +99,6 @@ public class CompilationManager : IDisposable {
         cancellationSource.Token);
 
       gutterIconManager.RecomputeVerificationTrees(parsedCompilation);
-      foreach (var root in parsedCompilation.RootUris) {
-        gutterIconManager.PublishGutterIcons(parsedCompilation, root, false);
-      }
-
       compilationUpdates.OnNext(parsedCompilation);
       logger.LogDebug(
         $"Passed parsedCompilation to documentUpdates.OnNext, resolving ParsedCompilation task for version {parsedCompilation.Version}.");
@@ -123,9 +119,6 @@ public class CompilationManager : IDisposable {
 
       if (!resolvedCompilation.Program.Reporter.HasErrors) {
         gutterIconManager.RecomputeVerificationTrees(resolvedCompilation);
-        foreach (var root in resolvedCompilation.RootUris) {
-          gutterIconManager.PublishGutterIcons(resolvedCompilation, root, true);
-        }
       }
 
       compilationUpdates.OnNext(resolvedCompilation);
@@ -252,7 +245,6 @@ public class CompilationManager : IDisposable {
         gutterIconManager.ReportImplementationsBeforeVerification(compilation,
           verifiable, implementations.Select(t => t.Value.Task.Implementation).ToArray());
 
-        gutterIconManager.PublishGutterIcons(compilation, verifiable.Tok.Uri, true);
         compilationUpdates.OnNext(compilation);
       }
 
@@ -361,8 +353,6 @@ public class CompilationManager : IDisposable {
         // All unvisited trees need to set them as "verified"
         gutterIconManager.SetAllUnvisitedMethodsAsVerified(compilation, canVerify);
       }
-
-      gutterIconManager.PublishGutterIcons(compilation, canVerify.Tok.Uri, true);
     }
 
     MarkVerificationFinished();

--- a/Source/DafnyLanguageServer/Workspace/GutterIconAndHoverVerificationDetailsManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/GutterIconAndHoverVerificationDetailsManager.cs
@@ -241,17 +241,6 @@ Send notifications about the verification status of each line in the program.
   }
 
   /// <summary>
-  /// Triggers sending of the current verification diagnostics to the client
-  /// </summary>
-  public void PublishGutterIcons(CompilationAfterParsing compilation, Uri uri, bool verificationStarted) {
-    if (options.Get(LineVerificationStatus)) {
-      lock (LockProcessing) {
-        notificationPublisher.PublishGutterIcons(uri, compilation.InitialIdeState(compilation, compilation.Program.Reporter.Options), verificationStarted);
-      }
-    }
-  }
-
-  /// <summary>
   /// Called when the verifier starts verifying an implementation
   /// </summary>
   public void ReportVerifyImplementationRunning(CompilationAfterResolution compilation, Implementation implementation) {
@@ -275,7 +264,6 @@ Send notifications about the verification status of each line in the program.
         }
 
         targetMethodNode.PropagateChildrenErrorsUp();
-        PublishGutterIcons(compilation, uri, true);
       }
     }
   }
@@ -318,7 +306,6 @@ Send notifications about the verification status of each line in the program.
 
         targetMethodNode.PropagateChildrenErrorsUp();
         targetMethodNode.RecomputeAssertionBatchNodeDiagnostics();
-        PublishGutterIcons(compilation, uri, true);
       }
     }
   }
@@ -429,7 +416,6 @@ Send notifications about the verification status of each line in the program.
         }
         targetMethodNode.PropagateChildrenErrorsUp();
         targetMethodNode.RecomputeAssertionBatchNodeDiagnostics();
-        PublishGutterIcons(compilation, uri, true);
       }
     }
   }

--- a/Source/DafnyLanguageServer/Workspace/GutterIconAndHoverVerificationDetailsManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/GutterIconAndHoverVerificationDetailsManager.cs
@@ -21,12 +21,10 @@ Send notifications about the verification status of each line in the program.
 
   private readonly DafnyOptions options;
   private readonly ILogger<GutterIconAndHoverVerificationDetailsManager> logger;
-  private readonly INotificationPublisher notificationPublisher;
 
   public GutterIconAndHoverVerificationDetailsManager(ILogger<GutterIconAndHoverVerificationDetailsManager> logger,
-    INotificationPublisher notificationPublisher, DafnyOptions options) {
+    DafnyOptions options) {
     this.logger = logger;
-    this.notificationPublisher = notificationPublisher;
     this.options = options;
   }
 

--- a/Source/DafnyLanguageServer/Workspace/INotificationPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/INotificationPublisher.cs
@@ -12,10 +12,5 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     /// </summary>
     /// <param name="state">The document whose diagnostics should be published.</param>
     Task PublishNotifications(IdeState previousState, IdeState state);
-
-    /// <summary>
-    /// Publishes the more precise real-time verification diagnostics to the connected LSP client
-    /// </summary>
-    void PublishGutterIcons(Uri uri, IdeState state, bool verificationStarted);
   }
 }


### PR DESCRIPTION
Fixes #4656

### Description
Publish gutter icons based on events coming from CompilationManager, instead of directly in CompilationManager. This PR is a preparation for larger refactorings.

### How has this been tested?
Added an XUnit test for the bug this fixes

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
