### PR TITLE
Replaceable module separate compilation

### DIFF
--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -205,8 +205,8 @@ public class ModuleDefinition : RangeNode, IAttributeBearingDeclaration, IClonea
       return compileName;
     }
 
-    if (Replacement != null) {
-      return Replacement.GetCompileName(options);
+    if (Implements is { Kind: ImplementationKind.Replacement }) {
+      return Implements.Target.Def.GetCompileName(options);
     }
 
     var externArgs = options.DisallowExterns ? null : Attributes.FindExpressions(this.Attributes, "extern");

--- a/Source/DafnyCore/AST/TypeDeclarations/Declaration.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/Declaration.cs
@@ -115,38 +115,13 @@ public abstract class Declaration : RangeNode, IAttributeBearingDeclaration, IDe
 
   public virtual string GetCompileName(DafnyOptions options) {
     if (compileName == null) {
-      IsExtern(options, out _, out compileName);
+      this.IsExtern(options, out _, out compileName);
       compileName ??= SanitizedName;
     }
 
     return compileName;
   }
 
-  public bool IsExtern(DafnyOptions options, out string/*?*/ qualification, out string/*?*/ name) {
-    // ensures result==false ==> qualification == null && name == null
-    Contract.Ensures(Contract.Result<bool>() || (Contract.ValueAtReturn(out qualification) == null && Contract.ValueAtReturn(out name) == null));
-    // ensures result==true ==> qualification != null ==> name != null
-    Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out qualification) == null || Contract.ValueAtReturn(out name) != null);
-
-    qualification = null;
-    name = null;
-    if (!options.DisallowExterns) {
-      var externArgs = Attributes.FindExpressions(this.Attributes, "extern");
-      if (externArgs != null) {
-        if (externArgs.Count == 0) {
-          return true;
-        } else if (externArgs.Count == 1 && externArgs[0] is StringLiteralExpr) {
-          name = externArgs[0].AsStringLiteral();
-          return true;
-        } else if (externArgs.Count == 2 && externArgs[0] is StringLiteralExpr && externArgs[1] is StringLiteralExpr) {
-          qualification = externArgs[0].AsStringLiteral();
-          name = externArgs[1].AsStringLiteral();
-          return true;
-        }
-      }
-    }
-    return false;
-  }
   public Attributes Attributes;  // readonly, except during class merging in the refinement transformations and when changed by Compiler.MarkCapitalizationConflict
   Attributes IAttributeBearingDeclaration.Attributes => Attributes;
 

--- a/Source/DafnyCore/Compilers/DafnyExecutableBackend.cs
+++ b/Source/DafnyCore/Compilers/DafnyExecutableBackend.cs
@@ -29,7 +29,7 @@ public abstract class DafnyExecutableBackend : ExecutableBackend {
   }
 
   public override void Compile(Program dafnyProgram, ConcreteSyntaxTree output) {
-    InstantiateReplaceableModules(dafnyProgram);
+    CheckInstantiationReplaceableModules(dafnyProgram);
     ProcessOuterModules(dafnyProgram);
     ((DafnyCompiler)compiler).Start();
     compiler.Compile(dafnyProgram, new ConcreteSyntaxTree());

--- a/Source/DafnyCore/Compilers/ExecutableBackend.cs
+++ b/Source/DafnyCore/Compilers/ExecutableBackend.cs
@@ -48,8 +48,10 @@ public abstract class ExecutableBackend : IExecutableBackend {
       }
 
       if (compiledModule.ModuleKind == ModuleKindEnum.Replaceable && compiledModule.Replacement == null) {
-        Reporter!.Error(MessageSource.Compiler, compiledModule.Tok,
-          $"when producing executable code, replaceable modules must be replaced somewhere in the program. For example, `module {compiledModule.Name}Impl replaces {compiledModule.Name} {{ ... }}`");
+        if (compiledModule.ShouldCompile(dafnyProgram.Compilation)) {
+          Reporter!.Error(MessageSource.Compiler, compiledModule.Tok,
+            $"when producing executable code, replaceable modules must be replaced somewhere in the program. For example, `module {compiledModule.Name}Impl replaces {compiledModule.Name} {{ ... }}`");
+        }
       }
     }
   }

