### PR TITLE
Add replaceable compiler methods

### DIFF
--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -3326,6 +3326,29 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".IsInteger() && ");
+    }
+
+    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Write("Dafny.Rune.IsRune");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" && ");
+    }
+
+    protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
+      wr.Write(" <= ");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" && ");
+
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" < ");
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
+      wr.Write(" && ");
+    }
+
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
         bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("{0}.FromElements", TypeHelperName(ct, wr, tok));

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -2323,9 +2323,7 @@ namespace Microsoft.Dafny.Compilers {
           };
         }
       } else {
-        typeTest = wr => EmitExpr(new LiteralExpr(tok, true) {
-          Type = Type.Bool
-        }, false, wr, null);
+        typeTest = wr => EmitExpr(Expression.CreateBoolLiteral(tok, true), false, wr, null);
       }
 
       return typeTest;

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -1474,6 +1474,14 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override ConcreteSyntaxTree EmitNullTest(bool testIsNull, ConcreteSyntaxTree wr) {
+      if (!testIsNull) {
+        wr.Write("!");
+      }
+      wr.Write("_dafny.IsDafnyNull");
+      return wr.ForkInParens();
+    }
+
     protected override ConcreteSyntaxTree EmitTailCallStructure(MemberDecl member, ConcreteSyntaxTree wr) {
       wr.WriteLine("goto TAIL_CALL_START");
       wr.WriteLine("TAIL_CALL_START:");
@@ -1826,7 +1834,7 @@ namespace Microsoft.Dafny.Compilers {
       return w;
     }
 
-    void EmitDummyVariableUse(string variableName, ConcreteSyntaxTree wr) {
+    protected override void EmitDummyVariableUse(string variableName, ConcreteSyntaxTree wr) {
       Contract.Requires(variableName != null);
       Contract.Requires(wr != null);
 

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -1021,8 +1021,8 @@ namespace Microsoft.Dafny.Compilers {
       var udt = UserDefinedType.FromTopLevelDecl(nt.tok, nt);
       // RTD
       {
-        CreateRTD(IdName(nt), null, out var wDefaultBody, wr);
         var d = TypeInitializationValue(udt, wr, nt.tok, false, true);
+        CreateRTD(IdName(nt), nt.TypeArgs, out var wDefaultBody, wr);
         wDefaultBody.WriteLine("return {0}", d);
       }
 
@@ -1051,12 +1051,11 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    private void CreateRTD(string typeName, List<TypeParameter>/*?*/ usedParams, out ConcreteSyntaxTree wDefaultBody, ConcreteSyntaxTree wr) {
+    private void CreateRTD(string typeName, List<TypeParameter> usedParams, out ConcreteSyntaxTree wDefaultBody, ConcreteSyntaxTree wr) {
       Contract.Requires(typeName != null);
+      Contract.Requires(usedParams != null);
       Contract.Requires(wr != null);
       Contract.Ensures(Contract.ValueAtReturn(out wDefaultBody) != null);
-
-      usedParams ??= new List<TypeParameter>();
 
       wr.WriteLine();
       wr.Write($"func {FormatRTDName(typeName)}(");

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -3614,6 +3614,29 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".IsInteger() && ");
+    }
+
+    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Write("_dafny.IsCodePoint");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" && ");
+    }
+
+    protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
+      wr.Write(".Cmp(");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(") <= 0 && ");
+
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".Cmp(");
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
+      wr.Write(") < 0 && ");
+    }
+
     private static bool EqualsUpToParameters(Type type1, Type type2) {
       // TODO Consider whether Type.SameHead should return true in this case
       return Type.SameHead(type1, type2) || (type1.IsArrayType && type1.IsArrayType);

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -975,8 +975,7 @@ namespace Microsoft.Dafny.Compilers {
       {
         var usedOrAutoInitTypeParams = UsedTypeParameters(dt, true);
         CreateRTD(name, usedOrAutoInitTypeParams, out var wDefault, wr);
-
-        WriteRuntimeTypeDescriptorsLocals(usedOrAutoInitTypeParams, true, wDefault);
+        WriteRuntimeTypeDescriptorsLocals(usedOrAutoInitTypeParams, wDefault);
 
         var usedTypeParams = UsedTypeParameters(dt);
         var sep = typeDescriptorUses.Length != 0 && usedTypeParams.Count != 0 ? ", " : "";
@@ -1353,15 +1352,13 @@ namespace Microsoft.Dafny.Compilers {
       return count;
     }
 
-    void WriteRuntimeTypeDescriptorsLocals(List<TypeParameter> typeParams, bool useAllTypeArgs, ConcreteSyntaxTree wr) {
+    void WriteRuntimeTypeDescriptorsLocals(List<TypeParameter> typeParams, ConcreteSyntaxTree wr) {
       Contract.Requires(typeParams != null);
       Contract.Requires(wr != null);
 
       foreach (var tp in typeParams) {
-        if (useAllTypeArgs || NeedsTypeDescriptor(tp)) {
-          wr.WriteLine("{0} := _this.{0}", FormatRTDName(tp.GetCompileName(Options)));
-          EmitDummyVariableUse(FormatRTDName(tp.GetCompileName(Options)), wr);
-        }
+        wr.WriteLine("{0} := _this.{0}", FormatRTDName(tp.GetCompileName(Options)));
+        EmitDummyVariableUse(FormatRTDName(tp.GetCompileName(Options)), wr);
       }
     }
 

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -4222,6 +4222,29 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".isInteger() && ");
+    }
+
+    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Write("dafny.CodePoint.isCodePoint");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" && ");
+    }
+
+    protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".compareTo(");
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
+      wr.Write(") >= 0 && ");
+
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".compareTo(");
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
+      wr.Write(") < 0 && ");
+    }
+
     protected override bool IssueCreateStaticMain(Method m) {
       return true;
     }

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -2468,6 +2468,29 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".isInteger() && ");
+    }
+
+    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Write("_dafny.CodePoint.isCodePoint");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" && ");
+    }
+
+    protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitLiteralExpr(wr.ForkInParens(), new LiteralExpr(source.tok, lo) { Type = Type.Int });
+      wr.Write(".isLessThanOrEqualTo");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" && ");
+
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".isLessThan");
+      EmitLiteralExpr(wr.ForkInParens(), new LiteralExpr(source.tok, hi) { Type = Type.Int });
+      wr.Write(" && ");
+    }
+
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
         bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (ct is SetType) {

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -615,6 +615,12 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override ConcreteSyntaxTree EmitNullTest(bool testIsNull, ConcreteSyntaxTree wr) {
+      var wrTarget = wr.ForkInParens();
+      wr.Write(testIsNull ? " == None" : " != None");
+      return wrTarget;
+    }
+
     protected override ConcreteSyntaxTree EmitTailCallStructure(MemberDecl member, ConcreteSyntaxTree wr) {
       if (!member.IsStatic) {
         wr.WriteLine("_this = self");

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -1704,6 +1704,29 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(".is_integer() and ");
+    }
+
+    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Write("_dafny.CodePoint.is_code_point");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" and ");
+    }
+
+    protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
+      wr.Write(" <= ");
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" and ");
+
+      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      wr.Write(" < ");
+      EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
+      wr.Write(" and ");
+    }
+
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
       bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var (open, close) = ct switch {

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -1416,14 +1416,14 @@ namespace Microsoft.Dafny.Compilers {
     ///     "TestIsRune(source) && "
     /// It is fine for the target code to repeat the mention of "source", if necessary.
     /// </summary>
-    protected virtual void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts){}
+    protected virtual void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) { }
 
     /// <summary>
     /// Emit conjuncts that test if the Dafny integer "source" is in the range lo..hi, like:
     ///     "lo <= source && source < hi && "
     /// It is fine for the target code to repeat the mention of "source", if necessary.
     /// </summary>
