### PR TITLE
Add --find-project option

### DIFF
--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -29,7 +29,7 @@ public class DafnyFile {
   private static readonly Dictionary<Uri, Uri> ExternallyVisibleEmbeddedFiles = new();
 
   static DafnyFile() {
-    DooFile.RegisterLibraryCheck(UnsafeDependencies, OptionCompatibility.OptionLibraryImpliesLocalError);
+    DooFile.RegisterLibraryCheck(DoNotVerifyDependencies, OptionCompatibility.OptionLibraryImpliesLocalError);
   }
 
   public static Uri ExposeInternalUri(string externalName, Uri internalUri) {
@@ -108,7 +108,7 @@ public class DafnyFile {
     }
   }
 
-  public static readonly Option<bool> UnsafeDependencies = new("--dont-verify-dependencies",
+  public static readonly Option<bool> DoNotVerifyDependencies = new("--dont-verify-dependencies",
     "Allows Dafny to accept dependencies that may not have been previously verified, which can be useful during development.");
 
   public static DafnyFile? HandleDafnyFile(IFileSystem fileSystem,
@@ -141,7 +141,7 @@ public class DafnyFile {
       return null;
     }
 
-    if (!options.Get(UnsafeDependencies) && asLibrary && warnLibrary) {
+    if (!options.Get(DoNotVerifyDependencies) && asLibrary && warnLibrary) {
       reporter.Warning(MessageSource.Project, "", origin,
         $"The file '{options.GetPrintPath(filePath)}' was passed to --library. " +
         $"Verification for that file might have used options incompatible with the current ones, or might have been skipped entirely. " +

--- a/Source/DafnyCore/Options/BoogieOptionBag.cs
+++ b/Source/DafnyCore/Options/BoogieOptionBag.cs
@@ -110,6 +110,7 @@ public static class BoogieOptionBag {
     DafnyOptions.RegisterLegacyBinding(NoVerify, (options, value) => {
       var shouldVerify = !value && !options.Get(HiddenNoVerify);
       options.Verify = shouldVerify;
+      options.DafnyVerify = shouldVerify;
     });
     DafnyOptions.RegisterLegacyBinding(VerificationTimeLimit, (o, f) => o.TimeLimit = f);
 

--- a/Source/DafnyCore/Options/BoogieOptionBag.cs
+++ b/Source/DafnyCore/Options/BoogieOptionBag.cs
@@ -110,7 +110,6 @@ public static class BoogieOptionBag {
     DafnyOptions.RegisterLegacyBinding(NoVerify, (options, value) => {
       var shouldVerify = !value && !options.Get(HiddenNoVerify);
       options.Verify = shouldVerify;
-      options.DafnyVerify = shouldVerify;
     });
     DafnyOptions.RegisterLegacyBinding(VerificationTimeLimit, (o, f) => o.TimeLimit = f);
 

--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -107,6 +107,7 @@ public static class DafnyCommands {
     CommonOptionBag.WarnMissingConstructorParenthesis,
     PrintStmt.TrackPrintEffectsOption,
     CommonOptionBag.AllowAxioms,
-    MethodOrFunction.AllowExternalContracts
+    MethodOrFunction.AllowExternalContracts,
+    DafnyProject.FindProjectOption
   }).Concat(ParserOptions).ToList();
 }

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -16,6 +16,9 @@ using Tomlyn.Model;
 namespace Microsoft.Dafny;
 
 public class DafnyProject : IEquatable<DafnyProject> {
+  public static Option<bool> FindProject = new("--find-project",
+    "From the location of the first specified source file, search for a project file by traversing up the file tree.");
+
   public const string Extension = ".toml";
   public const string FileName = "dfyconfig" + Extension;
 
@@ -48,7 +51,7 @@ public class DafnyProject : IEquatable<DafnyProject> {
     Options = options ?? new Dictionary<string, object>();
   }
 
-  public static async Task<DafnyProject> Open(IFileSystem fileSystem, DafnyOptions dafnyOptions, Uri uri, IToken uriOrigin,
+  public static async Task<DafnyProject> Open(IFileSystem fileSystem, Uri uri, IToken uriOrigin,
     bool defaultIncludes = true, bool serverNameCheck = true) {
 
     var emptyProject = new DafnyProject(uri, null, new HashSet<string>(), new HashSet<string>(),
@@ -67,7 +70,7 @@ public class DafnyProject : IEquatable<DafnyProject> {
         model.Options ?? new Dictionary<string, object>());
 
       if (result.Base != null) {
-        var baseProject = await Open(fileSystem, dafnyOptions, result.Base, new Token {
+        var baseProject = await Open(fileSystem, result.Base, new Token {
           Uri = uri,
           line = 1,
           col = 1

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using DafnyCore;
 using DafnyCore.Options;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Tomlyn;
@@ -16,8 +17,12 @@ using Tomlyn.Model;
 namespace Microsoft.Dafny;
 
 public class DafnyProject : IEquatable<DafnyProject> {
-  public static Option<bool> FindProject = new("--find-project",
-    "From the location of the first specified source file, search for a project file by traversing up the file tree.");
+  public static Option<FileInfo> FindProjectOption = new("--find-project",
+    "Given a filesystem path, search for a project file by traversing up the file tree.");
+
+  static DafnyProject() {
+    DooFile.RegisterNoChecksNeeded(FindProjectOption, false);
+  }
 
   public const string Extension = ".toml";
   public const string FileName = "dfyconfig" + Extension;

--- a/Source/DafnyCore/Options/ProjectFileOpener.cs
+++ b/Source/DafnyCore/Options/ProjectFileOpener.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Dafny;
+
+public class ProjectFileOpener {
+  private readonly IFileSystem fileSystem;
+  private readonly IToken origin;
+
+  public ProjectFileOpener(IFileSystem fileSystem, IToken origin) {
+    this.fileSystem = fileSystem;
+    this.origin = origin;
+  }
+
+  public async Task<DafnyProject?> TryFindProject(Uri uri) {
+    return uri.LocalPath.EndsWith(DafnyProject.FileName)
+      ? await DafnyProject.Open(fileSystem, uri, origin)
+      : await FindProjectFile(uri);
+  }
+
+  private async Task<DafnyProject?> FindProjectFile(Uri sourceUri) {
+    DafnyProject? projectFile = null;
+
+    var folder = Path.GetDirectoryName(sourceUri.LocalPath);
+    while (!string.IsNullOrEmpty(folder) && projectFile == null) {
+      projectFile = await OpenProjectInFolder(folder);
+
+      if (projectFile != null && projectFile.Uri != sourceUri &&
+          !(projectFile.Errors.HasErrors || projectFile.ContainsSourceFile(sourceUri))) {
+        projectFile = null;
+      }
+
+      folder = Path.GetDirectoryName(folder);
+    }
+
+    return projectFile;
+  }
+
+  protected virtual Task<DafnyProject?> OpenProjectInFolder(string folderPath) {
+    var configFileUri = new Uri(Path.Combine(folderPath, DafnyProject.FileName));
+    if (!fileSystem.Exists(configFileUri)) {
+      return Task.FromResult<DafnyProject?>(null);
+    }
+
+    return DafnyProject.Open(fileSystem, configFileUri, origin)!;
+  }
+}

--- a/Source/DafnyDriver/Commands/ResolveCommand.cs
+++ b/Source/DafnyDriver/Commands/ResolveCommand.cs
@@ -13,7 +13,7 @@ static class ResolveCommand {
       result.AddOption(option);
     }
     DafnyNewCli.SetHandlerUsingDafnyOptionsContinuation(result, async (options, _) => {
-      options.Set(DafnyFile.UnsafeDependencies, true);
+      options.Set(DafnyFile.DoNotVerifyDependencies, true);
       var compilation = CliCompilation.Create(options);
       compilation.Start();
       await compilation.Resolution;

--- a/Source/DafnyDriver/Commands/ServerCommand.cs
+++ b/Source/DafnyDriver/Commands/ServerCommand.cs
@@ -32,7 +32,7 @@ public class ServerCommand {
       result.Add(option);
     }
     DafnyNewCli.SetHandlerUsingDafnyOptionsContinuation(result, async (options, context) => {
-      options.Set(DafnyFile.UnsafeDependencies, true);
+      options.Set(DafnyFile.DoNotVerifyDependencies, true);
       LanguageServer.ConfigureDafnyOptionsForServer(options);
       await LanguageServer.Start(options);
       return 0;

--- a/Source/DafnyDriver/Commands/VerifyCommand.cs
+++ b/Source/DafnyDriver/Commands/VerifyCommand.cs
@@ -42,7 +42,7 @@ public static class VerifyCommand {
     new Option[] {
         FilterSymbol,
         FilterPosition,
-        DafnyFile.UnsafeDependencies
+        DafnyFile.DoNotVerifyDependencies
       }.Concat(DafnyCommands.VerificationOptions).
       Concat(DafnyCommands.ConsoleOutputOptions).
       Concat(DafnyCommands.ResolverOptions);

--- a/Source/DafnyDriver/DafnyNewCli.cs
+++ b/Source/DafnyDriver/DafnyNewCli.cs
@@ -290,7 +290,7 @@ public static class DafnyNewCli {
       yield break;
     }
 
-    if (options.Get(DafnyFile.UnsafeDependencies) || !options.Verify) {
+    if (options.Get(DafnyFile.DoNotVerifyDependencies) || !options.Verify) {
       foreach (var libraryRootSetFile in dependencyProject.GetRootSourceUris(fileSystem)) {
         var file = DafnyFile.HandleDafnyFile(fileSystem, reporter, dependencyOptions, libraryRootSetFile,
           dependencyProject.StartingToken, true, false);
@@ -313,7 +313,7 @@ public static class DafnyNewCli {
       dependencyOptions.Compile = true;
       dependencyOptions.RunAfterCompile = false;
       var exitCode = await SynchronousCliCompilation.Run(dependencyOptions);
-      if (exitCode == 0) {
+      if (exitCode == 0 && libraryBackend.DooPath != null) {
         var dooUri = new Uri(libraryBackend.DooPath);
         await foreach (var dooResult in DafnyFile.HandleDooFile(fileSystem, reporter, options, dooUri, uriOrigin, true)) {
           yield return dooResult;

--- a/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
+++ b/Source/DafnyLanguageServer.Test/DafnyLanguageServerTestBase.cs
@@ -105,7 +105,7 @@ lemma {:neverVerify} HasNeverVerifyAttribute(p: nat, q: nat)
     private Action<LanguageServerOptions> GetServerOptionsAction(Action<DafnyOptions> modifyOptions) {
       var dafnyOptions = DafnyOptions.CreateUsingOldParser(output);
       dafnyOptions.Set(ProjectManager.UpdateThrottling, 0);
-      dafnyOptions.Set(ProjectManagerDatabase.ProjectFileCacheExpiry, 0);
+      dafnyOptions.Set(CachingProjectFileOpener.ProjectFileCacheExpiry, 0);
       modifyOptions?.Invoke(dafnyOptions);
       dafnyOptions.UsingNewCli = true;
       LanguageServer.ConfigureDafnyOptionsForServer(dafnyOptions);

--- a/Source/DafnyLanguageServer.Test/ProjectFiles/ProjectFilesTest.cs
+++ b/Source/DafnyLanguageServer.Test/ProjectFiles/ProjectFilesTest.cs
@@ -92,7 +92,7 @@ module Consumer {
     const int cacheExpiry = 1000;
     await SetUp(options => {
       options.WarnShadowing = false;
-      options.Set(ProjectManagerDatabase.ProjectFileCacheExpiry, cacheExpiry);
+      options.Set(CachingProjectFileOpener.ProjectFileCacheExpiry, cacheExpiry);
     });
     var tempDirectory = GetFreshTempPath();
     Directory.CreateDirectory(tempDirectory);

--- a/Source/DafnyLanguageServer/LanguageServer.cs
+++ b/Source/DafnyLanguageServer/LanguageServer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Dafny.LanguageServer {
         VerifySnapshots,
         DafnyLangSymbolResolver.UseCaching,
         ProjectManager.UpdateThrottling,
-        ProjectManagerDatabase.ProjectFileCacheExpiry,
+        CachingProjectFileOpener.ProjectFileCacheExpiry,
         DeveloperOptionBag.BoogiePrint,
         CommonOptionBag.EnforceDeterminism,
         InternalDocstringRewritersPluginConfiguration.UseJavadocLikeDocstringRewriterOption,

--- a/Source/DafnyLanguageServer/Workspace/CachingProjectFileOpener.cs
+++ b/Source/DafnyLanguageServer/Workspace/CachingProjectFileOpener.cs
@@ -1,0 +1,45 @@
+using System;
+using System.CommandLine;
+using System.Runtime.Caching;
+using System.Threading.Tasks;
+using DafnyCore;
+using Microsoft.Dafny;
+
+public class CachingProjectFileOpener : ProjectFileOpener {
+  public const int DefaultProjectFileCacheExpiryTime = 100;
+  private readonly object nullRepresentative = new(); // Needed because you can't store null in the MemoryCache, but that's a value we want to cache.
+  private readonly DafnyOptions serverOptions;
+  private readonly MemoryCache projectFilePerFolderCache = new("projectFiles");
+
+
+  static CachingProjectFileOpener() {
+    DooFile.RegisterNoChecksNeeded(ProjectFileCacheExpiry, false);
+  }
+
+  public CachingProjectFileOpener(IFileSystem fileSystem, DafnyOptions serverOptions, IToken origin) : base(fileSystem, origin) {
+    this.serverOptions = serverOptions;
+  }
+
+  public static readonly Option<int> ProjectFileCacheExpiry = new("--project-file-cache-expiry", () => DefaultProjectFileCacheExpiryTime,
+    @"How many milliseconds the server will cache project file contents".TrimStart()) {
+    IsHidden = true
+  };
+
+  protected override async Task<DafnyProject?> OpenProjectInFolder(string folderPath) {
+    var cacheExpiry = serverOptions.Get(ProjectFileCacheExpiry);
+    if (cacheExpiry == 0) {
+      return await base.OpenProjectInFolder(folderPath);
+    }
+
+    var cachedResult = projectFilePerFolderCache.Get(folderPath);
+    if (cachedResult != null) {
+      return cachedResult == nullRepresentative ? null : ((DafnyProject?)cachedResult)?.Clone();
+    }
+
+    var result = await base.OpenProjectInFolder(folderPath);
+    projectFilePerFolderCache.Set(new CacheItem(folderPath, (object?)result ?? nullRepresentative), new CacheItemPolicy {
+      AbsoluteExpiration = new DateTimeOffset(DateTime.Now.Add(TimeSpan.FromMilliseconds(cacheExpiry)))
+    });
+    return result?.Clone();
+  }
+}

--- a/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
@@ -1,7 +1,6 @@
 ﻿using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Runtime.Caching;
@@ -10,23 +9,15 @@ using DafnyCore;
 using Microsoft.Boogie;
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using Token = Microsoft.Boogie.Token;
 
 namespace Microsoft.Dafny.LanguageServer.Workspace {
   /// <summary>
   /// Contains a collection of ProjectManagers
   /// </summary>
   public class ProjectManagerDatabase : IProjectDatabase {
-    public static readonly Option<int> ProjectFileCacheExpiry = new("--project-file-cache-expiry", () => DefaultProjectFileCacheExpiryTime,
-      @"How many milliseconds the server will cache project file contents".TrimStart()) {
-      IsHidden = true
-    };
-
-    static ProjectManagerDatabase() {
-      DooFile.RegisterNoChecksNeeded(ProjectFileCacheExpiry, false);
-    }
 
     private readonly object myLock = new();
-    public const int DefaultProjectFileCacheExpiryTime = 100;
 
     private readonly CreateProjectManager createProjectManager;
     private readonly ILogger<ProjectManagerDatabase> logger;
@@ -36,9 +27,8 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     private readonly LanguageServerFilesystem fileSystem;
     private readonly VerificationResultCache verificationCache = new();
     private readonly TaskScheduler scheduler;
-    private readonly MemoryCache projectFilePerFolderCache = new("projectFiles");
-    private readonly object nullRepresentative = new(); // Needed because you can't store null in the MemoryCache, but that's a value we want to cache.
     private readonly DafnyOptions serverOptions;
+    private CachingProjectFileOpener projectFileOpener;
 
     private const int stackSize = 10 * 1024 * 1024;
 
@@ -52,6 +42,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       this.fileSystem = fileSystem;
       this.serverOptions = serverOptions;
       this.scheduler = CustomStackSizePoolTaskScheduler.Create(stackSize, serverOptions.VcsCores);
+      projectFileOpener = new CachingProjectFileOpener(fileSystem, serverOptions, Token.Ide);
     }
 
     public async Task OpenDocument(TextDocumentItem document) {
@@ -204,9 +195,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     }
 
     public async Task<DafnyProject> GetProject(Uri uri) {
-      return uri.LocalPath.EndsWith(DafnyProject.FileName)
-        ? await DafnyProject.Open(fileSystem, serverOptions, uri, Token.Ide)
-        : (await FindProjectFile(uri) ?? ImplicitProject(uri));
+      return await projectFileOpener.TryFindProject(uri) ?? ImplicitProject(uri);
     }
 
     public static DafnyProject ImplicitProject(Uri uri) {
@@ -216,51 +205,6 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
         new HashSet<string>(),
         new Dictionary<string, object>());
       return implicitProject;
-    }
-
-    private async Task<DafnyProject?> FindProjectFile(Uri sourceUri) {
-      DafnyProject? projectFile = null;
-
-      var folder = Path.GetDirectoryName(sourceUri.LocalPath);
-      while (!string.IsNullOrEmpty(folder) && projectFile == null) {
-        projectFile = await OpenProjectInFolder(folder);
-
-        if (projectFile != null && projectFile.Uri != sourceUri &&
-            !(projectFile.Errors.HasErrors || projectFile.ContainsSourceFile(sourceUri))) {
-          projectFile = null;
-        }
-
-        folder = Path.GetDirectoryName(folder);
-      }
-
-      return projectFile;
-    }
-
-    private async Task<DafnyProject?> OpenProjectInFolder(string folderPath) {
-      var cacheExpiry = serverOptions.Get(ProjectFileCacheExpiry);
-      if (cacheExpiry == 0) {
-        return await OpenProjectInFolderUncached(folderPath);
-      }
-
-      var cachedResult = projectFilePerFolderCache.Get(folderPath);
-      if (cachedResult != null) {
-        return cachedResult == nullRepresentative ? null : ((DafnyProject?)cachedResult)?.Clone();
-      }
-
-      var result = await OpenProjectInFolderUncached(folderPath);
-      projectFilePerFolderCache.Set(new CacheItem(folderPath, (object?)result ?? nullRepresentative), new CacheItemPolicy {
-        AbsoluteExpiration = new DateTimeOffset(DateTime.Now.Add(TimeSpan.FromMilliseconds(cacheExpiry)))
-      });
-      return result?.Clone();
-    }
-
-    private Task<DafnyProject?> OpenProjectInFolderUncached(string folderPath) {
-      var configFileUri = new Uri(Path.Combine(folderPath, DafnyProject.FileName));
-      if (!fileSystem.Exists(configFileUri)) {
-        return Task.FromResult<DafnyProject?>(null);
-      }
-
-      return DafnyProject.Open(fileSystem, serverOptions, configFileUri, Token.Ide)!;
     }
 
     public IEnumerable<ProjectManager> Managers => managersByProject.Values;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy
@@ -37,4 +37,7 @@
 // Files excluded by the project file and included on the CLI, are included
 // RUN: ! %resolve "%S/dfyconfig.toml" "%S/src/excluded.dfy" &>> "%t"
 
+// A project file can be found from an input file
+// RUN: ! %resolve %S/src/input.dfy --find-project &>> "%t"
+
 // RUN: %diff "%s.expect" "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy
@@ -38,6 +38,6 @@
 // RUN: ! %resolve "%S/dfyconfig.toml" "%S/src/excluded.dfy" &>> "%t"
 
 // A project file can be found from an input file
-// RUN: ! %resolve %S/src/input.dfy --find-project &>> "%t"
+// RUN: ! %resolve --find-project %S/src/input.dfy &>> "%t"
 
 // RUN: %diff "%s.expect" "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy.expect
@@ -23,3 +23,5 @@ excluded.dfy(3,7): Error: Duplicate member name: Foo
 input.dfy(6,8): Warning: Shadowed local-variable name: x
 excluded.dfy(6,8): Warning: Shadowed local-variable name: z
 1 resolution/type errors detected in dfyconfig.toml
+input.dfy(6,8): Warning: Shadowed local-variable name: x
+Compilation failed because warnings were found and --allow-warnings is false


### PR DESCRIPTION
### Description
- Add `--find-project` option, which allows selecting a project file by traversing up from a certain path. This is useful when working in a particular file and wanting to to a Dafny CLI call that uses the project for that file.

### How has this been tested?
- Extended the existing CLI test `projectFile.dfy`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
