### PR TITLE
Use full type declaration names in Boogie generation

### DIFF
--- a/Source/DafnyCore/AST/Members/ICodeContext.cs
+++ b/Source/DafnyCore/AST/Members/ICodeContext.cs
@@ -163,6 +163,8 @@ public class NoContext : ICodeContext {
 public interface RedirectingTypeDecl : ICallable {
   string Name { get; }
 
+  string FullDafnyName { get; }
+
   IToken tok { get; }
   Attributes Attributes { get; }
   ModuleDefinition Module { get; }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
@@ -1379,7 +1379,7 @@ public partial class BoogieGenerator {
     Contract.Requires(currentModule == null && codeContext == null && isAllocContext == null);
     Contract.Ensures(currentModule == null && codeContext == null && isAllocContext == null);
 
-    proofDependencies.SetCurrentDefinition(MethodVerboseName(decl.Name, MethodTranslationKind.SpecWellformedness));
+    proofDependencies.SetCurrentDefinition(MethodVerboseName(decl.FullDafnyName, MethodTranslationKind.SpecWellformedness));
 
     if (!InVerificationScope(decl)) {
       // Checked in other file
@@ -1417,7 +1417,7 @@ public partial class BoogieGenerator {
     var proc = new Bpl.Procedure(decl.tok, name, new List<Bpl.TypeVariable>(),
       inParams, new List<Variable>(),
       false, req, mod, new List<Bpl.Ensures>(), etran.TrAttributes(decl.Attributes, null));
-    AddVerboseNameAttribute(proc, decl.Name, MethodTranslationKind.SpecWellformedness);
+    AddVerboseNameAttribute(proc, decl.FullDafnyName, MethodTranslationKind.SpecWellformedness);
     sink.AddTopLevelDeclaration(proc);
 
     // TODO: Can a checksum be inserted here?

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/github-issue-5029.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/github-issue-5029.dfy
@@ -1,0 +1,11 @@
+// RUN: %verify "%s" --warn-contradictory-assumptions
+abstract module Digit {
+  function BASE(): nat
+    ensures BASE() > 1
+
+  type digit = i: nat | 0 <= i < BASE()
+}
+
+module M refines Digit {
+    function BASE(): nat { 32 }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/github-issue-5029.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/github-issue-5029.dfy.expect
@@ -1,0 +1,1 @@
+Dafny program verifier finished with 4 verified, 0 errors


### PR DESCRIPTION
### Description

Use full type declaration names in Boogie generation. Failing to do this was leading to spurious warnings about proofs due to contradictory assumptions.

Fixes #5029

### How has this been tested?

`Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/github-issue-5029.dfy`

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
