### PR TITLE
Add validators for file argument, to prevent them being interpreted a…

### DIFF
--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -11,12 +11,13 @@ public static class DafnyCommands {
   public static Argument<List<FileInfo>> FilesArgument { get; }
   
   static DafnyCommands() {
-    string PrefixErrorMessage(string s) => $"The Dafny CLI uses a double-dash '--' as a prefix for specifying options. " +
-                                           $"To avoid confusion, the Dafny CLI does not except filenames starting with this prefix, such as {s}";
+    string PrefixErrorMessage(string file) =>
+      $"Command-line argument '{file}' is neither a recognized option nor a filename.";
+    
     FileArgument = new Argument<FileInfo>("file", "Dafny input file or Dafny project file");
     FileArgument.AddValidator(r => {
       var path = r.GetValueOrDefault<string>();
-      if (path.StartsWith("--")) {
+      if (!File.Exists(path)) {
         r.ErrorMessage = PrefixErrorMessage(path);
       }
     });


### PR DESCRIPTION
Requires an update of `check-examples`. Should probably rewrite it to something other than bash.

### Description
- Add validators for file arguments, to prevent them being interpreted as options

### How has this been tested?
- Updated existing tests

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
