### PR TITLE
Add the built-in format command instead of the discontinued dotnet-format tool

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Restore tools
       working-directory: dafny
       run: dotnet tool restore
+    - name: Check whitespace and style
+      working-directory: dafny
+      run: dotnet format whitespace Source/Dafny.sln --verify-no-changes --exclude Source/DafnyCore/Scanner.cs --exclude Source/DafnyCore/Parser.cs --exclude Source/DafnyCore/GeneratedFromDafny.cs --exclude Source/DafnyRuntime/DafnyRuntimeSystemModule.cs
     - name: Get Boogie Version
       run: |
         sudo apt-get update
@@ -51,9 +54,6 @@ jobs:
     - name: Build Dafny with local Boogie
       working-directory: dafny
       run: dotnet build Source/Dafny.sln
-    - name: Check whitespace and style
-      working-directory: dafny
-      run: dotnet format whitespace Source/Dafny.sln --verify-no-changes --exclude Source/DafnyCore/Scanner.cs --exclude Source/DafnyCore/Parser.cs --exclude Source/DafnyCore/GeneratedFromDafny.cs --exclude Source/DafnyRuntime/DafnyRuntimeSystemModule.cs
     - name: Create NuGet package (just to make sure it works)
       run: dotnet pack --no-build dafny/Source/Dafny.sln
     - name: Check uniformity of integration tests that exercise backends

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -53,7 +53,7 @@ jobs:
       run: dotnet build Source/Dafny.sln
     - name: Check whitespace and style
       working-directory: dafny
-      run: dotnet tool run dotnet-format -w -s error --check Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs --exclude DafnyCore/GeneratedFromDafny.cs --exclude DafnyRuntime/DafnyRuntimeSystemModule.cs
+      run: dotnet format whitespace Source/Dafny.sln --verify-no-changes --exclude Source/DafnyCore/Scanner.cs --exclude Source/DafnyCore/Parser.cs --exclude Source/DafnyCore/GeneratedFromDafny.cs --exclude Source/DafnyRuntime/DafnyRuntimeSystemModule.cs
     - name: Create NuGet package (just to make sure it works)
       run: dotnet pack --no-build dafny/Source/Dafny.sln
     - name: Check uniformity of integration tests that exercise backends

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,5 +4,5 @@ repos:
     -   id: dotnet-format
         name: dotnet-format
         language: system
-        entry: dotnet tool run dotnet-format --folder -w --include
+        entry: dotnet format whitespace Source/Dafny.sln --include
         types_or: ["c#"]

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ z3-ubuntu:
 	chmod +x ${DIR}/Binaries/z3/bin/z3-*
 
 format:
-	dotnet tool run dotnet-format -w -s error Source/Dafny.sln --exclude DafnyCore/Scanner.cs --exclude DafnyCore/Parser.cs --exclude DafnyCore/GeneratedFromDafny.cs
+	dotnet format whitespace Source/Dafny.sln --exclude Source/DafnyCore/Scanner.cs --exclude Source/DafnyCore/Parser.cs --exclude Source/DafnyCore/GeneratedFromDafny.cs --exclude Source/DafnyRuntime/DafnyRuntimeSystemModule.cs
 
 clean:
 	(cd ${DIR}; cd Source; rm -rf Dafny/bin Dafny/obj DafnyDriver/bin DafnyDriver/obj DafnyRuntime/obj DafnyRuntime/bin DafnyServer/bin DafnyServer/obj DafnyPipeline/obj DafnyPipeline/bin DafnyCore/obj DafnyCore/bin)

--- a/Source/DafnyCore.Test/DafnyProjectTest.cs
+++ b/Source/DafnyCore.Test/DafnyProjectTest.cs
@@ -1,6 +1,6 @@
 using Microsoft.Dafny;
 
