### PR TITLE
Set library back-end to stable

### DIFF
--- a/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
+++ b/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.CommandLine;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -14,7 +15,7 @@ public class LibraryBackend : ExecutableBackend {
 
   public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { };
 
-  public override string TargetName => "Dafny Library (.doo)";
+  public override string TargetName => "resolved Dafny";
   public override bool IsStable => true;
 
   public override string TargetExtension => "doo";
@@ -87,5 +88,9 @@ public class LibraryBackend : ExecutableBackend {
     ReadOnlyCollection<string> otherFileNames, object compilationResult, TextWriter outputWriter, TextWriter errorWriter) {
     var dooPath = DooFilePath(dafnyProgramName);
     return RunTargetDafnyProgram(dooPath, outputWriter, errorWriter, true);
+  }
+
+  public override Command GetCommand() {
+    return new Command(TargetId, $"Print the resolved Dafny sources.");
   }
 }

--- a/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
+++ b/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
@@ -15,7 +15,7 @@ public class LibraryBackend : ExecutableBackend {
   public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { };
 
   public override string TargetName => "Dafny Library (.doo)";
-  public override bool IsStable => false;
+  public override bool IsStable => true;
 
   public override string TargetExtension => "doo";
   public override string TargetId => "lib";

--- a/Source/DafnyCore/Compilers/ResolvedDesugaredExecutableDafny/ResolvedDesugaredExecutableDafnyBackend.cs
+++ b/Source/DafnyCore/Compilers/ResolvedDesugaredExecutableDafny/ResolvedDesugaredExecutableDafnyBackend.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.CommandLine;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -7,10 +8,11 @@ namespace Microsoft.Dafny.Compilers;
 public class ResolvedDesugaredExecutableDafnyBackend : DafnyExecutableBackend {
 
   public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { ".dfy" };
-  public override string TargetName => "ResolvedDesugaredExecutableDafny";
+  public override string TargetName => "Dafny code as data";
   public override bool IsStable => true;
   public override bool IsInternal => true;
   public override string TargetExtension => "dfy";
+  public override string TargetId => "meta";
   public override bool SupportsInMemoryCompilation => false;
   public override bool TextualTargetIsExecutable => false;
 
@@ -22,5 +24,9 @@ public class ResolvedDesugaredExecutableDafnyBackend : DafnyExecutableBackend {
   }
 
   public ResolvedDesugaredExecutableDafnyBackend(DafnyOptions options) : base(options) {
+  }
+
+  public override Command GetCommand() {
+    return new Command(TargetId, $"Translate the resolved Dafny program to equivalent Dafny code that represents the code as data using data type constructors. This representation is useful for metaprogramming tools written in Dafny.");
   }
 }


### PR DESCRIPTION
### Description
- Set library back-end to stable, which causes it to be tested better and be shown as one of the options for `dafny translate`.
- Update documentation for RDE back-end
- Update documentation for library back-end

### How has this been tested?
This change triggers many tests to include the Dafny back-end.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
