### PR TITLE
chore: update publishing plugin for Java runtime

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
 
 repositories {
@@ -97,4 +97,3 @@ nexusPublishing {
         }
     }
 }
-


### PR DESCRIPTION
### Description
This PR updates the Java runtime Gradle configuration to use the latest version of the [Maven publishing plugin](https://github.com/gradle-nexus/publish-plugin/).

### How has this been tested?
The updated plugin was used to publish the 4.4.0 Java runtime to Maven Central: https://central.sonatype.com/artifact/org.dafny/DafnyRuntime/4.4.0

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>