### PR TITLE
Add `const`, `export` and `expect` to LaTeX keyword list

### DIFF
--- a/docs/dafny.sty
+++ b/docs/dafny.sty
@@ -9,14 +9,14 @@
       bool,char,nat,int,real,object,set,iset,multiset,seq,string,map,imap,array,array2,array3,
       bv0,bv1,bv2,bv3,bv4,bv5,bv6,bv7,bv8,bv12,bv16,bv20,bv24,bv32,bv48,bv64,bv128,
       function,predicate,copredicate,inductive,
-      ghost,var,static,refines,
+      ghost,var,const,static,refines,
       method,lemma,constructor,colemma,twostate,
-      returns,yields,abstract,module,import,default,opened,as,in,
+      returns,yields,abstract,module,export,import,default,opened,as,in,
       requires,modifies,ensures,reads,decreases,include,provides,reveals,witness,
       % expressions
       match,case,false,true,null,old,fresh,allocated,unchanged,this,
       % statements
-      assert,by,assume,print,new,if,then,else,while,invariant,break,label,return,yield,
+      assert,by,assume,expect,print,new,if,then,else,while,invariant,break,label,return,yield,
       where,calc,modify
       },
   literate=%


### PR DESCRIPTION
### Description

Add "const", "export" and "expect" to the LaTeX keyword list. These are present in the KDE syntax definition, but missing from the LaTeX keyword list.

### How has this been tested?

This is a documentation-only change.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
