### PR TITLE
ci: Use —build:<temp dir> in MultiBackendTest

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4449.dfy.cs.check
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4449.dfy.cs.check
@@ -1,1 +1,1 @@
-CHECK-L: Errors compiling program into git-issue-4449
+CHECK: Errors compiling program into .*

--- a/Source/TestDafny/MultiBackendTest.cs
+++ b/Source/TestDafny/MultiBackendTest.cs
@@ -323,7 +323,7 @@ public class MultiBackendTest {
     var randomName = Path.ChangeExtension(Path.GetRandomFileName(), null);
     var tempOutputDirectory = Path.Combine(Path.GetTempPath(), randomName, randomName);
     Directory.CreateDirectory(tempOutputDirectory);
-    
+
     IEnumerable<string> dafnyArgs = new List<string> {
       "run",
       "--no-verify",

--- a/Source/TestDafny/MultiBackendTest.cs
+++ b/Source/TestDafny/MultiBackendTest.cs
@@ -315,10 +315,20 @@ public class MultiBackendTest {
       output.Write(" (with --include-runtime:false)");
     }
     output.WriteLine("...");
+
+    // Build to a dedicated temporary directory to make sure tests don't interfere with each other.
+    // The path will be something like "<user temp directory>/<random name>/<random name>"
+    // to ensure that all artifacts are put in a dedicated directory,
+    // which just "<user temp directory>/<random name>" would not.
+    var randomName = Path.ChangeExtension(Path.GetRandomFileName(), null);
+    var tempOutputDirectory = Path.Combine(Path.GetTempPath(), randomName, randomName);
+    Directory.CreateDirectory(tempOutputDirectory);
+    
     IEnumerable<string> dafnyArgs = new List<string> {
       "run",
       "--no-verify",
       $"--target:{backend.TargetId}",
+      $"--build:{tempOutputDirectory}",
       options.TestFile!,
     }.Concat(options.OtherArgs);
     if (!includeRuntime) {


### PR DESCRIPTION
### Description
Recently there was a change in MultibackendTest which causes DafnyRuntime.dll to be passed to Dafny as an input argument for C# runs. This triggers a potential crash in the C# back-end, which occurs when it fails to copy any input .dlls for any reason: https://github.com/dafny-lang/dafny/actions/runs/6755446930/job/18363885807

This change redirects the output of `dafny run ...` when using `%testDafnyForEachCompiler` to a unique temporary directory, so that tests can't step on each other in this way.

### How has this been tested?
Manually verified `--build` has the desired effect. Symptom only sometimes shows up in nightly builds unfortunately.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
