### PR TITLE
docs: Link to the _brittle_ section

### DIFF
--- a/Source/DafnyStandardLibraries/CONTRIBUTING.md
+++ b/Source/DafnyStandardLibraries/CONTRIBUTING.md
@@ -102,7 +102,7 @@ See [Makefile](Makefile) and [src/Std/TargetSpecific/Makefile](src/Std/TargetSpe
 There are two sides to brittleness relevant to this project:
 
 **Brittleness of the standard libraries**: This project uses the current 
-[best known defense against brittleness](https://dafny.org/dafny/DafnyRef/DafnyRef#sec-verification):
+[best known defense against brittleness](https://dafny.org/dafny/DafnyRef/DafnyRef#sec-brittle-verification):
 enforcing a tight upper-bound on the resources needed to verify each batch of assertions.
 For simplicitly, this project just sets a direct `--resource-limit`,
 rather than relying on the second-pass approach of the `dafny-reportgenerator`.

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1530,7 +1530,7 @@ and `dafny generate-tests --verification-coverage-report`,
 indicating which parts of the program were used, not used, or partly
 used in the verification of the entire program.
 
-### 13.7.6. Debugging brittle verification
+### 13.7.6. Debugging brittle verification {#sec-brittle-verification}
 
 When evolving a Dafny codebase, it can sometimes occur that a proof
 obligation succeeds at first only for the prover to time out or report a


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

This PR changes the "best known defense against brittleness" anchor in `Source/DafnyStandardLibraries/CONTRIBUTING.md` so that it points to the (only) Reference Manual section that discusses brittleness. Since that section's current anchor ([`#1376-debugging-brittle-verification`](https://dafny.org/dafny/DafnyRef/DafnyRef#1376-debugging-brittle-verification)) has the section number in it, this PR also removes the number from the anchor to make it less brittle (in the general sense of the word).

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
I ran a jekyll server using the instructions in `docs/DafnyRef/README.md` and the anchor changes as expected. If I'm not mistaken, a CI task will update the online docs.

----

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
