### PR TITLE
Fix: Override checks no longer crashing when substituting type parameters and equality

### DIFF
--- a/Source/DafnyCore/Verifier/FunctionCallSubstituter.cs
+++ b/Source/DafnyCore/Verifier/FunctionCallSubstituter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Dafny {
         }
         return new FunctionCallExpr(e.tok, e.Name, receiver, e.OpenParen, e.CloseParen, newArgs, e.AtLabel) {
           Function = function,
-          Type = e.Type, // TODO: this may not work with type parameters.
+          Type = e.Type.Subst(typeMap),
           TypeApplication_AtEnclosingClass = SubstituteTypeList(typeApplicationAtEnclosingClass), // resolve here
           TypeApplication_JustFunction = SubstituteTypeList(e.TypeApplication_JustFunction), // resolve here
           IsByMethodCall = e.IsByMethodCall

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4812.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4812.dfy
@@ -1,0 +1,16 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+trait ProblemHolder<T(!new, ==)> {
+  ghost function Solution(): T
+
+  predicate Problem(solution: T)
+    ensures Solution() == solution
+}
+
+trait Instantiation extends ProblemHolder<int> {
+  ghost function Solution(): int
+
+  predicate Problem(solution: int)
+    ensures Solution() == solution
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4812.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4812.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4812.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4812.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with TODO verified, TODO errors
+Dafny program verifier finished with 4 verified, 0 errors

--- a/docs/dev/news/4812.fix
+++ b/docs/dev/news/4812.fix
@@ -1,0 +1,1 @@
+Override checks no longer crashing when substituting type parameters and equality


### PR DESCRIPTION
This PR fixes #4812
I added the corresponding test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>