### PR TITLE
Report configured instead of actual runtime after a timeout.

### DIFF
--- a/Source/DafnyDriver/Commands/VerifyCommand.cs
+++ b/Source/DafnyDriver/Commands/VerifyCommand.cs
@@ -163,7 +163,7 @@ public static class VerifyCommand {
       var batchReporter = new BatchErrorReporter(compilation.Options);
       foreach (var completed in result.Results) {
         Compilation.ReportDiagnosticsInResult(compilation.Options, result.CanVerify.FullDafnyName, completed.Task.Token,
-          (uint)completed.Result.RunTime.Seconds,
+          completed.Task.Split.Implementation.GetTimeLimit(compilation.Options),
           completed.Result, batchReporter);
       }
 


### PR DESCRIPTION
### Description
- Report configured instead of actual runtime after a timeout. Not sure if we want this

### How has this been tested?
It's tested by `git-issue-3855.dfy`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
