### PR TITLE
Skip included files

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -246,7 +246,13 @@ true - Print debug information for the new type system.".TrimStart()) {
   };
 
   public static readonly Option<bool> VerifyIncludedFiles = new("--verify-included-files",
-    "Verify code in included files.");
+    "(deprecated) Has no affect.") {
+    IsHidden = true
+  };
+
+  public static readonly Option<bool> SkipIncludedFiles = new("--skip-included-files",
+    "Do not verify code in included files.");
+
   public static readonly Option<bool> UseBaseFileName = new("--use-basename-for-filename",
     "When parsing use basename of file for tokens instead of the path supplied on the command line") {
   };
@@ -502,8 +508,8 @@ NoGhost - disable printing of functions, ghost methods, and proof
     DafnyOptions.RegisterLegacyBinding(WarnMissingConstructorParenthesis,
       (options, value) => { options.DisallowConstructorCaseWithoutParentheses = value; });
     DafnyOptions.RegisterLegacyBinding(AllowWarnings, (options, value) => { options.FailOnWarnings = !value; });
-    DafnyOptions.RegisterLegacyBinding(VerifyIncludedFiles,
-      (options, value) => { options.VerifyAllModules = value; });
+    DafnyOptions.RegisterLegacyBinding(SkipIncludedFiles,
+      (options, value) => { options.VerifyAllModules = !value; });
     DafnyOptions.RegisterLegacyBinding(WarnContradictoryAssumptions, (options, value) => {
       if (value) { options.TrackVerificationCoverage = true; }
     });
