### PR TITLE
Rename the hidden option --show-inference to --show-hints

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -31,8 +31,8 @@ public class CommonOptionBag {
       IsHidden = true
     };
 
-  public static readonly Option<bool> ShowInference =
-    new("--show-inference", () => false, "Show information about things Dafny inferred from your code, for example triggers.") {
+  public static readonly Option<bool> ShowHints =
+    new("--show-hints", () => false, "Show hints that might help you better understand your code, such as what triggers Dafny generators for quantifiers") {
       IsHidden = true
     };
 
@@ -195,6 +195,7 @@ Note that the C++ backend has various limitations (see Docs/Compilation/Cpp.md).
     @"
 false - The char type represents any UTF-16 code unit.
 true - The char type represents any Unicode scalar value.".TrimStart()) {
+    IsHidden = true
   };
 
   public static readonly Option<bool> AllowAxioms = new("--allow-axioms", () => false,
@@ -368,7 +369,7 @@ If verification fails, report a detailed counterexample for the first failing as
     });
 
     DafnyOptions.RegisterLegacyUi(AllowAxioms, DafnyOptions.ParseBoolean, "Verification options", legacyName: "allowAxioms", defaultValue: true);
-    DafnyOptions.RegisterLegacyBinding(ShowInference, (options, value) => {
+    DafnyOptions.RegisterLegacyBinding(ShowHints, (options, value) => {
       options.PrintTooltips = value;
     });
 
@@ -594,7 +595,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
       LogLocation,
       LogLevelOption,
       ManualTriggerOption,
-      ShowInference,
+      ShowHints,
       Check,
       Libraries,
       Output,

--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -48,7 +48,6 @@ public static class DafnyCommands {
     CommonOptionBag.NoTimeStampForCoverageReport,
     CommonOptionBag.VerificationCoverageReport,
     CommonOptionBag.ExtractCounterexample,
-    CommonOptionBag.ShowInference,
     CommonOptionBag.ManualTriggerOption
   }.ToList();
 
@@ -103,6 +102,7 @@ public static class DafnyCommands {
   });
 
   public static IReadOnlyList<Option> ResolverOptions = new List<Option>(new Option[] {
+    CommonOptionBag.ShowHints,
     CommonOptionBag.WarnShadowing,
     CommonOptionBag.WarnMissingConstructorParenthesis,
     PrintStmt.TrackPrintEffectsOption,

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/GhostGuards.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/GhostGuards.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference --relax-definite-assignment "%s" > "%t"
+// RUN: %verify --show-hints --relax-definite-assignment "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 datatype Dt = Green | Dog

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/InSetComprehension.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/InSetComprehension.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" --allow-warnings > "%t"
+// RUN: %verify --show-hints "%s" --allow-warnings > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 lemma Tests<T>(t: T, uu: seq<T>) returns (z: bool)

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Matrix-OOB.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Matrix-OOB.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This is a regression test: OOB errors for matrices used to be reported on the

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/NativeTypeResolution.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/NativeTypeResolution.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 2 %build --show-inference --target cs "%s" > "%t"
+// RUN: %exits-with 2 %build --show-hints --target cs "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 newtype V = x | 0 <= x < 200  // byte

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TriggerInPredicate.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TriggerInPredicate.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 ghost predicate A(x: bool, y: bool) { x }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/Bug170.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/Bug170.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module InductiveThings {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1180a.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1180a.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 2 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 2 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // resolution errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1957.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1957.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 class {:autocontracts} Thing {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Main {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276a.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276a.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Main {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276b.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276b.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Testing constant folding of bool operations

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276c.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276c.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Testing constant folding of char, string operations

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276r.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276r.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Testing constant folding of real operations

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276v.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-276v.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // Testing constant folding of bit-vector operations

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3962.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3962.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %build --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %build --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 method Issues(a: bool, s: set) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-977.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-977.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 datatype Option<V> = Some(value: V) | None

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/auto-triggers-fix-an-issue-listed-in-the-ironclad-notebook.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/auto-triggers-fix-an-issue-listed-in-the-ironclad-notebook.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This example was listed in IronClad's notebook as one place were z3 picked

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/constructors-cause-matching-loops.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/constructors-cause-matching-loops.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file is just a small test to check that constructors do cause loops

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/function-applications-are-triggers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/function-applications-are-triggers.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference --allow-axioms "%s" > "%t"
+// RUN: %verify --show-hints --allow-axioms "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file checks that function applications yield trigger candidates

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/large-quantifiers-dont-break-dafny.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/large-quantifiers-dont-break-dafny.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This test ensures that the trigger  collector (the routine that picks trigger

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/let-expressions.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/let-expressions.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 ghost predicate Foo(s: seq<int>)

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/loop-detection-is-not-too-strict.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/loop-detection-is-not-too-strict.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference --allow-axioms "%s" > "%t"
+// RUN: %verify --show-hints --allow-axioms "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This test shows that the loop detection engine makes compromises when looking

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/loop-detection-looks-at-ranges-too.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/loop-detection-looks-at-ranges-too.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file checks that loops between the range and the term of a quantifier

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/loop-detection-messages--unit-tests.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/loop-detection-messages--unit-tests.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference --allow-warnings "%s" > "%t"
+// RUN: %verify --show-hints --allow-warnings "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file is a series of basic tests for loop detection, focusing on the

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/looping-is-hard-to-decide-modulo-equality.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/looping-is-hard-to-decide-modulo-equality.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file shows cases where loops could hide behind equalities. In all three

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/matrix-accesses-are-triggers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/matrix-accesses-are-triggers.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file checks that multi-dimensional array accesses yield trigger candidates

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/nested-quantifiers-all-get-triggers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/nested-quantifiers-all-get-triggers.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This checks that nested quantifiers do get triggers, and that the parent

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/old-is-a-special-case-for-triggers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/old-is-a-special-case-for-triggers.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" --allow-warnings > "%t"
+// RUN: %verify --show-hints "%s" --allow-warnings > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file ensures that `old()` receives the special treatment that it

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/redundancy-detection-is-bidirectional.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/redundancy-detection-is-bidirectional.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This test checks for tricky cases of redundancy suppression when building

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/regression-tests.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/regression-tests.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" --allow-warnings > "%t"
+// RUN: %verify --show-hints "%s" --allow-warnings > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This tests checks that quantifier splitting is resilient to the fact that

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/set-construction-is-a-good-trigger.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/set-construction-is-a-good-trigger.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file ensures that display expressions can be picked as triggers. This is

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/some-proofs-only-work-without-autoTriggers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/some-proofs-only-work-without-autoTriggers.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --allow-axioms --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --allow-axioms --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // The examples below work nicely with /autoTriggers:0, but break when we use

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/some-terms-do-not-look-like-the-triggers-they-match.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file shows how Dafny detects loops even for terms that are not literal

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/splitting-picks-the-right-tokens.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/splitting-picks-the-right-tokens.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file ensures that trigger splitting picks the right tokens

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/splitting-triggers-recovers-expressivity.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/splitting-triggers-recovers-expressivity.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 ghost predicate P(i: int)

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/splitting-triggers-yields-better-precondition-related-errors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/splitting-triggers-yields-better-precondition-related-errors.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This tests shows that, since quantifiers are split, it becomes possible to know more precisely what part of a precondition did not hold at the call site.

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/suppressing-warnings-behaves-properly.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/suppressing-warnings-behaves-properly.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference --allow-warnings "%s" > "%t"
+// RUN: %verify --show-hints --allow-warnings "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file checks that suppressing warnings works properly

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/triggers-prevent-some-inlining.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/triggers-prevent-some-inlining.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This  file looks  at the  interactions  between inlining  and triggers.   The

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/useless-triggers-are-removed.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/useless-triggers-are-removed.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This file ensures that Dafny does get rid of redundant triggers before

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/wf-checks-use-the-original-quantifier.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/triggers/wf-checks-use-the-original-quantifier.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // This test checks that typical expressions requiring WF checks do not suddenly

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/granted/useless-casts-in-decreases-clauses.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/granted/useless-casts-in-decreases-clauses.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference "%s" > "%t"
+// RUN: %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 method M() {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-inference "%s" > "%t"
+// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 ghost function fact(n: int): int

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/we-should-always-print-tooltips.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/we-should-always-print-tooltips.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --show-inference --allow-warnings %s > "%t"
+// RUN: %verify --show-hints --allow-warnings %s > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 // WISH it would be great to add /printTooltips to all tests


### PR DESCRIPTION
### Description
Rename the hidden option --show-inference to --show-hints

### How has this been tested?
Updated tests

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
