### PR TITLE
Provide more information when waiting for notification times out

### DIFF
--- a/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Util/ClientBasedLanguageServerTest.cs
@@ -176,7 +176,7 @@ public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase, IAsync
     bool allowStale = false) {
     cancellationToken ??= CancellationToken;
 
-    if ((!await WaitUntilResolutionFinished(documentId, cancellationToken))) {
+    if ((!await WaitUntilResolutionFinished(documentId, cancellationToken.Value))) {
       return null;
     }
 
@@ -198,11 +198,13 @@ public class ClientBasedLanguageServerTest : DafnyLanguageServerTestBase, IAsync
     }
   }
 
-  public async Task<bool> WaitUntilResolutionFinished(TextDocumentItem documentId, CancellationToken? cancellationToken) {
+  public async Task<bool> WaitUntilResolutionFinished(TextDocumentItem documentId,
+    CancellationToken cancellationToken = default) {
+
     CompilationStatusParams compilationStatusParams = compilationStatusReceiver.GetLast(s => s.Uri == documentId.Uri);
     while (compilationStatusParams == null || compilationStatusParams.Version != documentId.Version || compilationStatusParams.Uri != documentId.Uri ||
            compilationStatusParams.Status is CompilationStatus.Parsing or CompilationStatus.ResolutionStarted) {
-      compilationStatusParams = await compilationStatusReceiver.AwaitNextNotificationAsync(cancellationToken.Value);
+      compilationStatusParams = await compilationStatusReceiver.AwaitNextNotificationAsync(cancellationToken);
     }
 
     return compilationStatusParams.Status == CompilationStatus.ResolutionSucceeded;

--- a/Source/DafnyLanguageServer.Test/Util/TestNotificationReceiver.cs
+++ b/Source/DafnyLanguageServer.Test/Util/TestNotificationReceiver.cs
@@ -55,13 +55,15 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util {
       try {
         await availableNotifications.WaitAsync(cancellationToken);
       } catch (OperationCanceledException) {
-        logger.LogInformation($"Waited for {(DateTime.Now - start).Seconds} seconds");
+        var last = History.Any() ? History[-1].Stringify() : "none";
+        logger.LogInformation($"Waited for {(DateTime.Now - start).Seconds} seconds for new notification.\n" +
+                              $"Last received notification was {last}");
         throw;
       }
       if (notifications.TryDequeue(out var notification)) {
         return notification;
       }
-      throw new System.InvalidOperationException("got a signal for a received notification but it was not present in the queue");
+      throw new InvalidOperationException("got a signal for a received notification but it was not present in the queue");
     }
   }
 }


### PR DESCRIPTION
### Description
Provide more information when waiting for notification times out, which will help debug unstable tests

### How has this been tested?
Change to testing

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
