### PR TITLE
Chore: Internal backends should not fail CI

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/metatests/InconsistentCompilerBehavior.dfy.testdafny.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/metatests/InconsistentCompilerBehavior.dfy.testdafny.expect
@@ -50,4 +50,5 @@ Diff (changing expected into actual):
 +0
  
 
+(non-blocking) The Rust code generator is internal. Not having a '*.rs.check' file is acceptable for now.
 Executing on ResolvedDesugaredExecutableDafny...

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/metatests/TestBeyondVerifierExpect.dfy.testdafny.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/metatests/TestBeyondVerifierExpect.dfy.testdafny.expect
@@ -50,4 +50,5 @@ Diff (changing expected into actual):
 +hello
  
 
+(non-blocking) The Rust code generator is internal. Not having a '*.rs.check' file is acceptable for now.
 Executing on ResolvedDesugaredExecutableDafny...

--- a/Source/TestDafny/MultiBackendTest.cs
+++ b/Source/TestDafny/MultiBackendTest.cs
@@ -423,6 +423,12 @@ public class MultiBackendTest {
       }
 
       await output.WriteLineAsync(diffMessage);
+      if (backend.IsInternal) {
+        await output.WriteLineAsync(
+          $"(non-blocking) The '{backend.TargetName}' code generator is internal. Not having a '*.{backend.TargetName}.check' file is acceptable for now.");
+        return 0;
+      }
+
       return 1;
     }
 
@@ -456,9 +462,25 @@ public class MultiBackendTest {
         }
       }
 
+      if (backend.IsInternal && checkResult != 0) {
+        await output.WriteLineAsync(
+          $"(non-blocking) The '{backend.TargetName}' code generator is internal. An unmatched '*.{backend.TargetName}.check' file is acceptable for now.");
+        return 0;
+      }
+
       return checkResult;
     }
 
+
+    if (backend.IsInternal) {
+      await output.WriteLineAsync($"(non-blocking) Execution failed for the internal code generator to {backend.TargetName}, for reasons other than known unsupported features. Output:");
+      await output.WriteLineAsync(outputString);
+      await output.WriteLineAsync("Error:");
+      await output.WriteLineAsync(error);
+      await output.WriteLineAsync(
+        $"The '{backend.TargetName}' code generator is internal. An unmatched '*.{backend.TargetName}.check' file is acceptable for now.");
+      return 0;
+    }
     await output.WriteLineAsync("Execution failed, for reasons other than known unsupported features. Output:");
     await output.WriteLineAsync(outputString);
     await output.WriteLineAsync("Error:");

--- a/Source/TestDafny/MultiBackendTest.cs
+++ b/Source/TestDafny/MultiBackendTest.cs
@@ -425,7 +425,7 @@ public class MultiBackendTest {
       await output.WriteLineAsync(diffMessage);
       if (backend.IsInternal) {
         await output.WriteLineAsync(
-          $"(non-blocking) The '{backend.TargetName}' code generator is internal. Not having a '*.{backend.TargetName}.check' file is acceptable for now.");
+          $"(non-blocking) The {backend.TargetName} code generator is internal. Not having a '*.{backend.TargetId}.check' file is acceptable for now.");
         return 0;
       }
 
@@ -464,7 +464,7 @@ public class MultiBackendTest {
 
       if (backend.IsInternal && checkResult != 0) {
         await output.WriteLineAsync(
-          $"(non-blocking) The '{backend.TargetName}' code generator is internal. An unmatched '*.{backend.TargetName}.check' file is acceptable for now.");
+          $"(non-blocking) The {backend.TargetName} code generator is internal. An unmatched '*.{backend.TargetId}.check' file is acceptable for now.");
         return 0;
       }
 
@@ -473,12 +473,12 @@ public class MultiBackendTest {
 
 
     if (backend.IsInternal) {
-      await output.WriteLineAsync($"(non-blocking) Execution failed for the internal code generator to {backend.TargetName}, for reasons other than known unsupported features. Output:");
+      await output.WriteLineAsync($"(non-blocking) Execution failed for the internal {backend.TargetName} code generator, for reasons other than known unsupported features. Output:");
       await output.WriteLineAsync(outputString);
       await output.WriteLineAsync("Error:");
       await output.WriteLineAsync(error);
       await output.WriteLineAsync(
-        $"The '{backend.TargetName}' code generator is internal. An unmatched '*.{backend.TargetName}.check' file is acceptable for now.");
+        $"The {backend.TargetName} code generator is internal. An unmatched '*.{backend.TargetId}.check' file is acceptable for now.");
       return 0;
     }
     await output.WriteLineAsync("Execution failed, for reasons other than known unsupported features. Output:");


### PR DESCRIPTION
Until the Rust code generator is finished, we shouldn't block everyone else's work by requiring .rs.check files or even update them every time, since the process is manual and very lengthy

This does not remove the execution of the Rust compiler, only remove the check, so that we still have some kind of coverage. Also, we display non-blocking error messages.
However, this might kill the meta-tests, I'll see how to fix that.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
