### PR TITLE
chore: Remove warning on --type-system-refresh

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -199,7 +199,7 @@ true - The char type represents any Unicode scalar value.".TrimStart()) {
   public static readonly Option<bool> TypeSystemRefresh = new("--type-system-refresh", () => false,
     @"
 false - The type-inference engine and supported types are those of Dafny 4.0.
-true - Use an updated type-inference engine. Warning: This mode is under construction and probably won't work at this time.".TrimStart()) {
+true - Use an updated type-inference engine.".TrimStart()) {
     IsHidden = true
   };
 


### PR DESCRIPTION
### Description
The feature is quite stable now and the warning is no longer necessary.

Fixes #5164.

### How has this been tested?
Manually

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
