### PR TITLE
docs: Fix links to `RELEASE_NOTES.md` and `Source` in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you want to propose code changes for the Dafny project, please note:
 - To propose code changes, use the standard Github multi-user project process, which is described for Dafny on the [wiki](https://github.com/dafny-lang/dafny/wiki/Setting-up-a-development-copy-of-Dafny).
 
 If your change is user-visible, then part of the PR should be corresponding changes to the
-[`RELEASE_NOTES.md`](../RELEASE_NOTES.md) file and to the 
+[`RELEASE_NOTES.md`](./RELEASE_NOTES.md) file and to the 
 [Dafny Reference Manual](./docs/DafnyRef).
 
 Any PR should have tests that check whether the bug-fix fixes the problem addressed or that the new functionality 
@@ -40,7 +40,7 @@ is properly working.
 
     Each `.dfy` file in this directory is a test, with a  [`lit`](https://llvm.org/docs/CommandGuide/lit.html) header describing how to run it and a `.expect` file indicating the expected output.  See [this README.md file](Source/IntegrationTests/TestFiles/LitTests/LitTest/README.md) for more info on running Dafny' integration tests.
 
-  - Dafny's unit tests are in various `*.Test` directories in [`Source`](../Source).
+  - Dafny's unit tests are in various `*.Test` directories in [`Source`](./Source).
 
   Our CI is configured to run all tests when you create a PR.  To run tests locally, use `dotnet test Source/Dafny.sln` (but note that running the tests for our compiler backends requires installing lots of additional software).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you want to propose code changes for the Dafny project, please note:
 - To propose code changes, use the standard Github multi-user project process, which is described for Dafny on the [wiki](https://github.com/dafny-lang/dafny/wiki/Setting-up-a-development-copy-of-Dafny).
 
 If your change is user-visible, then part of the PR should be corresponding changes to the
-[`RELEASE_NOTES.md`](./RELEASE_NOTES.md) file and to the 
+[`RELEASE_NOTES.md`](./RELEASE_NOTES.md) file (by following [this](./docs/dev/README.md)) and to the 
 [Dafny Reference Manual](./docs/DafnyRef).
 
 Any PR should have tests that check whether the bug-fix fixes the problem addressed or that the new functionality 


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->
As per the title, this PR just fixes links to `RELEASE_NOTES.md` and `Source` in `CONTRIBUTING.md`.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
By clicking on the links in the preview.

----

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
