### PR TITLE
set RangeToken for ParensExpression

### DIFF
--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -3758,6 +3758,7 @@ ParensExpression<out Expression e>
        SystemModuleModifiers.Add(b => b.TupleType(lp, args.Count, true, argumentGhostness));
        e = new DatatypeValue(lp, SystemModuleManager.TupleTypeName(argumentGhostness), SystemModuleManager.TupleTypeCtorName(args.Count), args);
      }
+     e.RangeToken = new RangeToken(lp, rp);
   .)
   .
 


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->
RangeToken is not set for ParensExpression in https://github.com/dafny-lang/dafny/blob/99ad60af5b23ad83b2e49768cb32c8d2599cd60d/Source/DafnyCore/Dafny.atg#L3648 and it is assumed that it is going to be set in ParensExpression definition itself. However, RangeToken is not set in ParensExpression and this PR fixes it.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
Let me know if it is required to add a test for this. I couldn't find a similar test on RangeTokens to replicate.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
