### PR TITLE
feat: Extended call graph

### DIFF
--- a/Source/DafnyCore/AST/Grammar/Printer/Printer.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer/Printer.cs
@@ -230,23 +230,22 @@ NoGhost - disable printing of functions, ghost methods, and proof
     public void PrintCallGraph(ModuleDefinition module, int indent) {
       Contract.Requires(module != null);
       Contract.Requires(0 <= indent);
-      if (options.DafnyPrintResolvedFile != null && options.PrintMode == PrintModes.Everything) {
-        // print call graph
-        Indent(indent); wr.WriteLine("/* CALL GRAPH for module {0}:", module.Name);
-        var SCCs = module.CallGraph.TopologicallySortedComponents();
+
+      void PrintGraph(Graph<ICallable> graph) {
+        var SCCs = graph.TopologicallySortedComponents();
         // Sort output SCCs in order of: descending height, then decreasing size of SCC, then alphabetical order of the name of
         // the representative element. By being this specific, we reduce changes in output from minor changes in the code. (With
         // more effort, we could be even more deterministic, if needed in the future.)
         SCCs.Sort((m, n) => {
-          var mm = module.CallGraph.GetSCCRepresentativePredecessorCount(m);
-          var nn = module.CallGraph.GetSCCRepresentativePredecessorCount(n);
+          var mm = graph.GetSCCRepresentativePredecessorCount(m);
+          var nn = graph.GetSCCRepresentativePredecessorCount(n);
           if (mm < nn) {
             return 1;
           } else if (mm > nn) {
             return -1;
           }
-          mm = module.CallGraph.GetSCCSize(m);
-          nn = module.CallGraph.GetSCCSize(n);
+          mm = graph.GetSCCSize(m);
+          nn = graph.GetSCCSize(n);
           if (mm < nn) {
             return 1;
           } else if (mm > nn) {
@@ -256,13 +255,47 @@ NoGhost - disable printing of functions, ghost methods, and proof
         });
         foreach (var callable in SCCs) {
           Indent(indent);
-          wr.WriteLine(" * SCC at height {0}:", module.CallGraph.GetSCCRepresentativePredecessorCount(callable));
-          var r = module.CallGraph.GetSCC(callable);
+          wr.WriteLine(" * SCC at height {0}:", graph.GetSCCRepresentativePredecessorCount(callable));
+          var r = graph.GetSCC(callable);
           foreach (var m in r) {
             Indent(indent);
             var maybeByMethod = m is Method method && method.IsByMethod ? " (by method)" : "";
             wr.WriteLine($" *   {m.NameRelativeToModule}{maybeByMethod}");
           }
+        }
+      }
+
+      void PrintDot(Graph<ICallable> graph) {
+        var heights = new Dictionary<int, IEnumerable<string>>();
+        Indent(indent);
+        wr.WriteLine($"digraph {module.Name} {{");
+        foreach (var v in graph.GetVertices()) {
+            var height = graph.GetSCCRepresentativePredecessorCount(v.N);
+            var name = v.N.NameRelativeToModule;
+            heights[height] = (heights.TryGetValue(height, out var vs) ? vs : new List<string>()).Append(name);
+            Indent(indent+2);
+            var dashed = v.N.EnclosingModule != module ? "style=dashed, " : "";
+            wr.WriteLine($"\"{name}\" [{dashed}label=\"{name}: {height}\"];");
+          foreach (var s in v.Successors) {
+            Indent(indent+2);
+            wr.WriteLine($"\"{name}\" -> \"{s.N.NameRelativeToModule}\";");
+          }
+        }
+        foreach (var (_, vs) in heights) {
+          Indent(indent+2);
+          wr.WriteLine($"{{ rank = same; {Util.Comma("; ", vs, (v => $"\"{v}\""))}; }}");
+        }
+        Indent(indent);
+        wr.WriteLine("}");
+      }
+
+      if (options.DafnyPrintResolvedFile != null && options.PrintMode == PrintModes.Everything) {
+        // print call graph
+        Indent(indent); wr.WriteLine("/* CALL GRAPH for module {0}:", module.Name);
+        if (options.PrintDotCallGraph) {
+          PrintDot(module.CallGraph);
+        } else {
+          PrintGraph(module.CallGraph);
         }
         Indent(indent); wr.WriteLine(" */");
       }

