### PR TITLE
Fix deep tests path missing

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %baredafny verify --extract-counterexample "%s" > "%t"
+// RUN: %exits-with 4 %verify --extract-counterexample "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // NB: with recent Z3 versions (e.g., 4.12.1), this program no longer

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy.expect
@@ -28,9 +28,5 @@ git-issue-2026.dfy(18,18): Error: this invariant could not be proved to be maint
  	i : int = 1
  	@0 : seq<char> = ['o', 'd', 'd']
  
-   |
-18 |         invariant forall j :: 0 <= j < i ==> j % 2 == 0 ==> ret[j] == "even"
-   |                   ^^^^^^
-
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy.expect
@@ -1,28 +1,28 @@
-TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(18,18): Error: this invariant could not be proved to be maintained by the loop
+git-issue-2026.dfy(18,18): Error: this invariant could not be proved to be maintained by the loop
  Related message: loop invariant violation
  Related counterexample:
- TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(12,0): initial state:
+ git-issue-2026.dfy(12,0): initial state:
  	n : int = 2
  	ret : ? = ?
- TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(13,24):
+ git-issue-2026.dfy(13,24):
  	n : int = 2
  	ret : _System.array?<seq<char>> = (Length := 2, [0] := @0)
  	@0 : seq<char> = ['o', 'd', 'd']
- TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(15,14):
+ git-issue-2026.dfy(15,14):
  	n : int = 2
  	ret : _System.array?<seq<char>> = (Length := 2, [0] := @0)
  	i : int = 0
  	@0 : seq<char> = ['o', 'd', 'd']
- TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(16,4): after some loop iterations:
+ git-issue-2026.dfy(16,4): after some loop iterations:
  	n : int = 2
  	ret : _System.array?<seq<char>> = (Length := 2)
  	i : int = 0
- TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(22,27):
+ git-issue-2026.dfy(22,27):
  	n : int = 2
  	ret : _System.array?<seq<char>> = (Length := 2, [0] := @0)
  	i : int = 0
  	@0 : seq<char> = ['o', 'd', 'd']
- TestFiles/LitTests/LitTest/git-issues/git-issue-2026.dfy(26,18):
+ git-issue-2026.dfy(26,18):
  	n : int = 2
  	ret : _System.array?<seq<char>> = (Length := 2, [0] := @0)
  	i : int = 1


### PR DESCRIPTION
This file was missing from https://github.com/dafny-lang/dafny/pull/5266/files

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
