### PR TITLE
ci: remove --no-build from `dotnet pack` commands

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -79,11 +79,11 @@ jobs:
         rm dafny/Binaries/*.nupkg
     - name: Create release NuGet package (for uploading)
       if: ${{ !inputs.prerelease }}
-      run: dotnet pack --no-build dafny/Source/Dafny.sln
+      run: dotnet pack dafny/Source/Dafny.sln
     - name: Create prerelease NuGet package (for uploading)
       if: ${{ inputs.prerelease }}
       # NuGet will consider any package with a version-suffix as a prerelease
-      run: dotnet pack --version-suffix ${{ inputs.name }} --no-build dafny/Source/Dafny.sln
+      run: dotnet pack --version-suffix ${{ inputs.name }} dafny/Source/Dafny.sln
 
     - name: Make NuGet package available as an artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This removes the `--no-build` flag from `dotnet pack` commands in the `publish-release-reusable.yml` workflow file. This was causing a failure with the following message:
```
Error: /usr/share/dotnet/sdk/8.0.100/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): error NU5026: The file '/home/runner/work/dafny/dafny/dafny/Binaries/net6.0/DafnyDriver.runtimeconfig.json' to be packed was not found on disk. [/home/runner/work/dafny/dafny/dafny/Source/DafnyDriver/DafnyDriver.csproj]
...
Error: Process completed with exit code 1.
```
from this run: https://github.com/dafny-lang/dafny/actions/runs/6931560381/job/18866468076

This PR should unblock CI jobs for now, at the cost of a (maybe redundant?) rebuild of Dafny during each release job. I've left some notes below for root causing afterwards.

---

The last successful run of this workflow is here: https://github.com/dafny-lang/dafny/actions/runs/6921119802/job/18826708143

The first obvious difference to me is that, even though `dotnet-version: 6.0.x` was in the environment in both runs, the successful run used .NET 7 during the `dotnet build` command:
```
  .NET SDK:
   Version:   7.0.403
   Commit:    142776d834
  
  Runtime Environment:
   OS Name:     ubuntu
   OS Version:  20.04
   OS Platform: Linux
   RID:         ubuntu.20.04-x64
   Base Path:   /usr/share/dotnet/sdk/7.0.403/
  
  Host:
    Version:      7.0.13
    Architecture: x64
    Commit:       3f73a2f186
  
  .NET SDKs installed:
    6.0.416 [/usr/share/dotnet/sdk]
    6.0.417 [/usr/share/dotnet/sdk]
    7.0.113 [/usr/share/dotnet/sdk]
    7.0.203 [/usr/share/dotnet/sdk]
    7.0.310 [/usr/share/dotnet/sdk]
    7.0.403 [/usr/share/dotnet/sdk]
```

whereas the failing build used .NET 8.0:
```
   .NET SDK:
   Version:           8.0.100
   Commit:            57efcf1350
   Workload version:  8.0.100-manifests.6c33ef20
  
  Runtime Environment:
   OS Name:     ubuntu
   OS Version:  20.04
   OS Platform: Linux
   RID:         linux-x64
   Base Path:   /usr/share/dotnet/sdk/8.0.100/
  
  .NET workloads installed:
   Workload version: 8.0.100-manifests.6c33ef20
  There are no installed workloads to display.
  
  Host:
    Version:      8.0.0
    Architecture: x64
    Commit:       5535e31a71
  
  .NET SDKs installed:
    6.0.417 [/usr/share/dotnet/sdk]
    7.0.114 [/usr/share/dotnet/sdk]
    7.0.203 [/usr/share/dotnet/sdk]
    7.0.311 [/usr/share/dotnet/sdk]
    7.0.404 [/usr/share/dotnet/sdk]
    8.0.100 [/usr/share/dotnet/sdk]
```

### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
