### PR TITLE
Catch crash on reads with different datatype ordering

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -1559,8 +1559,13 @@ namespace Microsoft.Dafny {
         if (optTypeArguments != null) {
           ReportError(tok, "a field ({0}) does not take any type arguments (got {1})", field.Name, optTypeArguments.Count);
         }
-        subst = BuildPreTypeArgumentSubstitute(subst, receiverPreTypeBound);
-        rr.PreType = field.PreType.Substitute(subst);
+        if (field.PreType != null) {
+          subst = BuildPreTypeArgumentSubstitute(subst, receiverPreTypeBound);
+          rr.PreType = field.PreType.Substitute(subst);
+        } else {
+          ReportError(tok, "the PreType of the field ({0}) is undetermined", field.Name);
+        }
+        
       } else if (member is Function function) {
         if (function is TwoStateFunction && !resolutionContext.IsTwoState) {
           ReportError(tok, "two-state function ('{0}') can only be called in a two-state context", member.Name);


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
