### PR TITLE
Customize the options used by the language server less

### DIFF
--- a/Source/DafnyLanguageServer/LanguageServer.cs
+++ b/Source/DafnyLanguageServer/LanguageServer.cs
@@ -47,12 +47,6 @@ namespace Microsoft.Dafny.LanguageServer {
 
     public static void ConfigureDafnyOptionsForServer(DafnyOptions dafnyOptions) {
       dafnyOptions.Set(DafnyConsolePrinter.ShowSnippets, true);
-      dafnyOptions.PrintIncludesMode = DafnyOptions.IncludesModes.None;
-
-      // TODO This may be subject to change. See Microsoft.Boogie.Counterexample
-      //      A dash means write to the textwriter instead of a file.
-      // https://github.com/boogie-org/boogie/blob/b03dd2e4d5170757006eef94cbb07739ba50dddb/Source/VCGeneration/Couterexample.cs#L217
-      dafnyOptions.ModelViewFile = "-";
     }
 
     public static async Task Start(DafnyOptions dafnyOptions) {


### PR DESCRIPTION
Customize the options used by the language server less, by relying on fewer defaults

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
