### PR TITLE
fix: Apply name mangling to datatype names in Python more often

### DIFF
--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Dafny.Compilers {
 
     private string DtCtorDeclarationName(DatatypeCtor ctor, bool full = false) {
       var dt = ctor.EnclosingDatatype;
-      return $"{(full ? dt.GetFullCompileName(Options) : dt.GetCompileName(Options))}_{ctor.GetCompileName(Options)}";
+      return $"{(full ? dt.GetFullCompileName(Options) : IdProtect(dt.GetCompileName(Options)))}_{ctor.GetCompileName(Options)}";
     }
 
     protected IClassWriter DeclareType(TopLevelDecl d, SubsetTypeDecl.WKind witnessKind, Expression witness, ConcreteSyntaxTree wr) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5469.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5469.dfy
@@ -1,0 +1,15 @@
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s"
+
+module SomeDependencyModule {
+  datatype None = None
+}
+
+module SomeModule {
+  import SomeDependencyModule
+
+  const test := SomeDependencyModule.None
+}
+
+method Main() {
+  print SomeModule.test, "\n";
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5469.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5469.dfy.expect
@@ -1,0 +1,1 @@
+SomeDependencyModule.None.None

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5469.dfy.rs.check
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5469.dfy.rs.check
@@ -1,0 +1,1 @@
+CHECK: error

--- a/docs/dev/news/5476.fix
+++ b/docs/dev/news/5476.fix
@@ -1,0 +1,1 @@
+Apply name mangling to datatype names in Python more often


### PR DESCRIPTION
Fixes #5469