### PR TITLE
Ensure nightly skips Rust (fixed)

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -14,8 +14,9 @@ on:
         type: string
       compilers:
         description: 'Compilers to use'
+        type: string
         required: false
-        default: ''
+        default: ""
 
 env:
   dotnet-version: 6.0.x # SDK Version for building Dafny

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -12,10 +12,13 @@ on:
       ref:
         required: true
         type: string
+      compilers:
+        description: 'Compilers to use'
+        required: false
+        default: ''
 
 env:
   dotnet-version: 6.0.x # SDK Version for building Dafny
-
 
 jobs:
   # This job is used to dynamically calculate the matrix dimensions.
@@ -150,7 +153,8 @@ jobs:
       env:
         XUNIT_SHARD: ${{ matrix.shard }}
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
-        DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafny
+        DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafnyenv:
+        DAFNY_INTEGRATION_TESTS_ONLY_COMPILERS: ${{ inputs.compilers }}
       run: |
         cmd /c mklink D:\a\dafny\dafny\unzippedRelease\dafny\z3\bin\z3-4.12.1 D:\a\dafny\dafny\unzippedRelease\dafny\z3\bin\z3-4.12.1.exe
         dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" --settings dafny/Source/IntegrationTests/coverlet.runsettings dafny/Source/IntegrationTests/IntegrationTests.csproj

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -153,7 +153,7 @@ jobs:
       env:
         XUNIT_SHARD: ${{ matrix.shard }}
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
-        DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafnyenv:
+        DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafny
         DAFNY_INTEGRATION_TESTS_ONLY_COMPILERS: ${{ inputs.compilers }}
       run: |
         cmd /c mklink D:\a\dafny\dafny\unzippedRelease\dafny\z3\bin\z3-4.12.1 D:\a\dafny\dafny\unzippedRelease\dafny\z3\bin\z3-4.12.1.exe
@@ -171,6 +171,7 @@ jobs:
       env:
         XUNIT_SHARD: ${{ matrix.shard }}
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
+        DAFNY_INTEGRATION_TESTS_ONLY_COMPILERS: ${{ inputs.compilers }}
       run: |
         ${{ inputs.all_platforms }} && export DAFNY_RELEASE="${{ github.workspace }}/unzippedRelease/dafny"
         dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" --settings dafny/Source/IntegrationTests/coverlet.runsettings dafny/Source/IntegrationTests

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -26,9 +26,8 @@ jobs:
       ref: ${{ inputs.ref }}
       all_platforms: true
       num_shards: 10
-    # Omit Rust because Rust is known to have random issues
-    env:
-      DAFNY_INTEGRATION_TESTS_ONLY_COMPILERS: cs,java,go,js,cpp,dfy,py
+      # Omit Rust because Rust is known to have random issues
+      compilers: cs,java,go,js,cpp,dfy,py
 
   determine-vars:
     if: github.repository_owner == 'dafny-lang' && inputs.publish-prerelease


### PR DESCRIPTION
Ensure the nightly won't run the Rust code.

This time, we run the deep tests to ensure everything works as expected.
<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
