### PR TITLE
Revert "ci: Use macos-11 in all CI (#5493)"

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Populate OS list (all platforms)
         id: populate-os-list-all
         if: inputs.all_platforms
-        run: echo "os-list=[\"ubuntu-latest\", \"ubuntu-20.04\", \"macos-11\", \"windows-2019\"]" >> $GITHUB_OUTPUT
+        run: echo "os-list=[\"ubuntu-latest\", \"ubuntu-20.04\", \"macos-latest\", \"windows-2019\"]" >> $GITHUB_OUTPUT
       - name: Populate OS list (one platform)
         id: populate-os-list-one
         if: "!inputs.all_platforms"
@@ -35,7 +35,7 @@ jobs:
       - name: Populate OS mapping for package.py
         id: populate-os-mapping
         run: |
-          echo "os-mapping={\"ubuntu-latest\": \"ubuntu\", \"ubuntu-20.04\": \"ubuntu\", \"macos-11\": \"macos\", \"windows-2019\": \"windows\"}" >> $GITHUB_OUTPUT
+          echo "os-mapping={\"ubuntu-latest\": \"ubuntu\", \"ubuntu-20.04\": \"ubuntu\", \"macos-latest\": \"macos\", \"windows-2019\": \"windows\"}" >> $GITHUB_OUTPUT
       - name: Populate target runtime version list (all platforms)
         id: populate-target-runtime-version-all
         if: inputs.all_platforms

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -35,7 +35,7 @@ env:
 jobs:
 
   publish-release:
-    runs-on: macos-11   # Put back 'ubuntu-20.04' if macos-11 fails in any way
+    runs-on: macos-latest   # Put back 'ubuntu-20.04' if macos-latest fails in any way
     steps:
     - name: Print version
       run: echo ${{ inputs.name }}

--- a/.github/workflows/release-brew.yml
+++ b/.github/workflows/release-brew.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
 
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
     - name: Install dafny

--- a/.github/workflows/release-downloads-nuget.yml
+++ b/.github/workflows/release-downloads-nuget.yml
@@ -111,7 +111,7 @@ jobs:
         # but note we need to skip Dafny since nuget install doesn't work for dotnet tools.
         library-name: [ DafnyPipeline, DafnyServer, DafnyLanguageServer, DafnyRuntime, DafnyCore, DafnyDriver ]
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
-        os: [ ubuntu-latest, ubuntu-20.04, macos-11, windows-2019 ]
+        os: [ ubuntu-latest, ubuntu-20.04, macos-latest, windows-2019 ]
 
     steps:
     # Verify that the dependencies of the libraries we publish (e.g. DafnyLanguageServer)

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
-        os: [ ubuntu-latest, ubuntu-20.04, macos-11, windows-2019 ]
+        os: [ ubuntu-latest, ubuntu-20.04, macos-latest, windows-2019 ]
         include:
         - os:  'ubuntu-latest'
           osn: 'ubuntu-20.04'
         - os:  'ubuntu-20.04'
           osn: 'ubuntu-20.04'
-        - os:  'macos-11'
+        - os:  'macos-latest'
           osn: 'x64-macos-11'
         - os:  'windows-2019'
           osn: 'windows-2019'


### PR DESCRIPTION
This reverts PR https://github.com/dafny-lang/dafny/pull/5493 since it breaks nightly.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
