### PR TITLE
Fix direction of library implication for --allow-warnings

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -561,7 +561,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
         { ReadsClausesOnMethods, DooFile.CheckOptionLocalImpliesLibrary },
         { AllowAxioms, DooFile.CheckOptionLibraryImpliesLocal },
         { AllowWarnings, (reporter, origin, option, localValue, libraryFile, libraryValue) => {
-            if (DooFile.OptionValuesImplied(localValue, libraryValue)) {
+            if (DooFile.OptionValuesImplied(libraryValue, localValue)) {
               return true;
             }
             string message = DooFile.LocalImpliesLibraryMessage(option, localValue, libraryFile, libraryValue);


### PR DESCRIPTION
### Description
Fix the direction in which a consumer enforces --allow-warning to be used in a library

### How has this been tested?
Manually

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
