### PR TITLE
fix: Optimize datatype wrappers only in the absence of trait parents

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ErasableTypeWrappers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ErasableTypeWrappers.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --spill-translation --unicode-char:false
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --spill-translation --unicode-char:false --type-system-refresh --general-traits=datatype
 
 datatype SingletonRecord = SingletonRecord(u: int)
 datatype GhostOrNot = ghost Ghost(a: int, b: int) | Compiled(x: int)
@@ -18,6 +18,7 @@ method Main() {
   TestMembers();
   OptimizationChecks.Test();
   PrintRegressionTests.Test();
+  ConditionsThatDisableTheOptimization.Test();
 }
 
 method TestTargetTypesAndConstructors() {
@@ -410,5 +411,35 @@ module PrintRegressionTests {
   method PrintOne<X(0)>() {
     var x: X := *;
     print x, "\n";
+  }
+}
+
+// --------------------------------------------------------------------------------
+
+module ConditionsThatDisableTheOptimization {
+  trait Trait {
+    function F(): int
+  }
+  datatype WithTrait extends Trait = WithTrait(u: int)
+  {
+    function F(): int { 5 }
+  }
+
+  datatype WithCompiledField = WithCompiledField(u: int)
+  {
+    const n: int := 100
+  }
+
+  datatype WithGhostField = WithGhostField(u: int)
+  {
+    ghost const n: int := 100
+  }
+
+  method Test() {
+    var t0 := WithTrait(40);
+    var t1 := WithCompiledField(41);
+    var t2 := WithGhostField(42);
+    print t0, " ", t0.F(), " ", (t0 as Trait).F(), "\n"; // WithTrait(40) 5 5
+    print t1, " ", t1.n, " ", t2, "\n"; // WithCompiledField(41) 100 42
   }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ErasableTypeWrappers.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ErasableTypeWrappers.dfy.expect
@@ -18,3 +18,5 @@ HasConst.MakeC(4) (4, 4)
 OptimizationChecks.Ints.Ints(5, 7) OptimizationChecks.Ints.Ints(5, 7) OptimizationChecks.Ints.AnotherIntsWrapper(OptimizationChecks.Ints.Ints(5, 7))
 D D
 5 5
+ConditionsThatDisableTheOptimization.WithTrait.WithTrait(40) 5 5
+ConditionsThatDisableTheOptimization.WithCompiledField.WithCompiledField(41) 100 42

--- a/docs/dev/news/5234.fix
+++ b/docs/dev/news/5234.fix
@@ -1,0 +1,2 @@
+fix: Disable the "erase datatype wrappers" optimization if the datatype implements any traits.
+feat: Allow the "erase datatype wrappers" optimization if the only fields in the datatype are ghost fields.


### PR DESCRIPTION
This PR makes two changes to when the "erase datatype wrapper" optimization is engaged.

* The optimization is disabled if the datatype implements any traits. (Previously, the optimization was still allowed under this condition, which had caused malformed code, see issue #5233.)
* Allow the optimization in the presence of ghost fields. (Previously, the optimization was disabled if the datatype contained _any_ fields. But ghost fields pose no problems for compilation.)

Fixes #5233

### How has this been tested?

The tests (including the test case from the bug report) were added to `comp/ErasableTypeWrappers.dfy`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
