### PR TITLE
Fix: Formatting on the command line works again

### DIFF
--- a/Source/DafnyCore/AST/Grammar/IFileSystem.cs
+++ b/Source/DafnyCore/AST/Grammar/IFileSystem.cs
@@ -48,7 +48,10 @@ public class OnDiskFileSystem : IFileSystem {
   }
 
   public TextReader ReadFile(Uri uri) {
-    return new StreamReader(uri.LocalPath);
+    var reader = new StreamReader(uri.LocalPath);
+    var str = reader.ReadToEnd();
+    reader.Close();
+    return new StringReader(str);
   }
 
   public bool Exists(Uri path) {

--- a/Source/DafnyDriver.Test/FormatterCommandTest.cs
+++ b/Source/DafnyDriver.Test/FormatterCommandTest.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Reactive.Concurrency;
+using System.Reflection;
+using System.Text;
+using Microsoft.Dafny;
+using Microsoft.Extensions.Logging.Abstractions;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Client;
+using OmniSharp.Extensions.JsonRpc.Serialization;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace DafnyDriver.Test;
+
+public class FormatterCommandTest {
+  [Fact]
+  public async Task GitIssueVSCode452FormattingWorksOnBigFiles() {
+    // We write to a temporary file
+    var oneSource = (int i) => $@"function Test{i}(x: int): int
+// This returns {i} if x is greater than 20
+{{
+  if x < 10 then
+                  0
+                  else if x < 20 then
+                                       1
+                                          else {i}
+}}
+
+";
+
+    var oneSourceFormatted = (int i) => $@"function Test{i}(x: int): int
+  // This returns {i} if x is greater than 20
+{{
+  if x < 10 then
+    0
+  else if x < 20 then
+    1
+  else {i}
+}}
+
+";
+    var source = "";
+    var sourceFormatted = "";
+    for (var i = 0; i < 1000; i++) {
+      source += oneSource(i);
+      sourceFormatted += oneSourceFormatted(i);
+    }
+
+    var file = Path.GetTempFileName() + ".dfy";
+
+    await File.WriteAllTextAsync(file, source);
+    StringWriter strWriter = new StringWriter();
+    var options = DafnyOptions.Create(strWriter, null,
+      file
+      );
+
+    var exitValue = await FormatCommand.DoFormatting(options);
+    Assert.Equal(0, (int)exitValue);
+
+    var result = await File.ReadAllTextAsync(file);
+    Assert.Equal(sourceFormatted, result);
+    File.Delete(file);
+  }
+}

--- a/Source/DafnyDriver/Commands/FormatCommand.cs
+++ b/Source/DafnyDriver/Commands/FormatCommand.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Dafny;
 
-static class FormatCommand {
+public static class FormatCommand {
 
   public static IEnumerable<Option> Options => DafnyCommands.FormatOptions;
 

--- a/Source/DafnyPipeline.Test/FormatterIssues.cs
+++ b/Source/DafnyPipeline.Test/FormatterIssues.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using System.IO;
+using JetBrains.Annotations;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
This PR makes sure StreamReaders are closed after use, which prevented formatting from overwriting the files randomly.

Before, the "dafny format" command was throwing exceptions on large files, and now it no longer throws an exception (test added for that)

Even better, this solved the issue that when I create a blank Dafny file and try to save it, it used to complain with "Failed to save 'todelete.dfy': Unable to write file". (Fixes https://github.com/dafny-lang/ide-vscode/issues/452)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