-namespace DafnyCore.Test; 
+namespace DafnyCore.Test;
 
 public class DafnyProjectTest {
   [Fact]

--- a/Source/DafnyCore/AST/Members/ICanAutoReveal.cs
+++ b/Source/DafnyCore/AST/Members/ICanAutoReveal.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public interface ICanAutoRevealDependencies {
   public void AutoRevealDependencies(AutoRevealFunctionDependencies Rewriter, DafnyOptions Options, ErrorReporter Reporter);

--- a/Source/DafnyCore/Compilers/Dafny/WrapException.cs
+++ b/Source/DafnyCore/Compilers/Dafny/WrapException.cs
@@ -1,4 +1,4 @@
-namespace Microsoft.Dafny.Compilers; 
+namespace Microsoft.Dafny.Compilers;
 
 public class WrapException {
 

--- a/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
+++ b/Source/DafnyCore/Compilers/Library/LibraryBackend.cs
@@ -6,7 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using DafnyCore;
 
-namespace Microsoft.Dafny.Compilers; 
+namespace Microsoft.Dafny.Compilers;
 
 public class LibraryBackend : ExecutableBackend {
   public LibraryBackend(DafnyOptions options) : base(options) {

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -5741,21 +5741,18 @@ namespace Microsoft.Dafny.Compilers {
       IToken tok, ConcreteSyntaxTree wr, bool isReturning = false, bool elseReturnValue = false,
       bool isSubfiltering = false) {
       if (!boundVarType.Equals(collectionElementType, true) &&
-          boundVarType.NormalizeExpand(true) is UserDefinedType
-          {
+          boundVarType.NormalizeExpand(true) is UserDefinedType {
             TypeArgs: var typeArgs,
             ResolvedClass:
-            SubsetTypeDecl
-            {
+            SubsetTypeDecl {
               TypeArgs: var typeParametersArgs,
               Var: var variable,
               Constraint: var constraint
             }
           }) {
-        if (variable.Type.NormalizeExpandKeepConstraints() is UserDefinedType
-          {
-            ResolvedClass: SubsetTypeDecl
-          } normalizedVariableType) {
+        if (variable.Type.NormalizeExpandKeepConstraints() is UserDefinedType {
+          ResolvedClass: SubsetTypeDecl
+        } normalizedVariableType) {
           wr = MaybeInjectSubsetConstraint(boundVar, normalizedVariableType, collectionElementType,
               inLetExprBody, tok, wr, isReturning, elseReturnValue, true);
         }

--- a/Source/DafnyCore/CoverageReport/CoverageReport.cs
+++ b/Source/DafnyCore/CoverageReport/CoverageReport.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class CoverageReport {
 

--- a/Source/DafnyCore/CoverageReport/CoverageSpan.cs
+++ b/Source/DafnyCore/CoverageReport/CoverageSpan.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class CoverageSpan : IComparable<CoverageSpan> {
 

--- a/Source/DafnyCore/DafnyGeneratedFromDafny.sh
+++ b/Source/DafnyCore/DafnyGeneratedFromDafny.sh
@@ -28,4 +28,4 @@ with open ('$output.cs', 'r' ) as f:
 with open('$output.cs', 'w') as w:
   w.write(content_new)
 "
-dotnet tool run dotnet-format -w --include $output.cs 
+dotnet format whitespace --include $output.cs 

--- a/Source/DafnyCore/DooFile.cs
+++ b/Source/DafnyCore/DooFile.cs
@@ -9,7 +9,7 @@ using DafnyCore.Generic;
 using Microsoft.Dafny;
 using Tomlyn;
 
-namespace DafnyCore; 
+namespace DafnyCore;
 
 // Model class for the .doo file format for Dafny libraries.
 // Contains the validation logic for safely consuming libraries as well.

--- a/Source/DafnyCore/Generic/TomlUtil.cs
+++ b/Source/DafnyCore/Generic/TomlUtil.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using Tomlyn.Model;
 
-namespace DafnyCore.Generic; 
+namespace DafnyCore.Generic;
 
 public static class TomlUtil {
 

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.FileSystemGlobbing;
 using Tomlyn;
 using Tomlyn.Model;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class DafnyProject : IEquatable<DafnyProject> {
   public const string FileName = "dfyconfig.toml";

--- a/Source/DafnyCore/Plugins/CompilerInstrumenter.cs
+++ b/Source/DafnyCore/Plugins/CompilerInstrumenter.cs
@@ -1,6 +1,6 @@
 using Microsoft.Dafny.Compilers;
 
-namespace Microsoft.Dafny.Plugins; 
+namespace Microsoft.Dafny.Plugins;
 
 /// <summary>
 /// A hook for plugins to customize some of the code generation of other IExecutableBackends.

--- a/Source/DafnyCore/Plugins/ErrorReportingBase.cs
+++ b/Source/DafnyCore/Plugins/ErrorReportingBase.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.Contracts;
 
-namespace Microsoft.Dafny.Plugins; 
+namespace Microsoft.Dafny.Plugins;
 
 /// <summary>
 /// Abstract base class for plugin interfaces that may report errors.

--- a/Source/DafnyCore/Resolver/FuelAdjustment.cs
+++ b/Source/DafnyCore/Resolver/FuelAdjustment.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Numerics;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public static class FuelAdjustment {
 

--- a/Source/DafnyCore/Resolver/SubsetConstraintGhostChecker.cs
+++ b/Source/DafnyCore/Resolver/SubsetConstraintGhostChecker.cs
@@ -85,8 +85,7 @@ public class SubsetConstraintGhostChecker : ProgramTraverser {
 
     if (e is ForallExpr || e is ExistsExpr || e is SetComprehension || e is MapComprehension) {
       foreach (var boundVar in e.BoundVars) {
-        if (boundVar.Type.AsSubsetType is
-        {
+        if (boundVar.Type.AsSubsetType is {
           Constraint: var constraint,
           ConstraintIsCompilable: false and var constraintIsCompilable
         } and var subsetTypeDecl

--- a/Source/DafnyCore/Rewriters/RewriterCollection.cs
+++ b/Source/DafnyCore/Rewriters/RewriterCollection.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public static class RewriterCollection {
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Decreases.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Decreases.cs
@@ -22,7 +22,7 @@ using Action = System.Action;
 using PODesc = Microsoft.Dafny.ProofObligationDescription;
 using static Microsoft.Dafny.GenericErrors;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public partial class BoogieGenerator {
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Extremes.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Extremes.cs
@@ -22,7 +22,7 @@ using Action = System.Action;
 using PODesc = Microsoft.Dafny.ProofObligationDescription;
 using static Microsoft.Dafny.GenericErrors;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public partial class BoogieGenerator {
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
@@ -9,7 +9,7 @@ using Bpl = Microsoft.Boogie;
 using PODesc = Microsoft.Dafny.ProofObligationDescription;
 using static Microsoft.Dafny.GenericErrors;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public partial class BoogieGenerator {
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
@@ -22,7 +22,7 @@ using Action = System.Action;
 using PODesc = Microsoft.Dafny.ProofObligationDescription;
 using static Microsoft.Dafny.GenericErrors;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public partial class BoogieGenerator {
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -3994,8 +3994,7 @@ namespace Microsoft.Dafny {
           "it may have read effects");
       } else {
         desc = new PODesc.SubrangeCheck(errorMessagePrefix, sourceType.ToString(), targetType.ToString(),
-          targetType.NormalizeExpandKeepConstraints() is UserDefinedType
-          {
+          targetType.NormalizeExpandKeepConstraints() is UserDefinedType {
             ResolvedClass: SubsetTypeDecl or NewtypeDecl { Var: { } }
           },
           false, null);

--- a/Source/DafnyDriver/Commands/CoverageReportCommand.cs
+++ b/Source/DafnyDriver/Commands/CoverageReportCommand.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DafnyCore;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 static class CoverageReportCommand {
 

--- a/Source/DafnyDriver/CoverageReporter.cs
+++ b/Source/DafnyDriver/CoverageReporter.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 using DafnyCore.Verifier;
 using Microsoft.Boogie;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class CoverageReporter {
 

--- a/Source/DafnyLanguageServer.Test/Diagnostics/VerificationDiagnostics.cs
+++ b/Source/DafnyLanguageServer.Test/Diagnostics/VerificationDiagnostics.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 
 public class VerificationDiagnostics : ClientBasedLanguageServerTest {
 

--- a/Source/DafnyLanguageServer.Test/MultipleFilesNoProjectTest.cs
+++ b/Source/DafnyLanguageServer.Test/MultipleFilesNoProjectTest.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest;
 
 public class MultipleFilesNoProjectTest : ClientBasedLanguageServerTest {
   [Fact]

--- a/Source/DafnyLanguageServer.Test/Performance/ThreadUsageTest.cs
+++ b/Source/DafnyLanguageServer.Test/Performance/ThreadUsageTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Performance; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Performance;
 
 [Collection("Sequential Collection")]  // Seems to deadlock when run in parallel
 public class ThreadUsageTest : ClientBasedLanguageServerTest {

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/CompetingProjectFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/CompetingProjectFilesTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.ProjectFiles; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.ProjectFiles;
 
 public class CompetingProjectFilesTest : ClientBasedLanguageServerTest {
 

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/ProjectFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/ProjectFilesTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest;
 
 public class ProjectFilesTest : ClientBasedLanguageServerTest {
 

--- a/Source/DafnyLanguageServer.Test/Refinement/RefinementTests.cs
+++ b/Source/DafnyLanguageServer.Test/Refinement/RefinementTests.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Refinement; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Refinement;
 
 public class RefinementTests : ClientBasedLanguageServerTest {
   [Fact]

--- a/Source/DafnyLanguageServer.Test/Synchronization/CachingTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/CachingTest.cs
@@ -15,7 +15,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 
 public class CachingTest : ClientBasedLanguageServerTest {
   private InMemorySink sink;

--- a/Source/DafnyLanguageServer.Test/Synchronization/ProjectManagerDatabaseTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/ProjectManagerDatabaseTest.cs
@@ -9,7 +9,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization;
 
 [Collection("Sequential Collection")]
 public class ProjectManagerDatabaseTest : ClientBasedLanguageServerTest {

--- a/Source/DafnyLanguageServer.Test/Unit/ByteArrayEqualityTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/ByteArrayEqualityTest.cs
@@ -2,7 +2,7 @@ using System;
 using Microsoft.Dafny.LanguageServer.Language;
 using Xunit;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit;
 
 public class ByteArrayEqualityTest {
   [Fact]

--- a/Source/DafnyLanguageServer.Test/Unit/CompilationManagerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/CompilationManagerTest.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit;
 
 public class CompilationManagerTest {
   [Fact]

--- a/Source/DafnyLanguageServer.Test/Unit/TextReaderFromCharArraysTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/TextReaderFromCharArraysTest.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Microsoft.Dafny.LanguageServer.Language;
 using Xunit;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Unit;
 
 public class TextReaderFromCharArraysTest {
 

--- a/Source/DafnyLanguageServer.Test/Util/StringifyTest.cs
+++ b/Source/DafnyLanguageServer.Test/Util/StringifyTest.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util; 
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 
 public class StringifyTest {
 

--- a/Source/DafnyLanguageServer/Caching/PruneIfNotUsedSinceLastPruneCache.cs
+++ b/Source/DafnyLanguageServer/Caching/PruneIfNotUsedSinceLastPruneCache.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Dafny.LanguageServer.Workspace;
 
-namespace Microsoft.Dafny; 
+namespace Microsoft.Dafny;
 
 public class PruneIfNotUsedSinceLastPruneCache<TKey, TValue>
   where TValue : class

--- a/Source/DafnyLanguageServer/Util/PositionExtensions.cs
+++ b/Source/DafnyLanguageServer/Util/PositionExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Dafny.LanguageServer.Language;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
-namespace Microsoft.Dafny.LanguageServer.Util; 
+namespace Microsoft.Dafny.LanguageServer.Util;
 
 public static class PositionExtensions {
   public static DafnyPosition ToDafnyPosition(this IToken token) {

--- a/Source/DafnyTestGeneration.Test/ShortCircuitRemoval.cs
+++ b/Source/DafnyTestGeneration.Test/ShortCircuitRemoval.cs
@@ -13,7 +13,7 @@ using Microsoft.Dafny;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace DafnyTestGeneration.Test; 
+namespace DafnyTestGeneration.Test;
 
 public class ShortCircuitRemoval : Setup {
 

--- a/Source/DafnyTestGeneration/Inlining/FunctionCallToMethodCallRewriter.cs
+++ b/Source/DafnyTestGeneration/Inlining/FunctionCallToMethodCallRewriter.cs
@@ -11,7 +11,7 @@ using Function = Microsoft.Dafny.Function;
 using Program = Microsoft.Dafny.Program;
 
 
-namespace DafnyTestGeneration.Inlining; 
+namespace DafnyTestGeneration.Inlining;
 
 /// <summary>
 /// Change by-method function calls to method calls (after resolution)

--- a/Source/DafnyTestGeneration/Inlining/InliningTranslator.cs
+++ b/Source/DafnyTestGeneration/Inlining/InliningTranslator.cs
@@ -8,7 +8,7 @@ using Microsoft.Boogie;
 using Microsoft.Dafny;
 using Program = Microsoft.Dafny.Program;
 
-namespace DafnyTestGeneration.Inlining; 
+namespace DafnyTestGeneration.Inlining;
 
 public static class InliningTranslator {
   private static bool ShouldProcessForInlining(MemberDecl memberDecl) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4449.dfy.cs.check
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4449.dfy.cs.check
@@ -1,1 +1,1 @@
-CHECK-L: Errors compiling program into git-issue-4449
+CHECK: Errors compiling program into .*

--- a/Source/TestDafny/MultiBackendTest.cs
+++ b/Source/TestDafny/MultiBackendTest.cs
@@ -315,10 +315,20 @@ public class MultiBackendTest {
       output.Write(" (with --include-runtime:false)");
     }
     output.WriteLine("...");
+
+    // Build to a dedicated temporary directory to make sure tests don't interfere with each other.
+    // The path will be something like "<user temp directory>/<random name>/<random name>"
+    // to ensure that all artifacts are put in a dedicated directory,
+    // which just "<user temp directory>/<random name>" would not.
+    var randomName = Path.ChangeExtension(Path.GetRandomFileName(), null);
+    var tempOutputDirectory = Path.Combine(Path.GetTempPath(), randomName, randomName);
+    Directory.CreateDirectory(tempOutputDirectory);
+
     IEnumerable<string> dafnyArgs = new List<string> {
       "run",
       "--no-verify",
       $"--target:{backend.TargetId}",
+      $"--build:{tempOutputDirectory}",
       options.TestFile!,
     }.Concat(options.OtherArgs);
     if (!includeRuntime) {

--- a/Source/XUnitExtensions/Lit/NonUniformTestCommand.cs
+++ b/Source/XUnitExtensions/Lit/NonUniformTestCommand.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-namespace XUnitExtensions.Lit; 
+namespace XUnitExtensions.Lit;
 
 public class NonUniformTestCommand : ILitCommand {
   private NonUniformTestCommand(string reason) {

--- a/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
+++ b/Source/XUnitExtensions/Lit/OutputCheckCommand.cs
@@ -21,237 +21,237 @@ namespace XUnitExtensions.Lit {
 
     public abstract record CheckDirective(string File, int LineNumber) {
 
-    private static readonly Dictionary<string, Func<string, int, string, CheckDirective>> DirectiveParsers = new();
-    static CheckDirective() {
-      DirectiveParsers.Add("CHECK:", CheckRegexp.Parse);
-      DirectiveParsers.Add("CHECK-L:", CheckLiteral.Parse);
-      DirectiveParsers.Add("CHECK-NEXT:", CheckNextRegexp.Parse);
-      DirectiveParsers.Add("CHECK-NEXT-L:", CheckNextLiteral.Parse);
-      DirectiveParsers.Add("CHECK-NOT:", CheckNotRegexp.Parse);
-      DirectiveParsers.Add("CHECK-NOT-L:", CheckNotLiteral.Parse);
-    }
+      private static readonly Dictionary<string, Func<string, int, string, CheckDirective>> DirectiveParsers = new();
+      static CheckDirective() {
+        DirectiveParsers.Add("CHECK:", CheckRegexp.Parse);
+        DirectiveParsers.Add("CHECK-L:", CheckLiteral.Parse);
+        DirectiveParsers.Add("CHECK-NEXT:", CheckNextRegexp.Parse);
+        DirectiveParsers.Add("CHECK-NEXT-L:", CheckNextLiteral.Parse);
+        DirectiveParsers.Add("CHECK-NOT:", CheckNotRegexp.Parse);
+        DirectiveParsers.Add("CHECK-NOT-L:", CheckNotLiteral.Parse);
+      }
 
-    public static CheckDirective? Parse(string file, int lineNumber, string line) {
-      foreach (var (keyword, parser) in DirectiveParsers) {
-        var index = line.IndexOf(keyword);
-        if (index >= 0) {
-          var arguments = line[(index + keyword.Length)..].Trim();
-          return parser(file, lineNumber, arguments);
+      public static CheckDirective? Parse(string file, int lineNumber, string line) {
+        foreach (var (keyword, parser) in DirectiveParsers) {
+          var index = line.IndexOf(keyword);
+          if (index >= 0) {
+            var arguments = line[(index + keyword.Length)..].Trim();
+            return parser(file, lineNumber, arguments);
+          }
         }
+        return null;
       }
-      return null;
+
+      public abstract bool FindMatch(IEnumerator<string> lines);
     }
 
-    public abstract bool FindMatch(IEnumerator<string> lines);
-  }
+    private record CheckRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckRegexp(file, lineNumber, new Regex(arguments));
+      }
 
-  private record CheckRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckRegexp(file, lineNumber, new Regex(arguments));
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      while (lines.MoveNext()) {
-        if (Pattern.IsMatch(lines.Current)) {
-          return true;
+      public override bool FindMatch(IEnumerator<string> lines) {
+        while (lines.MoveNext()) {
+          if (Pattern.IsMatch(lines.Current)) {
+            return true;
+          }
         }
-      }
-      return false;
-    }
-
-    public override string ToString() {
-      return $"Check Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
-    }
-  }
-
-  private record CheckNextRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNextRegexp(file, lineNumber, new Regex(arguments));
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      if (!lines.MoveNext()) {
-        throw new Exception("No more lines to match against");
+        return false;
       }
 
-      return Pattern.IsMatch(lines.Current);
+      public override string ToString() {
+        return $"Check Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
+      }
     }
 
-    public override string ToString() {
-      return $"CheckNext Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
-    }
-  }
+    private record CheckNextRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNextRegexp(file, lineNumber, new Regex(arguments));
+      }
 
-  private record CheckLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckLiteral(file, lineNumber, arguments);
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      while (lines.MoveNext()) {
-        if (Literal == lines.Current.Trim()) {
-          return true;
+      public override bool FindMatch(IEnumerator<string> lines) {
+        if (!lines.MoveNext()) {
+          throw new Exception("No more lines to match against");
         }
-      }
-      return false;
-    }
 
-    public override string ToString() {
-      return $"CheckLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
-    }
-  }
-
-  private record CheckNextLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNextLiteral(file, lineNumber, arguments);
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      if (!lines.MoveNext()) {
-        throw new Exception("No more lines to match against");
+        return Pattern.IsMatch(lines.Current);
       }
 
-      return Literal == lines.Current.Trim();
-    }
-
-    public override string ToString() {
-      return $"CheckNextLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
-    }
-  }
-
-  private class CheckingEnumerator : IEnumerator<string> {
-    private readonly IEnumerator<string> Wrapped;
-    private readonly Action<string> Check;
-
-    public CheckingEnumerator(IEnumerator<string> wrapped, Action<string> check) {
-      Wrapped = wrapped;
-      Check = check;
-    }
-
-    public bool MoveNext() {
-      var result = Wrapped.MoveNext();
-      if (result) {
-        Check.Invoke(Wrapped.Current);
+      public override string ToString() {
+        return $"CheckNext Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
       }
+    }
+
+    private record CheckLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckLiteral(file, lineNumber, arguments);
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        while (lines.MoveNext()) {
+          if (Literal == lines.Current.Trim()) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      public override string ToString() {
+        return $"CheckLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
+      }
+    }
+
+    private record CheckNextLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNextLiteral(file, lineNumber, arguments);
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        if (!lines.MoveNext()) {
+          throw new Exception("No more lines to match against");
+        }
+
+        return Literal == lines.Current.Trim();
+      }
+
+      public override string ToString() {
+        return $"CheckNextLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
+      }
+    }
+
+    private class CheckingEnumerator : IEnumerator<string> {
+      private readonly IEnumerator<string> Wrapped;
+      private readonly Action<string> Check;
+
+      public CheckingEnumerator(IEnumerator<string> wrapped, Action<string> check) {
+        Wrapped = wrapped;
+        Check = check;
+      }
+
+      public bool MoveNext() {
+        var result = Wrapped.MoveNext();
+        if (result) {
+          Check.Invoke(Wrapped.Current);
+        }
+        return result;
+      }
+
+      public void Reset() {
+        throw new NotImplementedException();
+      }
+
+      object IEnumerator.Current => Current;
+
+      public string Current => Wrapped.Current;
+
+      public void Dispose() => Wrapped.Dispose();
+    }
+
+    private record CheckNotRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNotRegexp(file, lineNumber, new Regex(arguments));
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        // This directive is tested using a CheckingEnumerator instead.
+        throw new NotImplementedException();
+      }
+
+      public override string ToString() {
+        return $"CheckNot Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
+      }
+    }
+
+    private record CheckNotLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
+      public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
+        return new CheckNotLiteral(file, lineNumber, arguments);
+      }
+
+      public override bool FindMatch(IEnumerator<string> lines) {
+        // This directive is tested using a CheckingEnumerator instead.
+        throw new NotImplementedException();
+      }
+
+      public override string ToString() {
+        return $"CheckNotLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
+      }
+    }
+
+    public static ILitCommand Parse(IEnumerable<string> args, LitTestConfiguration config) {
+      ILitCommand? result = null;
+      Parser.Default.ParseArguments<OutputCheckOptions>(args).WithParsed(o => {
+        result = new OutputCheckCommand(o);
+      });
+      return result!;
+    }
+
+    public static IList<CheckDirective> ParseCheckFile(string fileName) {
+      var result = File.ReadAllLines(fileName)
+        .Select((line, index) => CheckDirective.Parse(fileName, index + 1, line))
+        .Where(e => e != null)
+        .Cast<CheckDirective>()
+        .ToList();
+      if (!result.Any()) {
+        throw new ArgumentException($"'{fileName}' does not contain any CHECK directives");
+      }
+
       return result;
     }
 
-    public void Reset() {
-      throw new NotImplementedException();
-    }
-
-    object IEnumerator.Current => Current;
-
-    public string Current => Wrapped.Current;
-
-    public void Dispose() => Wrapped.Dispose();
-  }
-
-  private record CheckNotRegexp(string File, int LineNumber, Regex Pattern) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNotRegexp(file, lineNumber, new Regex(arguments));
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      // This directive is tested using a CheckingEnumerator instead.
-      throw new NotImplementedException();
-    }
-
-    public override string ToString() {
-      return $"CheckNot Directive ({File}:{LineNumber} Pattern: '{Pattern}')";
-    }
-  }
-
-  private record CheckNotLiteral(string File, int LineNumber, string Literal) : CheckDirective(File, LineNumber) {
-    public new static CheckDirective Parse(string file, int lineNumber, string arguments) {
-      return new CheckNotLiteral(file, lineNumber, arguments);
-    }
-
-    public override bool FindMatch(IEnumerator<string> lines) {
-      // This directive is tested using a CheckingEnumerator instead.
-      throw new NotImplementedException();
-    }
-
-    public override string ToString() {
-      return $"CheckNotLiteral Directive ({File}:{LineNumber} Literal: '{Literal}')";
-    }
-  }
-
-  public static ILitCommand Parse(IEnumerable<string> args, LitTestConfiguration config) {
-    ILitCommand? result = null;
-    Parser.Default.ParseArguments<OutputCheckOptions>(args).WithParsed(o => {
-      result = new OutputCheckCommand(o);
-    });
-    return result!;
-  }
-
-  public static IList<CheckDirective> ParseCheckFile(string fileName) {
-    var result = File.ReadAllLines(fileName)
-      .Select((line, index) => CheckDirective.Parse(fileName, index + 1, line))
-      .Where(e => e != null)
-      .Cast<CheckDirective>()
-      .ToList();
-    if (!result.Any()) {
-      throw new ArgumentException($"'{fileName}' does not contain any CHECK directives");
-    }
-
-    return result;
-  }
-
-  public (int, string, string) Execute(TextReader inputReader,
-    TextWriter outputWriter, TextWriter errorWriter) {
-    if (options.FileToCheck == null) {
-      return (0, "", "");
-    }
-
-    var linesToCheck = File.ReadAllLines(options.FileToCheck).ToList();
-    var fileName = options.CheckFile;
-    if (fileName == null) {
-      return (0, "", "");
-    }
-    var checkDirectives = ParseCheckFile(options.CheckFile!);
-
-    return Execute(linesToCheck, checkDirectives);
-  }
-
-  public static (int, string, string) Execute(IEnumerable<string> linesToCheck, IEnumerable<CheckDirective> checkDirectives) {
-    IEnumerator<string> lineEnumerator = linesToCheck.GetEnumerator();
-    IEnumerator<string>? notCheckingEnumerator = null;
-    foreach (var directive in checkDirectives) {
-      // CHECK-NOT[-L] directives apply up until the next directive, so we handle
-      // them by wrapping the line enumerator for the next time through the loop.
-      if (directive is CheckNotRegexp(var _, var _, var pattern)) {
-        notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
-          if (pattern.IsMatch(line)) {
-            throw new Exception($"Match found for {directive}: {line}");
-          }
-        });
-      } else if (directive is CheckNotLiteral(var _, var _, var literal)) {
-        notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
-          if (literal == line.Trim()) {
-            throw new Exception($"Match found for {directive}: {line}");
-          }
-        });
-      } else {
-        var enumerator = notCheckingEnumerator ?? lineEnumerator;
-        if (!directive.FindMatch(enumerator)) {
-          return (1, "", $"ERROR: Could not find a match for {directive}");
-        }
-
-        notCheckingEnumerator = null;
+    public (int, string, string) Execute(TextReader inputReader,
+      TextWriter outputWriter, TextWriter errorWriter) {
+      if (options.FileToCheck == null) {
+        return (0, "", "");
       }
+
+      var linesToCheck = File.ReadAllLines(options.FileToCheck).ToList();
+      var fileName = options.CheckFile;
+      if (fileName == null) {
+        return (0, "", "");
+      }
+      var checkDirectives = ParseCheckFile(options.CheckFile!);
+
+      return Execute(linesToCheck, checkDirectives);
     }
 
-    if (notCheckingEnumerator != null) {
-      // Traverse the rest of the enumerator to make sure the CHECK-NOT[-L] directive is fully tested.
-      while (notCheckingEnumerator.MoveNext()) { }
+    public static (int, string, string) Execute(IEnumerable<string> linesToCheck, IEnumerable<CheckDirective> checkDirectives) {
+      IEnumerator<string> lineEnumerator = linesToCheck.GetEnumerator();
+      IEnumerator<string>? notCheckingEnumerator = null;
+      foreach (var directive in checkDirectives) {
+        // CHECK-NOT[-L] directives apply up until the next directive, so we handle
+        // them by wrapping the line enumerator for the next time through the loop.
+        if (directive is CheckNotRegexp(var _, var _, var pattern)) {
+          notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
+            if (pattern.IsMatch(line)) {
+              throw new Exception($"Match found for {directive}: {line}");
+            }
+          });
+        } else if (directive is CheckNotLiteral(var _, var _, var literal)) {
+          notCheckingEnumerator = new CheckingEnumerator(lineEnumerator, line => {
+            if (literal == line.Trim()) {
+              throw new Exception($"Match found for {directive}: {line}");
+            }
+          });
+        } else {
+          var enumerator = notCheckingEnumerator ?? lineEnumerator;
+          if (!directive.FindMatch(enumerator)) {
+            return (1, "", $"ERROR: Could not find a match for {directive}");
+          }
+
+          notCheckingEnumerator = null;
+        }
+      }
+
+      if (notCheckingEnumerator != null) {
+        // Traverse the rest of the enumerator to make sure the CHECK-NOT[-L] directive is fully tested.
+        while (notCheckingEnumerator.MoveNext()) { }
+      }
+
+      return (0, "", "");
     }
 
-    return (0, "", "");
+    public override string ToString() {
+      return $"OutputCheck --file-to-check {options.FileToCheck} {options.CheckFile}";
+    }
   }
-
-  public override string ToString() {
-    return $"OutputCheck --file-to-check {options.FileToCheck} {options.CheckFile}";
-  }
-}
 }

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,12 +8,6 @@
         "coco"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "boogie": {
       "version": "3.0.3",
       "commands": [


### PR DESCRIPTION
### Description
In CI and in the top-level Makefile, use the `dotnet format` command that comes with `dotnet`, instead of the discontinued dotnet-format tool.

### How has this been tested?
- Manually expected the formatting changes it makes. They look good.
- I also run the `style` and `analyzers` options but neither made any changes, so I've left them out of CI for now.
- Updated CI so it runs the newer format command
- Tried out `pre-commit` with the new command.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
