### PR TITLE
fix: print error context snippets after their messages

### DIFF
--- a/Source/DafnyCore/Generic/Reporting.cs
+++ b/Source/DafnyCore/Generic/Reporting.cs
@@ -66,13 +66,13 @@ namespace Microsoft.Dafny {
           errorLine += "\n";
         }
 
+        Options.OutputWriter.Write(errorLine);
+
         if (Options.Get(DafnyConsolePrinter.ShowSnippets) && tok != Token.NoToken) {
           TextWriter tw = new StringWriter();
           new DafnyConsolePrinter(Options).WriteSourceCodeSnippet(tok.ToRange(), tw);
           Options.OutputWriter.Write(tw.ToString());
         }
-
-        Options.OutputWriter.Write(errorLine);
 
         if (Options.OutputWriter == Console.Out) {
           Console.ForegroundColor = previousColor;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3304.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3304.dfy.expect
@@ -1,6 +1,6 @@
+git-issue-3304.dfy(5,9): Error: the type of this expression is underspecified
   |
 5 |   assert [] == [[]];
   |          ^
 
-git-issue-3304.dfy(5,9): Error: the type of this expression is underspecified
 1 resolution/type errors detected in git-issue-3304.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4787.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4787.dfy
@@ -1,0 +1,19 @@
+// RUN: %exits-with 4 %baredafny verify %args --warn-redundant-assumptions --warn-contradictory-assumptions --show-snippets:true "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module M {
+  opaque function ToSet(xs: seq<int>): set<int> {
+    set x: int | x in xs
+  }
+
+  lemma LemmaCardinality(xs: seq<int>)
+    ensures |ToSet(xs)| <= |xs|
+  {}
+
+  lemma LemmaEmpty(xs: seq<int>)
+    requires xs == []
+    ensures |ToSet(xs)| == 0
+  {
+    assume false;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4787.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4787.dfy.expect
@@ -1,0 +1,22 @@
+git-issue-4787.dfy(11,2): Error: a postcondition could not be proved on this return path
+   |
+11 |   {}
+   |   ^
+
+git-issue-4787.dfy(10,12): Related location: this is the postcondition that could not be proved
+   |
+10 |     ensures |ToSet(xs)| <= |xs|
+   |             ^^^^^^^^^^^^^^^^^^^
+
+git-issue-4787.dfy(15,12): Warning: ensures clause proved using contradictory assumptions
+   |
+15 |     ensures |ToSet(xs)| == 0
+   |             ^^^^^^^^^^^^^^^^
+
+git-issue-4787.dfy(14,13): Warning: unnecessary requires clause
+   |
+14 |     requires xs == []
+   |              ^^^^^^^^
+
+
+Dafny program verifier finished with 1 verified, 1 error

--- a/docs/dev/news/4787.fix
+++ b/docs/dev/news/4787.fix
@@ -1,0 +1,1 @@
+Fix error messages being printed after their context snippets


### PR DESCRIPTION
### Description
Fixes #4787.

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
Added `git-issue-4787.dfy` to test the reported case.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
