### PR TITLE
Make smaller changes to compilers

### DIFF
--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -173,6 +173,15 @@ public abstract class Type : TokenNode {
     ExpandSynonymsAndSubsetTypes
   }
 
+  public NativeType AsNativeType() {
+    if (AsNewtype != null) {
+      return AsNewtype.NativeType;
+    } else if (IsBitVectorType) {
+      return AsBitVectorType.NativeType;
+    }
+    return null;
+  }
+
   /// <summary>
   /// Return the type that "this" stands for, getting to the bottom of proxies and following type synonyms.
   ///

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -2072,7 +2072,7 @@ namespace Microsoft.Dafny.Compilers {
         coerceE1 = false;
 
         opString = op switch {
-          BinaryExpr.ResolvedOpcode.Iff => "==",
+          BinaryExpr.ResolvedOpcode.Iff => "<==>",
           BinaryExpr.ResolvedOpcode.And => "&&",
           BinaryExpr.ResolvedOpcode.Or => "||",
           BinaryExpr.ResolvedOpcode.BitwiseAnd => "&",

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -1272,7 +1272,8 @@ namespace Microsoft.Dafny.Compilers {
       throw new InvalidOperationException();
     }
 
-    protected override ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, bool surroundByUnchecked, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, [CanBeNull] NativeType nativeType,
+      bool surroundByUnchecked, ConcreteSyntaxTree wr) {
       throwGeneralUnsupported();
       throw new InvalidOperationException();
     }
@@ -2071,7 +2072,7 @@ namespace Microsoft.Dafny.Compilers {
         coerceE1 = false;
 
         opString = op switch {
-          BinaryExpr.ResolvedOpcode.Iff => "<==>",
+          BinaryExpr.ResolvedOpcode.Iff => "==",
           BinaryExpr.ResolvedOpcode.And => "&&",
           BinaryExpr.ResolvedOpcode.Or => "||",
           BinaryExpr.ResolvedOpcode.BitwiseAnd => "&",

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -1774,7 +1774,7 @@ namespace Microsoft.Dafny.Compilers {
         ConcreteSyntaxTree wr, bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       var bv = e0.Type.AsBitVectorType;
       if (truncate) {
-        wr = EmitBitvectorTruncation(bv, true, wr);
+        wr = EmitBitvectorTruncation(bv, nativeType, true, wr);
       }
       tr(e0, wr, inLetExprBody, wStmts);
       wr.Write($" {op} ");
@@ -1792,31 +1792,30 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, bool surroundByUnchecked, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, [CanBeNull] NativeType nativeType,
+      bool surroundByUnchecked, ConcreteSyntaxTree wr) {
+
       string nativeName = null, literalSuffix = null;
-      bool needsCastAfterArithmetic = false;
-      if (bvType.NativeType != null) {
-        GetNativeInfo(bvType.NativeType.Sel, out nativeName, out literalSuffix, out needsCastAfterArithmetic);
+      if (nativeType != null) {
+        GetNativeInfo(nativeType.Sel, out nativeName, out literalSuffix, out _);
       }
       // --- Before
-      if (bvType.NativeType == null) {
+      if (nativeType == null) {
         wr.Write("((");
       } else {
-        wr.Write($"({nativeName}) {CastIfSmallNativeType(bvType)}((");
+        wr.Write($"({nativeName}) {CastIfSmallNativeType(nativeType)}((");
       }
       // --- Middle
       var middle = wr.Fork();
       // --- After
       // do the truncation, if needed
-      if (bvType.NativeType == null) {
+      if (nativeType == null) {
         wr.Write($").and((java.math.BigInteger.ONE.shiftLeft({bvType.Width})).subtract(java.math.BigInteger.ONE)))");
+      } else if (bvType.Width < nativeType.Bitwidth) {
+        // print in hex, because that looks nice
+        wr.Write($") & {CastIfSmallNativeType(nativeType)}0x{(1UL << bvType.Width) - 1:X}{literalSuffix})");
       } else {
-        if (bvType.NativeType.Bitwidth != bvType.Width) {
-          // print in hex, because that looks nice
-          wr.Write($") & {CastIfSmallNativeType(bvType)}0x{(1UL << bvType.Width) - 1:X}{literalSuffix})");
-        } else {
-          wr.Write("))");  // close the parentheses for the cast
-        }
+        wr.Write("))"); // close the parentheses for the cast
       }
       return middle;
     }
@@ -3492,7 +3491,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitDowncastVariableAssignment(string boundVarName, Type boundVarType, string tmpVarName,
-      Type collectionElementType, bool introduceBoundVar, IToken tok, ConcreteSyntaxTree wr) {
+      Type sourceType, bool introduceBoundVar, IToken tok, ConcreteSyntaxTree wr) {
 
       var typeName = TypeName(boundVarType, wr, tok);
       wr.WriteLine("{0}{1} = ({2}){3};", introduceBoundVar ? typeName + " " : "", boundVarName, typeName, tmpVarName);

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -963,7 +963,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitDowncastVariableAssignment(string boundVarName, Type boundVarType, string tmpVarName,
-      Type collectionElementType, bool introduceBoundVar, IToken tok, ConcreteSyntaxTree wr) {
+      Type sourceType, bool introduceBoundVar, IToken tok, ConcreteSyntaxTree wr) {
       wr.WriteLine($"{boundVarName}{(introduceBoundVar ? $": {TypeName(boundVarType, wr, tok)}" : "")} = {tmpVarName}");
     }
 
@@ -1068,7 +1068,8 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, bool surroundByUnchecked, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, [CanBeNull] NativeType nativeType,
+      bool surroundByUnchecked, ConcreteSyntaxTree wr) {
       var vec = wr.ForkInParens();
       wr.Write($" & ((1 << {bvType.Width}) - 1)");
       return vec;
@@ -1087,7 +1088,7 @@ namespace Microsoft.Dafny.Compilers {
         bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       var bv = e0.Type.AsBitVectorType;
       if (truncate) {
-        wr = EmitBitvectorTruncation(bv, true, wr);
+        wr = EmitBitvectorTruncation(bv, null, true, wr);
       }
       tr(e0, wr, inLetExprBody, wStmts);
       wr.Write($" {op} ");

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -687,22 +687,22 @@ namespace Microsoft.Dafny.Compilers {
 
     /// <summary>
     /// Emit an upcast or (already verified) downcast assignment like:
-    /// 
+    ///
     ///     var boundVarName:boundVarType := tmpVarName as boundVarType;
     ///     [[bodyWriter]]
-    /// 
+    ///
     /// where
     ///   * "[[bodyWriter]]" is where the writer wr's position will be next
     /// </summary>
     /// <param name="boundVarName">Name of the variable after casting</param>
     /// <param name="boundVarType">Expected variable type</param>
     /// <param name="tmpVarName">The collection's variable name</param>
-    /// <param name="collectionElementType">type this variable is casted from, in case it is useful</param>
+    /// <param name="sourceType"></param>
     /// <param name="introduceBoundVar">Whether or not to declare the variable, in languages requiring declarations</param>
     /// <param name="tok">A position in the AST</param>
     /// <param name="wr">The concrete syntax tree writer</param>
     protected abstract void EmitDowncastVariableAssignment(string boundVarName, Type boundVarType, string tmpVarName,
-      Type collectionElementType, bool introduceBoundVar, IToken tok, ConcreteSyntaxTree wr);
+      Type sourceType, bool introduceBoundVar, IToken tok, ConcreteSyntaxTree wr);
 
     /// <summary>
     /// Emit a simple foreach loop over the elements (which are known as "ingredients") of a collection assembled for
@@ -775,7 +775,8 @@ namespace Microsoft.Dafny.Compilers {
 
     protected abstract void EmitLiteralExpr(ConcreteSyntaxTree wr, LiteralExpr e);
     protected abstract void EmitStringLiteral(string str, bool isVerbatim, ConcreteSyntaxTree wr);
-    protected abstract ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, bool surroundByUnchecked, ConcreteSyntaxTree wr);
+    protected abstract ConcreteSyntaxTree EmitBitvectorTruncation(BitvectorType bvType, [CanBeNull] NativeType nativeType,
+      bool surroundByUnchecked, ConcreteSyntaxTree wr);
     protected delegate void FCE_Arg_Translator(Expression e, ConcreteSyntaxTree wr, bool inLetExpr, ConcreteSyntaxTree wStmts);
 
     protected abstract void EmitRotate(Expression e0, Expression e1, bool isRotateLeft, ConcreteSyntaxTree wr,
@@ -5331,7 +5332,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (expr is UnaryOpExpr) {
         var e = (UnaryOpExpr)expr;
         if (e.ResolvedOp == UnaryOpExpr.ResolvedOpcode.BVNot) {
-          wr = EmitBitvectorTruncation(e.Type.AsBitVectorType, false, wr);
+          wr = EmitBitvectorTruncation(e.Type.AsBitVectorType, e.Type.AsNativeType(), true, wr);
         }
         EmitUnaryExpr(UnaryOpCodeMap[e.ResolvedOp], e.E, inLetExprBody, wr, wStmts);
       } else if (expr is ConversionExpr) {
@@ -5379,8 +5380,8 @@ namespace Microsoft.Dafny.Compilers {
             out var coerceE1,
             wr);
 
-          if (truncateResult && e.Type.IsBitVectorType) {
-            wr = EmitBitvectorTruncation(e.Type.AsBitVectorType, true, wr);
+          if (truncateResult && e.Type.AsBitVectorType is {} bitvectorType) {
+            wr = EmitBitvectorTruncation(bitvectorType, e.Type.AsNativeType(), true, wr);
           }
           var e0 = reverseArguments ? e.E1 : e.E0;
           var e1 = reverseArguments ? e.E0 : e.E1;

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -5380,7 +5380,7 @@ namespace Microsoft.Dafny.Compilers {
             out var coerceE1,
             wr);
 
-          if (truncateResult && e.Type.AsBitVectorType is {} bitvectorType) {
+          if (truncateResult && e.Type.AsBitVectorType is { } bitvectorType) {
             wr = EmitBitvectorTruncation(bitvectorType, e.Type.AsNativeType(), true, wr);
           }
           var e0 = reverseArguments ? e.E1 : e.E0;


### PR DESCRIPTION
This PR contains some minor changes to the compilers. These changes have been carved off from a larger set of changes (for supporting general `newtype`s and `is` expressions), to simplify the reviewing of the latter.

The changes in this PR are:
* Rename parameter of `EmitDowncastVariableAssignment` (`collectionElementType` to `sourceType`).
* Add `nativeType` parameter to ` EmitBitvectorTruncation` (to allow it to be different than `bvType.NativeType`).
* In some places, don't assume that native type of bitvector type is always as wide as the bitvector. (This happens to be true today, but it may not be true in the future (i) when a `newtype` can have a bitvector base type, which will happen soon, and (ii) if `IntBoundedPool` starts supporting bitvector types.

### How has this been tested?

Since the changes are meant to preserve current behaviors (but with an eye to the up-and-coming PRs with larger changes), this PR does not make any changes to tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
