### PR TITLE
Remove branches part from merge_group GH actions configuration

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches: [ master, main-* ]
   merge_group:
-    branches: [ master, main-* ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches: [ master, main-* ]
   merge_group:
-    branches: [ master, main-* ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches: [ master, main-* ]
   merge_group:
-    branches: [ master, main-* ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches: [ master, main-* ]
   merge_group:
-    branches: [ master, main-* ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/standard-libraries.yml
+++ b/.github/workflows/standard-libraries.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches: [ master, main-* ]
   merge_group:
-    branches: [ master, main-* ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Description
Remove branches part from merge_group GH actions configuration, in an attempt to make the merge queue work

### How has this been tested?
Not, but I don't see a risk with trying this.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
