### PR TITLE
chore: Double shard count and drop `ubuntu-lastest` from the nightly build

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Populate OS list (all platforms)
         id: populate-os-list-all
         if: inputs.all_platforms
-        run: echo "os-list=[\"ubuntu-latest\", \"ubuntu-20.04\", \"macos-latest\", \"windows-2019\"]" >> $GITHUB_OUTPUT
+        run: echo "os-list=[\"ubuntu-20.04\", \"macos-latest\", \"windows-2019\"]" >> $GITHUB_OUTPUT
       - name: Populate OS list (one platform)
         id: populate-os-list-one
         if: "!inputs.all_platforms"
@@ -35,7 +35,7 @@ jobs:
       - name: Populate OS mapping for package.py
         id: populate-os-mapping
         run: |
-          echo "os-mapping={\"ubuntu-latest\": \"ubuntu\", \"ubuntu-20.04\": \"ubuntu\", \"macos-latest\": \"macos\", \"windows-2019\": \"windows\"}" >> $GITHUB_OUTPUT
+          echo "os-mapping={\"ubuntu-20.04\": \"ubuntu\", \"macos-latest\": \"macos\", \"windows-2019\": \"windows\"}" >> $GITHUB_OUTPUT
       - name: Populate target runtime version list (all platforms)
         id: populate-target-runtime-version-all
         if: inputs.all_platforms

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   deep-integration-tests:
-    if: github.repository_owner == 'dafny-lang'
+    if: true
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
       ref: ${{ inputs.ref }}

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   deep-integration-tests:
-    if: true
+    if: github.repository_owner == 'dafny-lang'
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
       ref: ${{ inputs.ref }}

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       ref: ${{ inputs.ref }}
       all_platforms: true
-      num_shards: 5
+      num_shards: 10
 
   determine-vars:
     if: github.repository_owner == 'dafny-lang' && inputs.publish-prerelease

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,6 +28,6 @@ jobs:
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
-      publish-prerelease: true
+      publish-prerelease: false
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -24,10 +24,10 @@ on:
 
 jobs:
   nightly-build-for-master:
-    if: true
+    if: github.repository_owner == 'dafny-lang'
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
-      publish-prerelease: false
+      publish-prerelease: true
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   nightly-build-for-master:
-    if: github.repository_owner == 'dafny-lang'
+    if: true
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master


### PR DESCRIPTION
Should make make the nightly build more predictable