### PR TITLE
Do not crash Boogie when an empty {:trigger} attribute occurs

### DIFF
--- a/Source/DafnyCore/AST/Attributes.cs
+++ b/Source/DafnyCore/AST/Attributes.cs
@@ -44,7 +44,7 @@ public class Attributes : TokenNode {
 
   public override string ToString() {
     string result = Prev?.ToString() + "{:" + Name;
-    if (Args == null || Args.Count() == 0) {
+    if (Args == null || !Args.Any()) {
       return result + "}";
     } else {
       var exprs = String.Join(", ", Args.Select(e => e.ToString()));

--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -151,6 +151,12 @@ class SplitPartTriggerWriter {
     }
 
     if (!NeedsAutoTriggers()) {
+      var triggerAttribute = Attributes.Find(Comprehension.Attributes, "trigger");
+      if (triggerAttribute != null && triggerAttribute.Args.Count == 0) {
+        // Remove an empty trigger attribute, so it does not crash Boogie,
+        // and effectively becomes a way to silence a Dafny warning
+        triggerAttribute.Name = "deleted-trigger";
+      }
       return;
     }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/emptyTrigger.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/emptyTrigger.dfy
@@ -1,0 +1,9 @@
+// RUN: ! %verify "%s" > "%t"
+// RUN: ! %run "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method M() {
+  assert exists z :: z == 3;
+  assert exists z {:trigger} :: z == 3;
+  assert true;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/emptyTrigger.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/emptyTrigger.dfy.expect
@@ -1,0 +1,10 @@
+emptyTrigger.dfy(6,9): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section quantifier instantiation rules in the reference manual.
+emptyTrigger.dfy(6,9): Error: assertion might not hold
+emptyTrigger.dfy(7,9): Error: assertion might not hold
+
+Dafny program verifier finished with 0 verified, 2 errors
+emptyTrigger.dfy(6,9): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section quantifier instantiation rules in the reference manual.
+emptyTrigger.dfy(6,9): Error: assertion might not hold
+emptyTrigger.dfy(7,9): Error: assertion might not hold
+
+Dafny program verifier finished with 0 verified, 2 errors


### PR DESCRIPTION
Fixes #5167

### Description
- Let an empty `{:trigger}` attribute have the same meaning as `{:autotriggers false}`, instead of causing a Boogie crash

### Alternatives
Alternatively, we could let Dafny throw an error on an empty `{:trigger}` attribute, and update the documentation so that it tells you to either use `{:autotriggers false}` or `{:trigger <trigger>}`

### How has this been tested?
- Added a littish test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
