### PR TITLE
Chore: Omit Rust from the nightly release workflow

### DIFF
--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -26,6 +26,9 @@ jobs:
       ref: ${{ inputs.ref }}
       all_platforms: true
       num_shards: 10
+    # Omit Rust because Rust is known to have random issues
+    env:
+      DAFNY_INTEGRATION_TESTS_ONLY_COMPILERS: cs,java,go,js,cpp,dfy,py
 
   determine-vars:
     if: github.repository_owner == 'dafny-lang' && inputs.publish-prerelease


### PR DESCRIPTION
We have observed that the Rust compiler fails randomly. To not disrupt the workflow of the nightly release, and as the Rust compiler is still under active development, it does not make sense to include it as part of the nightly.

### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
