### PR TITLE
Add missing Unsupported Feature exception for Rust

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Deprecation.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Deprecation.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --allow-warnings --relax-definite-assignment
 
 // This file contains tests for messags about various deprecated features.
 // As those features go away completely, so can the corresponding tests.


### PR DESCRIPTION

Currently it seems there's a missing unsupported feature exception for the Rust back-end, that the current test suite due to a bug, which allows failing tests to pass, sadly does not expose. I'm fixing the bug [here](https://github.com/dafny-lang/dafny/pull/5118/files#diff-b6f8df623b1e9e4f9e8ca2381c43dbff6ba3f823b686de347cc6bafb4f4100e5R420). However, in the mean time I can expose the Rust problem updating `Deprecation.dfy`:

```
Using refresh resolver and verifying...
Executing on C#...
Executing on C# (with --include-runtime:false)...
Executing on JavaScript...
Executing on Go...
Executing on Java...
Executing on Python...
Executing on C++...
Executing on Rust...
Execution failed, for reasons other than known unsupported features. Output:
error[E0446]: private type `Sequence<T>` in public interface
   --> runtime/src/lib.rs:51:5
    |
51  | /     pub fn dafny_sequence_to_vec<T, X>(s: &Sequence<T>, elem_converter: fn(&T) -> X) -> Vec<X>
```

@MikaelMayer would you be willing to use this PR to figure out what check is missing in the Rust back-end ?

### Description
- TODO 'Add missing Unsupported Feature exception for Rust'

### How has this been tested?
- Updated Deprecation.dfy so it exposes the problem

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