@@ -578,6 +584,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
       new Dictionary<Option, OptionCompatibility.OptionCheck>() {
         { UnicodeCharacters, OptionCompatibility.CheckOptionMatches },
         { EnforceDeterminism, OptionCompatibility.CheckOptionLocalImpliesLibrary },
+        { SkipIncludedFiles, OptionCompatibility.CheckOptionLibraryImpliesLocal },
         { RelaxDefiniteAssignment, OptionCompatibility.CheckOptionLibraryImpliesLocal },
         { AllowAxioms, OptionCompatibility.CheckOptionLibraryImpliesLocal },
         { AllowWarnings, (reporter, origin, prefix, option, localValue, libraryValue) => {

--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -29,6 +29,7 @@ public static class DafnyCommands {
     CommonOptionBag.ProgressOption,
     CommonOptionBag.RelaxDefiniteAssignment,
     BoogieOptionBag.VerificationTimeLimit,
+    CommonOptionBag.SkipIncludedFiles,
     CommonOptionBag.VerifyIncludedFiles,
     CommonOptionBag.ManualLemmaInduction,
     BoogieOptionBag.SolverPath,

--- a/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
+++ b/Source/DafnyLanguageServer.Test/Synchronization/VerificationStatusTest.cs
@@ -170,7 +170,7 @@ module A.B.D {
 }".TrimStart();
     await SetUp(options => {
       options.Set(ProjectManager.Verification, VerifyOnMode.Never);
-      options.Set(CommonOptionBag.VerifyIncludedFiles, true);
+      options.Set(CommonOptionBag.SkipIncludedFiles, false);
 
     });
     var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Include.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Include.dfy
@@ -1,5 +1,5 @@
 // RUN: %exits-with 4 %verify "%s" > "%t"
-// RUN: %exits-with 4 %verify --verify-included-files "%s" >> "%t"
+// RUN: %exits-with 4 %verify "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
 include "Includee.dfy"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Stdin.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/Stdin.dfy
@@ -5,5 +5,5 @@
 // (regression test for https://github.com/dafny-lang/dafny/issues/4135)
 // We don't capture the output to %t because it ends up including paths,
 // which are platform-dependent (i.e. "\" on Windows vs. "/" on Mac OS and Linux)
-// RUN: %exits-with 4 %baredafny verify --show-snippets:false --verify-included-files --stdin < %S/Input/IncludesTuples.dfy
+// RUN: %exits-with 4 %baredafny verify --show-snippets:false --stdin < %S/Input/IncludesTuples.dfy
 // RUN: %diff "%s.expect" "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/CoverageReport.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/CoverageReport.dfy
@@ -1,7 +1,7 @@
 // NONUNIFORM: Not a compiler test
 // Verification coverage:
 // RUN: rm -rf "%t"/coverage_verification
-// RUN: %verify --allow-axioms --verify-included-files --no-timestamp-for-coverage-report --verification-coverage-report "%t/coverage_verification" %s
+// RUN: %verify --allow-axioms --no-timestamp-for-coverage-report --verification-coverage-report "%t/coverage_verification" %s
 // RUN: %sed 's/<h1 hidden.*//' "%t"/coverage_verification/ProofDependencies.dfy_verification.html > "%t"/coverage_verification_actual.html
 // RUN: %diff "%S/ProofDependencies.dfy_verification.html.expect" "%t/coverage_verification_actual.html"
 // Expected test coverage:

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/ProofDependencyLogging.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/ProofDependencyLogging.dfy
@@ -1,4 +1,4 @@
-// RUN: %baredafny verify --log-format:text --verify-included-files --allow-axioms --boogie -trackVerificationCoverage "%s" > "%t"
+// RUN: %baredafny verify --log-format:text --allow-axioms --boogie -trackVerificationCoverage "%s" > "%t"
 // RUN: %OutputCheck --file-to-check "%t" "%s"
 // CHECK: Results for M.RedundantAssumeMethod \(correctness\)
 // CHECK:     Proof dependencies:

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/ProofDependencyWarnings.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/ProofDependencyWarnings.dfy
@@ -1,4 +1,4 @@
-// RUN: %baredafny verify --use-basename-for-filename --allow-axioms --show-snippets false --verify-included-files --warn-contradictory-assumptions --warn-redundant-assumptions --allow-warnings "%s" > "%t.new"
+// RUN: %baredafny verify --use-basename-for-filename --allow-axioms --show-snippets false --warn-contradictory-assumptions --warn-redundant-assumptions --allow-warnings "%s" > "%t.new"
 // RUN: %diff "%s.expect" "%t.new"
 // Also test old CLI
 // RUN: %baredafny /compile:0 /useBaseNameForFileName /verifyAllModules /warnContradictoryAssumptions /warnRedundantAssumptions "%s" > "%t.old"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/DafnyTests/RunAllTestsOption.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/DafnyTests/RunAllTestsOption.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --allow-deprecation --unicode-char false --verify-included-files "%s" > "%t"
+// RUN: %verify --allow-deprecation --unicode-char false "%s" > "%t"
 // RUN: ! %baredafny test %args --allow-deprecation --unicode-char false --no-verify --target:cs "%s" >> "%t"
 // RUN: ! %baredafny test %args --allow-deprecation --unicode-char false --no-verify --target:java "%s" >> "%t"
 // RUN: ! %baredafny test %args --allow-deprecation --unicode-char false --no-verify --target:go "%s" >> "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Arrays.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Arrays.dfy
@@ -1,3 +1,3 @@
 // NONUNIFORM: https://github.com/dafny-lang/dafny/issues/2582
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --allow-warnings --unicode-char false --verify-included-files
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --allow-warnings --unicode-char false
 include "../../comp/Arrays.dfy"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Collections.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Collections.dfy
@@ -1,3 +1,3 @@
 // NONUNIFORM: https://github.com/dafny-lang/dafny/issues/4108
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --allow-deprecation --unicode-char false --spill-translation --verify-included-files
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --allow-deprecation --unicode-char false --spill-translation
 include "../../comp/Collections.dfy"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Comprehensions.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Comprehensions.dfy
@@ -1,3 +1,3 @@
 // NONUNIFORM: https://github.com/dafny-lang/dafny/issues/4108
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --spill-translation  --allow-deprecation --unicode-char false --verify-included-files
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --spill-translation  --allow-deprecation --unicode-char false
 include "../../comp/Comprehensions.dfy"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/NativeNumbers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/NativeNumbers.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --spill-translation --allow-deprecation --unicode-char false --verify-included-files
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --relax-definite-assignment --spill-translation --allow-deprecation --unicode-char false
 // Skip JavaScript because JavaScript doesn't have the same native types
 
 include "../../comp/NativeNumbers.dfy"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Numbers.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/comp/Numbers.dfy
@@ -1,3 +1,3 @@
 // NONUNIFORM: https://github.com/dafny-lang/dafny/issues/4174
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --allow-deprecation --relax-definite-assignment --unicode-char false --verify-included-files
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --allow-deprecation --relax-definite-assignment --unicode-char false
 include "../../comp/Numbers.dfy"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/expectations/ExpectWithNonStringMessage.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/unicodecharsFalse/expectations/ExpectWithNonStringMessage.dfy
@@ -1,4 +1,4 @@
-// RUN: %verify --verify-included-files --allow-deprecation --unicode-char false "%s" > "%t"
+// RUN: %verify --allow-deprecation --unicode-char false "%s" > "%t"
 // RUN: ! %run --no-verify --target cs --allow-deprecation --unicode-char false "%s" >> "%t"
 // RUN: ! %run --no-verify --target go --allow-deprecation --unicode-char false "%s" >> "%t"
 // RUN: ! %run --no-verify --target java --allow-deprecation --unicode-char false "%s" >> "%t"

--- a/docs/dev/news/4762.fix
+++ b/docs/dev/news/4762.fix
@@ -1,0 +1,1 @@
+By default, all included files are now verified as well. The option --verify-included-files has been replaced by --skip-included-files, which is false by default.


### PR DESCRIPTION
Fixes #4762

### Description
- By default, all included files are now verified as well
- The option `--verify-included-files` is replaced by `--skip-included-files`

### How has this been tested?
- TODO

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