--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -88,10 +88,6 @@ public class ModuleDefinition : RangeNode, IAttributeBearingDeclaration, IClonea
   [FilledInDuringResolution]
   public readonly Graph<ICallable> CallGraph = new();
 
-  // This field is only populated if `defaultFunctionOpacity` is set to something other than transparent
-  [FilledInDuringResolution]
-  public readonly Graph<ICallable> InterModuleCallGraph = new();
-
   [FilledInDuringResolution]
   public int Height;  // height in the topological sorting of modules;
 

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -348,6 +348,7 @@ namespace Microsoft.Dafny {
     public string MethodsToTest = null;
     public bool DisallowConstructorCaseWithoutParentheses = false;
     public bool PrintFunctionCallGraph = false;
+    public bool PrintDotCallGraph = false;
     public bool WarnShadowing = false;
     public FunctionSyntaxOptions FunctionSyntax = FunctionSyntaxOptions.Version4;
     public QuantifierSyntaxOptions QuantifierSyntax = QuantifierSyntaxOptions.Version4;
@@ -640,6 +641,10 @@ namespace Microsoft.Dafny {
 
         case "funcCallGraph":
           PrintFunctionCallGraph = true;
+          return true;
+
+        case "dotCallGraph":
+          PrintDotCallGraph = true;
           return true;
 
         case "warnShadowing":

--- a/Source/DafnyCore/Resolver/CallGraphBuilder.cs
+++ b/Source/DafnyCore/Resolver/CallGraphBuilder.cs
@@ -117,6 +117,8 @@ namespace Microsoft.Dafny {
       }
 
       public override void VisitFunction(Function f) {
+        // reporter.Warning(MessageSource.Resolver, ParseErrors.ErrorId.none, f.Tok, f.Name);
+
         if (f.OverriddenFunction != null) {
           // add an edge from the trait function to that of the class/type
           AddCallGraphEdgeRaw(f.OverriddenFunction, f);
@@ -178,6 +180,8 @@ namespace Microsoft.Dafny {
           if (function is ExtremePredicate extremePredicate) {
             extremePredicate.Uses.Add(functionCallExpr);
           }
+          //reporter.Warning(MessageSource.Resolver, ParseErrors.ErrorId.none, function.Tok, function.Name);
+
           AddCallGraphEdge(context.CodeContext, function, functionCallExpr,
             IsFunctionReturnValue(function, functionCallExpr.Receiver, functionCallExpr.Args, context));
 
@@ -270,9 +274,9 @@ namespace Microsoft.Dafny {
           if (context.CodeContext is ICallable caller0) {
             if (caller0 is IteratorDecl iteratorDecl) {
               // use the MoveNext() method as the caller
-              callerModule.InterModuleCallGraph.AddEdge(iteratorDecl.Member_MoveNext, callee);
+              callerModule.CallGraph.AddEdge(iteratorDecl.Member_MoveNext, callee);
             } else {
-              callerModule.InterModuleCallGraph.AddEdge(caller0, callee);
+              callerModule.CallGraph.AddEdge(caller0, callee);
             }
           }
 
@@ -303,17 +307,9 @@ namespace Microsoft.Dafny {
         ModuleDefinition callerModule = callingContext.EnclosingModule;
         ModuleDefinition calleeModule = callable is SpecialFunction ? null : callable.EnclosingModule;
         if (callerModule != calleeModule) {
-          // inter-module call; add edge in module's inter-module call graph
-          if (callingContext is ICallable context && callable is Function { EnclosingClass: TraitDecl }) {
+          // inter-module call
+          if (callingContext is ICallable context) {
             callerModule.CallGraph.AddEdge(context, callable);
-          }
-          if (callingContext is ICallable caller0) {
-            callerModule.InterModuleCallGraph.AddEdge(caller0, callable);
-            if (caller0 is Function f) {
-              if (e is FunctionCallExpr ee) {
-                // f.AllCalls.Add(ee);
-              }
-            }
           }
 
           return;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/BitvectorsMore.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/BitvectorsMore.dfy.expect
@@ -136,6 +136,10 @@ module _System {
  *   Shifts6
  * SCC at height 1:
  *   PQ
+ * SCC at height 1:
+ *   Rotate
+ * SCC at height 1:
+ *   TestActualRotate
  * SCC at height 0:
  *   EvenInt
  * SCC at height 0:
@@ -159,11 +163,11 @@ module _System {
  * SCC at height 0:
  *   R
  * SCC at height 0:
- *   Rotate
+ *   RotateLeft
+ * SCC at height 0:
+ *   RotateRight
  * SCC at height 0:
  *   SmallReal
- * SCC at height 0:
- *   TestActualRotate
  * SCC at height 0:
  *   TestActualShifting
  */

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/BitvectorsMore.dfy.refresh.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/BitvectorsMore.dfy.refresh.expect
@@ -196,6 +196,10 @@ module _System {
  *   Shifts6
  * SCC at height 1:
  *   PQ
+ * SCC at height 1:
+ *   Rotate
+ * SCC at height 1:
+ *   TestActualRotate
  * SCC at height 0:
  *   EvenInt
  * SCC at height 0:
@@ -219,11 +223,11 @@ module _System {
  * SCC at height 0:
  *   R
  * SCC at height 0:
- *   Rotate
+ *   RotateLeft
+ * SCC at height 0:
+ *   RotateRight
  * SCC at height 0:
  *   SmallReal
- * SCC at height 0:
- *   TestActualRotate
  * SCC at height 0:
  *   TestActualShifting
  */

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ModuleInsertion.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ModuleInsertion.dfy.expect
@@ -210,8 +210,16 @@ module _System {
 */
 
 /* CALL GRAPH for module _module:
- * SCC at height 0:
+ * SCC at height 1:
  *   Main
+ * SCC at height 0:
+ *   Test
+ * SCC at height 0:
+ *   Test
+ * SCC at height 0:
+ *   Test
+ * SCC at height 0:
+ *   h
  */
 method Main()
 {
@@ -223,8 +231,16 @@ method Main()
 
 module Outer {
   /* CALL GRAPH for module Outer:
-   * SCC at height 0:
+   * SCC at height 1:
    *   Test
+   * SCC at height 0:
+   *   a
+   * SCC at height 0:
+   *   b
+   * SCC at height 0:
+   *   c
+   * SCC at height 0:
+   *   d
    */
   method Test()
   {
@@ -233,8 +249,10 @@ module Outer {
 
   module C {
     /* CALL GRAPH for module C:
-     * SCC at height 0:
+     * SCC at height 1:
      *   c
+     * SCC at height 0:
+     *   d
      */
     const c: int := 2 + D.d
 
@@ -243,8 +261,12 @@ module Outer {
 
   module A {
     /* CALL GRAPH for module A:
-     * SCC at height 0:
+     * SCC at height 1:
      *   a
+     * SCC at height 0:
+     *   b
+     * SCC at height 0:
+     *   c
      */
     const a: int := B.b + C.c
 
@@ -308,8 +330,14 @@ module Outer {
 
 module XY {
   /* CALL GRAPH for module XY:
-   * SCC at height 0:
+   * SCC at height 1:
    *   Test
+   * SCC at height 0:
+   *   m
+   * SCC at height 0:
+   *   m
+   * SCC at height 0:
+   *   n
    */
   method Test()
   {
@@ -325,8 +353,10 @@ module XY {
 
     module M {
       /* CALL GRAPH for module M:
-       * SCC at height 0:
+       * SCC at height 1:
        *   n
+       * SCC at height 0:
+       *   m
        */
       const n: int := Y.m - 5
 
@@ -387,10 +417,14 @@ module U {
 
   module V {
     /* CALL GRAPH for module V:
-     * SCC at height 1:
+     * SCC at height 2:
      *   Test
-     * SCC at height 0:
+     * SCC at height 1:
      *   x2
+     * SCC at height 0:
+     *   x0
+     * SCC at height 0:
+     *   x1
      */
     const x2: int := 14 + W.x1 + W.X.x0
 
@@ -401,8 +435,10 @@ module U {
 
     module W {
       /* CALL GRAPH for module W:
-       * SCC at height 0:
+       * SCC at height 1:
        *   x1
+       * SCC at height 0:
+       *   x0
        */
       const x1: int := 12 * X.x0
 


### PR DESCRIPTION
This PR extends the call graph with calls to other modules, thus removing the need for `InterModularCallGraph`. It also add a new print mode targeting the dot format for call graphs accessed with `/dotCallGraph`.