### PR TITLE
Test: Compiled variable names without integer prefixes

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Variables/NonglobalVariable.cs
+++ b/Source/DafnyCore/AST/Expressions/Variables/NonglobalVariable.cs
@@ -80,7 +80,7 @@ public abstract class NonglobalVariable : TokenNode, IVariable {
 
   protected string compileName;
   public virtual string CompileName =>
-    compileName ??= SanitizedName;
+    compileName ??= SanitizeName(Name);
 
   Type type;
   public bool IsTypeExplicit = false;


### PR DESCRIPTION
This is a draft PR to determine what would happen if, in the current Dafny compilers, shadowing variables was enabled. It could make it possible to keep the original variable names for some compilers.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
