### PR TITLE
Add GoLang to the replaceable complex test case

### DIFF
--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -1528,7 +1528,7 @@ namespace Microsoft.Dafny.Compilers {
         } else if (cl is TupleTypeDecl tupleTypeDecl) {
           return HelperModulePrefix + "Tuple";
         }
-        if (udt.IsTraitType && udt.ResolvedClass.IsExtern(Options, out _, out _)) {
+        if (udt.ResolvedClass.IsExtern(Options, out _, out _)) {
           // To use an external interface, we need to have values of the
           // interface type, so we treat an extern trait as a plain interface
           // value, not a pointer (a Go interface value is basically a typed

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/Inputs/Interop.go
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/Inputs/Interop.go
@@ -1,0 +1,36 @@
+package Interop
+
+import (dafny "dafny"; math "math"; rand "math/rand"
+  wrappers "Std_Wrappers")
+
+type Dummy__ struct{}
+
+type CompanionStruct_Default___ struct {
+}
+var Companion_Default___ = CompanionStruct_Default___ {
+}
+
+func (_static *CompanionStruct_Default___) Int32ToInt(x int32) (r dafny.Int) {
+  r = dafny.IntOfInt32(x)
+  return
+}
+
+func (_static *CompanionStruct_Default___) Int31n(x int32) (r int32) {
+  r = rand.Int31n(x)
+  return
+}
+
+func (_static *CompanionStruct_Default___) MaxInt32() (r int32) {
+  r = math.MaxInt32
+  return
+}
+
+func (_static *CompanionStruct_Default___) IntToInt32(value dafny.Int) (r wrappers.Option) {  
+  if value.Cmp(dafny.IntOfInt32(math.MaxInt32)) == 1 || value.Cmp(dafny.IntOfInt32(math.MinInt32)) == -1 {
+    r = wrappers.Companion_Option_.Create_None_()
+  } else
+  {
+    r = wrappers.Companion_Option_.Create_Some_(value.Int32())
+  }
+  return
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/Inputs/Types.go
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/Inputs/Types.go
@@ -1,0 +1,3 @@
+package Types
+
+type Dummy__ struct{}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/Inputs/randomGo.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/Inputs/randomGo.dfy
@@ -1,0 +1,58 @@
+
+module RandomGo replaces DfyRandom {
+  import opened Interop
+  // import opened Math
+  // import Math.Random
+  import opened Types
+
+  method GetRandomNat ... {
+    
+    var ceilingInt32: Int32 := IntToInt32(ceiling).GetOr(Interop.MaxInt32);
+    Interop.MaxInt32Value();
+    var resultInt32 := Interop.Int31(ceilingInt32);
+    var resultInt := Int32ToInt(resultInt32);
+    return resultInt as nat;
+  }
+}
+
+module Interop {
+  import opened Std.Wrappers
+  import opened Types
+
+  function {:extern} IntToInt32(value: int): Option<Int32>
+    ensures var r := IntToInt32(value); 
+      if value <= MaxInt32.value 
+        then r.Some? && r.Extract().value == value
+        else r.None?
+    
+  function {:extern} Int32ToInt(value: Int32): int
+    ensures Int32ToInt(value) == value.value
+
+  // Even a const access becomes a function call in the Go translation, so this had to be in Interop
+  const {:extern "MaxInt32"} MaxInt32: Int32
+  lemma {:axiom} MaxInt32Value() ensures MaxInt32.value == 2147483647
+
+  // We can't seem to refer to something from a nested module, so this has to be in Interop
+  method {:extern "Int31n"} Int31(maxValue: Int32) returns (r: Int32)
+    ensures 0 <= r.value && r.value < maxValue.value
+}
+
+/*
+module {:extern "math"} {:dummyImportMember "MaxInt32", false} Math {
+  import opened Types
+
+  // We can't seem to refer to something from a nested module, so this has to be in Interop
+  module {:extern "math/rand" } Random {
+    import opened Types
+    method {:extern "Int31n"} Int31(maxValue: Int32) returns (r: Int32)
+      ensures 0 <= r.value && r.value < maxValue.value
+  }
+}
+*/
+
+module {:extern "Types"} {:dummyImportMember "Dummy__", true} Types {
+  class {:extern "", "int32" } Int32 {
+    ghost var value: int
+  }
+}
+ 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy
@@ -1,4 +1,5 @@
-// RUN: %baredafny run %args %s --target=java --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomJava.dfy --input %S/Inputs/Interop/__default.java > "%t"
+// RUN: %baredafny run %args %s --target=go --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomGo.dfy --input %S/Inputs/Interop.go > "%t"
+// RUN: %baredafny run %args %s --target=java --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomJava.dfy --input %S/Inputs/Interop/__default.java >> "%t"
 // RUN: %baredafny run %args %s --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomCSharp.dfy --input %S/Inputs/Interop.cs >> "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy.expect
@@ -2,3 +2,5 @@
 Dafny program verifier finished with 10 verified, 0 errors
 
 Dafny program verifier finished with 10 verified, 0 errors
+
+Dafny program verifier finished with 10 verified, 0 errors


### PR DESCRIPTION
### Description
- Add GoLang to the replaceable complex test case
- Do not ProtectId names of GoLang definition whose name has been customized using `{:extern <name>}`

### How has this been tested?
Its an added test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
