### PR TITLE
Include stacktrace in parser internal error message

### DIFF
--- a/Source/DafnyCore/AST/Grammar/ProgramParser.cs
+++ b/Source/DafnyCore/AST/Grammar/ProgramParser.cs
@@ -135,8 +135,7 @@ public class ProgramParser {
 
       var reporter = new BatchErrorReporter(options);
       reporter.Error(MessageSource.Parser, ErrorId.p_internal_exception, internalErrorDummyToken,
-        "[internal error] Parser exception: " + e.Message + (!options.Verbose ? "" :
-          "\n" + e.StackTrace));
+        "[internal error] Parser exception: " + e.Message + "\n" + e.StackTrace);
       return new DfyParseResult(reporter, new FileModuleDefinition(Token.NoToken), new Action<SystemModuleManager>[] { });
     }
   }


### PR DESCRIPTION
Helps with diagnosing https://github.com/dafny-lang/dafny/issues/5460

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
