### PR TITLE
Error message on exception during verification

### DIFF
--- a/Source/DafnyDriver/CliCompilation.cs
+++ b/Source/DafnyDriver/CliCompilation.cs
@@ -163,6 +163,13 @@ public class CliCompilation : IDisposable {
         canVerifyResult.Finished.SetException(boogieException.Exception);
       }
 
+      if (ev is InternalCompilationException compilationException) {
+        Compilation.Reporter.Error(MessageSource.Verifier, Token.NoToken,
+          $"Dafny encountered a compilation exception during verification.");
+        canVerifyResults.Values.ForEach(canVerifyResult =>
+          canVerifyResult.Finished.SetException(compilationException.Exception));
+      }
+
       if (ev is BoogieUpdate { BoogieStatus: Completed completed } boogieUpdate) {
         var canVerifyResult = canVerifyResults[boogieUpdate.CanVerify];
         canVerifyResult.CompletedParts.Enqueue((boogieUpdate.VerificationTask, completed));


### PR DESCRIPTION
When a verification task throws an InternalCompilationException, Dafny now prints an error message instead of hanging.

Aims to fix #5154 

### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
