### PR TITLE
Implement `GetAssertedExpr` for `CalculationStep`

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.TrStatement.cs
@@ -755,11 +755,11 @@ namespace Microsoft.Dafny {
             // assert step:
             AddComment(b, stmt, "assert line" + i.ToString() + " " + (stmt.StepOps[i] ?? stmt.Op).ToString() + " line" + (i + 1).ToString());
             if (!splitHappened) {
-              b.Add(AssertNS(stmt.Lines[i + 1].tok, etran.TrExpr(stmt.Steps[i]), new PODesc.CalculationStep()));
+              b.Add(AssertNS(stmt.Lines[i + 1].tok, etran.TrExpr(stmt.Steps[i]), new PODesc.CalculationStep(stmt.Steps[i], stmt.Hints[i])));
             } else {
               foreach (var split in ss) {
                 if (split.IsChecked) {
-                  b.Add(AssertNS(stmt.Lines[i + 1].tok, split.E, new PODesc.CalculationStep()));
+                  b.Add(AssertNS(stmt.Lines[i + 1].tok, split.E, new PODesc.CalculationStep(stmt.Steps[i], stmt.Hints[i])));
                 }
               }
             }

--- a/Source/DafnyCore/Verifier/ProofObligationDescription.cs
+++ b/Source/DafnyCore/Verifier/ProofObligationDescription.cs
@@ -645,6 +645,39 @@ public class CalculationStep : ProofObligationDescription {
     "the calculation step between the previous line and this line could not be proved";
 
   public override string ShortDescription => "calc step";
+
+  private readonly Expression expr;
+  private readonly BlockStmt hints;
+
+  public override Expression GetAssertedExpr(DafnyOptions options) {
+    return expr;
+  }
+
+  public override string GetExtraExplanation() {
+    if (hints is null || hints.Body is null || hints.Body.Count == 0) {
+      return null;
+    }
+
+    StringBuilder builder = new();
+    builder.Append("\n  asserted after the following statements:");
+
+    // These can be deeply nested for some reason
+    List<Statement> stmts = hints.Body;
+    while (stmts.Count == 1 && stmts[0] is BlockStmt bs) {
+      stmts = bs.Body;
+    }
+
+    foreach (var stmt in stmts) {
+      builder.Append($"\n    {stmt}");
+    }
+
+    return builder.ToString();
+  }
+
+  public CalculationStep(Expression expr, BlockStmt hints) {
+    this.expr = expr;
+    this.hints = hints;
+  }
 }
 
 public class EnsuresStronger : ProofObligationDescription {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/proof-obligation-desc/calc-step.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/proof-obligation-desc/calc-step.dfy
@@ -1,0 +1,40 @@
+// RUN: %exits-with 4 %verify --show-proof-obligation-expressions "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+ghost function f(x: int, y: int): int
+
+lemma {:axiom} Associativity(x: int, y: int, z: int)
+  ensures f(x, f(y, z)) == f(f(x, y), z)
+
+lemma {:axiom} Monotonicity(y: int, z: int)
+  requires y <= z
+  ensures forall x :: f(x, y) <= f(x, z)
+
+lemma {:axiom} DiagonalIdentity(x: int)
+  ensures f(x, x) == x
+
+// From these axioms, we can prove a lemma about "f":
+
+method CalculationalStyleProof(a: int, b: int, c: int, x: int)
+  requires c <= x == f(a, b)
+  ensures f(a, f(b, c)) <= x
+{
+  calc == {
+    f(a, f(b, c));
+    { Associativity(a, b, c); }
+    f(f(a, b), c);
+    { assert f(a, b) == x; }
+    f(x, c);
+    { assert c <= x; Monotonicity(c, x); }
+    // Error, because the relation here should be <=, not ==
+    f(x, x);
+    { DiagonalIdentity(x); }
+    x;
+  }
+}
+
+method NoHintProof(x: int) {
+  calc == {
+    x - 1 + 1;
+    x + 1;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/proof-obligation-desc/calc-step.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/proof-obligation-desc/calc-step.dfy.expect
@@ -1,0 +1,9 @@
+calc-step.dfy(29,5): Error: the calculation step between the previous line and this line could not be proved
+ Asserted expression: f(x, c) == f(x, x)
+   asserted after the following statements:
+     assert c <= x;
+     Monotonicity(c, x);
+calc-step.dfy(38,6): Error: the calculation step between the previous line and this line could not be proved
+ Asserted expression: x - 1 + 1 == x + 1
+
+Dafny program verifier finished with 0 verified, 2 errors


### PR DESCRIPTION
### Description

Implement `GetAssertedExpr` for `CalculationStep`.

### How has this been tested?

With the new test `proof-obligation-desc/calc-step.dfy`.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