-    protected virtual void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts){}
+    protected virtual void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) { }
 
     protected abstract void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
       bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts);  // used for sets, multisets, and sequences

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -1393,6 +1393,28 @@ namespace Microsoft.Dafny.Compilers {
     /// reference types or subset types thereof.
     /// </summary>
     protected abstract void EmitTypeTest(string localName, Type fromType, Type toType, IToken tok, ConcreteSyntaxTree wr);
+
+    /// <summary>
+    /// Emit a conjunct that tests if the Dafny real number "source" is an integer, like:
+    ///    "TestIsInteger(source) && "
+    /// It is fine for the target code to repeat the mention of "source", if necessary.
+    /// </summary>
+    protected virtual void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) { }
+
+    /// <summary>
+    /// Emit a conjunct that tests if the Dafny integer "source" is a character, like:
+    ///     "TestIsRune(source) && "
+    /// It is fine for the target code to repeat the mention of "source", if necessary.
+    /// </summary>
+    protected virtual void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts){}
+
+    /// <summary>
+    /// Emit conjuncts that test if the Dafny integer "source" is in the range lo..hi, like:
+    ///     "lo <= source && source < hi && "
+    /// It is fine for the target code to repeat the mention of "source", if necessary.
+    /// </summary>
+    protected virtual void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts){}
+
     protected abstract void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
       bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts);  // used for sets, multisets, and sequences
     protected abstract void EmitMapDisplay(MapType mt, IToken tok, List<ExpressionPair> elements,

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -316,6 +316,12 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
+    protected virtual ConcreteSyntaxTree EmitNullTest(bool testIsNull, ConcreteSyntaxTree wr) {
+      var wrTarget = wr.ForkInParens();
+      wr.Write(testIsNull ? " == null" : " != null");
+      return wrTarget;
+    }
+
     /// <summary>
     /// EmitTailCallStructure evolves "wr" into a structure that can be used as the jump target
     /// for tail calls (see EmitJumpToTailCallStart).
@@ -397,6 +403,10 @@ namespace Microsoft.Dafny.Compilers {
       var wStmts = wr.Fork();
       var w = DeclareLocalVar(name, type ?? rhs.Type, tok, wr);
       EmitExpr(rhs, inLetExprBody, w, wStmts);
+    }
+
+    protected virtual void EmitDummyVariableUse(string variableName, ConcreteSyntaxTree wr) {
+      // by default, do nothing
     }
 
     /// <summary>

--- a/Source/DafnyRuntime/DafnyRuntime.cs
+++ b/Source/DafnyRuntime/DafnyRuntime.cs
@@ -48,6 +48,10 @@ namespace Dafny {
       _value = value;
     }
 
+    public static bool IsRune(BigInteger i) {
+      return (0 <= i && i < 0xD800) || (0xE000 <= i && i < 0x11_0000);
+    }
+
     public int Value => (int)_value;
 
     public bool Equals(Rune other) => this == other;
@@ -1845,6 +1849,12 @@ namespace Dafny {
         return (num - den + 1) / den;
       }
     }
