### PR TITLE
fix: Don’t flag extern functions with {:axiom} as assumptions

### DIFF
--- a/Source/DafnyCore/AST/Members/Function.cs
+++ b/Source/DafnyCore/AST/Members/Function.cs
@@ -65,15 +65,14 @@ public class Function : MemberDecl, TypeParameter.ParentType, ICallable, ICanFor
       yield return new Assumption(this, tok, AssumptionDescription.NoBody(IsGhost));
     }
 
-    if (HasExternAttribute) {
+    if (HasExternAttribute && !HasAxiomAttribute) {
       yield return new Assumption(this, tok, AssumptionDescription.ExternFunction);
-      if (HasPostcondition && !HasAxiomAttribute) {
+      if (HasPostcondition) {
         yield return new Assumption(this, tok, AssumptionDescription.ExternWithPostcondition);
       }
-    }
-
-    if (HasExternAttribute && HasPrecondition && !HasAxiomAttribute) {
-      yield return new Assumption(this, tok, AssumptionDescription.ExternWithPrecondition);
+      if (HasPrecondition) {
+        yield return new Assumption(this, tok, AssumptionDescription.ExternWithPrecondition);
+      }
     }
 
     foreach (var c in this.Descendants()) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/auditor/TestAuditor.dfy-ietf.md.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/auditor/TestAuditor.dfy-ietf.md.expect
@@ -86,8 +86,6 @@
 
 * Declaration has explicit `{:axiom}` attribute. SHOULD provide a proof or test.
 
-* Function with `{:extern}` attribute. SHOULD use `method` with `modifies {}` instead.
-
 ## Type `T`
 
 * Trait method calls may not terminate (uses `{:termination false}`). MUST remove `{:termination false}` or justify.

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/separate-verification/assumptions.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/separate-verification/assumptions.dfy.expect
@@ -27,6 +27,5 @@ TestAuditor.dfy(139,2): Error: Definition contains [forall] statement with no bo
 TestAuditor.dfy(143,2): Error: Definition contains loop with no body.
 TestAuditor.dfy(150,2): Error: Assertion has explicit temporary [{:only}] attribute.
 TestAuditor.dfy(154,15): Error: Member has explicit temporary [{:only}] attribute.
-TestAuditor.dfy(164,28): Error: Function with [{:extern}] attribute.
 TestAuditor.dfy(89,27): Error: Trait method calls may not terminate (uses [{:termination false}]).
 Wrote textual form of partial target program to assumptions-lib/assumptions.doo


### PR DESCRIPTION
### Description
Fixes #4964, more directly and specifically than the general improvements @keyboardDrummer is making as per https://github.com/dafny-lang/dafny/issues/4964#issuecomment-1884898031 (which are also good improvements for the future). Pre/post-conditions on extern functions are already allowed in doo files with the `{:axiom}` attribute, so this just allows that to suppress the additional implicit requirement that the extern implementation behaves like a deterministic function.

### How has this been tested?
Existing tests of the auditor and doo files (removes an arguably duplicative assumption on `function {:extern} {:axiom} ...` declarations)

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
