### PR TITLE
Fix "assertion batch" anchor

### DIFF
--- a/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/HoverVerificationTest.cs
@@ -137,7 +137,7 @@ This is the only assertion in [batch](???) #??? of ??? in method `f`
         @"**Verification performance metrics for method `f`**:
 
 - Total resource usage: ??? RU  
-- Most costly [assertion batches](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-verification-attributes-on-assert-statements):  
+- Most costly [assertion batches](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-assertion-batches):  
   - #???/??? with 1 assertion  at line ???, ??? RU  
   - #???/??? with 1 assertion  at line ???, ??? RU  "
       );
@@ -223,7 +223,7 @@ This is assertion #1 of 2 in [batch](???) #2 of 2 in function `f`
         @"**Verification performance metrics for function `f`**:
 
 - Total resource usage: ??? RU  
-- Most costly [assertion batches](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-verification-attributes-on-assert-statements):  
+- Most costly [assertion batches](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-assertion-batches):  
   - #???/2 with 2 assertions at line ???, ??? RU  
   - #???/2 with 2 assertions at line ???, ??? RU"
       );

--- a/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/DafnyHoverHandler.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
     }
 
     private static string AddAssertionBatchDocumentation(string batchReference) {
-      return $"[{batchReference}](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-verification-attributes-on-assert-statements)";
+      return $"[{batchReference}](https://dafny-lang.github.io/dafny/DafnyRef/DafnyRef#sec-assertion-batches)";
     }
 
     private static Hover CreateMarkdownHover(string information) {


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

This is a fix for the broken "assertion batch" anchor -- an example use of it is below:

![assertion-batch-link](https://github.com/dafny-lang/dafny/assets/12002672/e34d1c7e-e5d9-4314-806e-41e3294f0a1e)

The anchor was originally `#sec-verification-attributes-on-assert-statements` which currently doesn't exist. The closest existing anchor appears to be [`#sec-verification-attributes-on-assertions`](https://dafny.org/dafny/DafnyRef/DafnyRef#sec-verification-attributes-on-assertions) but I think linking to the section for the anchor [`#sec-assertion-batches`](https://dafny.org/dafny/DafnyRef/DafnyRef#sec-assertion-batches) is better since that section introduces the  _assertion batch_ concept.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

I have not compiled the Dafny VSCode extension locally, but this PR changes tests and the CI should be green.

----

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
