### PR TITLE
Remove paths in test that were causing the Windows build to fail

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy
@@ -1,5 +1,5 @@
 
-// RUN: %exits-with 4 %baredafny verify --extract-counterexample "%s" > "%t"
+// RUN: %exits-with 4 %verify --extract-counterexample "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The following method performs string equality comparison whereas its 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy.expect
@@ -1,34 +1,26 @@
-TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy(30,20): Error: a postcondition could not be proved on this return path
+counterexample_commandline.dfy(30,20): Error: a postcondition could not be proved on this return path
  Related counterexample:
- TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy(21,8): initial state:
+ counterexample_commandline.dfy(21,8): initial state:
  	this : Patterns.Simple = (p := @0)
  	s : seq<char> = ['A']
  	@0 : seq<char> = ['?']
- TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy(22,22):
- 	this : Patterns.Simple = (p := @0)
- 	s : seq<char> = ['A']
- 	i : int = 0
- 	@0 : seq<char> = ['?']
- TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy(23,12): after some loop iterations:
+ counterexample_commandline.dfy(22,22):
  	this : Patterns.Simple = (p := @0)
  	s : seq<char> = ['A']
  	i : int = 0
  	@0 : seq<char> = ['?']
- TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy(30,32):
+ counterexample_commandline.dfy(23,12): after some loop iterations:
+ 	this : Patterns.Simple = (p := @0)
+ 	s : seq<char> = ['A']
+ 	i : int = 0
+ 	@0 : seq<char> = ['?']
+ counterexample_commandline.dfy(30,32):
  	this : Patterns.Simple = (p := @0)
  	s : seq<char> = ['A']
  	i : int = 0
  	b : bool = false
  	@0 : seq<char> = ['?']
  
-   |
-30 |                     return false;
-   |                     ^^^^^^
-
-TestFiles/LitTests/LitTest/server/counterexample_commandline.dfy(18,20): Related location: this is the postcondition that could not be proved
-   |
-18 |             ensures b <==> forall n :: 0 <= n < |s| ==> 
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+counterexample_commandline.dfy(18,22): Related location: this is the postcondition that could not be proved
 
 Dafny program verifier finished with 1 verified, 1 error


### PR DESCRIPTION
### Description
Remove paths in test that were causing the Windows build to fail

### How has this been tested?
Test is changed

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
