### PR TITLE
Add timeout support to tests of TestGeneration.Test

### DIFF
--- a/Source/DafnyTestGeneration.Test/BasicTypes.cs
+++ b/Source/DafnyTestGeneration.Test/BasicTypes.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using DafnyCore.Test;
 using Microsoft.Dafny;
@@ -37,8 +38,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(methods.All(m =>
         m.MethodName == "SimpleTest.compareToZero"));
@@ -67,8 +68,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(2 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "SimpleTest.checkIfTrue"));
       Assert.True(methods.All(m =>
@@ -103,8 +104,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(7 <= methods.Count);
       Assert.True(
         methods.All(m => m.MethodName == "SimpleTest.compareToZero"));
@@ -138,8 +139,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(
         methods.All(m => m.MethodName == "SimpleTest.compareToBase"));
@@ -171,8 +172,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "SimpleTest.compareToB"));
       Assert.True(methods.All(m =>
@@ -204,8 +205,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(2 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "SimpleTest.compareToB"));
       Assert.True(methods.All(m =>

--- a/Source/DafnyTestGeneration.Test/Collections.cs
+++ b/Source/DafnyTestGeneration.Test/Collections.cs
@@ -40,8 +40,8 @@ module SimpleTest {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(methods.All(m =>
         m.MethodName == "SimpleTest.tuple"));
@@ -84,8 +84,8 @@ module C {
 
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(methods.All(m =>
         m.MethodName == "C.compareStringLengthToOne"));

--- a/Source/DafnyTestGeneration.Test/Setup.cs
+++ b/Source/DafnyTestGeneration.Test/Setup.cs
@@ -4,15 +4,28 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Boogie;
 using Microsoft.Dafny;
 using Xunit;
+using Program = Microsoft.Dafny.Program;
 using Token = Microsoft.Dafny.Token;
 
 namespace DafnyTestGeneration.Test {
 
   public class Setup {
+    private readonly CancellationTokenSource cancellationTokenSource = new();
+
+    public Setup() {
+      cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(50));
+    }
+
+    public CancellationToken CancellationToken => cancellationTokenSource.Token;
+
     protected static DafnyOptions GetDafnyOptions(List<Action<DafnyOptions>> optionSettings, TextWriter writer, params string[] arguments) {
       var options = DafnyOptions.CreateUsingOldParser(writer, TextReader.Null, arguments ?? System.Array.Empty<string>());
       options.DefiniteAssignmentLevel = 3;
@@ -32,6 +45,18 @@ namespace DafnyTestGeneration.Test {
       var optionSettings = new TheoryData<List<Action<DafnyOptions>>>();
       optionSettings.Add(new() { options => options.TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates });
       return optionSettings;
+    }
+
+    /// <summary>
+    /// Parse a string read (from a certain file) to a Dafny Program
+    /// </summary>
+    public Task<Program> /*?*/ Parse(ErrorReporter reporter, string source, bool resolve = true, Uri uri = null) {
+      return Utils.Parse(reporter, source, resolve, uri, cancellationToken: CancellationToken);
+    }
+
+    protected Task<List<TestMethod>> GetTestMethodsForProgram(Program program)
+    {
+      return TestGenerator.GetTestMethodsForProgram(program).ToListAsync(CancellationToken).AsTask().WaitAsync(CancellationToken);
     }
   }
 }

--- a/Source/DafnyTestGeneration.Test/ShortCircuitRemoval.cs
+++ b/Source/DafnyTestGeneration.Test/ShortCircuitRemoval.cs
@@ -35,7 +35,7 @@ public class ShortCircuitRemoval : Setup {
     // If the following assertion fails, rename the corresponding variables in expected output of each test
     Assert.Equal(RemoveShortCircuitingRewriter.TmpVarPrefix, "#tmp");
     var options = GetDafnyOptions(new List<Action<DafnyOptions>>(), output);
-    var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
+    var program = await Parse(new BatchErrorReporter(options), source, false);
     var success = InliningTranslator.TranslateForFutureInlining(program, options, out var boogieProgram);
     Assert.True(success);
     var method = program.DefaultModuleDef.Children

--- a/Source/DafnyTestGeneration.Test/Various.cs
+++ b/Source/DafnyTestGeneration.Test/Various.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using DafnyCore.Test;
 using Microsoft.Dafny;
@@ -40,8 +41,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(2 <= methods.Count(m => m.MethodName == "M.b"));
       Assert.Equal(1, methods.Count(m => m.MethodName == "M.a"));
@@ -73,8 +74,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count >= 2);
       Assert.True(methods.All(m => m.MethodName == "M.a"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("M.a")));
@@ -102,8 +103,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count >= 2);
     }
 
@@ -124,8 +125,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.Single(methods);
     }
 
@@ -143,8 +144,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(2 <= methods.Count);
     }
 
@@ -170,8 +171,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count >= 3);
     }
 
@@ -197,8 +198,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count < 3);
     }
 
