### PR TITLE
fix: Avoid NPE when building a doo file with —no-verify

### DIFF
--- a/Source/DafnyCore/DooFile.cs
+++ b/Source/DafnyCore/DooFile.cs
@@ -39,7 +39,8 @@ public class DooFile {
       DafnyVersion = options.VersionNumber;
 
       SolverIdentifier = options.SolverIdentifier;
-      SolverVersion = options.SolverVersion.ToString();
+      // options.SolverVersion may be null (if --no-verify is used for example)
+      SolverVersion = options.SolverVersion?.ToString();
 
       Options = new Dictionary<string, object>();
       foreach (var (option, _) in OptionChecks) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/separate-verification/app.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/separate-verification/app.dfy
@@ -9,6 +9,9 @@
 // RUN: %baredafny build %args -t:lib --boogie /vcsSplitOnEveryAssert %S/Inputs/wrappers.dfy
 // RUN: %baredafny build %args -t:lib --boogie /vcsSplitOnEveryAssert %S/Inputs/seq.dfy --library %S/Inputs/wrappers.doo >> %t
 
+// RUN: %baredafny build %args -t:lib --no-verify %S/Inputs/wrappers.dfy
+// RUN: %baredafny build %args -t:lib --no-verify %S/Inputs/seq.dfy --library %S/Inputs/wrappers.doo >> %t
+
 // Supported: mismatching irrelevant options
 
 // RUN: %baredafny build %args -t:lib --function-syntax:3 %S/Inputs/wrappers3.dfy
@@ -20,6 +23,9 @@
 // RUN: ! %baredafny build %args -t:lib --unicode-char:false %S/Inputs/seq.dfy --library %S/Inputs/wrappers.doo >> %t
 
 // RUN: %baredafny build %args -t:lib --boogie /vcsLoad:2 %S/Inputs/wrappers.dfy
+// RUN: ! %baredafny build %args -t:lib %S/Inputs/seq.dfy --library %S/Inputs/wrappers.doo >> %t
+
+// RUN: %baredafny build %args -t:lib --no-verify %S/Inputs/wrappers.dfy
 // RUN: ! %baredafny build %args -t:lib %S/Inputs/seq.dfy --library %S/Inputs/wrappers.doo >> %t
 
 // RUN: %diff "%s.expect" %t

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/separate-verification/app.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/separate-verification/app.dfy.expect
@@ -8,6 +8,9 @@ Dafny program verifier finished with 1 verified, 0 errors
 
 Dafny program verifier finished with 2 verified, 0 errors
 
+Dafny program verifier did not attempt verification
+
 Dafny program verifier finished with 2 verified, 0 errors
 CLI: Error: cannot load wrappers.doo: --unicode-char is set locally to False, but the library was built with True
 CLI: Error: cannot load wrappers.doo: --boogie is set locally to [], but the library was built with [/vcsLoad:2]
+CLI: Error: cannot load wrappers.doo: --no-verify is set locally to False, but the library was built with True


### PR DESCRIPTION
### Description
Fixes #5143.

### How has this been tested?
Added this case to `separate-verification/app.dfy`.

`separate-verification/assumptions.dfy` SHOULD have caught this regression, but unfortunately the command that triggers the exception uses `!` to expect a non-zero exit code, and LIT test commands usually only redirect stdout to a file to diff against the expected output, so the extra stderr output with the exception trace is lost.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
