### PR TITLE
fix: Don't consider := * to be definite assignment for non-ghost variables of a (00) type

### DIFF
--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -352,6 +352,10 @@ public abstract class Type : TokenNode {
 
   public enum AutoInitInfo { MaybeEmpty, Nonempty, CompilableValue }
 
+  public bool HavocCountsAsDefiniteAssignment(bool inGhostContext) {
+    return inGhostContext ? IsNonempty : HasCompilableValue;
+  }
+
   /// <summary>
   /// This property returns
   ///     - CompilableValue, if the type has a known compilable value

--- a/Source/DafnyCore/Verifier/BoogieGenerator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.TrStatement.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Dafny {
         }
 
         // Mark off the simple variables as having definitely been assigned AND THEN havoc their values. By doing them
-        // in this order, they type antecedents will in effect be assumed.
+        // in this order, the type antecedents will in effect be assumed.
         var bHavocLHSs = new List<Bpl.IdentifierExpr>();
         foreach (var lhs in simpleLHSs) {
           MarkDefiniteAssignmentTracker(lhs, builder);
@@ -2402,7 +2402,7 @@ namespace Microsoft.Dafny {
               bldr.Add(cmd);
             }
 
-            if (!origRhsIsHavoc || ie.Type.IsNonempty) {
+            if (!origRhsIsHavoc || ie.Type.HavocCountsAsDefiniteAssignment(ie.Var.IsGhost)) {
               MarkDefiniteAssignmentTracker(ie, bldr);
             }
           });
@@ -2434,7 +2434,7 @@ namespace Microsoft.Dafny {
                 bldr.Add(cmd);
               }
 
-              if (!origRhsIsHavoc || field.Type.IsNonempty) {
+              if (!origRhsIsHavoc || field.Type.HavocCountsAsDefiniteAssignment(field.IsGhost)) {
                 MarkDefiniteAssignmentTracker(lhs.tok, nm, bldr);
               }
             });

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5023.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5023.dfy
@@ -1,0 +1,176 @@
+// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s"
+
+// ---------- compiled variables/fields ----------
+
+module GhostWitness {
+  type Five = x: int | x == 5 ghost witness 5
+
+  class ContainsFive {
+    var five: Five
+
+    constructor () {
+      five := *;
+    } // error: five not defined
+  }
+
+  method M() {
+    var five: Five := *;
+    var c := new ContainsFive();
+
+    if
+    case true =>
+      print five, "\n"; // error: five used before defined
+    case true =>
+      var x :=
+        var f: Five := five; // error: five used before defined
+        assert f == 5;
+        if f == 5 then 200 else 200/0;
+    case true =>
+      print c.five, "\n";
+  }
+}
+
+module CompiledWitness {
+  type Five = x: int | x == 5 witness 5
+
+  class ContainsFive {
+    var five: Five
+
+    constructor () {
+      five := *;
+    }
+  }
+
+  method M() {
+    var five: Five := *;
+    var c := new ContainsFive();
+
+    if
+    case true =>
+      print five, "\n";
+    case true =>
+      var x :=
+        var f: Five := five;
+        assert f == 5;
+        if f == 5 then 200 else 200/0;
+    case true =>
+      print c.five, "\n";
+  }
+}
+
+module NoWitness {
+  type Five = x: int | x == 5 witness *
+
+  class ContainsFive {
+    var five: Five
+
+    constructor () {
+      five := *;
+    } // error: five not defined
+  }
+
+  method M() {
+    var five: Five := *;
+    var c := new ContainsFive();
+
+    if
+    case true =>
+      print five, "\n"; // error: five used before defined
+    case true =>
+      var x :=
+        var f: Five := five; // error: five used before defined
+        assert f == 5;
+        if f == 5 then 200 else 200/0;
+    case true =>
+      print c.five, "\n";
+  }
+}
+
+// ---------- ghost variables/fields ----------
+
+module XGhostWitness {
+  type Five = x: int | x == 5 ghost witness 5
+
+  class ContainsFive {
+    ghost var five: Five
+
+    constructor () {
+      five := *;
+    }
+  }
+
+  method M() returns (ghost g: int) {
+    g := 0;
+    ghost var five: Five := *;
+    var c := new ContainsFive();
+
+    if
+    case true =>
+      g := five;
+    case true =>
+      ghost var x :=
+        var f: Five := five;
+        assert f == 5;
+        if f == 5 then 200 else 200/0;
+    case true =>
+      g := c.five;
+  }
+}
+
+module XCompiledWitness {
+  type Five = x: int | x == 5 witness 5
+
+  class ContainsFive {
+    ghost var five: Five
+
+    constructor () {
+      five := *;
+    }
+  }
+
+  method M() returns (ghost g: int) {
+    g := 0;
+    ghost var five: Five := *;
+    var c := new ContainsFive();
+
+    if
+    case true =>
+      g := five;
+    case true =>
+      ghost var x :=
+        var f: Five := five;
+        assert f == 5;
+        if f == 5 then 200 else 200/0;
+    case true =>
+      g := c.five;
+  }
+}
+
+module XNoWitness {
+  type Five = x: int | x == 5 witness *
+
+  class ContainsFive {
+    ghost var five: Five
+
+    constructor () {
+      five := *;
+    } // error: five not defined
+  }
+
+  method M() returns (ghost g: int) {
+    g := 0;
+    ghost var five: Five := *;
+    var c := new ContainsFive();
+
+    if
+    case true =>
+      g := five; // error: five used before defined
+    case true =>
+      ghost var x :=
+        var f: Five := five; // error: five used before defined
+        assert f == 5;
+        if f == 5 then 200 else 200/0;
+    case true =>
+      g := c.five;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5023.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5023.dfy.expect
@@ -1,0 +1,11 @@
+git-issue-5023.dfy(13,4): Error: field 'five', which is subject to definite-assignment rules, might be uninitialized at this point in the constructor body
+git-issue-5023.dfy(22,12): Error: variable 'five', which is subject to definite-assignment rules, might be uninitialized here
+git-issue-5023.dfy(25,23): Error: variable 'five', which is subject to definite-assignment rules, might be uninitialized here
+git-issue-5023.dfy(69,4): Error: field 'five', which is subject to definite-assignment rules, might be uninitialized at this point in the constructor body
+git-issue-5023.dfy(78,12): Error: variable 'five', which is subject to definite-assignment rules, might be uninitialized here
+git-issue-5023.dfy(81,23): Error: variable 'five', which is subject to definite-assignment rules, might be uninitialized here
+git-issue-5023.dfy(157,4): Error: field 'five', which is subject to definite-assignment rules, might be uninitialized at this point in the constructor body
+git-issue-5023.dfy(167,11): Error: variable 'five', which is subject to definite-assignment rules, might be uninitialized here
+git-issue-5023.dfy(170,23): Error: variable 'five', which is subject to definite-assignment rules, might be uninitialized here
+
+Dafny program verifier finished with 7 verified, 9 errors


### PR DESCRIPTION
Fixes #5023

### Description

Previously, the verifier allowed `:= *` to satisfy the definite-assignment obligation for any known-to-be-nonempty type, regardless of context. The fix is to use `(0)`, not `(00)`, for non-ghost assignments.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
