### PR TITLE
Fix no newline before "or" in Mac install instruction

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -141,11 +141,13 @@ After the compiler dependencies are installed, you can run a quick test of the i
 ## Mac (Binary) {#Mac-binary}
 
 To install a binary installation of dafny on Mac OS, do one of the following:
-Either
+
+Either  
    * Install the Mac binary version of Dafny, from `https://github.com/dafny-lang/dafny/releases/latest`
    * Unzip the downloaded file in a (empty) location of your choice ($INSTALL)
    * cd into the installation directory (`$INSTALL/dafny`) and run the script `./allow_on_mac.sh`
    * dafny is run with the command `$INSTALL/dafny/dafny`
+
 or
    * install dafny using brew, with the command `brew install dafny` (the version on brew sometimes lags the
      project release page)


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

Mac install instruction missing newline before or:
![image](https://github.com/dafny-lang/dafny/assets/57718207/22992dad-e238-47b9-9a73-92c4a123773b)

But should be:
![image](https://github.com/dafny-lang/dafny/assets/57718207/cc8182c2-7e7a-48d7-8ff1-652848447288)


### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
in preview mode (see screenshot above)


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