--- a/Source/DafnyCore/Compilers/ExecutableBackend.cs
+++ b/Source/DafnyCore/Compilers/ExecutableBackend.cs
@@ -40,7 +40,7 @@ public abstract class ExecutableBackend : IExecutableBackend {
       if (compiledModule.Implements is { Kind: ImplementationKind.Replacement }) {
         if (compiledModule.IsExtern(Options, out _, out var name) && name != null) {
           Reporter!.Error(MessageSource.Compiler, compiledModule.Tok,
-            "a module that replaces another may not have an {:extern} attribute");
+            "inside a module that replaces another, {:extern} attributes may only be used without arguments");
         }
         var target = compiledModule.Implements.Target.Def;
         if (target.Replacement != null) {

--- a/Source/DafnyCore/Compilers/ExecutableBackend.cs
+++ b/Source/DafnyCore/Compilers/ExecutableBackend.cs
@@ -38,6 +38,10 @@ public abstract class ExecutableBackend : IExecutableBackend {
   protected void InstantiateReplaceableModules(Program dafnyProgram) {
     foreach (var compiledModule in dafnyProgram.Modules().OrderByDescending(m => m.Height)) {
       if (compiledModule.Implements is { Kind: ImplementationKind.Replacement }) {
+        if (Attributes.FindExpressions(compiledModule.Attributes, "extern") != null) {
+          Reporter!.Error(MessageSource.Compiler, compiledModule.Tok,
+            "a module that replaces another may not have an {:extern} attribute");
+        }
         var target = compiledModule.Implements.Target.Def;
         if (target.Replacement != null) {
           Reporter!.Error(MessageSource.Compiler, new NestedToken(compiledModule.Tok, target.Replacement.Tok, "Other replacing module:"),

--- a/Source/DafnyCore/Compilers/ExecutableBackend.cs
+++ b/Source/DafnyCore/Compilers/ExecutableBackend.cs
@@ -38,7 +38,7 @@ public abstract class ExecutableBackend : IExecutableBackend {
   protected void InstantiateReplaceableModules(Program dafnyProgram) {
     foreach (var compiledModule in dafnyProgram.Modules().OrderByDescending(m => m.Height)) {
       if (compiledModule.Implements is { Kind: ImplementationKind.Replacement }) {
-        if (Attributes.FindExpressions(compiledModule.Attributes, "extern") != null) {
+        if (compiledModule.IsExtern(Options, out _, out var name) && name != null) {
           Reporter!.Error(MessageSource.Compiler, compiledModule.Tok,
             "a module that replaces another may not have an {:extern} attribute");
         }

--- a/Source/DafnyCore/Compilers/ExternExtensions.cs
+++ b/Source/DafnyCore/Compilers/ExternExtensions.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.Contracts;
+
+namespace Microsoft.Dafny;
+
+public static class ExternExtensions {
+
+  public static bool IsExtern(this IAttributeBearingDeclaration declaration, DafnyOptions options, out string/*?*/ qualification, out string/*?*/ name) {
+    // ensures result==false ==> qualification == null && name == null
+    Contract.Ensures(Contract.Result<bool>() || (Contract.ValueAtReturn(out qualification) == null && Contract.ValueAtReturn(out name) == null));
+    // ensures result==true ==> qualification != null ==> name != null
+    Contract.Ensures(!Contract.Result<bool>() || Contract.ValueAtReturn(out qualification) == null || Contract.ValueAtReturn(out name) != null);
+
+    qualification = null;
+    name = null;
+    if (!options.DisallowExterns) {
+      var externArgs = Attributes.FindExpressions(declaration.Attributes, "extern");
+      if (externArgs != null) {
+        if (externArgs.Count == 0) {
+          return true;
+        } else if (externArgs.Count == 1 && externArgs[0] is StringLiteralExpr) {
+          name = externArgs[0].AsStringLiteral();
+          return true;
+        } else if (externArgs.Count == 2 && externArgs[0] is StringLiteralExpr && externArgs[1] is StringLiteralExpr) {
+          qualification = externArgs[0].AsStringLiteral();
+          name = externArgs[1].AsStringLiteral();
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/Source/DafnyCore/Compilers/Java/JavaBackend.cs
+++ b/Source/DafnyCore/Compilers/Java/JavaBackend.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Dafny.Compilers;
 
 public class JavaBackend : ExecutableBackend {
 
-  public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { ".java" };
+  public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { ".java", ".jar" };
 
   public override string TargetName => "Java";
   public override bool IsStable => true;

--- a/Source/DafnyCore/Compilers/Java/JavaBackend.cs
+++ b/Source/DafnyCore/Compilers/Java/JavaBackend.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Dafny.Compilers;
 
 public class JavaBackend : ExecutableBackend {
 
-  public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { ".java", ".jar" };
+  public override IReadOnlySet<string> SupportedExtensions => new HashSet<string> { ".java" };
 
   public override string TargetName => "Java";
   public override bool IsStable => true;

--- a/Source/DafnyDriver/CompilerDriver.cs
+++ b/Source/DafnyDriver/CompilerDriver.cs
@@ -500,7 +500,7 @@ namespace Microsoft.Dafny {
 
       var compiler = options.Backend;
 
-      var hasMain = Compilers.SinglePassCompiler.HasMain(dafnyProgram, out var mainMethod);
+      var hasMain = SinglePassCompiler.HasMain(dafnyProgram, out var mainMethod);
       if (hasMain) {
         mainMethod.IsEntryPoint = true;
         dafnyProgram.MainMethod = mainMethod;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy
@@ -1,9 +1,7 @@
-// RUN: %build --target=lib --output=%S/Build/build %S/Inputs/wrappers.dfy %S/Inputs/random.dfy > "%t"
-// RU2N: %build --target=java --output=%S/Build/build %S/Build/build.doo %S/Inputs/randomJava.dfy  %S/Inputs/Interop/__default.java > "%t"
-// RU2N: %run %s --target=java --build=%S/Build/build --library=%S/Build/build.doo --input %S/Build/build.jar > "%t"
-// RUN: %build --target=cs --output=%S/Build/build %S/Build/build.doo %S/Inputs/randomCSharp.dfy  %S/Inputs/Interop.cs >> "%t"
-// RUN: %run %s --target=cs --build=%S/Build/build --library=%S/Build/build.doo --input %S/Build/build.dll >> "%t"
-// RU2N: %baredafny run %args %s --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomCSharp.dfy --input %S/Inputs/Interop.cs >> "%t"
+// RUN: %build --target=lib --output=%S/Build1/build %S/Inputs/wrappers.dfy %S/Inputs/random.dfy > "%t"
+// RUN: %build --target=cs --output=%S/Build1/build %S/Build1/build.doo %S/Inputs/randomCSharp.dfy  %S/Inputs/Interop.cs >> "%t"
+// RUN: %run %s --input %S/Build1/build.dll --target=cs --build=%S/Build2 --library=%S/Build1/build.doo >> "%t"
+// RUN: %baredafny run %args %s --target=java --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomJava.dfy --input %S/Inputs/Interop/__default.java >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Test can fail non-deterministically by design, but the chance is ~10^-30

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy
@@ -1,5 +1,9 @@
-// RUN: %baredafny run %args %s --target=java --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomJava.dfy --input %S/Inputs/Interop/__default.java > "%t"
-// RUN: %baredafny run %args %s --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomCSharp.dfy --input %S/Inputs/Interop.cs >> "%t"
+// RUN: %build --target=lib --output=%S/Build/build %S/Inputs/wrappers.dfy %S/Inputs/random.dfy > "%t"
+// RU2N: %build --target=java --output=%S/Build/build %S/Build/build.doo %S/Inputs/randomJava.dfy  %S/Inputs/Interop/__default.java > "%t"
+// RU2N: %run %s --target=java --build=%S/Build/build --library=%S/Build/build.doo --input %S/Build/build.jar > "%t"
+// RUN: %build --target=cs --output=%S/Build/build %S/Build/build.doo %S/Inputs/randomCSharp.dfy  %S/Inputs/Interop.cs >> "%t"
+// RUN: %run %s --target=cs --build=%S/Build/build --library=%S/Build/build.doo --input %S/Build/build.dll >> "%t"
+// RU2N: %baredafny run %args %s --build=%S/Build/build --input %S/Inputs/wrappers.dfy --input %S/Inputs/random.dfy --input %S/Inputs/randomCSharp.dfy --input %S/Inputs/Interop.cs >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Test can fail non-deterministically by design, but the chance is ~10^-30

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/complex/user.dfy.expect
@@ -1,4 +1,8 @@
 
-Dafny program verifier finished with 10 verified, 0 errors
+Dafny program verifier finished with 4 verified, 0 errors
+
+Dafny program verifier finished with 5 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors
 
 Dafny program verifier finished with 10 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy
@@ -1,0 +1,12 @@
+// RUN: ! %run %s > %t
+// RUN: %diff "%s.expect" "%t"
+
+replaceable module {:extern "FooNameOverride"} Foo {
+  method {:extern "ZazOverride1"} Zaz() returns (i: int) 
+    ensures i >= 2
+}
+
+module {:extern "BarNameOverride1"} Bar replaces Foo { 
+  method {:extern "BarNameOverride2", "ZazOverride2"} Zaz() returns (i: int) 
+    ensures i >= 2
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy
@@ -7,6 +7,7 @@ replaceable module {:extern "FooNameOverride"} Foo {
 }
 
 module {:extern "BarNameOverride1"} Bar replaces Foo { 
+  // missing error on BarNameOverride2
   method {:extern "BarNameOverride2", "ZazOverride2"} Zaz() returns (i: int) 
     ensures i >= 2
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy
@@ -6,8 +6,18 @@ replaceable module {:extern "FooNameOverride"} Foo {
     ensures i >= 2
 }
 
-module {:extern "BarNameOverride1"} Bar replaces Foo { 
+module {:extern "BarNameOverride1"} TwoErrors replaces Foo { 
   // missing error on BarNameOverride2
   method {:extern "BarNameOverride2", "ZazOverride2"} Zaz() returns (i: int) 
+    ensures i >= 2
+}
+
+replaceable module {:extern "FaaNameOverride"} Faa {
+  method {:extern "ZazOverride1"} Zaz() returns (i: int) 
+    ensures i >= 2
+}
+
+module {:extern} NoErrors replaces Faa { 
+  method {:extern "ZazOverride2"} Zaz() returns (i: int) 
     ensures i >= 2
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+externErrors.dfy(9,35): Error: a module that replaces another may not have an {:extern} attribute

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy.expect
@@ -1,3 +1,3 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
-externErrors.dfy(9,35): Error: a module that replaces another may not have an {:extern} attribute
+externErrors.dfy(9,36): Error: a module that replaces another may not have an {:extern} attribute

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/externErrors.dfy.expect
@@ -1,3 +1,3 @@
 
 Dafny program verifier finished with 0 verified, 0 errors
-externErrors.dfy(9,36): Error: a module that replaces another may not have an {:extern} attribute
+externErrors.dfy(9,36): Error: inside a module that replaces another, {:extern} attributes may only be used without arguments

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/replaceableExecutionErrors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/replaceableExecutionErrors.dfy
@@ -6,32 +6,7 @@ replaceable module NeverReplaced {
     ensures i >= 2
 }
 
-replaceable module ReplacedThrice {
-  method Foo() returns (i: int) 
-    ensures i >= 2
-}
-
-module Replace1 replaces ReplacedThrice {
-  method Foo() returns (i: int) {
-    return 3;
-  }
-}
-
-module Replace2 replaces ReplacedThrice {
-  method Foo() returns (i: int) {
-    return 3;
-  }
-}
-
-module Replace3 replaces ReplacedThrice {
-  method Foo() returns (i: int) {
-    return 3;
-  }
-}
-
 method Main() {
   var x := NeverReplaced.Foo();
   print x, "\n";
-  var y := ReplacedThrice.Foo();
-  print y, "\n";
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/replaceableExecutionErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/replaceableExecutionErrors.dfy.expect
@@ -1,5 +1,3 @@
 
-Dafny program verifier finished with 4 verified, 0 errors
-replaceableExecutionErrors.dfy(20,7): Error: a replaceable module may only be replaced once Other replacing module: replaceableExecutionErrors.dfy(26,7)
-replaceableExecutionErrors.dfy(14,7): Error: a replaceable module may only be replaced once Other replacing module: replaceableExecutionErrors.dfy(26,7)
+Dafny program verifier finished with 1 verified, 0 errors
 replaceableExecutionErrors.dfy(4,19): Error: when producing executable code, replaceable modules must be replaced somewhere in the program. For example, `module NeverReplacedImpl replaces NeverReplaced { ... }`

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/resolveManyReplacement.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/resolveManyReplacement.dfy
@@ -1,5 +1,7 @@
-// RUN: %resolve %s
+// RUN: ! %resolve %s > %t
+// RUN: %diff "%s.expect" "%t"
 
+// Currently this creates a resolution error.
 replaceable module FooModule {
   method Foo() returns (i: int) 
     ensures i >= 2

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/resolveManyReplacement.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/replaceables/resolveManyReplacement.dfy.expect
@@ -1,0 +1,3 @@
+resolveManyReplacement.dfy(10,7): Error: a replaceable module may only be replaced once Other replacing module: resolveManyReplacement.dfy(15,7)
+resolveManyReplacement.dfy(15,7): Error: modules 'Replacement1' and 'Replacement2' both have CompileName 'FooModule'
+2 resolution/type errors detected in resolveManyReplacement.dfy


### PR DESCRIPTION
### Description
- Make separate compilation work reliably for replaceable modules

### Caveats
- There is a still a check that should be added but is missing in this PR, which is to emit an error if an `{:extern}` attribute is used to overwrite the compiled name of a replaced definition. I would've added that check to this PR but I'm saving it for the future since I'm not yet sure what the best way is.
- This PR adds the restriction that you can't overwrite names using `{:extern}` inside modules that replace another module. This takes some of the fun out of using replaceable modules, since now users may have to create not one but two modules in their target specific code: 
  - one that uses `{:extern}` with the desired name overrides
  - another that replaces the replaceable module and delegates its implementation to the `{:extern}` one. 

  I can imagine that we add an attribute `{:wrapped}` that automatically generates this indirection so that module using `replaces` can once again overwrite names using `{:extern}`, but I'm leaving that as future work.

### How has this been tested?
- Updated the test `replaceables/complex/user.dfy` to make the C# case separately compiled
- Added a test `externErrors.dfy` that captures a new restriction

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
