### PR TITLE
Retry LSP tests in case of error

### DIFF
--- a/.github/workflows/xunit-tests-reusable.yml
+++ b/.github/workflows/xunit-tests-reusable.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         chmod +x Binaries/z3/bin/z3*
     - name: Build
-      run: dotnet build --no-restore ${{env.solutionPath}}
+      run: dotnet build ${{env.solutionPath}}
     - name: Run DafnyCore Tests
       run: dotnet test --no-restore --logger "console;verbosity=normal" --logger trx --collect:"XPlat Code Coverage" --settings Source/DafnyCore.Test/coverlet.runsettings Source/DafnyCore.Test
     # Retry LSP tests 3 times because there are some spurious errors

--- a/.github/workflows/xunit-tests-reusable.yml
+++ b/.github/workflows/xunit-tests-reusable.yml
@@ -67,14 +67,15 @@ jobs:
       run: dotnet build --no-restore ${{env.solutionPath}}
     - name: Run DafnyCore Tests
       run: dotnet test --no-restore --logger "console;verbosity=normal" --logger trx --collect:"XPlat Code Coverage" --settings Source/DafnyCore.Test/coverlet.runsettings Source/DafnyCore.Test
+    # Retry LSP tests 3 times because there are some spurious errors
     - name: Run DafnyLanguageServer Tests
-      run: |
-        ## Run twice to catch unstable code (Issue #2673)
-        dotnet test --no-restore --blame-hang-timeout 360s --logger "console;verbosity=normal" --logger trx --collect:"XPlat Code Coverage" --settings Source/DafnyLanguageServer.Test/coverlet.runsettings Source/DafnyLanguageServer.Test
-        ## On the second run, collect test coverage data
-        ##  Note that, for some mysterious reason, --collect doesn't work with the DafnyLanguageServer.Test package
-        dotnet coverage collect -o DafnyLanguageServer.Test.coverage dotnet test --no-restore --blame-hang-timeout 360s --logger "console;verbosity=normal" --logger trx Source/DafnyLanguageServer.Test
-
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        command: |
+          ##  Note that, for some mysterious reason, --collect doesn't work with the DafnyLanguageServer.Test package
+          dotnet coverage collect -o DafnyLanguageServer.Test.coverage dotnet test --no-restore --blame-hang-timeout 360s --logger "console;verbosity=normal" --logger trx Source/DafnyLanguageServer.Test
     - name: Run DafnyDriver Tests
       run: dotnet test --no-restore --logger "console;verbosity=normal" --logger trx --collect:"XPlat Code Coverage" --settings Source/DafnyDriver.Test/coverlet.runsettings Source/DafnyDriver.Test
     - name: Run DafnyPipeline Tests

--- a/.github/workflows/xunit-tests-reusable.yml
+++ b/.github/workflows/xunit-tests-reusable.yml
@@ -71,6 +71,7 @@ jobs:
         timeout_minutes: 45
         max_attempts: 3
         command: |
+          cd dafny
           dotnet restore ${{env.solutionPath}}
           dotnet tool install dotnet-coverage
           dotnet coverage collect -o DafnyLanguageServer.Test.coverage dotnet test --no-restore --blame-hang-timeout 360s --logger "console;verbosity=normal" --logger trx Source/DafnyLanguageServer.Test

--- a/.github/workflows/xunit-tests-reusable.yml
+++ b/.github/workflows/xunit-tests-reusable.yml
@@ -45,10 +45,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
-    - name: Install dependencies
-      run: |
-        dotnet restore ${{env.solutionPath}}
-        dotnet tool install dotnet-coverage
     - name: Load Z3
       shell: pwsh
       run: |
@@ -68,13 +64,15 @@ jobs:
     - name: Run DafnyCore Tests
       run: dotnet test --no-restore --logger "console;verbosity=normal" --logger trx --collect:"XPlat Code Coverage" --settings Source/DafnyCore.Test/coverlet.runsettings Source/DafnyCore.Test
     # Retry LSP tests 3 times because there are some spurious errors
+    #  Note that, for some mysterious reason, --collect doesn't work with the DafnyLanguageServer.Test package
     - name: Run DafnyLanguageServer Tests
       uses: nick-fields/retry@v3
       with:
         timeout_minutes: 45
         max_attempts: 3
         command: |
-          ##  Note that, for some mysterious reason, --collect doesn't work with the DafnyLanguageServer.Test package
+          dotnet restore ${{env.solutionPath}}
+          dotnet tool install dotnet-coverage
           dotnet coverage collect -o DafnyLanguageServer.Test.coverage dotnet test --no-restore --blame-hang-timeout 360s --logger "console;verbosity=normal" --logger trx Source/DafnyLanguageServer.Test
     - name: Run DafnyDriver Tests
       run: dotnet test --no-restore --logger "console;verbosity=normal" --logger trx --collect:"XPlat Code Coverage" --settings Source/DafnyDriver.Test/coverlet.runsettings Source/DafnyDriver.Test


### PR DESCRIPTION
### Description

This PR changes how the language server unit tests execute, retrying them up to three times if they fail. Ultimately, this is what we're doing by hand, anyway, so we might as well automate it.

The proper solution to this problem is to ensure that the language server tests don't spuriously fail, but this will accelerate our development process in the meantime.

### How has this been tested?

By running CI normally.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