+
+    public bool IsInteger() {
+      var floored = new BigRational(this.ToBigInteger(), BigInteger.One);
+      return this == floored;
+    }
+
     /// <summary>
     /// Returns values such that aa/dd == a and bb/dd == b.
     /// </summary>

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
@@ -297,7 +297,11 @@ func (cp CodePoint) String() string {
   return fmt.Sprintf("'%s'", cp.Escape())
 }
 
-
+func IsCodePoint(i Int) bool {
+  return (
+    (i.Sign() != -1 && i.Cmp(IntOfInt32(0xD800)) < 0) ||
+    (IntOfInt32(0xE000).Cmp(i) <= 0 && i.Cmp(IntOfInt32(0x11_0000)) < 0))
+}
 
 // AllUnicodeChars returns an iterator that returns all Unicode scalar values.
 func AllUnicodeChars() Iterator {
@@ -2732,6 +2736,10 @@ func (x Real) Int() Int {
     a.Add(a, One.impl)
     return intOf(a.Quo(a, x.impl.Denom())) // note: *truncated* division
   }
+}
+
+func (x Real) IsInteger() bool {
+  return RealOfFrac(x.Int(), One).Cmp(x) == 0
 }
 
 // Num returns the given Real's numerator as an Int

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/BigRational.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/BigRational.java
@@ -132,6 +132,11 @@ public class BigRational {
         }
     }
 
+    public boolean isInteger() {
+      BigRational floored = new BigRational(this.ToBigInteger(), BigInteger.ONE);
+      return this.equals(floored);
+    }
+
     // In order to compare, add, and subtract fractions, they must have the same denominator. This computes the
     // common denominator of the fractions, and returns a tuple containing:
     // aa: the numerator for a when multiplied by the common denominator

--- a/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/CodePoint.java
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/src/main/java/dafny/CodePoint.java
@@ -1,5 +1,7 @@
 package dafny;
 
