### PR TITLE
typo: code sample uses the variable name `index`

### DIFF
--- a/docs/OnlineTutorial/guide.md
+++ b/docs/OnlineTutorial/guide.md
@@ -1426,7 +1426,7 @@ method Find(a: array<int>, key: int) returns (index: int)
 ```
 
 This says that everything before, but excluding, the current
-index is not the key. Notice that upon entering the loop, `i`
+index is not the key. Notice that upon entering the loop, `index`
 is zero, so the first part of the implication is always false, and thus the
 quantified property is always true. This common situation is known as
 *vacuous truth*: the


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

Small typo fix `i` -> `index`.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
