### PR TITLE
Don't define ORDINAL as equal to Box

### DIFF
--- a/Source/DafnyCore/DafnyPrelude.bpl
+++ b/Source/DafnyCore/DafnyPrelude.bpl
@@ -394,7 +394,7 @@ axiom (forall d: DatatypeType :: {BoxRank($Box(d))} BoxRank($Box(d)) == DtRank(d
 // -- Big Ordinals -----------------------------------------------
 // ---------------------------------------------------------------
 
-type ORDINAL = Box;  // :| There are more big ordinals than boxes
+type ORDINAL;
 
 // The following two functions give an abstracton over all ordinals.
 // Function ORD#IsNat returns true when the ordinal is one of the natural


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