@@ -220,10 +221,10 @@ module Paths {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
+      var program = await Parse(new BatchErrorReporter(options), source, false);
       options.TestGenOptions.Mode =
         TestGenerationOptions.Modes.Path;
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(8 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "Paths.eightPaths"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("Paths.eightPaths")));
@@ -261,10 +262,10 @@ module Paths {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
+      var program = await Parse(new BatchErrorReporter(options), source, false);
       options.TestGenOptions.Mode =
         TestGenerationOptions.Modes.InlinedBlock;
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count is >= 2 and <= 6);
       Assert.True(methods.All(m => m.MethodName == "Paths.eightPaths"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("Paths.eightPaths")));
@@ -300,8 +301,8 @@ module Paths {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count is >= 1 and <= 2);
       Assert.True(methods.All(m => m.MethodName == "Paths.eightPaths"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("Paths.eightPaths")));
@@ -343,8 +344,8 @@ module Objects {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(methods.Count >= 5);
       Assert.True(methods.All(m =>
         m.MethodName == "Objects.List.IsACircleOfTwoOrLessNodes"));
@@ -408,8 +409,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.Single(methods);
     }
 
@@ -433,8 +434,8 @@ module DataTypes {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(3 <= methods.Count);
       Assert.True(methods.All(m =>
         m.MethodName == "DataTypes.List.Depth"));
@@ -470,8 +471,8 @@ module Module {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.Single(methods);
       var m = methods[0];
       Assert.Equal("Module.ignoreNonNullableObject", m.MethodName);
@@ -497,7 +498,7 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
+      var program = await Parse(new BatchErrorReporter(options), source, false);
       options.TestGenOptions.WarnDeadCode = true;
       var stats = await TestGenerator.GetDeadCodeStatistics(program, new Modifications(options)).ToListAsync();
       Assert.Contains(stats, s => s.Contains("(6,14) is potentially unreachable."));
@@ -551,7 +552,7 @@ method {:testEntry} m(a:int) returns (b:int)
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
+      var program = await Parse(new BatchErrorReporter(options), source, false);
       options.TestGenOptions.WarnDeadCode = true;
       var stats = await TestGenerator.GetDeadCodeStatistics(program, new Modifications(options)).ToListAsync();
       Assert.Single(stats); // the only line with stats
@@ -573,9 +574,9 @@ module Test {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
+      var program = await Parse(new BatchErrorReporter(options), source, false);
       options.TestGenOptions.SeqLengthLimit = 1;
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(2 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "Test.IsEvenLength"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("Test.IsEvenLength")));
@@ -601,8 +602,8 @@ module Math {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(2 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "Math.Min"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("Math.Min")));
@@ -629,8 +630,8 @@ module ShortCircuit {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.True(2 <= methods.Count);
       Assert.True(methods.All(m => m.MethodName == "ShortCircuit.Or"));
       Assert.True(methods.All(m => m.DafnyInfo.IsStatic("ShortCircuit.Or")));
@@ -659,8 +660,8 @@ module C {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.Equal(3, methods.Count);
       Assert.True(methods.Exists(m => m.MethodName == "A.m" &&
                                         m.DafnyInfo.IsStatic("A.m") &&
@@ -700,8 +701,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.Single(methods);
       Assert.True(methods.All(m =>
         m.MethodName == "M.Instance.setI"));
@@ -730,8 +731,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      await GetTestMethodsForProgram(program);
     }
 
     [Theory]
@@ -743,8 +744,8 @@ module M {
 }
 ".TrimStart();
       var options = GetDafnyOptions(optionSettings, output);
-      var program = await Utils.Parse(new BatchErrorReporter(options), source, false);
-      var methods = await TestGenerator.GetTestMethodsForProgram(program).ToListAsync();
+      var program = await Parse(new BatchErrorReporter(options), source, false);
+      var methods = await GetTestMethodsForProgram(program);
       Assert.Single(methods);
     }
 

--- a/Source/DafnyTestGeneration/Utils.cs
+++ b/Source/DafnyTestGeneration/Utils.cs
@@ -84,18 +84,18 @@ namespace DafnyTestGeneration {
     /// <summary>
     /// Parse a string read (from a certain file) to a Dafny Program
     /// </summary>
-    public static async Task<Program> /*?*/ Parse(ErrorReporter reporter, string source, bool resolve = true, Uri uri = null) {
+    public static async Task<Program> /*?*/ Parse(ErrorReporter reporter, string source, bool resolve = true, Uri uri = null, CancellationToken cancellationToken = default) {
       uri ??= new Uri(Path.Combine(Path.GetTempPath(), "parseUtils.dfy"));
 
       var fs = new InMemoryFileSystem(ImmutableDictionary<Uri, string>.Empty.Add(uri, source));
       var dafnyFile = DafnyFile.HandleDafnyFile(fs, reporter, reporter.Options, uri, Token.NoToken, false);
       var program = await new ProgramParser().ParseFiles(uri.LocalPath,
-        new[] { dafnyFile }, reporter, CancellationToken.None);
+        new[] { dafnyFile }, reporter, cancellationToken);
 
       if (!resolve) {
         return program;
       }
-      await new ProgramResolver(program).Resolve(CancellationToken.None);
+      await new ProgramResolver(program).Resolve(cancellationToken);
       return program;
     }
 


### PR DESCRIPTION
### Description
Add timeout support to tests of TestGeneration.Test, to help with https://github.com/dafny-lang/dafny/issues/5488

### How has this been tested?
Manually tested that if the timeout is lowered, tests get cancelled.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
