### PR TITLE
ci: pin Pandoc to 3.1.9

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -116,11 +116,12 @@ jobs:
         unset HOMEBREW_NO_INSTALL_FROM_API
         brew untap Homebrew/core
         brew update-reset && brew update
-        brew install pandoc
         brew install --cask basictex
         eval "$(/usr/libexec/path_helper)"
         sudo tlmgr update --self
         sudo tlmgr install framed tcolorbox environ trimspaces unicode-math
+        wget -O pandoc.pkg https://github.com/jgm/pandoc/releases/download/3.1.9/pandoc-3.1.9-x86_64-macOS.pkg
+        installer -pkg pandoc.pkg -target /
         pandoc -v
         which latex || echo NOT FOUND latex
         which xelatex || echo NOT FOUND xelatex


### PR DESCRIPTION
### Description

This PR pins the version of Pandoc used to build the reference manual in CI to version 3.1.9.

The last nightly prerelease workflow [failed](https://github.com/dafny-lang/dafny/actions/runs/7557266047/job/20578717283#step:23:35) due to a LaTeX error when building the reference manual:

```
./concat DafnyRef.md | sed -e '/numbered toc/d' -e '/:toc/d' -e '/PDFOMIT/d'  -e 's/<!--PDF NEWPAGE-->/\\newpage/' -e 's/<!--.*-->//' | pandoc --citeproc --toc --syntax-definition="../KDESyntaxDefinition/dafny.xml"  --syntax-definition="../KDESyntaxDefinition/grammar.xml" --highlight-style=../KDESyntaxDefinition/dafny.theme --pdf-engine=xelatex --bibliography=DafnyRef.bib --bibliography=krml250.bib --bibliography=poc.bib --bibliography=paper-full.bib --bibliography=references.bib -H head.tex -B header.tex -V colorlinks=true -t pdf -o DafnyRef.pdf
Error producing PDF.
! Undefined control sequence.
\__tcobox_set_backslash_removed:Nn ...1\tl_set:Ne 
                                                  #1{\exp_last_unbraced:NV \...
l.2522 \DeclareTotalTCBox{\tcboxverb}

make: *** [all] Error 43
```

That failing build used the latest version of Pandoc, 3.1.11.1, whereas the [last successful build](https://github.com/dafny-lang/dafny/actions/runs/7142605180) used version 3.1.9.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
