### PR TITLE
chore: Rename EmitIsRuneTest to EmitIsUnicodeScalarValueTest

### DIFF
--- a/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
+++ b/Source/DafnyCore/Compilers/CSharp/Compiler-Csharp.cs
@@ -3357,7 +3357,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(".IsInteger() && ");
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("Dafny.Rune.IsRune");
       EmitExpr(source, false, wr.ForkInParens(), wStmts);
       wr.Write(" && ");

--- a/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
+++ b/Source/DafnyCore/Compilers/Cplusplus/Compiler-cpp.cs
@@ -2375,7 +2375,7 @@ namespace Microsoft.Dafny.Compilers {
       throw new UnsupportedFeatureException(source.Tok, Feature.TypeTests);
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       throw new UnsupportedFeatureException(source.Tok, Feature.TypeTests);
     }
 

--- a/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
+++ b/Source/DafnyCore/Compilers/Dafny/Compiler-dafny.cs
@@ -2148,7 +2148,7 @@ namespace Microsoft.Dafny.Compilers {
       throw new UnsupportedFeatureException(source.Tok, Feature.TypeTests);
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       throw new UnsupportedFeatureException(source.Tok, Feature.TypeTests);
     }
 

--- a/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
+++ b/Source/DafnyCore/Compilers/GoLang/Compiler-go.cs
@@ -3651,7 +3651,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(".IsInteger() && ");
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("_dafny.IsCodePoint");
       EmitExpr(source, false, wr.ForkInParens(), wStmts);
       wr.Write(" && ");

--- a/Source/DafnyCore/Compilers/Java/Compiler-java.cs
+++ b/Source/DafnyCore/Compilers/Java/Compiler-java.cs
@@ -4247,7 +4247,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(".isInteger() && ");
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("dafny.CodePoint.isCodePoint");
       EmitExpr(source, false, wr.ForkInParens(), wStmts);
       wr.Write(" && ");

--- a/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
+++ b/Source/DafnyCore/Compilers/JavaScript/Compiler-js.cs
@@ -2483,7 +2483,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(".isInteger() && ");
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("_dafny.CodePoint.isCodePoint");
       EmitExpr(source, false, wr.ForkInParens(), wStmts);
       wr.Write(" && ");

--- a/Source/DafnyCore/Compilers/Python/Compiler-python.cs
+++ b/Source/DafnyCore/Compilers/Python/Compiler-python.cs
@@ -1739,7 +1739,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(".is_integer() and ");
     }
 
-    protected override void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("_dafny.CodePoint.is_code_point");
       EmitExpr(source, false, wr.ForkInParens(), wStmts);
       wr.Write(" and ");

--- a/Source/DafnyCore/Compilers/SinglePassCompiler.cs
+++ b/Source/DafnyCore/Compilers/SinglePassCompiler.cs
@@ -1417,10 +1417,10 @@ namespace Microsoft.Dafny.Compilers {
 
     /// <summary>
     /// Emit a conjunct that tests if the Dafny integer "source" is a character, like:
-    ///     "TestIsRune(source) && "
+    ///     "TestIsUnicodeScalarValue(source) && "
     /// It is fine for the target code to repeat the mention of "source", if necessary.
     /// </summary>
-    protected abstract void EmitIsRuneTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts);
+    protected abstract void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts);
 
     /// <summary>
     /// Emit conjuncts that test if the Dafny integer "source" is in the range lo..hi, like:
@@ -5761,7 +5761,7 @@ namespace Microsoft.Dafny.Compilers {
       if (needsCharCheck) {
         var fromAsInt = new ConversionExpr(from.tok, from, Type.Int) { Type = Type.Int };
         if (UnicodeCharEnabled) {
-          EmitIsRuneTest(fromAsInt, wr, wStmts);
+          EmitIsUnicodeScalarValueTest(fromAsInt, wr, wStmts);
         } else {
           EmitIsInIntegerRange(fromAsInt, 0, 0x1_0000, wr, wStmts);
         }


### PR DESCRIPTION
This PR renames a virtual method in the compiler. The change was suggested in the (now abandoned and closed) PR https://github.com/dafny-lang/dafny/pull/5053.

Note, the PR does not rename other occurrences of "rune". In particular, .NET has a class `System.Text.Rune` and the Dafny runtime (therefore?) has a class named `Rune` (and inside it, a method `IsRune`). These have not been renamed.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
