### PR TITLE
Fix: Compiled disjunctive nested pattern matching no longer crashing

### DIFF
--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Statement.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Statement.cs
@@ -594,6 +594,10 @@ namespace Microsoft.Dafny.Compilers {
         writer = thenWriter;
       } else if (pattern is IdPattern idPattern) {
         if (idPattern.BoundVar != null) {
+          if (idPattern.BoundVar.Tok.val.StartsWith("_")) {
+            return writer;
+          }
+
           var boundVar = idPattern.BoundVar;
           var valueWriter = DeclareLocalVar(IdName(boundVar), boundVar.Type, idPattern.Tok, writer);
           valueWriter.Write(sourceName);
@@ -651,9 +655,11 @@ namespace Microsoft.Dafny.Compilers {
           var childPattern = idPattern.Arguments[index];
           if (childPattern is IdPattern { BoundVar: not null } childIdPattern) {
             var boundVar = childIdPattern.BoundVar;
-            newSourceName = IdName(boundVar);
-            var valueWriter = DeclareLocalVar(newSourceName, boundVar.Type, idPattern.Tok, result);
-            valueWriter.Append(destructor);
+            if (!childIdPattern.BoundVar.Name.StartsWith("_")) {
+              newSourceName = IdName(boundVar);
+              var valueWriter = DeclareLocalVar(newSourceName, boundVar.Type, idPattern.Tok, result);
+              valueWriter.Append(destructor);
+            }
           } else {
             newSourceName = ProtectedFreshId(arg.CompileName);
             var valueWriter = DeclareLocalVar(newSourceName, type, idPattern.Tok, result);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy
@@ -9,5 +9,6 @@ datatype D = A(int) | C(int) {
   }
 }
 method Main() {
-  print C(0).Test();
+  var x := C(0).Test();
+  print "ok";
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy
@@ -1,0 +1,13 @@
+// RUN: %testDafnyForEachCompiler "%s"
+
+datatype D = A(int) | C(int) {
+  function Test(): D {
+    match this{
+      case A(_) | C(_) =>
+        this
+    }
+  }
+}
+method Main() {
+  print C(0).Test();
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5572.dfy.expect
@@ -1,2 +1,3 @@
 
-Dafny program verifier finished with TODO verified, TODO errors
+Dafny program verifier finished with 0 verified, 0 errors
+ok

--- a/docs/dev/news/5572.fix
+++ b/docs/dev/news/5572.fix
@@ -1,0 +1,1 @@
+Compiled disjunctive nested pattern matching no longer crashing


### PR DESCRIPTION
This PR fixes #5572
I added the corresponding test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>