### PR TITLE
fix: Fix initialization problem in PreType.Substitute

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/PreType.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreType.cs
@@ -360,7 +360,10 @@ namespace Microsoft.Dafny {
         }
       }
 
-      return newArguments == null && printablePreType == PrintablePreType ? this : new DPreType(Decl, newArguments, printablePreType);
+      if (newArguments == null && printablePreType == PrintablePreType) {
+        return this;
+      }
+      return new DPreType(Decl, newArguments ?? Arguments, printablePreType);
     }
 
     /// <summary>

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy
@@ -5,7 +5,7 @@ module A {
 
   datatype D<U> = D(x: R<string, U>)
 
-  method foo<U>(x: R<string, U>)
+  method Foo<U>(x: R<string, U>)
   {
     var _ := D(x);
   }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy
@@ -1,0 +1,25 @@
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s"
+
+module A {
+  type R<T, U> = T
+
+  datatype D<U> = D(x: R<string, U>)
+
+  method foo<U>(x: R<string, U>)
+  {
+    var _ := D(x);
+  }
+}
+
+module B {
+  type MyType<X>
+
+  type R<T, U> = T
+
+  datatype D<U> = D(x: R<MyType<char>, U>)
+
+  method Foo(x: R<MyType<char>, real>)
+  {
+    var y := D<bool>.D(x);
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy.expect
@@ -1,0 +1,2 @@
+git-issue-4866.dfy(10,8): Error: the type of this variable is underspecified
+1 resolution/type errors detected in git-issue-4866.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy.refresh.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4866.dfy.refresh.expect
@@ -1,0 +1,2 @@
+git-issue-4866.dfy(10,8): Error: the type ('D<?0>') of this variable is underspecified
+1 resolution/type errors detected in git-issue-4866.dfy

--- a/docs/dev/news/4875.fix
+++ b/docs/dev/news/4875.fix
@@ -1,0 +1,1 @@
+Fix null-pointer problem in new resolver


### PR DESCRIPTION
Fixes a problem in PreType substitution that caused a null dereference later on.

Fixes #4866

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
