### PR TITLE
Add more logging to QuickEditsInLargeFile

### DIFF
--- a/Source/DafnyLanguageServer.Test/Performance/LargeFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/Performance/LargeFilesTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Microsoft.Dafny.LanguageServer.Language.Symbols;
 using Microsoft.Dafny.LanguageServer.Workspace;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -25,6 +27,9 @@ public class LargeFilesTest : ClientBasedLanguageServerTest {
   }
 
   /// <summary>
+  /// When you run this test with a debugger, it grinds to a halt and will appear deadlocked.
+  /// Change all the numbers to smaller values (let's say 1) to workaround this problem.
+  /// 
   /// This test should complete in less than a second, because it opens a moderately sized file
   /// on which it makes edits so quickly that the edits should all be processed in a single compilation.
   /// And a single compilation should complete in less than 200ms.
@@ -43,12 +48,13 @@ public class LargeFilesTest : ClientBasedLanguageServerTest {
     }
     var source = contentBuilder.ToString();
 
-    double lowest = double.MaxValue;
     Exception lastException = null;
+    List<double> timeToScheduleHistory = new();
+    List<double> divisionHistory = new();
     try {
       for (int attempt = 0; attempt < 10; attempt++) {
-        var cancelSource = new CancellationTokenSource();
-        var measurementTask = AssertThreadPoolIsAvailable(cancelSource.Token);
+        var threadPoolSchedulingCancellationToken = new CancellationTokenSource();
+        var threadPoolSchedulingTimeTask = TrackThreadPoolSchedulingTime(threadPoolSchedulingCancellationToken.Token);
         var beforeOpen = DateTime.Now;
         var documentItem = await CreateOpenAndWaitForResolve(source, "ManyFastEditsUsingLargeFiles.dfy",
           cancellationToken: CancellationTokenWithHighTimeout);
@@ -62,11 +68,12 @@ public class LargeFilesTest : ClientBasedLanguageServerTest {
         var afterChange = DateTime.Now;
         var changeMilliseconds = (afterChange - afterOpen).TotalMilliseconds;
         await AssertNoDiagnosticsAreComing(CancellationTokenWithHighTimeout);
-        cancelSource.Cancel();
-        var averageTimeToSchedule = await measurementTask;
+        threadPoolSchedulingCancellationToken.Cancel();
+        var averageTimeToSchedule = await threadPoolSchedulingTimeTask;
         var division = changeMilliseconds / openMilliseconds;
-        lowest = Math.Min(lowest, division);
 
+        timeToScheduleHistory.Add(averageTimeToSchedule);
+        divisionHistory.Add(division);
         // Commented code left in intentionally
         // await output.WriteLineAsync("openMilliseconds: " + openMilliseconds);
         // await output.WriteLineAsync("changeMilliseconds: " + changeMilliseconds);
@@ -88,18 +95,21 @@ public class LargeFilesTest : ClientBasedLanguageServerTest {
     } catch (OperationCanceledException) {
     }
 
-    await output.WriteLineAsync("lowest division " + lowest);
+    logger.LogInformation("Average time to schedule history: \n" + string.Join(", ", timeToScheduleHistory));
+    logger.LogInformation("Division history: \n" + string.Join(", ", divisionHistory));
     throw lastException!;
   }
 
-  private async Task<double> AssertThreadPoolIsAvailable(CancellationToken durationToken) {
+  private async Task<double> TrackThreadPoolSchedulingTime(CancellationToken durationToken) {
     int ticks = 0;
     var waitTime = 100;
     var start = DateTime.Now;
     while (!durationToken.IsCancellationRequested) {
+      // Measuring the time Task.Run takes is the point of this method.
       await Task.Run(() => {
         Thread.Sleep(waitTime);
       });
+
       ticks++;
     }
 

--- a/Source/DafnyLanguageServer.Test/Performance/ThreadUsageTest.cs
+++ b/Source/DafnyLanguageServer.Test/Performance/ThreadUsageTest.cs
@@ -34,16 +34,14 @@ public class ThreadUsageTest : ClientBasedLanguageServerTest {
         var difference = threadCountAfter - threadCountBefore;
         history.Add(difference);
         Assert.InRange(difference, -maxThreadCountIncrease, maxThreadCountIncrease);
-        break;
+        return;
       } catch (InRangeException e) {
         lastException = e;
       }
     }
 
-    if (lastException != null) {
-      logger.LogInformation("Difference history: " + string.Join(", ", history));
-      throw lastException;
-    }
+    logger.LogInformation("Difference history: " + string.Join(", ", history));
+    throw lastException!;
   }
 
   public ThreadUsageTest(ITestOutputHelper output, LogLevel dafnyLogLevel = LogLevel.Information)

--- a/Source/DafnyLanguageServer.Test/Performance/ThreadUsageTest.cs
+++ b/Source/DafnyLanguageServer.Test/Performance/ThreadUsageTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,7 @@ public class ThreadUsageTest : ClientBasedLanguageServerTest {
   [Fact]
   public async Task NoExtraThreadAfterEachChange() {
     Exception lastException = null;
+    var history = new List<int>();
     for (var attempt = 0; attempt < 100; attempt++) {
       try {
         var source = "method Foo() { assert false; }";
@@ -29,7 +31,9 @@ public class ThreadUsageTest : ClientBasedLanguageServerTest {
 
         var threadCountAfter = Process.GetCurrentProcess().Threads.Count;
         const int maxThreadCountIncrease = 5;
-        Assert.InRange(threadCountAfter - threadCountBefore, -maxThreadCountIncrease, maxThreadCountIncrease);
+        var difference = threadCountAfter - threadCountBefore;
+        history.Add(difference);
+        Assert.InRange(difference, -maxThreadCountIncrease, maxThreadCountIncrease);
         break;
       } catch (InRangeException e) {
         lastException = e;
@@ -37,6 +41,7 @@ public class ThreadUsageTest : ClientBasedLanguageServerTest {
     }
 
     if (lastException != null) {
+      logger.LogInformation("Difference history: " + string.Join(", ", history));
       throw lastException;
     }
   }

--- a/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ConcurrentInteractionsTest.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using OmniSharp.Extensions.JsonRpc.Server;
 using Xunit;
 using Xunit.Abstractions;
+using XunitAssertMessages;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Various {
@@ -107,7 +108,7 @@ method Multiply(x: bv10, y: bv10) returns (product: bv10)
       var diagnostics = await GetLatestDiagnosticsParams(documentItem, CancellationToken);
       Assert.Equal(documentItem.Version, diagnostics.Version);
       Assert.Single(diagnostics.Diagnostics);
-      Assert.Equal("assertion might not hold", diagnostics.Diagnostics.First().Message);
+      AssertM.Equal("assertion might not hold", diagnostics.Diagnostics.First().Message, "actual diagnostic message was: " + diagnostics.Diagnostics.First().Message);
     }
 
     [Fact]


### PR DESCRIPTION
### Description
- Add more logging to QuickEditsInLargeFile and two other unstable tests
- Fix the retry mechanic for `NoExtraThreadAfterEachChange`, which probably resolves all flakiness in this test.

### How has this been tested?
Test logging change, no additional tests needed

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
