### PR TITLE
Fix: No more spurious restart needed in the IDE

### DIFF
--- a/Source/DafnyLanguageServer/Workspace/ProjectManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.CommandLine;
@@ -65,7 +66,7 @@ Determine when to automatically verify the program. Choose from: Never, OnChange
   /// </summary>
   private int version;
 
-  private int openFileCount;
+  private ConcurrentDictionary<Uri, int> openFiles = new();
 
   private VerifyOnMode AutomaticVerificationMode => options.Get(Verification);
 
@@ -234,8 +235,8 @@ Determine when to automatically verify the program. Choose from: Never, OnChange
   /// Needs to be thread-safe
   /// </summary>
   /// <returns></returns>
-  public bool CloseDocument() {
-    if (Interlocked.Decrement(ref openFileCount) == 0) {
+  public bool CloseDocument(Uri uri) {
+    if (openFiles.TryRemove(uri, out _) && openFiles.IsEmpty) {
       CloseAsync();
       return true;
     }
@@ -345,7 +346,7 @@ Determine when to automatically verify the program. Choose from: Never, OnChange
   }
 
   public void OpenDocument(Uri uri, bool triggerCompilation) {
-    Interlocked.Increment(ref openFileCount);
+    openFiles.TryAdd(uri, 1);
 
     if (triggerCompilation) {
       StartNewCompilation();

--- a/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
           return;
         }
 
-        if (manager.CloseDocument()) {
+        if (manager.CloseDocument(documentId.Uri.ToUri())) {
           managersByProject.Remove(manager.Project.Uri, out _);
         }
       }
@@ -139,7 +139,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
               projectManagerForFile.CloseAsync();
               managersByProject.Remove(project.Uri);
             } else {
-              var previousProjectHasNoDocuments = projectManagerForFile.CloseDocument();
+              var previousProjectHasNoDocuments = projectManagerForFile.CloseDocument(projectManagerForFile.Project.Uri);
               if (previousProjectHasNoDocuments) {
                 // Enable garbage collection
                 managersByProject.Remove(projectManagerForFile.Project.Uri);

--- a/docs/dev/news/4833.fix
+++ b/docs/dev/news/4833.fix
@@ -1,0 +1,1 @@
+Removed one cause of need for restarting the IDE.


### PR DESCRIPTION
Fixes #4833 

### Description
I replaced the openFileCount by openFiles so that closing a document, even if unexpected like VSCode does randomly, won't trigger the Compilation object to be disposed, which crashes the IDE every 3-4 minutes on projects with multiple files open.

### How has this been tested?
I have been enjoying the IDE for 20 minutes straight without restarting it. It's a fantastic experience. I'm going to turn on "verification on change" again.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
