### PR TITLE
Fix: Formatting on VSCode and CLI

### DIFF
--- a/Source/DafnyCore/AST/Grammar/IFileSystem.cs
+++ b/Source/DafnyCore/AST/Grammar/IFileSystem.cs
@@ -48,7 +48,10 @@ public class OnDiskFileSystem : IFileSystem {
   }
 
   public TextReader ReadFile(Uri uri) {
-    return new StreamReader(uri.LocalPath);
+    var reader = new StreamReader(uri.LocalPath);
+    var str = reader.ReadToEnd();
+    reader.Close();
+    return new StringReader(str);
   }
 
   public bool Exists(Uri path) {

--- a/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Compilers/Rust/Dafny-compiler-rust.dfy
@@ -17,15 +17,12 @@ module {:extern "DCOMP"} DCOMP {
   }
 
   function replaceDots(i: string): string {
-    if |i| == 0 then (
-                       ""
-                     ) else (
-                              if i[0] == '.' then (
-                                                    "_" + replaceDots(i[1..])
-                                                  ) else (
-                                                           [i[0]] + replaceDots(i[1..])
-                                                         )
-                            )
+    if |i| == 0 then
+      ""
+    else if i[0] == '.' then
+      "_" + replaceDots(i[1..])
+    else
+      [i[0]] + replaceDots(i[1..])
   }
 
   function escapeIdent(i: string): string {

--- a/Source/DafnyDriver/CompilerDriver.cs
+++ b/Source/DafnyDriver/CompilerDriver.cs
@@ -596,6 +596,7 @@ namespace Microsoft.Dafny {
       if (moreText != null) {
         target.Write(moreText);
       }
+      target.Close();
     }
 
     private static void CheckFilenameIsLegal(string filename) {


### PR DESCRIPTION
This PR makes sure StreamReaders are closed after use, which prevented formatting from overwriting the files randomly.
I don't think I can write a test case for that.

I manually tested and before, the "dafny format" command was throwing exceptions, and now it no longer throws an exception.

This does not yet solves the issue that when I create a blank Dafny file and try to save it, it will complain with "Failed to save 'todelete.dfy': Unable to write file", but I guess I'll continue searching this one for now.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