+import java.math.BigInteger;
+
 /**
  * An int wrapper type just like java.lang.Integer,
  * but used as a more type-safe reference to a Unicode scalar value
@@ -37,6 +39,12 @@ public final class CodePoint {
             throw new IllegalArgumentException("Code point out of range: " + value);
         }
         this.value = value;
+    }
+
+     public static boolean isCodePoint(BigInteger i) {
+        return
+            (i.signum() != -1 && i.compareTo(BigInteger.valueOf(0xD800)) < 0) ||
+            (i.compareTo(BigInteger.valueOf(0xE000)) >= 0 && i.compareTo(BigInteger.valueOf(0x11_0000)) < 0);
     }
 
     @Override

--- a/Source/DafnyRuntime/DafnyRuntimeJs/DafnyRuntime.js
+++ b/Source/DafnyRuntime/DafnyRuntimeJs/DafnyRuntime.js
@@ -488,6 +488,11 @@ let _dafny = (function() {
     toString() {
       return "'" + $module.escapeCharacter(this) + "'";
     }
+    static isCodePoint(i) {
+      return (
+        (_dafny.ZERO.isLessThanOrEqualTo(i) && i.isLessThan(new BigNumber(0xD800))) ||
+        (new BigNumber(0xE000).isLessThanOrEqualTo(i) && i.isLessThan(new BigNumber(0x11_0000))))
+    }
   }
   $module.Seq = class Seq extends Array {
     constructor(...elems) {
@@ -819,7 +824,7 @@ let _dafny = (function() {
       } else {
         return undefined;
       }
-}
+    }
     toBigNumber() {
       if (this.num.isZero() || this.den.isEqualTo(1)) {
         return this.num;
@@ -828,6 +833,9 @@ let _dafny = (function() {
       } else {
         return this.num.minus(this.den).plus(1).dividedToIntegerBy(this.den);
       }
+    }
+    isInteger() {
+      return this.equals(new _dafny.BigRational(this.toBigNumber(), _dafny.ONE));
     }
     // Returns values such that aa/dd == a and bb/dd == b.
     normalize(b) {

--- a/Source/DafnyRuntime/DafnyRuntimePython/_dafny.py
+++ b/Source/DafnyRuntime/DafnyRuntimePython/_dafny.py
@@ -7,6 +7,7 @@ from collections import Counter, deque
 from collections.abc import Iterable
 from functools import reduce
 from types import GeneratorType, FunctionType
+from math import floor
 from itertools import chain, combinations, count
 
 class classproperty(property):
@@ -94,6 +95,10 @@ class CodePoint(str):
 
     def __sub__(self, other):
         return CodePoint(minus_char(self, other))
+
+    @staticmethod
+    def is_code_point(i):
+        return (0 <= i and i < 0xD800) or (0xE000 <= i and i < 0x11_0000)
 
 class Concat:
     def __init__(self, l, r):
@@ -411,6 +416,9 @@ class BigRational(Fraction):
             y += 1
             x //= f
         return x, y
+
+    def is_integer(self):
+        return BigRational(floor(self), 1) == self
 
     @staticmethod
     def divides_a_power_of_10(x):


### PR DESCRIPTION
This PR adds some virtual methods of the compilers. The new methods and overrides are not used for anything new in this PR. Instead, the purpose of this PR is to simplify the reviewing of an upcoming `newtype`/`as`/`is` PR, by making these standalone changes reviewable separately.

The changes in this PR are:
* Add virtual methods that emit
    * a test to see if a `real` is integer (`EmitIntegerTest`)
    * a test to see if an integer is a Unicode `char` (`EmitIsRunTest`) (the analogous check for non-unicode `char` is handled separately by a range test)
    * a test to see if an integer lies within a given range (`EmitIsInIntegerRange`)
    * a test to see if a Dafny reference equals the Dafny `null` (`EmitNullTest`)
* Virtualize the method `EmitDummyVariableUse` (this method makes a difference only for Go, but by making it virtual, it can be called by `SinglePassCompiler.cs`)
* Add runtime support in the target languages for `IsInteger` and `IsRune`.
* Remove the unused `usedParam` parameter of method `CreateRTD` in the Go compiler
* Remove the unnecessary `useAllTypeArgs` parameter to `WriteRuntimeTypeDescriptorsLocals` in the Go compiler, since this parameter was always passed in as `true`.
* Call `Expression.CreateBoolLiteral` instead of `new LiteralExpr...`.

### How has this been tested?

This PR does not change the behavior of the compilers. There are no changes to the tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
