### PR TITLE
Add options to configure logging severity and location for IDE

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -30,6 +30,7 @@
       <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
+      <PackageReference Include="Serilog" Version="2.12.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />

--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -3,12 +3,23 @@ using System.CommandLine;
 using System.IO;
 using System.Linq;
 using DafnyCore;
+using Serilog.Events;
 
 namespace Microsoft.Dafny;
 
 public class CommonOptionBag {
 
   public static void EnsureStaticConstructorHasRun() { }
+
+  public static readonly Option<string> LogLocation =
+    new("--log-location", "Sets the directory where to store log files") {
+      IsHidden = true
+    };
+
+  public static readonly Option<LogEventLevel> LogLevelOption =
+    new("--log-level", () => LogEventLevel.Error, "Sets the level at which events are logged") {
+      IsHidden = true
+    };
 
   public static readonly Option<bool> ManualTriggerOption =
     new("--manual-triggers", "Do not generate {:trigger} annotations for user-level quantifiers") {
@@ -555,6 +566,8 @@ NoGhost - disable printing of functions, ghost methods, and proof
       }
     );
     DooFile.RegisterNoChecksNeeded(
+      LogLocation,
+      LogLevelOption,
       ManualTriggerOption,
       ShowInference,
       Check,

--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -94,7 +94,9 @@ public static class DafnyCommands {
     CommonOptionBag.TypeInferenceDebug,
     CommonOptionBag.NewTypeInferenceDebug,
     CommonOptionBag.ReadsClausesOnMethods,
-    CommonOptionBag.UseStandardLibraries
+    CommonOptionBag.UseStandardLibraries,
+    CommonOptionBag.LogLevelOption,
+    CommonOptionBag.LogLocation
   });
 
   public static IReadOnlyList<Option> ResolverOptions = new List<Option>(new Option[] {

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.appsettings.json
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.appsettings.json
@@ -6,7 +6,7 @@
       "Override": {
         "Microsoft.Dafny": "Information"
       }
-    },
+    },  
     "WriteTo": [
       {
         "Name": "Debug",

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RangeTree" Version="3.0.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />

--- a/Source/DafnyLanguageServer/LanguageServer.cs
+++ b/Source/DafnyLanguageServer/LanguageServer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Dafny.LanguageServer {
 
     public static async Task Start(DafnyOptions dafnyOptions) {
       var configuration = CreateConfiguration();
-      InitializeLogger(configuration);
+      InitializeLogger(dafnyOptions, configuration);
 
       dafnyOptions = new DafnyOptions(dafnyOptions, true);
       try {
@@ -73,7 +73,7 @@ namespace Microsoft.Dafny.LanguageServer {
         await server.WaitForExit;
       }
       finally {
-        Log.CloseAndFlush();
+        await Log.CloseAndFlushAsync();
       }
     }
 
@@ -83,11 +83,14 @@ namespace Microsoft.Dafny.LanguageServer {
         .Build();
     }
 
-    private static void InitializeLogger(IConfiguration configuration) {
+    private static void InitializeLogger(DafnyOptions options, IConfiguration configuration) {
       // The environment variable is used so a log file can be explicitly created in the application dir.
-      Environment.SetEnvironmentVariable("DAFNYLS_APP_DIR", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+      var logLevel = options.Get(CommonOptionBag.LogLevelOption);
+      var logLocation = options.Get(CommonOptionBag.LogLocation) ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+      Environment.SetEnvironmentVariable("DAFNYLS_APP_DIR", logLocation);
       Log.Logger = new LoggerConfiguration()
         .ReadFrom.Configuration(configuration)
+        .MinimumLevel.Override("Microsoft.Dafny", logLevel)
         .CreateLogger();
     }
 


### PR DESCRIPTION
### Description
Add hidden options to configure logging severity and location for the language server, which help to debug language server issue

How to configure:
<img width="1124" alt="image" src="https://github.com/dafny-lang/dafny/assets/3121201/80884e8e-aec3-48af-a488-2e2acc1e827d">

Output:
<img width="2043" alt="image" src="https://github.com/dafny-lang/dafny/assets/3121201/ed0961cb-a1f8-41f6-a880-43a25e28a309">


### How has this been tested?
Manually

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
