### PR TITLE
Update pre-type infrastructure

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/PreTypeConstraint.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeConstraint.cs
@@ -38,4 +38,17 @@ namespace Microsoft.Dafny {
       this.errorFormatStringProducer = errorFormatStringProducer;
     }
   }
+
+  public abstract class OptionalErrorPreTypeConstraint : PreTypeConstraint {
+    public readonly bool ReportErrors;
+    public OptionalErrorPreTypeConstraint(IToken tok, string errorFormatString, PreTypeConstraint baseError, bool reportErrors)
+      : base(tok, errorFormatString, baseError) {
+      ReportErrors = reportErrors;
+    }
+
+    public OptionalErrorPreTypeConstraint(IToken tok, Func<string> errorFormatStringProducer, bool reportErrors)
+      : base(tok, errorFormatStringProducer) {
+      ReportErrors = reportErrors;
+    }
+  }
 }

--- a/Source/DafnyCore/Resolver/PreType/PreTypeConstraints.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeConstraints.cs
@@ -665,7 +665,7 @@ namespace Microsoft.Dafny {
     /// If "super" is an ancestor of "sub", then return a list "L" of arguments for "super" such that
     /// "super<L>" is a supertype of "sub<subArguments>".
     /// Otherwise, return "null".
-    /// If "forAsOrIs" is "true", then allow "sub" to be replaced by an ancestore type of "sub" if "sub" is a newtype.
+    /// If "forAsOrIs" is "true", then allow "sub" to be replaced by an ancestor type of "sub" if "sub" is a newtype.
     /// </summary>
     public List<PreType> /*?*/ GetTypeArgumentsForSuperType(TopLevelDecl super, TopLevelDecl sub, List<PreType> subArguments, bool forAsOrIs) {
       Contract.Requires(sub.TypeArgs.Count == subArguments.Count);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeEqualityConstraint.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeEqualityConstraint.cs
@@ -11,12 +11,12 @@ using System.Diagnostics.Contracts;
 
 namespace Microsoft.Dafny {
 
-  class EqualityConstraint : PreTypeConstraint {
+  class EqualityConstraint : OptionalErrorPreTypeConstraint {
     public PreType A;
     public PreType B;
 
-    public EqualityConstraint(PreType a, PreType b, IToken tok, string msgFormat, PreTypeConstraint baseError = null)
-      : base(tok, msgFormat, baseError) {
+    public EqualityConstraint(PreType a, PreType b, IToken tok, string msgFormat, PreTypeConstraint baseError = null, bool reportErrors = true)
+      : base(tok, msgFormat, baseError, reportErrors) {
       A = a;
       B = b;
     }
@@ -44,9 +44,9 @@ namespace Microsoft.Dafny {
         Contract.Assert(da.Arguments.Count == db.Arguments.Count);
         for (var i = 0; i < da.Arguments.Count; i++) {
           // TODO: should the error message in the following line be more specific?
-          yield return new EqualityConstraint(da.Arguments[i], db.Arguments[i], tok, ErrorFormatString);
+          yield return new EqualityConstraint(da.Arguments[i], db.Arguments[i], tok, ErrorFormatString, null, ReportErrors);
         }
-      } else {
+      } else if (ReportErrors) {
         constraints.PreTypeResolver.ReportError(tok, ErrorFormatString, a, b);
       }
     }

--- a/Source/DafnyCore/Resolver/PreType/PreTypeSubtypeConstraint.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeSubtypeConstraint.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Diagnostics.Contracts;
 
 namespace Microsoft.Dafny {
-  class SubtypeConstraint : PreTypeConstraint {
+  class SubtypeConstraint : OptionalErrorPreTypeConstraint {
     public readonly PreType Super;
     public readonly PreType Sub;
 
@@ -19,16 +19,16 @@ namespace Microsoft.Dafny {
       return string.Format(ErrorFormatString, Super, Sub);
     }
 
-    public SubtypeConstraint(PreType super, PreType sub, IToken tok, string errorFormatString, PreTypeConstraint baseError = null)
-      : base(tok, errorFormatString, baseError) {
+    public SubtypeConstraint(PreType super, PreType sub, IToken tok, string errorFormatString, PreTypeConstraint baseError = null, bool reportErrors = true)
+      : base(tok, errorFormatString, baseError, reportErrors) {
       Contract.Assert(super != null);
       Contract.Assert(sub != null);
       Super = super.Normalize();
       Sub = sub.Normalize();
     }
 
-    public SubtypeConstraint(PreType super, PreType sub, IToken tok, Func<string> errorFormatStringProducer)
-      : base(tok, errorFormatStringProducer) {
+    public SubtypeConstraint(PreType super, PreType sub, IToken tok, Func<string> errorFormatStringProducer, bool reportErrors = true)
+      : base(tok, errorFormatStringProducer, reportErrors) {
       Contract.Assert(super != null);
       Contract.Assert(sub != null);
       Super = super.Normalize();
@@ -41,7 +41,7 @@ namespace Microsoft.Dafny {
       if (object.ReferenceEquals(super, Super) && object.ReferenceEquals(sub, Sub)) {
         return this;
       } else {
-        return new SubtypeConstraint(super, sub, Token.NoToken, ErrorFormatString);
+        return new SubtypeConstraint(super, sub, Token.NoToken, ErrorFormatString, null, ReportErrors);
       }
     }
 
@@ -59,12 +59,12 @@ namespace Microsoft.Dafny {
         //     Constrain g(x,y) :> b
         //     Constrain c == h(x,y)
         // else report an error
-        var arguments = constraints.GetTypeArgumentsForSuperType(ptSuper.Decl, ptSub.Decl, ptSub.Arguments);
+        var arguments = constraints.GetTypeArgumentsForSuperType(ptSuper.Decl, ptSub.Decl, ptSub.Arguments, false);
         if (arguments != null) {
           Contract.Assert(arguments.Count == ptSuper.Decl.TypeArgs.Count);
           ConstrainTypeArguments(ptSuper.Decl.TypeArgs, ptSuper.Arguments, arguments, tok, this, constraints);
           return true;
-        } else {
+        } else if (ReportErrors) {
           constraints.PreTypeResolver.ReportError(tok, ErrorMessage());
           return true;
         }
@@ -77,9 +77,9 @@ namespace Microsoft.Dafny {
         //     Constrain beta :> b
         // else do nothing for now
         if (ptSuper.Decl is not TraitDecl) {
-          var arguments = CreateProxiesForTypesAccordingToVariance(tok, ptSuper.Decl.TypeArgs, ptSuper.Arguments, false, constraints);
+          var arguments = CreateProxiesForTypesAccordingToVariance(tok, ptSuper.Decl.TypeArgs, ptSuper.Arguments, false, ReportErrors, constraints);
           var pt = new DPreType(ptSuper.Decl, arguments);
-          constraints.AddEqualityConstraint(pt, sub, tok, ErrorFormatString);
+          constraints.AddEqualityConstraint(pt, sub, tok, ErrorFormatString, null, ReportErrors);
           return true;
         }
       } else if (ptSub != null) {
@@ -93,9 +93,9 @@ namespace Microsoft.Dafny {
         if (PreTypeResolver.HasTraitSupertypes(ptSub)) {
           // there are parent traits
         } else {
-          var arguments = CreateProxiesForTypesAccordingToVariance(tok, ptSub.Decl.TypeArgs, ptSub.Arguments, true, constraints);
+          var arguments = CreateProxiesForTypesAccordingToVariance(tok, ptSub.Decl.TypeArgs, ptSub.Arguments, true, ReportErrors, constraints);
           var pt = new DPreType(ptSub.Decl, arguments);
-          constraints.AddEqualityConstraint(super, pt, tok, ErrorFormatString);
+          constraints.AddEqualityConstraint(super, pt, tok, ErrorFormatString, null, ReportErrors);
           return true;
         }
       } else {
@@ -110,7 +110,7 @@ namespace Microsoft.Dafny {
     /// For every contra-variant parameters[i], constrain subArguments[i] :> superArguments[i].
     /// </summary>
     static void ConstrainTypeArguments(List<TypeParameter> parameters, List<PreType> superArguments, List<PreType> subArguments, IToken tok,
-      PreTypeConstraint baseError, PreTypeConstraints constraints) {
+      OptionalErrorPreTypeConstraint baseError, PreTypeConstraints constraints) {
       Contract.Requires(parameters.Count == superArguments.Count && superArguments.Count == subArguments.Count);
 
       for (var i = 0; i < parameters.Count; i++) {
@@ -119,13 +119,13 @@ namespace Microsoft.Dafny {
         var arg1 = subArguments[i];
         if (tp.Variance == TypeParameter.TPVariance.Non) {
           constraints.AddEqualityConstraint(arg0, arg1, tok,
-            $"non-variant type parameter '{tp.Name}' would require {{0}} = {{1}}", baseError);
+            $"non-variant type parameter '{tp.Name}' would require {{0}} = {{1}}", baseError, baseError.ReportErrors);
         } else if (tp.Variance == TypeParameter.TPVariance.Co) {
           constraints.AddSubtypeConstraint(arg0, arg1, tok,
-            $"covariant type parameter '{tp.Name}' would require {{0}} :> {{1}}", baseError);
+            $"covariant type parameter '{tp.Name}' would require {{0}} :> {{1}}", baseError, baseError.ReportErrors);
         } else {
           constraints.AddSubtypeConstraint(arg1, arg0, tok,
-            $"contravariant type parameter '{tp.Name}' would require {{0}} :> {{1}}", baseError);
+            $"contravariant type parameter '{tp.Name}' would require {{0}} :> {{1}}", baseError, baseError.ReportErrors);
         }
       }
     }
@@ -140,7 +140,7 @@ namespace Microsoft.Dafny {
     ///   - else a new proxy constrained by:  ai :> proxy
     /// </summary>
     static List<PreType> CreateProxiesForTypesAccordingToVariance(IToken tok, List<TypeParameter> parameters, List<PreType> arguments,
-      bool proxiesAreSupertypes, PreTypeConstraints state) {
+      bool proxiesAreSupertypes, bool reportErrors, PreTypeConstraints state) {
       Contract.Requires(parameters.Count == arguments.Count);
 
       if (parameters.All(tp => tp.Variance == TypeParameter.TPVariance.Non)) {
@@ -157,9 +157,9 @@ namespace Microsoft.Dafny {
           var proxy = state.PreTypeResolver.CreatePreTypeProxy($"type used in {co}variance constraint");
           newArgs.Add(proxy);
           if ((tp.Variance == TypeParameter.TPVariance.Co) == proxiesAreSupertypes) {
-            state.AddSubtypeConstraint(proxy, arguments[i], tok, "bad"); // TODO: improve error message
+            state.AddSubtypeConstraint(proxy, arguments[i], tok, "bad", null, reportErrors); // TODO: improve error message
           } else {
-            state.AddSubtypeConstraint(arguments[i], proxy, tok, "bad"); // TODO: improve error message
+            state.AddSubtypeConstraint(arguments[i], proxy, tok, "bad", null, reportErrors); // TODO: improve error message
           }
         }
       }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/OnDemandResolutionCycle.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/OnDemandResolutionCycle.dfy.expect
@@ -1,13 +1,15 @@
 OnDemandResolutionCycle.dfy(5,6): Error: Cyclic dependency among declarations: a -> A -> a
+OnDemandResolutionCycle.dfy(4,15): Error: arguments must have comparable types (got ?1 and ?0)
 OnDemandResolutionCycle.dfy(9,9): Error: Cyclic dependency among declarations: FB -> B -> FB -> b
 OnDemandResolutionCycle.dfy(7,5): Error: Cyclic dependency among declarations: B -> B -> FB -> b
 OnDemandResolutionCycle.dfy(11,6): Error: Cyclic dependency among declarations: c0 -> c1 -> c0
 OnDemandResolutionCycle.dfy(15,6): Error: Cyclic dependency among declarations: d -> D -> d
 OnDemandResolutionCycle.dfy(14,8): Error: newtype's base type is not fully determined; add an explicit type for bound variable 'x'
+OnDemandResolutionCycle.dfy(14,18): Error: arguments must have comparable types (got ?1 and ?0)
 OnDemandResolutionCycle.dfy(19,9): Error: Cyclic dependency among declarations: FE -> E -> FE -> e
 OnDemandResolutionCycle.dfy(17,8): Error: Cyclic dependency among declarations: E -> E -> FE -> e
 OnDemandResolutionCycle.dfy(22,9): Error: Cyclic dependency among declarations: f -> F -> f
 OnDemandResolutionCycle.dfy(21,8): Error: Cyclic dependency among declarations: F -> F -> f
 OnDemandResolutionCycle.dfy(24,6): Error: Cyclic dependency among declarations: g -> g
 OnDemandResolutionCycle.dfy(15,14): Error: integer literal used as if it had type D
-12 resolution/type errors detected in OnDemandResolutionCycle.dfy
+14 resolution/type errors detected in OnDemandResolutionCycle.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeInferenceRefreshErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeInferenceRefreshErrors.dfy.expect
@@ -3,8 +3,8 @@ TypeInferenceRefreshErrors.dfy(19,10): Error: a reads-clause expression must den
 TypeInferenceRefreshErrors.dfy(20,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got set<real>)
 TypeInferenceRefreshErrors.dfy(21,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got () ~> set<real>)
 TypeInferenceRefreshErrors.dfy(22,10): Error: a reads-clause expression must denote an object, a set/iset/multiset/seq of objects, or a function to a set/iset/multiset/seq of objects (instead got () ~> map<object, object>)
-TypeInferenceRefreshErrors.dfy(33,12): Error: type cast to reference type 'C' must be from an expression assignable to it (got 'D')
-TypeInferenceRefreshErrors.dfy(34,12): Error: type cast to reference type 'D' must be from an expression assignable to it (got 'C')
+TypeInferenceRefreshErrors.dfy(33,12): Error: type cast to reference type 'C' must be from an expression of a compatible type (got 'D')
+TypeInferenceRefreshErrors.dfy(34,12): Error: type cast to reference type 'D' must be from an expression of a compatible type (got 'C')
 TypeInferenceRefreshErrors.dfy(49,8): Error: the type ('E?<?0>') of this variable is underspecified
 TypeInferenceRefreshErrors.dfy(50,16): Error: the type ('E<?2>') of this expression is underspecified
 TypeInferenceRefreshErrors.dfy(51,16): Error: the type ('E<set<?6>>') of this expression is underspecified

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2134.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2134.dfy.expect
@@ -6,12 +6,14 @@ git-issue-2134.dfy(22,12): Error: Cyclic dependency among declarations: P -> B -
 git-issue-2134.dfy(20,10): Error: newtype's base type is not fully determined; add an explicit type for bound variable 'b'
 git-issue-2134.dfy(27,8): Error: Cyclic dependency among declarations: X -> B -> X
 git-issue-2134.dfy(26,10): Error: newtype's base type is not fully determined; add an explicit type for bound variable 'b'
+git-issue-2134.dfy(26,20): Error: arguments must have comparable types (got ?1 and ?0)
 git-issue-2134.dfy(32,11): Error: Cyclic dependency among declarations: X -> B -> X
 git-issue-2134.dfy(31,10): Error: Cyclic dependency among declarations: B -> B -> X
 git-issue-2134.dfy(41,12): Error: Cyclic dependency among declarations: P -> A -> B -> P
 git-issue-2134.dfy(48,12): Error: Cyclic dependency among declarations: P -> A -> Q -> B -> P
 git-issue-2134.dfy(55,12): Error: Cyclic dependency among declarations: P -> B -> P
 git-issue-2134.dfy(60,8): Error: Cyclic dependency among declarations: X -> B -> X
+git-issue-2134.dfy(59,17): Error: arguments must have comparable types (got ?1 and ?0)
 git-issue-2134.dfy(65,11): Error: Cyclic dependency among declarations: X -> B -> X
 git-issue-2134.dfy(64,7): Error: Cyclic dependency among declarations: B -> B -> X
-16 resolution/type errors detected in git-issue-2134.dfy
+18 resolution/type errors detected in git-issue-2134.dfy


### PR DESCRIPTION
This PR is the result of carving off some self-contained edits from some upcoming changes to supporting general `newtype`s and full `is` expressions. Alas, what this PR may lack is the motivation for these changes.

### Description

* Introduce a common supertype (`OptionalErrorPreTypeConstraint`) to `SubtypeConstraint` and `EqualityConstraint`. This supertype keeps track of whether or not to report errors.
* New method `AssertThatStateIsClear` checks that all pre-type constraints have been considered. (This was found to be a problem in one previous case. The test for this is coming up in a future PR that contains the appropriate context.)
* The pre-type "confirmations" (which are checks that are performed after all pre-type inference has happened) infrastructure is improved, in two ways. One improvement is to be able to output debug information about the different confirmations (previously, this debug information only said how many confirmations there were). The other improvement is to be to customize what happens if a confirmation fails because of some underspecified type. This is detected by the pre-type in question being a proxy.
* `GetTypeArgumentsForSuperType` is being prepped for handling `as`/`is` for general `newtype`s.
* The definition of _comparable types_ is substantially improved. It now divides the comparable types that come about from `trait` parents from the comparable types that arise for `as`/`is`. It maintains the meaning of what is allowed in the "legacy" case--that is, with `--general-newtypes=false` (which is still the default; support for `--general-newtypes=true` is coming up in other PRs.

### How has this been tested?

The full code changes (which will be added in separate PRs) contain tests for these changes and the new functionality they bring. For this PR itself, the goal is just to pass the current test suite.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
