### PR TITLE
Fix: Ghost diagnostics correctly updated when becoming empty

### DIFF
--- a/Source/DafnyLanguageServer.Test/Synchronization/GhostDiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/GhostDiagnosticsTest.cs
@@ -224,6 +224,30 @@ class C {
       Assert.Equal(new Range((15, 4), (15, 14)), diagnostics[3].Range);
     }
 
+    [Fact]
+    public async Task OpeningDocumentContainingGhostAndRemovingGhostPublishesEmptyRange() {
+      var source = @"
+method Test() {
+  ghost var x := 2;
+  var nonghost := 3;
+}
+".TrimStart();
+      await SetUp(options => {
+        options.Set(GhostStateDiagnosticCollector.GhostIndicators, true);
+      });
+      var documentItem = CreateTestDocument(source, "OpeningDocumentContainingGhostAndRemovingGhostPublishesEmptyRange.dfy");
+      await client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      var report = await ghostnessReceiver.AwaitNextNotificationAsync(CancellationToken);
+      var diagnostics = report.Diagnostics
+        .OrderBy(diagnostic => diagnostic.Range.Start)
+        .ToArray();
+      Assert.Single(diagnostics);
+      Assert.Equal(new Range((1, 2), (1, 19)), diagnostics[0].Range);
+      ApplyChange(ref documentItem, ((1, 0), (2, 0)), "");
+      report = await ghostnessReceiver.AwaitNextNotificationAsync(CancellationToken);
+      Assert.Empty(report.Diagnostics.ToArray());
+    }
+
     public GhostDiagnosticsTest(ITestOutputHelper output) : base(output) {
     }
   }

--- a/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
+++ b/Source/DafnyLanguageServer/Workspace/NotificationPublisher.cs
@@ -259,6 +259,17 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
           }).ToArray(),
         });
       }
+
+      // If we don't have ghost state anymore, publish empty ghost diagnostics
+      foreach (var (uri, _) in previousParams) {
+        if (!newParams.ContainsKey(uri)) {
+          languageServer.TextDocument.SendNotification(new GhostDiagnosticsParams {
+            Uri = uri,
+            Version = state.Version,
+            Diagnostics = new List<Diagnostic>()
+          });
+        }
+      }
     }
   }
 }

--- a/docs/dev/news/4693.fix
+++ b/docs/dev/news/4693.fix
@@ -1,0 +1,1 @@
+Ghost diagnostics are now correctly updated when they become empty


### PR DESCRIPTION
Fixes #4693
I added a test that was previously failing.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
