### PR TITLE
Restore fractional seconds in text logger

### DIFF
--- a/Source/DafnyDriver/TextVerificationLogger.cs
+++ b/Source/DafnyDriver/TextVerificationLogger.cs
@@ -30,7 +30,7 @@ public class TextVerificationLogger : IVerificationResultFormatLogger {
     var verificationScope = scopeResult.Scope;
     var results = scopeResult.Results.Select(t => t.Result).ToList();
     var outcome = results.Aggregate(VcOutcome.Correct, (o, r) => JsonVerificationLogger.MergeOutcomes(o, r.Outcome));
-    var runtime = TimeSpan.FromSeconds(results.Sum(r => r.RunTime.Seconds));
+    var runtime = results.Aggregate(TimeSpan.Zero, (a, r) => a + r.RunTime);
     textWriter.WriteLine("");
     textWriter.WriteLine($"Results for {verificationScope.Name}");
     textWriter.WriteLine($"  Overall outcome: {outcome}");


### PR DESCRIPTION
### Description

In previous Dafny releases, `--log-format text` would report overall times with fractions of a second. Recent changes led to that including only whole seconds. This restores the previous behavior.

### How has this been tested?

Existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
