### PR TITLE
fix: Fix crash for lookup of non-existing member in new resolver

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -1047,7 +1047,8 @@ namespace Microsoft.Dafny {
       if (receiverDecl is TopLevelDeclWithMembers receiverDeclWithMembers) {
         // TODO: does this case need to do something like this?  var cd = ctype?.AsTopLevelTypeWithMembersBypassInternalSynonym;
 
-        if (!resolver.GetClassMembers(receiverDeclWithMembers).TryGetValue(memberName, out var member)) {
+        var members = resolver.GetClassMembers(receiverDeclWithMembers);
+        if (members == null || !members.TryGetValue(memberName, out var member)) {
           if (!reportErrorOnMissingMember) {
             // don't report any error
           } else if (memberName == "_ctor") {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4953.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4953.dfy
@@ -1,0 +1,17 @@
+// RUN: %testDafnyForEachResolver "%s" --expect-exit-code=2
+
+// The lookup of a non-existing member once caused a crash in the new resolver.
+
+function Foo(): (result: seq<int>)
+  ensures result.NonExistingMember
+
+function Bar(formal: seq<int>): int
+  requires formal.NonExistingMember
+
+method Zap(i: seq<int>) returns (o: seq<int>) {
+  var local: seq<int> := [];
+
+  var a := i.NonExistingMember;
+  var b := o.NonExistingMember;
+  var c := local.NonExistingMember;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4953.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4953.dfy.expect
@@ -1,0 +1,6 @@
+git-issue-4953.dfy(6,17): Error: type seq<int> does not have a member NonExistingMember
+git-issue-4953.dfy(9,18): Error: type seq<int> does not have a member NonExistingMember
+git-issue-4953.dfy(14,13): Error: type seq<int> does not have a member NonExistingMember
+git-issue-4953.dfy(15,13): Error: type seq<int> does not have a member NonExistingMember
+git-issue-4953.dfy(16,17): Error: type seq<int> does not have a member NonExistingMember
+5 resolution/type errors detected in git-issue-4953.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4953.dfy.refresh.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4953.dfy.refresh.expect
@@ -1,0 +1,6 @@
+git-issue-4953.dfy(6,17): Error: member 'NonExistingMember' does not exist in type 'seq'
+git-issue-4953.dfy(9,18): Error: member 'NonExistingMember' does not exist in type 'seq'
+git-issue-4953.dfy(14,13): Error: member 'NonExistingMember' does not exist in type 'seq'
+git-issue-4953.dfy(15,13): Error: member 'NonExistingMember' does not exist in type 'seq'
+git-issue-4953.dfy(16,17): Error: member 'NonExistingMember' does not exist in type 'seq'
+5 resolution/type errors detected in git-issue-4953.dfy

--- a/docs/dev/news/4955.fix
+++ b/docs/dev/news/4955.fix
@@ -1,0 +1,1 @@
+Fix crash for lookup of non-existing member in new resolver


### PR DESCRIPTION
Fixes #4953


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
