### PR TITLE
Consider all errors reported in exit code

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/ProofDependencyWarnings.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/ProofDependencyWarnings.dfy
@@ -1,6 +1,7 @@
-// RUN: %baredafny verify --use-basename-for-filename --show-snippets false --verify-included-files --warn-contradictory-assumptions --warn-redundant-assumptions "%s" > "%t.new"
+// RUN: %verify --verify-included-files --warn-contradictory-assumptions --warn-redundant-assumptions "%s" > "%t.new"
 // RUN: %diff "%s.expect" "%t.new"
 // RUN: %baredafny /compile:0 /useBaseNameForFileName /verifyAllModules /warnContradictoryAssumptions /warnRedundantAssumptions "%s" > "%t.old"
 // RUN: %diff "%s.expect" "%t.old"
+// RUN: %exits-with 4 %verify --verify-included-files --warn-contradictory-assumptions --warn-redundant-assumptions --warn-as-errors "%s"
 
 include "ProofDependencies.dfy"


### PR DESCRIPTION
### Description

Previously, Dafny returned an exit code corresponding to a verification or compilation error if the associated method calls returned false. However, errors could occur during either that would be tracked by the reporter but not influence these return values. Now, a non-zero number of errors tracked during either verification or compilation leads to the respective error return code. This allows, as one example, proof dependency warnings to lead to a non-zero exit code when `--warn-as-errors` is enabled. 

### How has this been tested?

The `logger/ProofDependencyWarnings.dfy` test now checks that `--warn-as-errors` leads to a verification failure exit code.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.