### PR TITLE
Turn on more logging for `ProjectFileDoesNotOwnAllSourceFilesItUses`

### DIFF
--- a/Source/DafnyCore/Pipeline/Compilation.cs
+++ b/Source/DafnyCore/Pipeline/Compilation.cs
@@ -106,6 +106,19 @@ public class Compilation : IDisposable {
     RootFiles = DetermineRootFiles();
     ParsedProgram = ParseAsync();
     Resolution = ResolveAsync();
+
+    _ = LogExceptions();
+  }
+
+  private async Task LogExceptions() {
+    try {
+      await RootFiles;
+      await ParsedProgram;
+      await Resolution;
+    } catch (Exception e) {
+      logger.LogCritical(e, "internal exception");
+      updates.OnNext(new InternalCompilationException(MessageSource.Parser, e));
+    }
   }
 
   public void Start() {
@@ -168,12 +181,10 @@ public class Compilation : IDisposable {
       }
     }
 
-    var libraryDafnyFiles = new List<DafnyFile>();
     var libraryPaths = CommonOptionBag.SplitOptionValueIntoFiles(Options.Get(CommonOptionBag.Libraries).Select(f => f.FullName));
     foreach (var library in libraryPaths) {
       await foreach (var file in DafnyFile.CreateAndValidate(fileSystem, errorReporter, Options, new Uri(library), Project.StartingToken, true)) {
         result.Add(file);
-        libraryDafnyFiles.Add(file);
       }
     }
 
@@ -194,53 +205,37 @@ public class Compilation : IDisposable {
   }
 
   private async Task<Program?> ParseAsync() {
-    try {
-      await RootFiles;
-      if (HasErrors) {
-        return null;
-      }
-
-      transformedProgram = await documentLoader.ParseAsync(this, cancellationSource.Token);
-      transformedProgram.HasParseErrors = HasErrors;
-
-      var cloner = new Cloner(true);
-      programAfterParsing = new Program(cloner, transformedProgram);
-
-      updates.OnNext(new FinishedParsing(programAfterParsing));
-      logger.LogDebug(
-        $"Passed parsedCompilation to documentUpdates.OnNext, resolving ParsedCompilation task for version {Input.Version}.");
-      return programAfterParsing;
-
-    } catch (OperationCanceledException) {
-      throw;
-    } catch (Exception e) {
-      updates.OnNext(new InternalCompilationException(MessageSource.Parser, e));
-      throw;
+    await RootFiles;
+    if (HasErrors) {
+      return null;
     }
+
+    transformedProgram = await documentLoader.ParseAsync(this, cancellationSource.Token);
+    transformedProgram.HasParseErrors = HasErrors;
+
+    var cloner = new Cloner(true);
+    programAfterParsing = new Program(cloner, transformedProgram);
+
+    updates.OnNext(new FinishedParsing(programAfterParsing));
+    logger.LogDebug(
+      $"Passed parsedCompilation to documentUpdates.OnNext, resolving ParsedCompilation task for version {Input.Version}.");
+    return programAfterParsing;
   }
 
   private async Task<ResolutionResult?> ResolveAsync() {
-    try {
-      await ParsedProgram;
-      if (transformedProgram == null) {
-        return null;
-      }
-      var resolution = await documentLoader.ResolveAsync(this, transformedProgram!, cancellationSource.Token);
-      if (resolution == null) {
-        return null;
-      }
-
-      updates.OnNext(new FinishedResolution(resolution));
-      staticDiagnosticsSubscription.Dispose();
-      logger.LogDebug($"Passed resolvedCompilation to documentUpdates.OnNext, resolving ResolvedCompilation task for version {Input.Version}.");
-      return resolution;
-
-    } catch (OperationCanceledException) {
-      throw;
-    } catch (Exception e) {
-      updates.OnNext(new InternalCompilationException(MessageSource.Resolver, e));
-      throw;
+    await ParsedProgram;
+    if (transformedProgram == null) {
+      return null;
     }
+    var resolution = await documentLoader.ResolveAsync(this, transformedProgram!, cancellationSource.Token);
+    if (resolution == null) {
+      return null;
+    }
+
+    updates.OnNext(new FinishedResolution(resolution));
+    staticDiagnosticsSubscription.Dispose();
+    logger.LogDebug($"Passed resolvedCompilation to documentUpdates.OnNext, resolving ResolvedCompilation task for version {Input.Version}.");
+    return resolution;
   }
 
   public static string GetTaskName(IVerificationTask task) {

--- a/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
+++ b/Source/DafnyLanguageServer.Test/Lookup/DocumentSymbolTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Lookup {
 
     [Fact]
     public async Task CanResolveSymbolsForMultiFileProjects() {
-      var temp = Path.GetTempPath();
+      var temp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
       await CreateOpenAndWaitForResolve("", Path.Combine(temp, DafnyProject.FileName));
       var file1 = CreateAndOpenTestDocument("method Foo() {}", Path.Combine(temp, "file1.dfy"));
       var file2 = CreateAndOpenTestDocument("method Bar() {}", Path.Combine(temp, "file2.dfy"));

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/CompetingProjectFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/CompetingProjectFilesTest.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Microsoft.Dafny.LanguageServer.Workspace;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Xunit.Abstractions;
@@ -77,6 +78,6 @@ warn-shadowing = true
     Assert.Empty(diagnostics1);
   }
 
-  public CompetingProjectFilesTest(ITestOutputHelper output) : base(output) {
+  public CompetingProjectFilesTest(ITestOutputHelper output) : base(output, LogLevel.Debug) {
   }
 }

--- a/Source/DafnyLanguageServer.Test/Various/CancelVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CancelVerificationTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Util;
 using Microsoft.Dafny.LanguageServer.Workspace;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 using Xunit.Abstractions;

--- a/Source/DafnyLanguageServer.Test/Various/CancelVerificationTest.cs
+++ b/Source/DafnyLanguageServer.Test/Various/CancelVerificationTest.cs
@@ -102,7 +102,7 @@ method {:resource_limit ""10e6""} test() {
       }
     }
 
-    public CancelVerificationTest(ITestOutputHelper output) : base(output) {
+    public CancelVerificationTest(ITestOutputHelper output) : base(output, LogLevel.Debug) {
     }
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     public async Task<IdeState?> GetResolvedDocumentAsyncInternal(TextDocumentIdentifier documentId) {
       var manager = await GetProjectManager(documentId, false);
+      logger.LogDebug($"project manager found for {documentId.Uri}");
       if (manager != null) {
         return await manager.GetStateAfterResolutionAsync();
       }


### PR DESCRIPTION
This PR attempts to help debug flaky tests: https://github.com/dafny-lang/dafny/issues/5420, https://github.com/dafny-lang/dafny/issues/5443, https://github.com/dafny-lang/dafny/issues/5436

### Description
- Improve logging for `Compilation`
- Turn on more logging for `ProjectFileDoesNotOwnAllSourceFilesItUses`

### How has this been tested?
Not

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
