### PR TITLE
Fix a bug in AwaitNextNotificationAsync that prevented the 'Waited fo…

### DIFF
--- a/Source/DafnyLanguageServer.Test/Util/TestNotificationReceiver.cs
+++ b/Source/DafnyLanguageServer.Test/Util/TestNotificationReceiver.cs
@@ -52,10 +52,10 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Util {
       }
     }
 
-    public Task<TNotification> AwaitNextNotificationAsync(CancellationToken cancellationToken) {
+    public async Task<TNotification> AwaitNextNotificationAsync(CancellationToken cancellationToken) {
       var start = DateTime.Now;
       try {
-        return notifications.Dequeue(cancellationToken);
+        return await notifications.Dequeue(cancellationToken);
       } catch (OperationCanceledException) {
         var last = History.Any() ? History[^1].Stringify() : "none";
         logger.LogInformation($"Waited for {(DateTime.Now - start).Seconds} seconds for new notification.\n" +


### PR DESCRIPTION
### Changes

Fix a bug in AwaitNextNotificationAsync that prevented the 'Waited for' log line to show up, to help debug https://github.com/dafny-lang/dafny/issues/5384

### Testing

Since this was a bug in the testing code, I'm OK with not testing it.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
