### PR TITLE
Warn against deeply nested let exprs (WIP)

### DIFF
--- a/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
@@ -1627,13 +1627,13 @@ namespace Microsoft.Dafny.Compilers {
     private string CharTypeName => UnicodeCharEnabled ? "Dafny.Rune" : "char";
     private string CharTypeDescriptorName => DafnyHelpersClass + (UnicodeCharEnabled ? ".RUNE" : ".CHAR");
 
-    private void ConvertFromChar(Expression e, ConcreteSyntaxTree wr, bool inLetExprBody, ConcreteSyntaxTree wStmts) {
+    private void ConvertFromChar(Expression e, ConcreteSyntaxTree wr, int letExprNesting, ConcreteSyntaxTree wStmts) {
       if (e.Type.IsCharType && UnicodeCharEnabled) {
         wr.Write("(");
-        TrParenExpr(e, wr, inLetExprBody, wStmts);
+        TrParenExpr(e, wr, letExprNesting, wStmts);
         wr.Write(".Value)");
       } else {
-        TrParenExpr(e, wr, inLetExprBody, wStmts);
+        TrParenExpr(e, wr, letExprNesting, wStmts);
       }
     }
 
@@ -2320,7 +2320,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitRotate(Expression e0, Expression e1, bool isRotateLeft, ConcreteSyntaxTree wr,
-        bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
+        int letExprNesting, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       string nativeName = null;
       bool needsCast = false;
       var nativeType = AsNativeType(e0.Type);
@@ -2332,27 +2332,27 @@ namespace Microsoft.Dafny.Compilers {
       if (needsCast) {
         wr = wr.Write("(" + nativeName + ")").ForkInParens();
       }
-      EmitShift(e0, e1, isRotateLeft ? "<<" : ">>", isRotateLeft, nativeType, true, wr.ForkInParens(), inLetExprBody, wStmts, tr);
+      EmitShift(e0, e1, isRotateLeft ? "<<" : ">>", isRotateLeft, nativeType, true, wr.ForkInParens(), letExprNesting, wStmts, tr);
 
       wr.Write(" | ");
 
-      EmitShift(e0, e1, isRotateLeft ? ">>" : "<<", !isRotateLeft, nativeType, false, wr.ForkInParens(), inLetExprBody, wStmts, tr);
+      EmitShift(e0, e1, isRotateLeft ? ">>" : "<<", !isRotateLeft, nativeType, false, wr.ForkInParens(), letExprNesting, wStmts, tr);
     }
 
     private void EmitShift(Expression e0, Expression e1, string op, bool truncate, [CanBeNull] NativeType nativeType, bool firstOp,
-        ConcreteSyntaxTree wr, bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
+        ConcreteSyntaxTree wr, int letExprNesting, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       var bv = e0.Type.NormalizeToAncestorType().AsBitVectorType;
       if (truncate) {
         wr = EmitBitvectorTruncation(bv, nativeType, true, wr);
       }
-      tr(e0, wr, inLetExprBody, wStmts);
+      tr(e0, wr, letExprNesting, wStmts);
       wr.Write(" {0} ", op);
       if (!firstOp) {
         wr = wr.ForkInParens().Write("{0} - ", bv.Width);
       }
 
       wr.Write("(int)");
-      tr(e1, wr.ForkInParens(), inLetExprBody, wStmts);
+      tr(e1, wr.ForkInParens(), letExprNesting, wStmts);
     }
 
     protected override bool CompareZeroUsingSign(Type type) {
@@ -2715,7 +2715,7 @@ namespace Microsoft.Dafny.Compilers {
       return w;
     }
 
-    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, bool inLetExprBody,
+    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, int letExprNesting,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       Contract.Assert(indices != null && 1 <= indices.Count);  // follows from precondition
       var w = wr.Fork();
@@ -2723,81 +2723,81 @@ namespace Microsoft.Dafny.Compilers {
       var sep = "";
       foreach (var index in indices) {
         wr.Write("{0}(int)", sep);
-        TrParenExpr(index, wr, inLetExprBody, wStmts);
+        TrParenExpr(index, wr, letExprNesting, wStmts);
         sep = ", ";
       }
       wr.Write("]");
       return w;
     }
 
-    protected override void EmitExprAsNativeInt(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr("(int)", expr, wr, inLetExprBody, wStmts);
+    protected override void EmitExprAsNativeInt(Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr("(int)", expr, wr, letExprNesting, wStmts);
     }
 
-    protected override void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody,
+    protected override void EmitIndexCollectionSelect(Expression source, Expression index, int letExprNesting,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var xType = source.Type.NormalizeToAncestorType();
       if (xType is MapType) {
         var inner = wr.Write(TypeHelperName(xType, wr, source.tok) + ".Select").ForkInParens();
-        inner.Append(Expr(source, inLetExprBody, wStmts));
+        inner.Append(Expr(source, letExprNesting, wStmts));
         inner.Write(",");
-        inner.Append(Expr(index, inLetExprBody, wStmts));
+        inner.Append(Expr(index, letExprNesting, wStmts));
       } else {
-        TrParenExpr(source, wr, inLetExprBody, wStmts);
-        TrParenExpr(".Select", index, wr, inLetExprBody, wStmts);
+        TrParenExpr(source, wr, letExprNesting, wStmts);
+        TrParenExpr(".Select", index, wr, letExprNesting, wStmts);
       }
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value,
-        CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        CollectionType resultCollectionType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (resultCollectionType is SeqType or MapType) {
         wr.Write(TypeHelperName(resultCollectionType, wr, source.tok) + ".Update");
         wr.Append(ParensList(
-          Expr(source, inLetExprBody, wStmts),
-          Expr(index, inLetExprBody, wStmts),
-          CoercedExpr(value, resultCollectionType.ValueArg, inLetExprBody, wStmts)));
+          Expr(source, letExprNesting, wStmts),
+          Expr(index, letExprNesting, wStmts),
+          CoercedExpr(value, resultCollectionType.ValueArg, letExprNesting, wStmts)));
       } else {
-        TrParenExpr(source, wr, inLetExprBody, wStmts);
+        TrParenExpr(source, wr, letExprNesting, wStmts);
         wr.Write(".Update");
         wr.Append(ParensList(
-          Expr(index, inLetExprBody, wStmts),
-          CoercedExpr(value, resultCollectionType.ValueArg, inLetExprBody, wStmts)));
+          Expr(index, letExprNesting, wStmts),
+          CoercedExpr(value, resultCollectionType.ValueArg, letExprNesting, wStmts)));
       }
     }
 
     protected override void EmitSeqSelectRange(Expression source, Expression lo /*?*/, Expression hi /*?*/,
-      bool fromArray, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      bool fromArray, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromArray) {
         wr.Write($"{DafnyHelpersClass}.SeqFromArray");
       }
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       if (hi != null) {
         if (lo != null) {
           wr.Write(".Subsequence");
-          wr.Append(ParensList(Expr(lo, inLetExprBody, wStmts), Expr(hi, inLetExprBody, wStmts)));
+          wr.Append(ParensList(Expr(lo, letExprNesting, wStmts), Expr(hi, letExprNesting, wStmts)));
         } else {
-          TrParenExpr(".Take", hi, wr, inLetExprBody, wStmts);
+          TrParenExpr(".Take", hi, wr, letExprNesting, wStmts);
         }
       } else {
         if (lo != null) {
-          TrParenExpr(".Drop", lo, wr, inLetExprBody, wStmts);
+          TrParenExpr(".Drop", lo, wr, letExprNesting, wStmts);
         }
       }
     }
 
-    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr,
+    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, int letExprNesting, ConcreteSyntaxTree wr,
       ConcreteSyntaxTree wStmts) {
       if (expr.Initializer is LambdaExpr lam) {
         Contract.Assert(lam.BoundVars.Count == 1);
-        EmitSeqConstructionExprFromLambda(expr.N, lam.BoundVars[0], lam.Body, inLetExprBody, wr);
+        EmitSeqConstructionExprFromLambda(expr.N, lam.BoundVars[0], lam.Body, letExprNesting, wr);
       } else {
         wr.Write($"{DafnySeqClass}<{TypeName(expr.Type.NormalizeToAncestorType().AsSeqType.Arg, wr, expr.tok)}>.Create");
-        wr.Append(ParensList(Expr(expr.N, inLetExprBody, wStmts), Expr(expr.Initializer, inLetExprBody, wStmts)));
+        wr.Append(ParensList(Expr(expr.N, letExprNesting, wStmts), Expr(expr.Initializer, letExprNesting, wStmts)));
       }
     }
 
-    protected override void EmitSeqBoundedPool(Expression of, bool includeDuplicates, string _, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(of, wr, inLetExprBody, wStmts);
+    protected override void EmitSeqBoundedPool(Expression of, bool includeDuplicates, string _, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr(of, wr, letExprNesting, wStmts);
       wr.Write(includeDuplicates ? ".CloneAsArray()" : ".UniqueElements");
     }
 
@@ -2827,12 +2827,12 @@ namespace Microsoft.Dafny.Compilers {
     //     }
     //     return Dafny.Sequence<T>.FromArray(a);
     //   }))();
-    private void EmitSeqConstructionExprFromLambda(Expression lengthExpr, BoundVar boundVar, Expression body, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    private void EmitSeqConstructionExprFromLambda(Expression lengthExpr, BoundVar boundVar, Expression body, int letExprNesting, ConcreteSyntaxTree wr) {
       wr.Format($"((System.Func<{TypeName(new SeqType(body.Type), wr, body.tok)}>) (() =>{ExprBlock(out ConcreteSyntaxTree wrLamBody)}))()");
 
       var indexType = lengthExpr.Type;
       var lengthVar = idGenerator.FreshId("dim");
-      DeclareLocalVar(lengthVar, indexType, lengthExpr.tok, lengthExpr, inLetExprBody, wrLamBody);
+      DeclareLocalVar(lengthVar, indexType, lengthExpr.tok, lengthExpr, letExprNesting, wrLamBody);
       var arrVar = idGenerator.FreshId("arr");
       wrLamBody.Write($"var {arrVar} = ");
       var wrDims = EmitNewArray(body.Type, body.tok, dimCount: 1, mustInitialize: false, wr: wrLamBody);
@@ -2852,22 +2852,22 @@ namespace Microsoft.Dafny.Compilers {
       wrLamBody.WriteLine("return {0}<{1}>.FromArray({2});", DafnySeqClass, TypeName(body.Type, wr, body.tok), arrVar);
     }
 
-    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr,
+    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, int letExprNesting, ConcreteSyntaxTree wr,
         ConcreteSyntaxTree wStmts) {
       wr.Write("{0}<{1}>", DafnyMultiSetClass, TypeName(expr.E.Type.NormalizeToAncestorType().AsCollectionType.Arg, wr, expr.tok));
       var eeType = expr.E.Type.NormalizeToAncestorType();
       if (eeType is SeqType) {
-        TrParenExpr(".FromSeq", expr.E, wr, inLetExprBody, wStmts);
+        TrParenExpr(".FromSeq", expr.E, wr, letExprNesting, wStmts);
       } else if (eeType is SetType) {
-        TrParenExpr(".FromSet", expr.E, wr, inLetExprBody, wStmts);
+        TrParenExpr(".FromSet", expr.E, wr, letExprNesting, wStmts);
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();
       }
     }
 
-    protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function, List<Expression> arguments, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      wr.Write($"{DafnyHelpersClass}.Id<{TypeName(functionType, wr, tok)}>({Expr(function, inLetExprBody, wStmts)})");
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+    protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function, List<Expression> arguments, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Write($"{DafnyHelpersClass}.Id<{TypeName(functionType, wr, tok)}>({Expr(function, letExprNesting, wStmts)})");
+      TrExprList(arguments, wr, letExprNesting, wStmts);
     }
 
     protected override ConcreteSyntaxTree FromFatPointer(Type type, ConcreteSyntaxTree wr) {
@@ -2948,13 +2948,13 @@ namespace Microsoft.Dafny.Compilers {
     protected override bool TargetLambdaCanUseEnclosingLocals => false;
 
     protected override ConcreteSyntaxTree EmitBetaRedex(List<string> boundVars, List<Expression> arguments,
-      List<Type> boundTypes, Type resultType, IToken tok, bool inLetExprBody, ConcreteSyntaxTree wr,
+      List<Type> boundTypes, Type resultType, IToken tok, int letExprNesting, ConcreteSyntaxTree wr,
       ref ConcreteSyntaxTree wStmts) {
       var tas = Util.Snoc(boundTypes, resultType);
       var typeArgs = TypeName_UDT(ArrowType.Arrow_FullCompileName, tas.ConvertAll(_ => TypeParameter.TPVariance.Non), tas, wr, tok);
       var result = new ConcreteSyntaxTree();
       wr.Format($"{DafnyHelpersClass}.Id<{typeArgs}>(({boundVars.Comma()}) => {result})");
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+      TrExprList(arguments, wr, letExprNesting, wStmts);
       return result;
     }
 
@@ -3014,20 +3014,20 @@ namespace Microsoft.Dafny.Compilers {
       return result;
     }
 
-    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       switch (op) {
         case ResolvedUnaryOp.BoolNot:
-          TrParenExpr("!", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("!", expr, wr, letExprNesting, wStmts);
           break;
         case ResolvedUnaryOp.BitwiseNot:
-          TrParenExpr("~", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("~", expr, wr, letExprNesting, wStmts);
           break;
         case ResolvedUnaryOp.Cardinality:
           if (expr.Type.NormalizeToAncestorType().AsCollectionType is MultiSetType) {
-            TrParenExpr(expr, wr, inLetExprBody, wStmts);
+            TrParenExpr(expr, wr, letExprNesting, wStmts);
             wr.Write(".ElementCount");
           } else {
-            TrParenExpr("new BigInteger(", expr, wr, inLetExprBody, wStmts);
+            TrParenExpr("new BigInteger(", expr, wr, letExprNesting, wStmts);
             wr.Write(".Count)");
           }
           break;
@@ -3219,7 +3219,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("{0} == 0", varName);
     }
 
-    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromType.IsNumericBased(Type.NumericPersuasion.Int) || fromType.NormalizeToAncestorType().IsBitVectorType || fromType.IsCharType) {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // (int or bv or char) -> real
@@ -3228,18 +3228,18 @@ namespace Microsoft.Dafny.Compilers {
           if (AsNativeType(fromType) != null) {
             wr.Write("new BigInteger");
           }
-          ConvertFromChar(fromExpr, wr, inLetExprBody, wStmts);
+          ConvertFromChar(fromExpr, wr, letExprNesting, wStmts);
           wr.Write(", BigInteger.One)");
         } else if (toType.IsCharType) {
           if (fromType.IsCharType) {
-            EmitExpr(fromExpr, inLetExprBody, wr, wStmts);
+            EmitExpr(fromExpr, letExprNesting, wr, wStmts);
           } else if (UnicodeCharEnabled) {
             wr.Write($"new {CharTypeName}((int)");
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
             wr.Write(")");
           } else {
             wr.Write($"({CharTypeName})");
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           }
         } else {
           // (int or bv or char) -> (int or bv or ORDINAL)
@@ -3249,15 +3249,15 @@ namespace Microsoft.Dafny.Compilers {
             if (fromType.IsCharType) {
               // char -> big-integer (int or bv or ORDINAL)
               wr.Write("new BigInteger");
-              ConvertFromChar(fromExpr, wr, inLetExprBody, wStmts);
+              ConvertFromChar(fromExpr, wr, letExprNesting, wStmts);
             } else {
               // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-              wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+              wr.Append(Expr(fromExpr, letExprNesting, wStmts));
             }
           } else if (fromNative != null && toNative == null) {
             // native (int or bv) -> big-integer (int or bv)
             wr.Write("new BigInteger");
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           } else {
             GetNativeInfo(toNative.Sel, out string toNativeName, out string toNativeSuffix, out var toNativeNeedsCast);
             // any (int or bv) -> native (int or bv)
@@ -3272,7 +3272,7 @@ namespace Microsoft.Dafny.Compilers {
               wr.Write("(" + literal + toNativeSuffix + ")");
             } else if (u != null && u.Op == UnaryOpExpr.Opcode.Cardinality) {
               // Optimize .Count to avoid intermediate BigInteger
-              TrParenExpr(u.E, wr, inLetExprBody, wStmts);
+              TrParenExpr(u.E, wr, letExprNesting, wStmts);
               if (toNative.UpperBound <= new BigInteger(0x80000000U)) {
                 wr.Write(".Count");
               } else {
@@ -3280,7 +3280,7 @@ namespace Microsoft.Dafny.Compilers {
               }
             } else if (m != null && m.MemberName == "Length" && m.Obj.Type.IsArrayType) {
               // Optimize .Length to avoid intermediate BigInteger
-              TrParenExpr(m.Obj, wr, inLetExprBody, wStmts);
+              TrParenExpr(m.Obj, wr, letExprNesting, wStmts);
               if (toNative.UpperBound <= new BigInteger(0x80000000U)) {
                 wr.Write(".Length");
               } else {
@@ -3288,7 +3288,7 @@ namespace Microsoft.Dafny.Compilers {
               }
             } else {
               // no optimization applies; use the standard translation
-              ConvertFromChar(fromExpr, wr, inLetExprBody, wStmts);
+              ConvertFromChar(fromExpr, wr, letExprNesting, wStmts);
             }
           }
         }
@@ -3297,7 +3297,7 @@ namespace Microsoft.Dafny.Compilers {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(toType) == null);
-          wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+          wr.Append(Expr(fromExpr, letExprNesting, wStmts));
         } else {
           // real -> (int or bv or char or ordinal)
           if (toType.IsCharType) {
@@ -3305,35 +3305,35 @@ namespace Microsoft.Dafny.Compilers {
           } else if (AsNativeType(toType) != null) {
             wr.Write("({0})", GetNativeTypeName(AsNativeType(toType)));
           }
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           wr.Write(".ToBigInteger()");
         }
       } else if (fromType.IsBigOrdinalType) {
         if (toType.IsNumericBased(Type.NumericPersuasion.Int) || toType.IsBigOrdinalType) {
-          wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+          wr.Append(Expr(fromExpr, letExprNesting, wStmts));
         } else if (toType.IsCharType) {
           wr.Write($"({CharTypeName})");
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
         } else if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           wr.Write("new Dafny.BigRational(");
           if (AsNativeType(fromType) != null) {
             wr.Write("new BigInteger");
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
             wr.Write(", BigInteger.One)");
           } else {
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
             wr.Write(", 1)");
           }
         } else if (toType.NormalizeToAncestorType().IsBitVectorType) {
           // ordinal -> bv
           var typename = TypeName(toType, wr, null, null);
           wr.Write($"({typename})");
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
         } else {
           Contract.Assert(false, $"not implemented for C#: {fromType} -> {toType}");
         }
       } else if (fromType.Equals(toType) || fromType.AsNewtype != null || toType.AsNewtype != null) {
-        wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+        wr.Append(Expr(fromExpr, letExprNesting, wStmts));
       } else {
         Contract.Assert(false, $"not implemented for C#: {fromType} -> {toType}");
       }
@@ -3376,17 +3376,17 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
-        bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("{0}.FromElements", TypeHelperName(ct, wr, tok));
-      TrExprList(elements, wr, inLetExprBody, wStmts, typeAt: _ => ct.Arg);
+      TrExprList(elements, wr, letExprNesting, wStmts, typeAt: _ => ct.Arg);
     }
 
     protected override void EmitMapDisplay(MapType mt, IToken tok, List<ExpressionPair> elements,
-        bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var arguments = elements.Select(p => {
         var result = new ConcreteSyntaxTree();
         result.Format($"new Dafny.Pair{BracketList((LineSegment)TypeName(p.A.Type, result, p.A.tok), (LineSegment)TypeName(p.B.Type, result, p.B.tok))}");
-        result.Append(ParensList(Expr(p.A, inLetExprBody, wStmts), Expr(p.B, inLetExprBody, wStmts)));
+        result.Append(ParensList(Expr(p.A, letExprNesting, wStmts), Expr(p.B, letExprNesting, wStmts)));
         return result;
       }).ToArray<ICanRender>();
       wr.Write($"{TypeHelperName(mt, wr, tok)}.FromElements{ParensList(arguments)}");
@@ -3405,21 +3405,21 @@ namespace Microsoft.Dafny.Compilers {
       wrVarInit.Write($"new System.Collections.Generic.List<Dafny.Pair<{domtypeName},{rantypeName}>>()");
     }
 
-    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, int letExprNesting, ConcreteSyntaxTree wr) {
       if (ct is SetType) {
         var wStmts = wr.Fork();
-        wr.FormatLine($"{collName}.Add({Expr(elmt, inLetExprBody, wStmts)});");
+        wr.FormatLine($"{collName}.Add({Expr(elmt, letExprNesting, wStmts)});");
       } else {
         Contract.Assume(false);  // unexpected collection type
       }
     }
 
-    protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term, int letExprNesting, ConcreteSyntaxTree wr) {
       var domtypeName = TypeName(mt.Domain, wr, tok);
       var rantypeName = TypeName(mt.Range, wr, tok);
       var termLeftWriter = new ConcreteSyntaxTree();
       var wStmts = wr.Fork();
-      wr.FormatLine($"{collName}.Add(new Dafny.Pair<{domtypeName},{rantypeName}>{ParensList(termLeftWriter, Expr(term, inLetExprBody, wStmts))});");
+      wr.FormatLine($"{collName}.Add(new Dafny.Pair<{domtypeName},{rantypeName}>{ParensList(termLeftWriter, Expr(term, letExprNesting, wStmts))});");
       return termLeftWriter;
     }
 
@@ -3439,9 +3439,9 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override void EmitSingleValueGenerator(Expression e, bool inLetExprBody, string type, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitSingleValueGenerator(Expression e, int letExprNesting, string type, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write($"{DafnyHelpersClass}.SingleValue<{type}>");
-      TrParenExpr(e, wr, inLetExprBody, wStmts);
+      TrParenExpr(e, wr, letExprNesting, wStmts);
     }
 
     private void AddTestCheckerIfNeeded(string name, Declaration decl, ConcreteSyntaxTree wr) {

--- a/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
@@ -1243,7 +1243,7 @@ namespace Microsoft.Dafny.Compilers {
       }
       if (nt.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var wStmts = w.Fork();
-        var witness = Expr(nt.Witness, false, wStmts).ToString();
+        var witness = Expr(nt.Witness, 0, wStmts).ToString();
         string typeName;
         if (nt.NativeType == null) {
           typeName = TypeName(nt.BaseType, cw.StaticMemberWriter, nt.tok);
@@ -1308,7 +1308,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var sw = new ConcreteSyntaxTree(cw.InstanceMemberWriter.RelativeIndentLevel);
         var wStmts = cw.InstanceMemberWriter.Fork();
-        sw.Append(Expr(sst.Witness, false, wStmts));
+        sw.Append(Expr(sst.Witness, 0, wStmts));
         var witness = sw.ToString();
         var typeName = TypeName(sst.Rhs, cw.StaticMemberWriter, sst.tok);
         if (sst.TypeArgs.Count == 0) {
@@ -1995,7 +1995,7 @@ namespace Microsoft.Dafny.Compilers {
       var type = DatatypeWrapperEraser.SimplifyTypeAndTrimNewtypes(Options, arg.Type);
       var typeArgs = type.AsArrowType == null ? "" : $"<{TypeName(type, wr, null, null)}>";
       var suffix = type.IsStringType && UnicodeCharEnabled ? ".ToVerbatimString(false)" : "";
-      wr.WriteLine($"{DafnyHelpersClass}.Print{typeArgs}(({Expr(arg, false, wStmts)}){suffix});");
+      wr.WriteLine($"{DafnyHelpersClass}.Print{typeArgs}(({Expr(arg, 0, wStmts)}){suffix});");
     }
 
     protected override void EmitReturn(List<Formal> outParams, ConcreteSyntaxTree wr) {
@@ -2035,7 +2035,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitHalt(IToken tok, Expression/*?*/ messageExpr, ConcreteSyntaxTree wr) {
-      var exceptionMessage = Expr(messageExpr, false, wr.Fork());
+      var exceptionMessage = Expr(messageExpr, 0, wr.Fork());
       if (tok != null) {
         exceptionMessage.Prepend(new LineSegment(SymbolDisplay.FormatLiteral(tok.TokenToString(Options) + ": ", true) + " + "));
       }
@@ -3353,23 +3353,23 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".IsInteger() && ");
     }
 
     protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("Dafny.Rune.IsRune");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" && ");
     }
 
     protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
       wr.Write(" <= ");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" && ");
 
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" < ");
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
       wr.Write(" && ");

--- a/Source/DafnyCore/Backends/CSharp/CsharpSynthesizer.cs
+++ b/Source/DafnyCore/Backends/CSharp/CsharpSynthesizer.cs
@@ -151,7 +151,7 @@ public class CsharpSynthesizer {
   private void SynthesizeExpression(ConcreteSyntaxTree wr, Expression expr, ConcreteSyntaxTree wStmts) {
     switch (expr) {
       case LiteralExpr literalExpr:
-        wr.Append(codeGenerator.Expr(literalExpr, false, wStmts));
+        wr.Append(codeGenerator.Expr(literalExpr, 0, wStmts));
         break;
       case ApplySuffix applySuffix:
         SynthesizeExpression(wr, applySuffix, wStmts);
@@ -199,7 +199,7 @@ public class CsharpSynthesizer {
       if (bound != null) { // if true, arg is a bound variable
         wr.Write(bound.Item2);
       } else {
-        wr.Append(codeGenerator.Expr(arg, false, wStmts));
+        wr.Append(codeGenerator.Expr(arg, 0, wStmts));
       }
       if (i != applySuffix.Args.Count - 1) {
         wr.Write(", ");
@@ -230,7 +230,7 @@ public class CsharpSynthesizer {
         fieldName, obj.Name, lastSynthesizedMethod.Name);
       var tmpId = codeGenerator.idGenerator.FreshId("tmp");
       wr.Format($"{objectToMockName[obj]}.SetupGet({tmpId} => {tmpId}.@{fieldName}).Returns( ");
-      wr.Append(codeGenerator.Expr(binaryExpr.E1, false, wStmts));
+      wr.Append(codeGenerator.Expr(binaryExpr.E1, 0, wStmts));
       wr.WriteLine(");");
       return;
     }
@@ -256,7 +256,7 @@ public class CsharpSynthesizer {
       }
     }
     wr.Write(")=>");
-    wr.Append(codeGenerator.Expr(binaryExpr.E1, false, wStmts));
+    wr.Append(codeGenerator.Expr(binaryExpr.E1, 0, wStmts));
     wr.WriteLine(");");
   }
 
@@ -286,7 +286,7 @@ public class CsharpSynthesizer {
     switch (binaryExpr.Op) {
       case BinaryExpr.Opcode.Imp:
         wr.Write("\treturn ");
-        wr.Append(codeGenerator.Expr(binaryExpr.E0, false, wStmts));
+        wr.Append(codeGenerator.Expr(binaryExpr.E0, 0, wStmts));
         wr.WriteLine(";");
         binaryExpr = (BinaryExpr)binaryExpr.E1.Resolved;
         break;

--- a/Source/DafnyCore/Backends/Cplusplus/CppCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Cplusplus/CppCodeGenerator.cs
@@ -1528,7 +1528,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitRotate(Expression e0, Expression e1, bool isRotateLeft, ConcreteSyntaxTree wr,
-      bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
+      int letExprNesting, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       throw new UnsupportedFeatureException(e0.tok, Feature.BitvectorRotateFunctions);
     }
 
@@ -1828,50 +1828,50 @@ namespace Microsoft.Dafny.Compilers {
       return w;
     }
 
-    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, bool inLetExprBody,
+    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, int letExprNesting,
         ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       Contract.Assert(indices != null && 1 <= indices.Count);  // follows from precondition
       var w = wr.Fork();
       foreach (var index in indices) {
         wr.Write(".at(");
-        wr.Append(Expr(index, inLetExprBody, wStmts));
+        wr.Append(Expr(index, letExprNesting, wStmts));
         wr.Write(")");
       }
       return w;
     }
 
-    protected override void EmitExprAsNativeInt(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(expr, inLetExprBody, wr, wStmts);
+    protected override void EmitExprAsNativeInt(Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      EmitExpr(expr, letExprNesting, wr, wStmts);
     }
 
-    protected override void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody,
+    protected override void EmitIndexCollectionSelect(Expression source, Expression index, int letExprNesting,
         ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       if (source.Type.NormalizeToAncestorType() is SeqType) {
         // seq
         wr.Write(".select(");
-        wr.Append(Expr(index, inLetExprBody, wStmts));
+        wr.Append(Expr(index, letExprNesting, wStmts));
         wr.Write(")");
       } else {
         // map or imap
         wr.Write(".get(");
-        wr.Append(Expr(index, inLetExprBody, wStmts));
+        wr.Append(Expr(index, letExprNesting, wStmts));
         wr.Write(")");
       }
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value,
-        CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+        CollectionType resultCollectionType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       wr.Write(".update(");
-      wr.Append(Expr(index, inLetExprBody, wStmts));
+      wr.Append(Expr(index, letExprNesting, wStmts));
       wr.Write(", ");
-      wr.Append(CoercedExpr(value, resultCollectionType.ValueArg, inLetExprBody, wStmts));
+      wr.Append(CoercedExpr(value, resultCollectionType.ValueArg, letExprNesting, wStmts));
       wr.Write(")");
     }
 
     protected override void EmitSeqSelectRange(Expression source, Expression lo /*?*/, Expression hi /*?*/,
-        bool fromArray, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        bool fromArray, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromArray) {
         string typeName = "";
 
@@ -1886,69 +1886,69 @@ namespace Microsoft.Dafny.Compilers {
         if (lo == null) {
           if (hi == null) {
             wr.Write("DafnySequence<{0}>::SeqFromArray", typeName);
-            TrParenExpr(source, wr, inLetExprBody, wStmts);
+            TrParenExpr(source, wr, letExprNesting, wStmts);
           } else {
             wr.Write("DafnySequence<{0}>::SeqFromArrayPrefix(", typeName);
-            TrParenExpr(source, wr, inLetExprBody, wStmts);
+            TrParenExpr(source, wr, letExprNesting, wStmts);
             wr.Write(",");
-            TrParenExpr(hi, wr, inLetExprBody, wStmts);
+            TrParenExpr(hi, wr, letExprNesting, wStmts);
             wr.Write(")");
           }
         } else {
           if (hi == null) {
             wr.Write("DafnySequence<{0}>::SeqFromArraySuffix(", typeName);
-            TrParenExpr(source, wr, inLetExprBody, wStmts);
+            TrParenExpr(source, wr, letExprNesting, wStmts);
             wr.Write(",");
-            TrParenExpr(lo, wr, inLetExprBody, wStmts);
+            TrParenExpr(lo, wr, letExprNesting, wStmts);
             wr.Write(")");
           } else {
             wr.Write("DafnySequence<{0}>::SeqFromArraySlice(", typeName);
-            TrParenExpr(source, wr, inLetExprBody, wStmts);
+            TrParenExpr(source, wr, letExprNesting, wStmts);
             wr.Write(",");
-            TrParenExpr(lo, wr, inLetExprBody, wStmts);
+            TrParenExpr(lo, wr, letExprNesting, wStmts);
             wr.Write(",");
-            TrParenExpr(hi, wr, inLetExprBody, wStmts);
+            TrParenExpr(hi, wr, letExprNesting, wStmts);
             wr.Write(")");
           }
         }
       } else {
-        TrParenExpr(source, wr, inLetExprBody, wStmts);
+        TrParenExpr(source, wr, letExprNesting, wStmts);
 
         if (hi != null) {
-          TrParenExpr(".take", hi, wr, inLetExprBody, wStmts);
+          TrParenExpr(".take", hi, wr, letExprNesting, wStmts);
         }
         if (lo != null) {
-          TrParenExpr(".drop", lo, wr, inLetExprBody, wStmts);
+          TrParenExpr(".drop", lo, wr, letExprNesting, wStmts);
         }
       }
     }
 
-    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("DafnySequence<{0}>::Create(", TypeName(expr.Type, wr, expr.tok, null, false));
-      wr.Append(Expr(expr.N, inLetExprBody, wStmts));
+      wr.Append(Expr(expr.N, letExprNesting, wStmts));
       wr.Write(", ");
-      wr.Append(Expr(expr.Initializer, inLetExprBody, wStmts));
+      wr.Append(Expr(expr.Initializer, letExprNesting, wStmts));
       wr.Write(")");
     }
 
-    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr,
+    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, int letExprNesting, ConcreteSyntaxTree wr,
       ConcreteSyntaxTree wStmts) {
       throw new UnsupportedFeatureException(expr.tok, Feature.Multisets);
     }
 
     protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function, List<Expression> arguments,
-        bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(function, wr, inLetExprBody, wStmts);
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+        int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr(function, wr, letExprNesting, wStmts);
+      TrExprList(arguments, wr, letExprNesting, wStmts);
     }
 
     protected override ConcreteSyntaxTree EmitBetaRedex(List<string> boundVars, List<Expression> arguments,
-      List<Type> boundTypes, Type resultType, IToken tok, bool inLetExprBody, ConcreteSyntaxTree wr,
+      List<Type> boundTypes, Type resultType, IToken tok, int letExprNesting, ConcreteSyntaxTree wr,
       ref ConcreteSyntaxTree wStmts) {
       wr.Write("(({0}) => ", Util.Comma(boundVars));
       var w = wr.Fork();
       wr.Write(")");
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+      TrExprList(arguments, wr, letExprNesting, wStmts);
       return w;
     }
 
@@ -2014,22 +2014,22 @@ namespace Microsoft.Dafny.Compilers {
       throw new UnsupportedFeatureException(resultTok, Feature.LetSuchThatExpressions);
     }
 
-    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       switch (op) {
         case ResolvedUnaryOp.BoolNot:
-          TrParenExpr("!", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("!", expr, wr, letExprNesting, wStmts);
           break;
         case ResolvedUnaryOp.BitwiseNot:
           if (AsNativeType(expr.Type) != null) {
             wr.Write("~ ");
-            TrParenExpr(expr, wr, inLetExprBody, wStmts);
+            TrParenExpr(expr, wr, letExprNesting, wStmts);
           } else {
-            TrParenExpr(expr, wr, inLetExprBody, wStmts);
+            TrParenExpr(expr, wr, letExprNesting, wStmts);
             wr.Write(".Not()");
           }
           break;
         case ResolvedUnaryOp.Cardinality:
-          TrParenExpr(expr, wr, inLetExprBody, wStmts);
+          TrParenExpr(expr, wr, letExprNesting, wStmts);
           wr.Write(".size()");
           break;
         default:
@@ -2282,13 +2282,13 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("{0} == 0", varName);
     }
 
-    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromType.IsNumericBased(Type.NumericPersuasion.Int) || fromType.IsBitVectorType || fromType.IsCharType) {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           throw new UnsupportedFeatureException(fromExpr.tok, Feature.RealNumbers);
         } else if (toType.IsCharType) {
           wr.Write("(char)");
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
         } else {
           // (int or bv or char) -> (int or bv or ORDINAL)
           var fromNative = AsNativeType(fromType);
@@ -2296,7 +2296,7 @@ namespace Microsoft.Dafny.Compilers {
           if (fromNative != null && toNative != null) {
             // from a native, to a native -- simple!
             wr.Write(GetNativeTypeName(toNative));
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           } else if (fromType.IsCharType) {
             Contract.Assert(fromNative == null);
             if (toNative == null) {
@@ -2304,17 +2304,17 @@ namespace Microsoft.Dafny.Compilers {
             } else {
               // char -> native
               wr.Write($"({GetNativeTypeName(toNative)})");
-              TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+              TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
             }
           } else if (fromNative == null && toNative == null) {
             // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-            wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+            wr.Append(Expr(fromExpr, letExprNesting, wStmts));
           } else if (fromNative != null) {
             Contract.Assert(toNative == null); // follows from other checks
 
             // native (int or bv) -> big-integer (int or bv)
             wr.Write("_dafny.IntOf{0}(", Capitalize(GetNativeTypeName(fromNative)));
-            wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+            wr.Append(Expr(fromExpr, letExprNesting, wStmts));
             wr.Write(')');
           } else {
             // any (int or bv) -> native (int or bv)
@@ -2327,16 +2327,16 @@ namespace Microsoft.Dafny.Compilers {
               wr.Write("{0}({1})", GetNativeTypeName(toNative), literal);
             } else if (u != null && u.Op == UnaryOpExpr.Opcode.Cardinality) {
               wr.Write("({0})(", GetNativeTypeName(toNative));
-              TrParenExpr(u.E, wr, inLetExprBody, wStmts);
+              TrParenExpr(u.E, wr, letExprNesting, wStmts);
               wr.Write(".size())");
             } else if (m != null && m.MemberName == "Length" && m.Obj.Type.IsArrayType) {
               // Optimize .Length to avoid intermediate BigInteger
               wr.Write("({0})(", GetNativeTypeName(toNative));
-              TrParenExpr(m.Obj, wr, inLetExprBody, wStmts);
+              TrParenExpr(m.Obj, wr, letExprNesting, wStmts);
               wr.Write(".size())");
             } else {
               // no optimization applies; use the standard translation
-              TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+              TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
               wr.Write(".{0}()", Capitalize(GetNativeTypeName(toNative)));
             }
 
@@ -2347,10 +2347,10 @@ namespace Microsoft.Dafny.Compilers {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(toType) == null);
-          wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+          wr.Append(Expr(fromExpr, letExprNesting, wStmts));
         } else {
           // real -> (int or bv)
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           wr.Write(".Int()");
           if (AsNativeType(toType) is NativeType nt) {
             wr.Write(".{0}()", Capitalize(GetNativeTypeName(nt)));
@@ -2359,11 +2359,11 @@ namespace Microsoft.Dafny.Compilers {
       } else if (fromType.IsBigOrdinalType) {
         Contract.Assert(toType.IsNumericBased(Type.NumericPersuasion.Int));
         // identity will do
-        wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+        wr.Append(Expr(fromExpr, letExprNesting, wStmts));
       } else {
         // identity will do
         Contract.Assert(fromType.Equals(toType) || fromType.AsNewtype != null || toType.AsNewtype != null);
-        wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+        wr.Append(Expr(fromExpr, letExprNesting, wStmts));
       }
     }
 
@@ -2384,11 +2384,11 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
-      bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (ct is SetType) {
         wr.Write("DafnySet<{0}>::Create({{", TypeName(ct.TypeArgs[0], wr, tok, null, false));
         for (var i = 0; i < elements.Count; i++) {
-          wr.Append(Expr(elements[i], inLetExprBody, wStmts));
+          wr.Append(Expr(elements[i], letExprNesting, wStmts));
           if (i < elements.Count - 1) {
             wr.Write(",");
           }
@@ -2403,7 +2403,7 @@ namespace Microsoft.Dafny.Compilers {
         } else {
           wr.Write("DafnySequence<{0}>::Create({{", TypeName(ct.TypeArgs[0], wr, tok, null, false));
           for (var i = 0; i < elements.Count; i++) {
-            wr.Append(Expr(elements[i], inLetExprBody, wStmts));
+            wr.Append(Expr(elements[i], letExprNesting, wStmts));
             if (i < elements.Count - 1) {
               wr.Write(",");
             }
@@ -2414,7 +2414,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitMapDisplay(MapType mt, IToken tok, List<ExpressionPair> elements,
-      bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("DafnyMap<{0},{1}>::Create({{",
                TypeName(mt.TypeArgs[0], wr, tok, null, false),
                TypeName(mt.TypeArgs[1], wr, tok, null, false));
@@ -2422,9 +2422,9 @@ namespace Microsoft.Dafny.Compilers {
       foreach (ExpressionPair p in elements) {
         wr.Write(sep);
         wr.Write("{");
-        wr.Append(Expr(p.A, inLetExprBody, wStmts));
+        wr.Append(Expr(p.A, letExprNesting, wStmts));
         wr.Write(",");
-        wr.Append(Expr(p.B, inLetExprBody, wStmts));
+        wr.Append(Expr(p.B, letExprNesting, wStmts));
         wr.Write("}");
         sep = ", ";
       }
@@ -2440,7 +2440,7 @@ namespace Microsoft.Dafny.Compilers {
       throw new UnsupportedFeatureException(e.tok, Feature.MapComprehensions);
     }
 
-    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, int letExprNesting, ConcreteSyntaxTree wr) {
       Contract.Assume(ct is SetType || ct is MultiSetType);  // follows from precondition
       if (ct is MultiSetType) {
         // This should never occur since there is no syntax for multiset comprehensions yet
@@ -2448,11 +2448,11 @@ namespace Microsoft.Dafny.Compilers {
       }
       var wStmts = wr.Fork();
       wr.Write("{0}.set.emplace(", collName);
-      wr.Append(Expr(elmt, inLetExprBody, wStmts));
+      wr.Append(Expr(elmt, letExprNesting, wStmts));
       wr.WriteLine(");");
     }
 
-    protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term, int letExprNesting, ConcreteSyntaxTree wr) {
       throw new UnsupportedFeatureException(tok, Feature.MapComprehensions);
     }
 
@@ -2462,7 +2462,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(collName);
     }
 
-    protected override void EmitSingleValueGenerator(Expression e, bool inLetExprBody, string type,
+    protected override void EmitSingleValueGenerator(Expression e, int letExprNesting, string type,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       throw new UnsupportedFeatureException(Token.NoToken, Feature.ExactBoundedPool);
     }

--- a/Source/DafnyCore/Backends/Cplusplus/CppCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Cplusplus/CppCodeGenerator.cs
@@ -621,9 +621,9 @@ namespace Microsoft.Dafny.Compilers {
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
         if (nt.NativeType == null) {
-          witness.Append(Expr(nt.Witness, false, wStmts));
+          witness.Append(Expr(nt.Witness, 0, wStmts));
         } else {
-          TrParenExpr(nt.Witness, witness, false, wStmts);
+          TrParenExpr(nt.Witness, witness, 0, wStmts);
           witness.Write(".toNumber()");
         }
         DeclareField(className, nt.TypeArgs, "Witness", true, true, nt.BaseType, nt.tok, witness.ToString(), w, wr);
@@ -658,7 +658,7 @@ namespace Microsoft.Dafny.Compilers {
 
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
-        witness.Append(Expr(sst.Witness, false, w));
+        witness.Append(Expr(sst.Witness, 0, w));
         DeclareField(className, sst.TypeArgs, "Witness", true, true, sst.Rhs, sst.tok, witness.ToString(), w, wr);
       }
 
@@ -1260,7 +1260,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override void EmitPrintStmt(ConcreteSyntaxTree wr, Expression arg) {
       var wStmts = wr.Fork();
       wr.Write("dafny_print(");
-      wr.Append(Expr(arg, false, wStmts));
+      wr.Append(Expr(arg, 0, wStmts));
       wr.WriteLine(");");
     }
 
@@ -1314,7 +1314,7 @@ namespace Microsoft.Dafny.Compilers {
 
       if (messageExpr.Type.IsStringType) {
         wr.Write("ToVerbatimString(");
-        wr.Append(Expr(messageExpr, false, wStmts));
+        wr.Append(Expr(messageExpr, 0, wStmts));
         wr.Write(")");
       } else {
         throw new UnsupportedFeatureException(tok, Feature.ConvertingValuesToStrings);
@@ -1415,7 +1415,7 @@ namespace Microsoft.Dafny.Compilers {
             Formal p = ctor.Ins[i];
             if (!p.IsGhost) {
               wr.Write(sep);
-              wr.Append(Expr(initCall.Args[i], false, wStmts));
+              wr.Append(Expr(initCall.Args[i], 0, wStmts));
               sep = ", ";
             }
           }

--- a/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Dafny.Compilers {
         var statementBuf = new StatementBuffer();
         if (nt.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           EmitExpr(
-            nt.Witness, false,
+            nt.Witness, 0,
             EmitCoercionIfNecessary(nt.Witness.Type, erasedType, null,
               new BuilderSyntaxTree<ExprContainer>(buf, this)),
             new BuilderSyntaxTree<StatementContainer>(statementBuf, this)
@@ -401,7 +401,7 @@ namespace Microsoft.Dafny.Compilers {
         var buf = new ExprBuffer(null);
         if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
           EmitExpr(
-            sst.Witness, false,
+            sst.Witness, 0,
             EmitCoercionIfNecessary(sst.Witness.Type, erasedType, null, new BuilderSyntaxTree<ExprContainer>(buf, this)),
             new BuilderSyntaxTree<StatementContainer>(statementBuf, this)
           );
@@ -1030,7 +1030,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override ILvalue SeqSelectLvalue(SeqSelectExpr ll, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var sourceBuf = new ExprBuffer(null);
       EmitExpr(
-        ll.Seq, false,
+        ll.Seq, 0,
         EmitCoercionIfNecessary(
           ll.Seq.Type,
           ll.Seq.Type.IsNonNullRefType || !ll.Seq.Type.IsRefType ? null : UserDefinedType.CreateNonNullType((UserDefinedType)ll.Seq.Type.NormalizeExpand()),
@@ -1040,7 +1040,7 @@ namespace Microsoft.Dafny.Compilers {
       );
 
       var indexBuf = new ExprBuffer(null);
-      EmitExpr(ll.E0, false, new BuilderSyntaxTree<ExprContainer>(indexBuf, this), wStmts);
+      EmitExpr(ll.E0, 0, new BuilderSyntaxTree<ExprContainer>(indexBuf, this), wStmts);
 
       var source = sourceBuf.Finish();
       var index = indexBuf.Finish();
@@ -1069,7 +1069,7 @@ namespace Microsoft.Dafny.Compilers {
     protected override void EmitPrintStmt(ConcreteSyntaxTree wr, Expression arg) {
       if (wr is BuilderSyntaxTree<StatementContainer> stmtContainer) {
         ExprBuffer buffer = new(null);
-        EmitExpr(arg, false, new BuilderSyntaxTree<ExprContainer>(buffer, this), wr);
+        EmitExpr(arg, 0, new BuilderSyntaxTree<ExprContainer>(buffer, this), wr);
         stmtContainer.Builder.Print(buffer.Finish());
       } else {
         throw new InvalidOperationException("Cannot print outside of a statement container: " + currentBuilder);
@@ -1260,7 +1260,7 @@ namespace Microsoft.Dafny.Compilers {
             .Select(tp => {
               var buf = new ExprBuffer(null);
               var localWriter = new BuilderSyntaxTree<ExprContainer>(buf, this);
-              EmitExpr(initCall.Args[tp.i], false, localWriter, wStmts);
+              EmitExpr(initCall.Args[tp.i], 0, localWriter, wStmts);
               return buf.Finish();
             });
         }
@@ -1615,7 +1615,7 @@ namespace Microsoft.Dafny.Compilers {
         currentBuilder = origBuilder;
       } else if (expr is IdentifierExpr) {
         // we don't need to create a copy of the identifier, that's language specific
-        base.EmitExpr(expr, false, actualWr, wStmts);
+        base.EmitExpr(expr, 0, actualWr, wStmts);
       } else if (expr is QuantifierExpr) {
         AddUnsupported("<i>QuantifierExpr</i>");
       } else {
@@ -2684,7 +2684,7 @@ namespace Microsoft.Dafny.Compilers {
     // Normally wStmt is a BuilderSyntaxTree<StatementContainer> but it might not while the compiler is being developed
     private DAST.Expression ConvertExpression(Expression term, ConcreteSyntaxTree wStmt) {
       var buffer0 = new ExprBuffer(null);
-      EmitExpr(term, false, new BuilderSyntaxTree<ExprContainer>(buffer0, this), wStmt);
+      EmitExpr(term, 0, new BuilderSyntaxTree<ExprContainer>(buffer0, this), wStmt);
       return buffer0.Finish();
     }
 
@@ -2770,7 +2770,7 @@ namespace Microsoft.Dafny.Compilers {
           };
         }
       } else {
-        typeTest = wr => EmitExpr(Expression.CreateBoolLiteral(tok, true), false, wr, null);
+        typeTest = wr => EmitExpr(Expression.CreateBoolLiteral(tok, true), 0, wr, null);
       }
 
       return typeTest;

--- a/Source/DafnyCore/Backends/GeneratorErrors.cs
+++ b/Source/DafnyCore/Backends/GeneratorErrors.cs
@@ -46,6 +46,7 @@ public class GeneratorErrors {
     c_abstract_type_cannot_be_compiled_extern,
     c_Go_unsupported_field,
     c_Go_infeasible_conversion,
+    c_let_expr_nesting_too_deep,
 
     f_unsupported_feature,
 
@@ -371,6 +372,11 @@ _Documentation of the Go compiler errors is in progress._
     Add(ErrorId.c_Go_infeasible_conversion,
     @"
 _Documentation of the Go compiler errors is in progress._
+".TrimStart());
+    
+    Add(ErrorId.c_let_expr_nesting_too_deep,
+      @"
+_TODO_
 ".TrimStart());
   }
 

--- a/Source/DafnyCore/Backends/GoLang/GoCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/GoLang/GoCodeGenerator.cs
@@ -1065,10 +1065,10 @@ namespace Microsoft.Dafny.Compilers {
         var wStmts = wWitness.Fork();
         wWitness.Write("return ");
         if (nt.NativeType == null) {
-          wWitness.Append(Expr(nt.Witness, false, wStmts));
+          wWitness.Append(Expr(nt.Witness, 0, wStmts));
           wWitness.WriteLine();
         } else {
-          TrParenExpr(nt.Witness, wWitness, false, wStmts);
+          TrParenExpr(nt.Witness, wWitness, 0, wStmts);
           wWitness.WriteLine(".{0}()", Capitalize(GetNativeTypeName(nt.NativeType)));
         }
       }
@@ -1097,7 +1097,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
-        witness.Append(Expr(sst.Witness, false, wStmts));
+        witness.Append(Expr(sst.Witness, 0, wStmts));
         DeclareField("Witness", false, true, true, sst.Rhs, sst.tok, witness.ToString(), cw.ClassName, cw.StaticFieldWriter, cw.StaticFieldInitWriter, cw.ConcreteMethodWriter);
       }
       // RTD
@@ -1962,17 +1962,17 @@ namespace Microsoft.Dafny.Compilers {
       var wStmts = wr.Fork();
       if (isString && UnicodeCharEnabled) {
         wr.Write("_dafny.Print(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.WriteLine(".VerbatimString(false))");
       } else if (!isString ||
                  (arg.Resolved is MemberSelectExpr mse &&
                   mse.Member.IsExtern(Options, out _, out _))) {
         wr.Write("_dafny.Print(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.WriteLine(")");
       } else {
         wr.Write("_dafny.Print((");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.Write(")");
         if (!UnicodeCharEnabled) {
           wr.Write(".SetString()");
@@ -2057,7 +2057,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write("\"" + tok.TokenToString(Options) + ": \" + ");
       }
 
-      TrParenExpr(messageExpr, wr, false, wStmts);
+      TrParenExpr(messageExpr, wr, 0, wStmts);
       if (UnicodeCharEnabled && messageExpr.Type.IsStringType) {
         wr.Write(".VerbatimString(false))");
       } else {
@@ -3784,23 +3784,23 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".IsInteger() && ");
     }
 
     protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("_dafny.IsCodePoint");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" && ");
     }
 
     protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
       wr.Write(".Cmp(");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(") <= 0 && ");
 
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".Cmp(");
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
       wr.Write(") < 0 && ");

--- a/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
@@ -276,17 +276,17 @@ namespace Microsoft.Dafny.Compilers {
       var wrTuple = EmitAddTupleToList(ingredients, tupleTypeArgs, wr);
       wrTuple.Write($"{L}<{tupleTypeArgs}>(");
       if (s0.Lhs is MemberSelectExpr lhs1) {
-        wrTuple.Append(Expr(lhs1.Obj, false, wStmts));
+        wrTuple.Append(Expr(lhs1.Obj, 0, wStmts));
       } else if (s0.Lhs is SeqSelectExpr lhs2) {
-        wrTuple.Append(Expr(lhs2.Seq, false, wStmts));
+        wrTuple.Append(Expr(lhs2.Seq, 0, wStmts));
         wrTuple.Write(", ");
-        TrParenExpr(lhs2.E0, wrTuple, false, wStmts);
+        TrParenExpr(lhs2.E0, wrTuple, 0, wStmts);
       } else {
         var lhs = (MultiSelectExpr)s0.Lhs;
-        wrTuple.Append(Expr(lhs.Array, false, wStmts));
+        wrTuple.Append(Expr(lhs.Array, 0, wStmts));
         foreach (var t in lhs.Indices) {
           wrTuple.Write(", ");
-          TrParenExpr(t, wrTuple, false, wStmts);
+          TrParenExpr(t, wrTuple, 0, wStmts);
         }
       }
 
@@ -296,7 +296,7 @@ namespace Microsoft.Dafny.Compilers {
         wrTuple.Write($"({TypeName(t, wrTuple, rhs.tok)})");
       }
 
-      wrTuple.Append(Expr(rhs, false, wStmts));
+      wrTuple.Append(Expr(rhs, 0, wStmts));
       return wrOuter;
     }
 
@@ -415,7 +415,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var sw = new ConcreteSyntaxTree(cw.InstanceMemberWriter.RelativeIndentLevel);
         var wStmts = cw.InstanceMemberWriter.Fork();
-        sw.Append(Expr(sst.Witness, false, wStmts));
+        sw.Append(Expr(sst.Witness, 0, wStmts));
         var witness = sw.ToString();
         var typeName = TypeName(sst.Rhs, cw.StaticMemberWriter, sst.tok);
         if (sst.TypeArgs.Count == 0) {
@@ -2325,7 +2325,7 @@ namespace Microsoft.Dafny.Compilers {
         }
       } else {
         var argumentWriter = EmitToString(wr, arg.Type);
-        argumentWriter.Append(Expr(arg, false, wStmts));
+        argumentWriter.Append(Expr(arg, 0, wStmts));
       }
     }
 
@@ -3632,7 +3632,7 @@ namespace Microsoft.Dafny.Compilers {
       if (nt.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var wStmts = w.Fork();
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
-        witness.Append(Expr(nt.Witness, false, wStmts));
+        witness.Append(Expr(nt.Witness, 0, wStmts));
         if (nt.NativeType == null) {
           cw.DeclareField("Witness", nt, true, true, nt.BaseType, nt.tok, witness.ToString(), null);
         } else {
@@ -4283,23 +4283,23 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".isInteger() && ");
     }
 
     protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("dafny.CodePoint.isCodePoint");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" && ");
     }
 
     protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".compareTo(");
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
       wr.Write(") >= 0 && ");
 
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".compareTo(");
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
       wr.Write(") < 0 && ");

--- a/Source/DafnyCore/Backends/JavaScript/JavaScriptCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/JavaScript/JavaScriptCodeGenerator.cs
@@ -1488,7 +1488,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitRotate(Expression e0, Expression e1, bool isRotateLeft, ConcreteSyntaxTree wr,
-        bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
+        int letExprNesting, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       bool needsCast = false;
       var nativeType = AsNativeType(e0.Type);
       if (nativeType != null) {
@@ -1497,12 +1497,12 @@ namespace Microsoft.Dafny.Compilers {
 
       var bv = e0.Type.NormalizeToAncestorType().AsBitVectorType;
       if (bv.Width == 0) {
-        tr(e0, wr, inLetExprBody, wStmts);
+        tr(e0, wr, letExprNesting, wStmts);
       } else {
         wr.Write("_dafny.{0}(", isRotateLeft ? "RotateLeft" : "RotateRight");
-        tr(e0, wr, inLetExprBody, wStmts);
+        tr(e0, wr, letExprNesting, wStmts);
         wr.Write(", (");
-        tr(e1, wr, inLetExprBody, wStmts);
+        tr(e1, wr, letExprNesting, wStmts);
         wr.Write(").toNumber(), {0})", bv.Width);
         if (needsCast) {
           wr.Write(".toNumber()");
@@ -1817,19 +1817,19 @@ namespace Microsoft.Dafny.Compilers {
       return w;
     }
 
-    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, bool inLetExprBody,
+    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, int letExprNesting,
         ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       Contract.Assert(indices != null && 1 <= indices.Count);  // follows from precondition
       var w = wr.Fork();
       if (indices.Count == 1) {
         wr.Write("[");
-        wr.Append(Expr(indices[0], inLetExprBody, wStmts));
+        wr.Append(Expr(indices[0], letExprNesting, wStmts));
         wr.Write("]");
       } else {
         wr.Write(".elmts");
         foreach (var index in indices) {
           wr.Write("[");
-          wr.Append(Expr(index, inLetExprBody, wStmts));
+          wr.Append(Expr(index, letExprNesting, wStmts));
           wr.Write("]");
         }
       }
@@ -1843,62 +1843,62 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(")");
     }
 
-    protected override void EmitExprAsNativeInt(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(expr, wr, inLetExprBody, wStmts);
+    protected override void EmitExprAsNativeInt(Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr(expr, wr, letExprNesting, wStmts);
       if (AsNativeType(expr.Type) == null) {
         wr.Write(".toNumber()");
       }
     }
 
-    protected override void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody,
+    protected override void EmitIndexCollectionSelect(Expression source, Expression index, int letExprNesting,
         ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       if (source.Type.NormalizeToAncestorType() is SeqType) {
         // seq
         wr.Write("[");
-        wr.Append(Expr(index, inLetExprBody, wStmts));
+        wr.Append(Expr(index, letExprNesting, wStmts));
         wr.Write("]");
       } else {
         // map or imap
         wr.Write(".get(");
-        wr.Append(Expr(index, inLetExprBody, wStmts));
+        wr.Append(Expr(index, letExprNesting, wStmts));
         wr.Write(")");
       }
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value,
-        CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        CollectionType resultCollectionType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (resultCollectionType.AsSeqType != null) {
         wr.Write($"{DafnySeqClass}.update(");
-        wr.Append(Expr(source, inLetExprBody, wStmts));
+        wr.Append(Expr(source, letExprNesting, wStmts));
         wr.Write(", ");
       } else {
-        TrParenExpr(source, wr, inLetExprBody, wStmts);
+        TrParenExpr(source, wr, letExprNesting, wStmts);
         wr.Write(".update(");
       }
-      wr.Append(Expr(index, inLetExprBody, wStmts));
+      wr.Append(Expr(index, letExprNesting, wStmts));
       wr.Write(", ");
-      wr.Append(CoercedExpr(value, resultCollectionType.ValueArg, inLetExprBody, wStmts));
+      wr.Append(CoercedExpr(value, resultCollectionType.ValueArg, letExprNesting, wStmts));
       wr.Write(")");
     }
 
     protected override void EmitSeqSelectRange(Expression source, Expression lo /*?*/, Expression hi /*?*/,
-        bool fromArray, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        bool fromArray, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromArray) {
         wr.Write($"{DafnySeqClass}.of(...");
       }
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       if (lo != null) {
         wr.Write(".slice(");
-        wr.Append(Expr(lo, inLetExprBody, wStmts));
+        wr.Append(Expr(lo, letExprNesting, wStmts));
         if (hi != null) {
           wr.Write(", ");
-          wr.Append(Expr(hi, inLetExprBody, wStmts));
+          wr.Append(Expr(hi, letExprNesting, wStmts));
         }
         wr.Write(")");
       } else if (hi != null) {
         wr.Write(".slice(0, ");
-        wr.Append(Expr(hi, inLetExprBody, wStmts));
+        wr.Append(Expr(hi, letExprNesting, wStmts));
         wr.Write(")");
       } else if (fromArray) {
         wr.Write(".slice()");
@@ -1908,35 +1908,35 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var fromType = (ArrowType)expr.Initializer.Type.NormalizeExpand();
       wr.Write($"{DafnySeqClass}.Create(");
-      wr.Append(Expr(expr.N, inLetExprBody, wStmts));
+      wr.Append(Expr(expr.N, letExprNesting, wStmts));
       wr.Write(", ");
-      wr.Append(Expr(expr.Initializer, inLetExprBody, wStmts));
+      wr.Append(Expr(expr.Initializer, letExprNesting, wStmts));
       wr.Write(")");
       if (fromType.Result.IsCharType && !UnicodeCharEnabled) {
         wr.Write(".join('')");
       }
     }
 
-    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr($"{DafnyMultiSetClass}.FromArray", expr.E, wr, inLetExprBody, wStmts);
+    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr($"{DafnyMultiSetClass}.FromArray", expr.E, wr, letExprNesting, wStmts);
     }
 
     protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function,
-        List<Expression> arguments, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(function, wr, inLetExprBody, wStmts);
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+        List<Expression> arguments, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr(function, wr, letExprNesting, wStmts);
+      TrExprList(arguments, wr, letExprNesting, wStmts);
     }
 
     protected override ConcreteSyntaxTree EmitBetaRedex(List<string> boundVars, List<Expression> arguments,
-      List<Type> boundTypes, Type resultType, IToken tok, bool inLetExprBody, ConcreteSyntaxTree wr,
+      List<Type> boundTypes, Type resultType, IToken tok, int letExprNesting, ConcreteSyntaxTree wr,
       ref ConcreteSyntaxTree wStmts) {
       wr.Write("(({0}) => ", Util.Comma(boundVars));
       var w = wr.Fork();
       wr.Write(")");
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+      TrExprList(arguments, wr, letExprNesting, wStmts);
       return w;
     }
 
@@ -2014,10 +2014,10 @@ namespace Microsoft.Dafny.Compilers {
 
     }
 
-    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       switch (op) {
         case ResolvedUnaryOp.BoolNot:
-          TrParenExpr("!", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("!", expr, wr, letExprNesting, wStmts);
           break;
         case ResolvedUnaryOp.BitwiseNot: {
             var exprType = expr.Type.NormalizeToAncestorType();
@@ -2030,13 +2030,13 @@ namespace Microsoft.Dafny.Compilers {
               wr.Write("0");
             } else {
               wr.Write("_dafny.BitwiseNot(");
-              wr.Append(Expr(expr, inLetExprBody, wStmts));
+              wr.Append(Expr(expr, letExprNesting, wStmts));
               wr.Write(", {0})", exprType.AsBitVectorType.Width);
             }
             break;
           }
         case ResolvedUnaryOp.Cardinality:
-          TrParenExpr("new BigNumber(", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("new BigNumber(", expr, wr, letExprNesting, wStmts);
           if (expr.Type.NormalizeToAncestorType().AsMultiSetType != null) {
             wr.Write(".cardinality())");
           } else {
@@ -2350,10 +2350,10 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write("{0}.isZero()", varName);
     }
 
-    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (fromType.IsNumericBased(Type.NumericPersuasion.Int) || fromType.NormalizeToAncestorType().IsBitVectorType || fromType.IsCharType || fromType.IsBigOrdinalType) {
         if (toType.Equals(fromType)) {
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
         } else if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // (int or bv or char) -> real
           Contract.Assert(AsNativeType(toType) == null);
@@ -2365,7 +2365,7 @@ namespace Microsoft.Dafny.Compilers {
             wr.Write("(");
           }
 
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           if (fromType.IsCharType) {
             wr.Write(UnicodeCharEnabled ? ".value)" : ".charCodeAt(0))");
           }
@@ -2373,10 +2373,10 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write(", new BigNumber(1))");
         } else if (toType.IsCharType) {
           if (fromType.IsCharType) {
-            EmitExpr(fromExpr, inLetExprBody, wr, wStmts);
+            EmitExpr(fromExpr, letExprNesting, wr, wStmts);
           } else {
             wr.Write($"{CharFromNumberMethodName()}(");
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
             if (AsNativeType(fromType) == null) {
               wr.Write(".toNumber()");
             }
@@ -2388,26 +2388,26 @@ namespace Microsoft.Dafny.Compilers {
           var toNative = AsNativeType(toType);
           if (fromNative != null && toNative != null) {
             // from a native, to a native -- simple!
-            wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+            wr.Append(Expr(fromExpr, letExprNesting, wStmts));
           } else if (fromType.IsCharType) {
             Contract.Assert(fromNative == null);
             if (toNative == null) {
               // char -> big-integer (int or bv or ORDINAL)
               wr.Write("new BigNumber(");
-              TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+              TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
               wr.Write(UnicodeCharEnabled ? ".value)" : ".charCodeAt(0))");
             } else {
               // char -> native
-              TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+              TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
               wr.Write(UnicodeCharEnabled ? ".value" : ".charCodeAt(0)");
             }
           } else if (fromNative == null && toNative == null) {
             // big-integer (int or bv) -> big-integer (int or bv or ORDINAL), so identity will do
-            wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+            wr.Append(Expr(fromExpr, letExprNesting, wStmts));
           } else if (fromNative != null && toNative == null) {
             // native (int or bv) -> big-integer (int or bv)
             wr.Write("new BigNumber");
-            TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+            TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           } else {
             // any (int or bv) -> native (int or bv)
             // Consider some optimizations
@@ -2419,15 +2419,15 @@ namespace Microsoft.Dafny.Compilers {
               wr.Write("(" + literal + ")");
             } else if (u != null && u.Op == UnaryOpExpr.Opcode.Cardinality) {
               // Optimize .Count to avoid intermediate BigInteger
-              TrParenExpr(u.E, wr, inLetExprBody, wStmts);
+              TrParenExpr(u.E, wr, letExprNesting, wStmts);
               wr.Write(".length");
             } else if (m != null && m.MemberName == "Length" && m.Obj.Type.IsArrayType) {
               // Optimize .Length to avoid intermediate BigInteger
-              TrParenExpr(m.Obj, wr, inLetExprBody, wStmts);
+              TrParenExpr(m.Obj, wr, letExprNesting, wStmts);
               wr.Write(".length");
             } else {
               // no optimization applies; use the standard translation
-              TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+              TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
               wr.Write(".toNumber()");
             }
           }
@@ -2437,14 +2437,14 @@ namespace Microsoft.Dafny.Compilers {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
           // real -> real
           Contract.Assert(AsNativeType(toType) == null);
-          wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+          wr.Append(Expr(fromExpr, letExprNesting, wStmts));
         } else if (toType.IsCharType) {
           wr.Write($"{CharFromNumberMethodName()}(");
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           wr.Write(".toBigNumber().toNumber())");
         } else {
           // real -> (int or bv)
-          TrParenExpr(fromExpr, wr, inLetExprBody, wStmts);
+          TrParenExpr(fromExpr, wr, letExprNesting, wStmts);
           wr.Write(".toBigNumber()");
           if (AsNativeType(toType) != null) {
             wr.Write(".toNumber()");
@@ -2455,12 +2455,12 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write($"{CharFromNumberMethodName()}((");
         }
 
-        wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+        wr.Append(Expr(fromExpr, letExprNesting, wStmts));
         if (toType.IsCharType) {
           wr.Write(").toNumber())");
         }
       } else if (fromType.Equals(toType) || fromType.AsNewtype != null || toType.AsNewtype != null) {
-        wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+        wr.Append(Expr(fromExpr, letExprNesting, wStmts));
       } else {
         Contract.Assert(false, $"not implemented for javascript: {fromType} -> {toType}");
       }
@@ -2511,13 +2511,13 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
-        bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       if (ct is SetType) {
         wr.Write($"{DafnySetClass}.fromElements");
-        TrExprList(elements, wr, inLetExprBody, wStmts);
+        TrExprList(elements, wr, letExprNesting, wStmts);
       } else if (ct is MultiSetType) {
         wr.Write($"{DafnyMultiSetClass}.fromElements");
-        TrExprList(elements, wr, inLetExprBody, wStmts);
+        TrExprList(elements, wr, letExprNesting, wStmts);
       } else {
         Contract.Assert(ct is SeqType);  // follows from precondition
         ConcreteSyntaxTree wrElements;
@@ -2532,18 +2532,18 @@ namespace Microsoft.Dafny.Compilers {
           wrElements = wr.Fork();
           wr.Write(")");
         }
-        TrExprList(elements, wrElements, inLetExprBody, wStmts, typeAt: _ => ct.Arg, parens: false);
+        TrExprList(elements, wrElements, letExprNesting, wStmts, typeAt: _ => ct.Arg, parens: false);
       }
     }
 
     protected override void EmitMapDisplay(MapType mt, IToken tok, List<ExpressionPair> elements,
-        bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+        int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write($"{DafnyMapClass}.Empty.slice()");
       foreach (ExpressionPair p in elements) {
         wr.Write(".updateUnsafe(");
-        wr.Append(Expr(p.A, inLetExprBody, wStmts));
+        wr.Append(Expr(p.A, letExprNesting, wStmts));
         wr.Write(",");
-        wr.Append(Expr(p.B, inLetExprBody, wStmts));
+        wr.Append(Expr(p.B, letExprNesting, wStmts));
         wr.Write(")");
       }
     }
@@ -2558,20 +2558,20 @@ namespace Microsoft.Dafny.Compilers {
       wrVarInit.Write($"new {DafnyMapClass}()");
     }
 
-    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, int letExprNesting, ConcreteSyntaxTree wr) {
       Contract.Assume(ct is SetType || ct is MultiSetType);  // follows from precondition
       var wStmts = wr.Fork();
       wr.Write("{0}.add(", collName);
-      wr.Append(Expr(elmt, inLetExprBody, wStmts));
+      wr.Append(Expr(elmt, letExprNesting, wStmts));
       wr.WriteLine(");");
     }
 
-    protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term, bool inLetExprBody, ConcreteSyntaxTree wr) {
+    protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term, int letExprNesting, ConcreteSyntaxTree wr) {
       var wStmts = wr.Fork();
       wr.Write("{0}.push([", collName);
       var termLeftWriter = wr.Fork();
       wr.Write(",");
-      wr.Append(Expr(term, inLetExprBody, wStmts));
+      wr.Append(Expr(term, letExprNesting, wStmts));
       wr.WriteLine("]);");
       return termLeftWriter;
     }
@@ -2582,8 +2582,8 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(collName);
     }
 
-    protected override void EmitSingleValueGenerator(Expression e, bool inLetExprBody, string type, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr("_dafny.SingleValue", e, wr, inLetExprBody, wStmts);
+    protected override void EmitSingleValueGenerator(Expression e, int letExprNesting, string type, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr("_dafny.SingleValue", e, wr, letExprNesting, wStmts);
     }
 
     protected override void EmitHaltRecoveryStmt(Statement body, string haltMessageVarName, Statement recoveryBody, ConcreteSyntaxTree wr) {

--- a/Source/DafnyCore/Backends/JavaScript/JavaScriptCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/JavaScript/JavaScriptCodeGenerator.cs
@@ -586,9 +586,9 @@ namespace Microsoft.Dafny.Compilers {
         var witness = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
         if (nt.NativeType == null) {
-          witness.Append(Expr(nt.Witness, false, wStmts));
+          witness.Append(Expr(nt.Witness, 0, wStmts));
         } else {
-          TrParenExpr(nt.Witness, witness, false, wStmts);
+          TrParenExpr(nt.Witness, witness, 0, wStmts);
           witness.Write(".toNumber()");
         }
         DeclareField("Witness", true, true, nt.BaseType, nt.tok, witness.ToString(), w);
@@ -644,7 +644,7 @@ namespace Microsoft.Dafny.Compilers {
       if (sst.WitnessKind == SubsetTypeDecl.WKind.Compiled) {
         var sw = new ConcreteSyntaxTree(w.RelativeIndentLevel);
         var wStmts = w.Fork();
-        sw.Append(Expr(sst.Witness, false, wStmts));
+        sw.Append(Expr(sst.Witness, 0, wStmts));
         DeclareField("Witness", true, true, sst.Rhs, sst.tok, sw.ToString(), w);
         d = TypeName_UDT(FullTypeName(udt), udt, wr, udt.tok) + ".Witness";
       } else {
@@ -1149,16 +1149,16 @@ namespace Microsoft.Dafny.Compilers {
       if (isStringLiteral && !UnicodeCharEnabled) {
         // process.stdout.write(_dafny.toString(x));
         wr.Write("process.stdout.write(_dafny.toString(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.WriteLine("));");
       } else if (isString) {
         if (UnicodeCharEnabled) {
           wr.Write($"process.stdout.write(");
-          TrParenExpr(arg, wr, false, wStmts);
+          TrParenExpr(arg, wr, 0, wStmts);
           wr.WriteLine(".toVerbatimString(false));");
         } else {
           wr.Write($"process.stdout.write(_dafny.toString({DafnySeqClass}.JoinIfPossible(");
-          wr.Append(Expr(arg, false, wStmts));
+          wr.Append(Expr(arg, 0, wStmts));
           wr.WriteLine(")));");
         }
       } else if (isGeneric && !UnicodeCharEnabled) {
@@ -1166,24 +1166,24 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write("try { process.stdout.write(_dafny.toString(");
         wr.Write("(");
         wr.Write("(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.Write(") instanceof Array && typeof((");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.Write(")[0]) == \"string\") ? ");
         wr.Write("(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.Write(").join(\"\")");
         wr.Write(":");
         wr.Write("(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.Write(")));");
         wr.Write("} catch (_error) { process.stdout.write(_dafny.toString(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.WriteLine("));}");
       } else { // !isString && !isGeneric
         // process.stdout.write(_dafny.toString(x));
         wr.Write("process.stdout.write(_dafny.toString(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.WriteLine("));");
       }
     }
@@ -1234,7 +1234,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write("\"" + tok.TokenToString(Options) + ": \" + ");
       }
 
-      TrParenExpr(messageExpr, wr, false, wStmts);
+      TrParenExpr(messageExpr, wr, 0, wStmts);
       if (UnicodeCharEnabled && messageExpr.Type.IsStringType) {
         wr.Write(".toVerbatimString(false)");
       }
@@ -2488,23 +2488,23 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".isInteger() && ");
     }
 
     protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("_dafny.CodePoint.isCodePoint");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" && ");
     }
 
     protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       EmitLiteralExpr(wr.ForkInParens(), new LiteralExpr(source.tok, lo) { Type = Type.Int });
       wr.Write(".isLessThanOrEqualTo");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" && ");
 
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".isLessThan");
       EmitLiteralExpr(wr.ForkInParens(), new LiteralExpr(source.tok, hi) { Type = Type.Int });
       wr.Write(" && ");

--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Dafny.Compilers {
       var wStmts = block.Fork();
       block.Write("return ");
       if (witnessKind == SubsetTypeDecl.WKind.Compiled) {
-        block.Append(Expr(witness, false, wStmts));
+        block.Append(Expr(witness, 0, wStmts));
       } else {
         block.Write(TypeInitializationValue(udt, wr, d.tok, false, false));
       }
@@ -965,11 +965,11 @@ namespace Microsoft.Dafny.Compilers {
 
     private void EmitToString(ConcreteSyntaxTree wr, Expression arg, ConcreteSyntaxTree wStmts) {
       if (UnicodeCharEnabled && DatatypeWrapperEraser.SimplifyTypeAndTrimNewtypes(Options, arg.Type).IsStringType) {
-        TrParenExpr(arg, wr, false, wStmts);
+        TrParenExpr(arg, wr, 0, wStmts);
         wr.Write(".VerbatimString(False)");
       } else {
         wr.Write($"{DafnyRuntimeModule}.string_of(");
-        wr.Append(Expr(arg, false, wStmts));
+        wr.Append(Expr(arg, 0, wStmts));
         wr.Write(")");
       }
     }
@@ -1849,23 +1849,23 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitIsIntegerTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(".is_integer() and ");
     }
 
     protected override void EmitIsUnicodeScalarValueTest(Expression source, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("_dafny.CodePoint.is_code_point");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" and ");
     }
 
     protected override void EmitIsInIntegerRange(Expression source, BigInteger lo, BigInteger hi, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, lo) { Type = Type.Int });
       wr.Write(" <= ");
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" and ");
 
-      EmitExpr(source, false, wr.ForkInParens(), wStmts);
+      EmitExpr(source, 0, wr.ForkInParens(), wStmts);
       wr.Write(" < ");
       EmitLiteralExpr(wr, new LiteralExpr(source.tok, hi) { Type = Type.Int });
       wr.Write(" and ");

--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -1208,27 +1208,27 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitRotate(Expression e0, Expression e1, bool isRotateLeft, ConcreteSyntaxTree wr,
-        bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
+        int letExprNesting, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       // (( e0 op1 e1) | (e0 op2 (width - e1)))
       wr = wr.ForkInParens();
-      EmitShift(e0, e1, isRotateLeft ? "<<" : ">>", isRotateLeft, true, wr.ForkInParens(), inLetExprBody, wStmts, tr);
+      EmitShift(e0, e1, isRotateLeft ? "<<" : ">>", isRotateLeft, true, wr.ForkInParens(), letExprNesting, wStmts, tr);
       wr.Write(" | ");
-      EmitShift(e0, e1, isRotateLeft ? ">>" : "<<", !isRotateLeft, false, wr.ForkInParens(), inLetExprBody, wStmts, tr);
+      EmitShift(e0, e1, isRotateLeft ? ">>" : "<<", !isRotateLeft, false, wr.ForkInParens(), letExprNesting, wStmts, tr);
     }
 
     void EmitShift(Expression e0, Expression e1, string op, bool truncate, bool firstOp, ConcreteSyntaxTree wr,
-        bool inLetExprBody, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
+        int letExprNesting, ConcreteSyntaxTree wStmts, FCE_Arg_Translator tr) {
       var bv = e0.Type.NormalizeToAncestorType().AsBitVectorType;
       if (truncate) {
         wr = EmitBitvectorTruncation(bv, null, true, wr);
       }
-      tr(e0, wr, inLetExprBody, wStmts);
+      tr(e0, wr, letExprNesting, wStmts);
       wr.Write($" {op} ");
       if (!firstOp) {
         wr = wr.ForkInParens().Write($"{bv.Width} - ");
       }
 
-      tr(e1, wr.ForkInParens(), inLetExprBody, wStmts);
+      tr(e1, wr.ForkInParens(), letExprNesting, wStmts);
     }
 
     protected override void EmitEmptyTupleList(string tupleTypeArgs, ConcreteSyntaxTree wr) {
@@ -1460,82 +1460,82 @@ namespace Microsoft.Dafny.Compilers {
       return w;
     }
 
-    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, bool inLetExprBody,
+    protected override ConcreteSyntaxTree EmitArraySelect(List<Expression> indices, Type elmtType, int letExprNesting,
         ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       Contract.Assert(indices != null);  // follows from precondition
-      var strings = indices.Select<Expression, Action<ConcreteSyntaxTree>>(index => wr => EmitExpr(index, inLetExprBody, wr, wStmts));
+      var strings = indices.Select<Expression, Action<ConcreteSyntaxTree>>(index => wr => EmitExpr(index, letExprNesting, wr, wStmts));
       return EmitArraySelect(strings.ToList(), elmtType, wr);
     }
 
-    protected override void EmitExprAsNativeInt(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr,
+    protected override void EmitExprAsNativeInt(Expression expr, int letExprNesting, ConcreteSyntaxTree wr,
       ConcreteSyntaxTree wStmts) {
       // This is also used for bit shift operators, or more generally any binary operation where CompileBinOp()
       // sets the convertE1_to_int out parameter to true. This compiler always sets that to false, however,
       // so this method is only called for non-sequentializable forall statements.
-      TrParenExpr("int", expr, wr, inLetExprBody, wStmts);
+      TrParenExpr("int", expr, wr, letExprNesting, wStmts);
     }
 
-    protected override void EmitIndexCollectionSelect(Expression source, Expression index, bool inLetExprBody,
+    protected override void EmitIndexCollectionSelect(Expression source, Expression index, int letExprNesting,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       wr.Write("[");
-      wr.Append(Expr(index, inLetExprBody, wStmts));
+      wr.Append(Expr(index, letExprNesting, wStmts));
       wr.Write("]");
     }
 
     protected override void EmitIndexCollectionUpdate(Expression source, Expression index, Expression value,
-      CollectionType resultCollectionType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      CollectionType resultCollectionType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       wr.Write(".set(");
-      wr.Append(Expr(index, inLetExprBody, wStmts));
+      wr.Append(Expr(index, letExprNesting, wStmts));
       wr.Write(", ");
-      wr.Append(CoercedExpr(value, resultCollectionType.ValueArg, inLetExprBody, wStmts));
+      wr.Append(CoercedExpr(value, resultCollectionType.ValueArg, letExprNesting, wStmts));
       wr.Write(")");
     }
 
     protected override void EmitSeqSelectRange(Expression source, Expression lo, Expression hi, bool fromArray,
-      bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write($"{DafnySeqMakerFunction}(");
-      TrParenExpr(source, wr, inLetExprBody, wStmts);
+      TrParenExpr(source, wr, letExprNesting, wStmts);
       wr.Write("[");
-      if (lo != null) { wr.Append(Expr(lo, inLetExprBody, wStmts)); }
+      if (lo != null) { wr.Append(Expr(lo, letExprNesting, wStmts)); }
       wr.Write(":");
-      if (hi != null) { wr.Append(Expr(hi, inLetExprBody, wStmts)); }
+      if (hi != null) { wr.Append(Expr(hi, letExprNesting, wStmts)); }
 
       wr.Write(":])");
     }
 
-    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitSeqConstructionExpr(SeqConstructionExpr expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       ConcreteSyntaxTree valueExpression;
-      var range = $"range({Expr(expr.N, inLetExprBody, wStmts)})";
+      var range = $"range({Expr(expr.N, letExprNesting, wStmts)})";
       wr.Write(DafnySeqMakerFunction);
       if (expr.Initializer is LambdaExpr lam) {
-        valueExpression = Expr(lam.Body, inLetExprBody, wStmts);
+        valueExpression = Expr(lam.Body, letExprNesting, wStmts);
         var binder = IdProtect(lam.BoundVars[0].CompileName);
         wr.Write($"([{valueExpression} for {binder} in {range}])");
       } else {
-        valueExpression = Expr(expr.Initializer, inLetExprBody, wStmts);
+        valueExpression = Expr(expr.Initializer, letExprNesting, wStmts);
         wr.Write($"(tuple(map({valueExpression}, {range})))");
       }
     }
 
-    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, bool inLetExprBody, ConcreteSyntaxTree wr,
+    protected override void EmitMultiSetFormingExpr(MultiSetFormingExpr expr, int letExprNesting, ConcreteSyntaxTree wr,
       ConcreteSyntaxTree wStmts) {
-      TrParenExpr(DafnyMultiSetClass, expr.E, wr, inLetExprBody, wStmts);
+      TrParenExpr(DafnyMultiSetClass, expr.E, wr, letExprNesting, wStmts);
     }
 
     protected override void EmitApplyExpr(Type functionType, IToken tok, Expression function,
-        List<Expression> arguments, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
-      wr.Append(Expr(function, inLetExprBody, wStmts));
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+        List<Expression> arguments, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      wr.Append(Expr(function, letExprNesting, wStmts));
+      TrExprList(arguments, wr, letExprNesting, wStmts);
     }
 
     protected override ConcreteSyntaxTree EmitBetaRedex(List<string> boundVars, List<Expression> arguments,
-      List<Type> boundTypes, Type resultType, IToken resultTok, bool inLetExprBody, ConcreteSyntaxTree wr,
+      List<Type> boundTypes, Type resultType, IToken resultTok, int letExprNesting, ConcreteSyntaxTree wr,
       ref ConcreteSyntaxTree wStmts) {
       var functionName = ProtectedFreshId("_lambda");
       wr.Write($"{functionName}");
-      TrExprList(arguments, wr, inLetExprBody, wStmts);
+      TrExprList(arguments, wr, letExprNesting, wStmts);
       var wrBody = wStmts.NewBlockPy($"def {functionName}({boundVars.Comma()}):", close: BlockStyle.Newline);
       wStmts = wrBody.Fork();
       return EmitReturnExpr(wrBody);
@@ -1603,19 +1603,19 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitUnaryExpr(ResolvedUnaryOp op, Expression expr, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       switch (op) {
         case ResolvedUnaryOp.Cardinality:
           var multiset = expr.Type.NormalizeToAncestorType().AsMultiSetType != null;
           if (!multiset) { wr.Write("len"); }
-          TrParenExpr(expr, wr, inLetExprBody, wStmts);
+          TrParenExpr(expr, wr, letExprNesting, wStmts);
           if (multiset) { wr.Write(".cardinality"); }
           break;
         case ResolvedUnaryOp.BitwiseNot:
-          TrParenExpr("~", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("~", expr, wr, letExprNesting, wStmts);
           break;
         case ResolvedUnaryOp.BoolNot:
-          TrParenExpr("not", expr, wr, inLetExprBody, wStmts);
+          TrParenExpr("not", expr, wr, letExprNesting, wStmts);
           break;
         default:
           Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
@@ -1784,13 +1784,13 @@ namespace Microsoft.Dafny.Compilers {
       }
     }
 
-    protected override void EmitITE(Expression guard, Expression thn, Expression els, Type resultType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitITE(Expression guard, Expression thn, Expression els, Type resultType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       Contract.Requires(guard != null);
       Contract.Requires(thn != null);
       Contract.Requires(els != null);
       Contract.Requires(wr != null);
 
-      ConcreteSyntaxTree Tree(Expression e) => Expr(e, inLetExprBody, wStmts);
+      ConcreteSyntaxTree Tree(Expression e) => Expr(e, letExprNesting, wStmts);
 
       wr.Format($"({Tree(thn)} if {Tree(guard)} else {Tree(els)})");
     }
@@ -1799,7 +1799,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write($"{varName} == 0");
     }
 
-    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    protected override void EmitConversionExpr(Expression fromExpr, Type fromType, Type toType, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var (pre, post) = ("", "");
       if (fromType.IsNumericBased(Type.NumericPersuasion.Int) || fromType.NormalizeToAncestorType().IsBitVectorType || fromType.IsBigOrdinalType) {
         if (toType.IsNumericBased(Type.NumericPersuasion.Real)) {
@@ -1831,7 +1831,7 @@ namespace Microsoft.Dafny.Compilers {
         }
       }
       wr.Write(pre);
-      wr.Append(Expr(fromExpr, inLetExprBody, wStmts));
+      wr.Append(Expr(fromExpr, letExprNesting, wStmts));
       wr.Write(post);
     }
 
@@ -1872,7 +1872,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void EmitCollectionDisplay(CollectionType ct, IToken tok, List<Expression> elements,
-      bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+      int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       var (open, close) = ct switch {
         SeqType or MultiSetType => ("[", "]"),
         _ => ("{", "}")
@@ -1880,7 +1880,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(ct is SeqType ? DafnySeqMakerFunction : TypeHelperName(ct));
       wr.Write("(");
       wr.Write(open);
-      TrExprList(elements, wr, inLetExprBody, wStmts, typeAt: _ => ct.Arg, parens: false);
+      TrExprList(elements, wr, letExprNesting, wStmts, typeAt: _ => ct.Arg, parens: false);
       wr.Write(close);
       wr.Write(")");
     }
@@ -1895,15 +1895,15 @@ namespace Microsoft.Dafny.Compilers {
       };
     }
 
-    protected override void EmitMapDisplay(MapType mt, IToken tok, List<ExpressionPair> elements, bool inLetExprBody,
+    protected override void EmitMapDisplay(MapType mt, IToken tok, List<ExpressionPair> elements, int letExprNesting,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write($"{DafnyMapClass}({{");
       var sep = "";
       foreach (var p in elements) {
         wr.Write(sep);
-        wr.Append(Expr(p.A, inLetExprBody, wStmts));
+        wr.Append(Expr(p.A, letExprNesting, wStmts));
         wr.Write(": ");
-        wr.Append(Expr(p.B, inLetExprBody, wStmts));
+        wr.Append(Expr(p.B, letExprNesting, wStmts));
         sep = ", ";
       }
       wr.Write("})");
@@ -1917,17 +1917,17 @@ namespace Microsoft.Dafny.Compilers {
       wr.WriteLine($"{collectionName} = {DafnyMapClass}()");
     }
 
-    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, bool inLetExprBody,
+    protected override void EmitSetBuilder_Add(CollectionType ct, string collName, Expression elmt, int letExprNesting,
         ConcreteSyntaxTree wr) {
       var wStmts = wr.Fork();
-      wr.WriteLine($"{collName} = {collName}.union({DafnySetClass}([{Expr(elmt, inLetExprBody, wStmts)}]))");
+      wr.WriteLine($"{collName} = {collName}.union({DafnySetClass}([{Expr(elmt, letExprNesting, wStmts)}]))");
     }
 
     protected override ConcreteSyntaxTree EmitMapBuilder_Add(MapType mt, IToken tok, string collName, Expression term,
-        bool inLetExprBody, ConcreteSyntaxTree wr) {
+        int letExprNesting, ConcreteSyntaxTree wr) {
       var termLeftWriter = new ConcreteSyntaxTree();
       var wStmts = wr.Fork();
-      wr.FormatLine($"{collName}[{termLeftWriter}] = {Expr(term, inLetExprBody, wStmts)}");
+      wr.FormatLine($"{collName}[{termLeftWriter}] = {Expr(term, letExprNesting, wStmts)}");
       return termLeftWriter;
     }
 
@@ -1961,10 +1961,10 @@ namespace Microsoft.Dafny.Compilers {
       );
     }
 
-    protected override void EmitSingleValueGenerator(Expression e, bool inLetExprBody, string type,
+    protected override void EmitSingleValueGenerator(Expression e, int letExprNesting, string type,
       ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       wr.Write("[");
-      wr.Append(Expr(e, inLetExprBody, wStmts));
+      wr.Append(Expr(e, letExprNesting, wStmts));
       wr.Write("]");
     }
 

--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Expression.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Expression.cs
@@ -223,8 +223,8 @@ namespace Microsoft.Dafny.Compilers {
         case FunctionCallExpr callExpr: {
             FunctionCallExpr e = callExpr;
 
-            void EmitExpr(Expression e2, ConcreteSyntaxTree wr2, bool inLetExpr, ConcreteSyntaxTree wStmts2) {
-              this.EmitExpr(e2, inLetExpr, wr2, wStmts2);
+            void EmitExpr(Expression e2, ConcreteSyntaxTree wr2, int letExprNesting, ConcreteSyntaxTree wStmts2) {
+              this.EmitExpr(e2, letExprNesting, wr2, wStmts2);
             }
 
             if (e.Function is SpecialFunction) {
@@ -514,7 +514,7 @@ namespace Microsoft.Dafny.Compilers {
               var tmpVar = ProtectedFreshId("_compr_");
               var wStmtsLoop = wr.Fork();
               var elementType = CompileCollection(bound, bv, letExprNesting, true, null, out var collection, out var newtypeConversionsWereExplicit, wStmtsLoop);
-              wr = CreateGuardedForeachLoop(tmpVar, elementType, bv, newtypeConversionsWereExplicit, true, false, bv.tok, collection, wr);
+              wr = CreateGuardedForeachLoop(tmpVar, elementType, bv, newtypeConversionsWereExplicit, true, 0, bv.tok, collection, wr);
               wr = EmitGuardFragment(unusedConjuncts, processedBounds, wr);
             }
 

--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Expression.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Expression.cs
@@ -19,7 +19,7 @@ using static Microsoft.Dafny.GeneratorErrors;
 namespace Microsoft.Dafny.Compilers {
   public abstract partial class SinglePassCodeGenerator {
 
-    public virtual void EmitExpr(Expression expr, bool inLetExprBody, ConcreteSyntaxTree wr,
+    public virtual void EmitExpr(Expression expr, int letExprNesting, ConcreteSyntaxTree wr,
       ConcreteSyntaxTree wStmts) {
       switch (expr) {
         case LiteralExpr literalExpr: {
@@ -43,7 +43,7 @@ namespace Microsoft.Dafny.Compilers {
           }
         case IdentifierExpr identifierExpr: {
             var e = identifierExpr;
-            if (inLetExprBody && !(e.Var is BoundVar)) {
+            if (letExprNesting && !(e.Var is BoundVar)) {
               // copy variable to a temp since
               //   - C# doesn't allow out param in letExpr body, and
               //   - Java doesn't allow any non-final variable in letExpr body.
@@ -58,23 +58,23 @@ namespace Microsoft.Dafny.Compilers {
           }
         case SetDisplayExpr displayExpr: {
             var e = displayExpr;
-            EmitCollectionDisplay(e.Type.NormalizeToAncestorType().AsSetType, e.tok, e.Elements, inLetExprBody, wr, wStmts);
+            EmitCollectionDisplay(e.Type.NormalizeToAncestorType().AsSetType, e.tok, e.Elements, letExprNesting, wr, wStmts);
             break;
           }
         case MultiSetDisplayExpr displayExpr: {
             var e = displayExpr;
-            EmitCollectionDisplay(e.Type.NormalizeToAncestorType().AsMultiSetType, e.tok, e.Elements, inLetExprBody, wr,
+            EmitCollectionDisplay(e.Type.NormalizeToAncestorType().AsMultiSetType, e.tok, e.Elements, letExprNesting, wr,
               wStmts);
             break;
           }
         case SeqDisplayExpr displayExpr: {
             var e = displayExpr;
-            EmitCollectionDisplay(e.Type.NormalizeToAncestorType().AsSeqType, e.tok, e.Elements, inLetExprBody, wr, wStmts);
+            EmitCollectionDisplay(e.Type.NormalizeToAncestorType().AsSeqType, e.tok, e.Elements, letExprNesting, wr, wStmts);
             break;
           }
         case MapDisplayExpr displayExpr: {
             var e = displayExpr;
-            EmitMapDisplay(e.Type.NormalizeToAncestorType().AsMapType, e.tok, e.Elements, inLetExprBody, wr, wStmts);
+            EmitMapDisplay(e.Type.NormalizeToAncestorType().AsMapType, e.tok, e.Elements, letExprNesting, wr, wStmts);
             break;
           }
         case MemberSelectExpr selectExpr: {
@@ -97,7 +97,7 @@ namespace Microsoft.Dafny.Compilers {
                   //Contract.Assert(!sf.IsStatic);
                   w = EmitCoercionIfNecessary(e.Obj.Type, UserDefinedType.UpcastToMemberEnclosingType(e.Obj.Type, e.Member),
                     e.tok, w);
-                  TrParenExpr(e.Obj, w, inLetExprBody, wStmts);
+                  TrParenExpr(e.Obj, w, letExprNesting, wStmts);
                 }
 
                 var typeArgs = CombineAllTypeArguments(e.Member, e.TypeApplication_AtEnclosingClass,
@@ -119,11 +119,11 @@ namespace Microsoft.Dafny.Compilers {
                 if (e.Member is Function && typeArgs.Count != 0) {
                   // need to eta-expand wrap the receiver
                   var etaReceiver = ProtectedFreshId("_eta_this");
-                  wr = CreateIIFE_ExprBody(etaReceiver, e.Obj.Type, e.Obj.tok, e.Obj, inLetExprBody, e.Type.Subst(typeMap),
+                  wr = CreateIIFE_ExprBody(etaReceiver, e.Obj.Type, e.Obj.tok, e.Obj, letExprNesting, e.Type.Subst(typeMap),
                     e.tok, wr, ref wStmts);
                   obj = w => EmitIdentifier(etaReceiver, w);
                 } else {
-                  obj = w => EmitExpr(e.Obj, inLetExprBody, w, wStmts);
+                  obj = w => EmitExpr(e.Obj, letExprNesting, w, wStmts);
                 }
 
                 EmitMemberSelect(obj, e.Obj.Type, e.Member, typeArgs, typeMap, selectExpr.Type).EmitRead(wr);
@@ -132,7 +132,7 @@ namespace Microsoft.Dafny.Compilers {
                 if (customReceiver && e.Member is Function) {
                   // need to eta-expand wrap the receiver
                   customReceiverName = ProtectedFreshId("_eta_this");
-                  wr = CreateIIFE_ExprBody(customReceiverName, e.Obj.Type, e.Obj.tok, e.Obj, inLetExprBody,
+                  wr = CreateIIFE_ExprBody(customReceiverName, e.Obj.Type, e.Obj.tok, e.Obj, letExprNesting,
                     e.Type.Subst(typeMap), e.tok, wr, ref wStmts);
                 }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Dafny.Compilers {
             if (e.Seq.Type.IsArrayType) {
               if (e.SelectOne) {
                 Contract.Assert(e.E0 != null && e.E1 == null);
-                var w = EmitArraySelect(new List<Expression>() { e.E0 }, e.Type, inLetExprBody, wr, wStmts);
+                var w = EmitArraySelect(new List<Expression>() { e.E0 }, e.Type, letExprNesting, wr, wStmts);
                 w = EmitCoercionIfNecessary(
                   e.Seq.Type,
                   e.Seq.Type.IsNonNullRefType || !e.Seq.Type.IsRefType
@@ -158,48 +158,48 @@ namespace Microsoft.Dafny.Compilers {
                   e.tok,
                   w
                 );
-                TrParenExpr(e.Seq, w, inLetExprBody, wStmts);
+                TrParenExpr(e.Seq, w, letExprNesting, wStmts);
               } else {
-                EmitSeqSelectRange(e.Seq, e.E0, e.E1, true, inLetExprBody, wr, wStmts);
+                EmitSeqSelectRange(e.Seq, e.E0, e.E1, true, letExprNesting, wr, wStmts);
               }
             } else if (e.SelectOne) {
               Contract.Assert(e.E0 != null && e.E1 == null);
-              EmitIndexCollectionSelect(e.Seq, e.E0, inLetExprBody, wr, wStmts);
+              EmitIndexCollectionSelect(e.Seq, e.E0, letExprNesting, wr, wStmts);
             } else {
-              EmitSeqSelectRange(e.Seq, e.E0, e.E1, false, inLetExprBody, wr, wStmts);
+              EmitSeqSelectRange(e.Seq, e.E0, e.E1, false, letExprNesting, wr, wStmts);
             }
 
             break;
           }
         case SeqConstructionExpr constructionExpr: {
             var e = constructionExpr;
-            EmitSeqConstructionExpr(e, inLetExprBody, wr, wStmts);
+            EmitSeqConstructionExpr(e, letExprNesting, wr, wStmts);
             break;
           }
         case MultiSetFormingExpr formingExpr: {
             var e = formingExpr;
-            EmitMultiSetFormingExpr(e, inLetExprBody, wr, wStmts);
+            EmitMultiSetFormingExpr(e, letExprNesting, wr, wStmts);
             break;
           }
         case MultiSelectExpr selectExpr: {
             MultiSelectExpr e = selectExpr;
             WriteCast(TypeName(e.Type.NormalizeExpand(), wr, e.tok), wr);
-            var w = EmitArraySelect(e.Indices, e.Type, inLetExprBody, wr, wStmts);
-            TrParenExpr(e.Array, w, inLetExprBody, wStmts);
+            var w = EmitArraySelect(e.Indices, e.Type, letExprNesting, wr, wStmts);
+            TrParenExpr(e.Array, w, letExprNesting, wStmts);
             break;
           }
         case SeqUpdateExpr updateExpr: {
             SeqUpdateExpr e = updateExpr;
             var collectionType = e.Type.NormalizeToAncestorType().AsCollectionType;
             Contract.Assert(collectionType != null);
-            EmitIndexCollectionUpdate(e.Seq, e.Index, e.Value, collectionType, inLetExprBody, wr, wStmts);
+            EmitIndexCollectionUpdate(e.Seq, e.Index, e.Value, collectionType, letExprNesting, wr, wStmts);
             break;
           }
         case DatatypeUpdateExpr updateExpr: {
             var e = updateExpr;
             if (e.Members.All(member => member.IsGhost)) {
               // all fields to be updated are ghost, which doesn't change the value
-              EmitExpr(e.Root, inLetExprBody, wr, wStmts);
+              EmitExpr(e.Root, letExprNesting, wr, wStmts);
               return;
             }
 
@@ -211,13 +211,13 @@ namespace Microsoft.Dafny.Compilers {
                 Contract.Assert(Enumerable.Range(0, e.Members.Count).All(j => j == i || e.Members[j].IsGhost));
                 Contract.Assert(e.Members.Count == e.Updates.Count);
                 var rhs = e.Updates[i].Item3;
-                EmitExpr(rhs, inLetExprBody, wr, wStmts);
+                EmitExpr(rhs, letExprNesting, wr, wStmts);
                 return;
               }
             }
 
             // the optimized cases don't apply, so proceed according to the desugaring
-            EmitExpr(e.ResolvedExpression, inLetExprBody, wr, wStmts);
+            EmitExpr(e.ResolvedExpression, letExprNesting, wr, wStmts);
             break;
           }
         case FunctionCallExpr callExpr: {
@@ -228,16 +228,16 @@ namespace Microsoft.Dafny.Compilers {
             }
 
             if (e.Function is SpecialFunction) {
-              CompileSpecialFunctionCallExpr(e, wr, inLetExprBody, wStmts, EmitExpr);
+              CompileSpecialFunctionCallExpr(e, wr, letExprNesting, wStmts, EmitExpr);
             } else {
-              CompileFunctionCallExpr(e, wr, inLetExprBody, wStmts, EmitExpr);
+              CompileFunctionCallExpr(e, wr, letExprNesting, wStmts, EmitExpr);
             }
 
             break;
           }
         case ApplyExpr applyExpr: {
             var e = applyExpr;
-            EmitApplyExpr(e.Function.Type, e.tok, e.Function, e.Args, inLetExprBody, wr, wStmts);
+            EmitApplyExpr(e.Function.Type, e.tok, e.Function, e.Args, letExprNesting, wr, wStmts);
             break;
           }
         case DatatypeValue value: {
@@ -247,7 +247,7 @@ namespace Microsoft.Dafny.Compilers {
             if (DatatypeWrapperEraser.IsErasableDatatypeWrapper(Options, dtv.Ctor.EnclosingDatatype, out var dtor)) {
               var i = dtv.Ctor.Destructors.IndexOf(dtor);
               Contract.Assert(0 <= i);
-              EmitExpr(dtv.Arguments[i], inLetExprBody, wr, wStmts);
+              EmitExpr(dtv.Arguments[i], letExprNesting, wr, wStmts);
               return;
             }
 
@@ -264,7 +264,7 @@ namespace Microsoft.Dafny.Compilers {
                 wrArgumentList.Write(sep);
                 var w = EmitCoercionIfNecessary(from: dtv.Arguments[i].Type, to: dtv.Ctor.Formals[i].Type.Subst(typeSubst),
                   toOrig: dtv.Ctor.Formals[i].Type, tok: dtv.tok, wr: wrArgumentList);
-                EmitExpr(dtv.Arguments[i], inLetExprBody, w, wStmts);
+                EmitExpr(dtv.Arguments[i], letExprNesting, w, wStmts);
                 sep = ", ";
               }
             }
@@ -282,7 +282,7 @@ namespace Microsoft.Dafny.Compilers {
                 wr);
             }
 
-            EmitUnaryExpr(UnaryOpCodeMap[e.ResolvedOp], e.E, inLetExprBody, wr, wStmts);
+            EmitUnaryExpr(UnaryOpCodeMap[e.ResolvedOp], e.E, letExprNesting, wr, wStmts);
             break;
           }
         case ConversionExpr conversionExpr: {
@@ -294,18 +294,18 @@ namespace Microsoft.Dafny.Compilers {
             if (toType.IsRefType || toType.IsTraitType || fromType.IsTraitType) {
               var w = EmitCoercionIfNecessary(e.E.Type, e.ToType, e.tok, wr);
               w = EmitDowncastIfNecessary(e.E.Type, e.ToType, e.tok, w);
-              EmitExpr(e.E, inLetExprBody, w, wStmts);
+              EmitExpr(e.E, letExprNesting, w, wStmts);
             } else {
-              EmitConversionExpr(e.E, fromType, toType, inLetExprBody, wr, wStmts);
+              EmitConversionExpr(e.E, fromType, toType, letExprNesting, wr, wStmts);
             }
 
             break;
           }
         case TypeTestExpr typeTestExpr:
-          CompileTypeTest(typeTestExpr, inLetExprBody, wr, ref wStmts);
+          CompileTypeTest(typeTestExpr, letExprNesting, wr, ref wStmts);
           break;
         case BinaryExpr binary:
-          EmitBinaryExpr(inLetExprBody, wr, wStmts, binary);
+          EmitBinaryExpr(letExprNesting, wr, wStmts, binary);
           break;
         case TernaryExpr:
           Contract.Assume(false); // currently, none of the ternary expressions is compilable
@@ -325,7 +325,7 @@ namespace Microsoft.Dafny.Compilers {
                 var lhs = e.LHSs[i];
                 if (Contract.Exists(lhs.Vars, bv => !bv.IsGhost)) {
                   var rhsName = $"_pat_let{GetUniqueAstNumber(e)}_{i}";
-                  w = CreateIIFE_ExprBody(rhsName, e.RHSs[i].Type, e.RHSs[i].tok, e.RHSs[i], inLetExprBody, e.Body.Type,
+                  w = CreateIIFE_ExprBody(rhsName, e.RHSs[i].Type, e.RHSs[i].tok, e.RHSs[i], letExprNesting, e.Body.Type,
                     e.Body.tok, w, ref wStmts);
                   w = TrCasePattern(lhs, wr => EmitIdentifier(rhsName, wr), e.RHSs[i].Type, e.Body.Type, w, ref wStmts);
                 }
@@ -337,7 +337,7 @@ namespace Microsoft.Dafny.Compilers {
               //    ghost var x,y :| Constraint; E
               // is compiled just like E is, because the resolver has already checked that x,y (or other ghost variables, for that matter) don't
               // occur in E (moreover, the verifier has checked that values for x,y satisfying Constraint exist).
-              EmitExpr(e.Body, inLetExprBody, wr, wStmts);
+              EmitExpr(e.Body, letExprNesting, wr, wStmts);
             } else {
               // The Dafny "let" expression
               //    var x,y :| Constraint; E
@@ -365,7 +365,7 @@ namespace Microsoft.Dafny.Compilers {
                 }
 
                 TrAssignSuchThat(new List<IVariable>(e.BoundVars).ConvertAll(bv => (IVariable)bv), e.RHSs[0],
-                  e.Constraint_Bounds, e.tok.line, w, inLetExprBody);
+                  e.Constraint_Bounds, e.tok.line, w, letExprNesting);
                 EmitReturnExpr(e.Body, e.Body.Type, true, w);
               }
             }
@@ -373,17 +373,17 @@ namespace Microsoft.Dafny.Compilers {
             break;
           }
         case NestedMatchExpr nestedMatchExpr:
-          EmitNestedMatchExpr(nestedMatchExpr, inLetExprBody, wr, wStmts);
+          EmitNestedMatchExpr(nestedMatchExpr, letExprNesting, wr, wStmts);
           break;
         case MatchExpr matchExpr:
-          EmitMatchExpr(matchExpr, inLetExprBody, wr, wStmts);
+          EmitMatchExpr(matchExpr, letExprNesting, wr, wStmts);
           break;
         case QuantifierExpr quantifierExpr: {
             var e = quantifierExpr;
 
             // Compilation does not check whether a quantifier was split.
 
-            wr = CaptureFreeVariables(quantifierExpr, true, out var su, inLetExprBody, wr, ref wStmts);
+            wr = CaptureFreeVariables(quantifierExpr, true, out var su, letExprNesting, wr, ref wStmts);
             var logicalBody = su.Substitute(e.LogicalBody(true));
 
             Contract.Assert(e.Bounds !=
@@ -395,7 +395,7 @@ namespace Microsoft.Dafny.Compilers {
               var bound = e.Bounds[i];
               var bv = e.BoundVars[i];
 
-              var collectionElementType = CompileCollection(bound, bv, inLetExprBody, false, su, out var collection,
+              var collectionElementType = CompileCollection(bound, bv, letExprNesting, false, su, out var collection,
             out var newtypeConversionsWereExplicit, wStmts,
                 e.Bounds, e.BoundVars, i);
               wBody = EmitQuantifierExpr(collection, quantifierExpr is ForallExpr, collectionElementType, bv, wBody);
@@ -406,15 +406,15 @@ namespace Microsoft.Dafny.Compilers {
               wStmts = newWBody.Fork();
               newWBody = MaybeInjectSubtypeConstraintWrtTraits(
                 tmpVarName, collectionElementType, bv.Type,
-                inLetExprBody, e.tok, newWBody, true, e is ForallExpr);
+                letExprNesting, e.tok, newWBody, true, e is ForallExpr);
               EmitDowncastVariableAssignment(
                 IdName(bv), bv.Type, tmpVarName, collectionElementType, true, e.tok, newWBody);
               newWBody = MaybeInjectSubsetConstraint(
-                bv, bv.Type, inLetExprBody, e.tok, newWBody, newtypeConversionsWereExplicit, isReturning: true, elseReturnValue: e is ForallExpr);
+                bv, bv.Type, letExprNesting, e.tok, newWBody, newtypeConversionsWereExplicit, isReturning: true, elseReturnValue: e is ForallExpr);
               wBody = newWBody;
             }
 
-            EmitExpr(logicalBody, inLetExprBody, wBody, wStmts);
+            EmitExpr(logicalBody, letExprNesting, wBody, wStmts);
             break;
           }
         case SetComprehension comprehension: {
@@ -436,7 +436,7 @@ namespace Microsoft.Dafny.Compilers {
             //   return Dafny.Set<G>.FromCollection(_coll);
             // }))()
             // We also split R(i,j,k,l) to evaluate it as early as possible.
-            wr = CaptureFreeVariables(e, true, out var su, inLetExprBody, wr, ref wStmts);
+            wr = CaptureFreeVariables(e, true, out var su, letExprNesting, wr, ref wStmts);
             e = (SetComprehension)su.Substitute(e);
 
             Contract.Assert(e.Bounds != null); // the resolver would have insisted on finding bounds
@@ -459,12 +459,12 @@ namespace Microsoft.Dafny.Compilers {
               processedBounds.Add(bv);
               var tmpVar = ProtectedFreshId("_compr_");
               var wStmtsLoop = wr.Fork();
-              var elementType = CompileCollection(bound, bv, inLetExprBody, true, null, out var collection, out var newtypeConversionsWereExplicit, wStmtsLoop);
-              wr = CreateGuardedForeachLoop(tmpVar, elementType, bv, newtypeConversionsWereExplicit, true, inLetExprBody, e.tok, collection, wr);
+              var elementType = CompileCollection(bound, bv, letExprNesting, true, null, out var collection, out var newtypeConversionsWereExplicit, wStmtsLoop);
+              wr = CreateGuardedForeachLoop(tmpVar, elementType, bv, newtypeConversionsWereExplicit, true, letExprNesting, e.tok, collection, wr);
               wr = EmitGuardFragment(unusedConjuncts, processedBounds, wr);
             }
 
-            EmitSetBuilder_Add(setType, collectionName, e.Term, inLetExprBody, wr);
+            EmitSetBuilder_Add(setType, collectionName, e.Term, letExprNesting, wr);
             var returned = EmitReturnExpr(bwr);
             GetCollectionBuilder_Build(setType, e.tok, collectionName, returned, wStmts);
             break;
@@ -488,7 +488,7 @@ namespace Microsoft.Dafny.Compilers {
             //   return Dafny.Map<U, V>.FromCollection(_coll);
             // }))()
             // We also split R(i,j,k,l) to evaluate it as early as possible.
-            wr = CaptureFreeVariables(e, true, out var su, inLetExprBody, wr, ref wStmts);
+            wr = CaptureFreeVariables(e, true, out var su, letExprNesting, wr, ref wStmts);
             e = (MapComprehension)su.Substitute(e);
 
             Contract.Assert(e.Bounds != null); // the resolver would have insisted on finding bounds
@@ -513,17 +513,17 @@ namespace Microsoft.Dafny.Compilers {
               processedBounds.Add(bv);
               var tmpVar = ProtectedFreshId("_compr_");
               var wStmtsLoop = wr.Fork();
-              var elementType = CompileCollection(bound, bv, inLetExprBody, true, null, out var collection, out var newtypeConversionsWereExplicit, wStmtsLoop);
+              var elementType = CompileCollection(bound, bv, letExprNesting, true, null, out var collection, out var newtypeConversionsWereExplicit, wStmtsLoop);
               wr = CreateGuardedForeachLoop(tmpVar, elementType, bv, newtypeConversionsWereExplicit, true, false, bv.tok, collection, wr);
               wr = EmitGuardFragment(unusedConjuncts, processedBounds, wr);
             }
 
-            var termLeftWriter = EmitMapBuilder_Add(mapType, e.tok, collection_name, e.Term, inLetExprBody, wr);
+            var termLeftWriter = EmitMapBuilder_Add(mapType, e.tok, collection_name, e.Term, letExprNesting, wr);
             if (e.TermLeft == null) {
               Contract.Assert(e.BoundVars.Count == 1);
               EmitIdentifier(IdName(e.BoundVars[0]), termLeftWriter);
             } else {
-              EmitExpr(e.TermLeft, inLetExprBody, termLeftWriter, wStmts);
+              EmitExpr(e.TermLeft, letExprNesting, termLeftWriter, wStmts);
             }
 
             var returned = EmitReturnExpr(bwr);
@@ -542,10 +542,10 @@ namespace Microsoft.Dafny.Compilers {
               };
               var _this = new ThisExpr(thisContext);
               wr = EmitBetaRedex(new List<string>() { IdName(receiver) }, new List<Expression>() { _this },
-                new List<Type>() { _this.Type }, lambdaExpr.Type, lambdaExpr.tok, inLetExprBody, wr, ref wStmts);
+                new List<Type>() { _this.Type }, lambdaExpr.Type, lambdaExpr.tok, letExprNesting, wr, ref wStmts);
             }
 
-            wr = CaptureFreeVariables(e, false, out var su, inLetExprBody, wr, ref wStmts);
+            wr = CaptureFreeVariables(e, false, out var su, letExprNesting, wr, ref wStmts);
             if (receiver != null) {
               su = new Substituter(new IdentifierExpr(e.tok, receiver), su.substMap, su.typeMap);
             }
@@ -556,12 +556,12 @@ namespace Microsoft.Dafny.Compilers {
             wr = EmitReturnExpr(wr);
             // May need an upcast or boxing conversion to coerce to the generic arrow result type
             wr = EmitCoercionIfNecessary(e.Body.Type, TypeForCoercion(e.Type.AsArrowType.Result), e.Body.tok, wr);
-            EmitExpr(su.Substitute(e.Body), inLetExprBody, wr, wStmts);
+            EmitExpr(su.Substitute(e.Body), letExprNesting, wr, wStmts);
             break;
           }
         case StmtExpr stmtExpr: {
             var e = stmtExpr;
-            EmitExpr(e.E, inLetExprBody, wr, wStmts);
+            EmitExpr(e.E, letExprNesting, wr, wStmts);
             break;
           }
         case ITEExpr iteExpr: {
@@ -569,12 +569,12 @@ namespace Microsoft.Dafny.Compilers {
             // The ghost-ITE optimization applies only to at "the top" of the expression structure of a function
             // body. Those cases are handled in TrExprOpt, so we expect the be compiling both branches here.
             Contract.Assert(e.HowToCompile == ITEExpr.ITECompilation.CompileBothBranches);
-            EmitITE(e.Test, e.Thn, e.Els, e.Type, inLetExprBody, wr, wStmts);
+            EmitITE(e.Test, e.Thn, e.Els, e.Type, letExprNesting, wr, wStmts);
             break;
           }
         case ConcreteSyntaxExpression expression: {
             var e = expression;
-            EmitExpr(e.ResolvedExpression, inLetExprBody, wr, wStmts);
+            EmitExpr(e.ResolvedExpression, letExprNesting, wr, wStmts);
             break;
           }
         default:
@@ -593,20 +593,20 @@ namespace Microsoft.Dafny.Compilers {
 
         if (!LiteralExpr.IsTrue(localGuard)) {
           wr = EmitIf(out var guardWriter, false, wr);
-          EmitExpr(localGuard, inLetExprBody, guardWriter, wStmts);
+          EmitExpr(localGuard, letExprNesting, guardWriter, wStmts);
         }
 
         return wr;
       }
     }
 
-    private void EmitBinaryExpr(bool inLetExprBody, ConcreteSyntaxTree wr,
+    private void EmitBinaryExpr(int letExprNesting, ConcreteSyntaxTree wr,
       ConcreteSyntaxTree wStmts, BinaryExpr binary) {
       if (IsComparisonToZero(binary, out var arg, out var sign, out var negated) &&
           CompareZeroUsingSign(arg.Type)) {
         // Transform e.g. x < BigInteger.Zero into x.Sign == -1
         var w = EmitSign(arg.Type, wr);
-        TrParenExpr(arg, w, inLetExprBody, wStmts);
+        TrParenExpr(arg, w, letExprNesting, wStmts);
         wr.Write(negated ? " != " : " == ");
         wr.Write(sign.ToString());
       } else {
@@ -629,12 +629,12 @@ namespace Microsoft.Dafny.Compilers {
         var e0 = reverseArguments ? binary.E1 : binary.E0;
         var e1 = reverseArguments ? binary.E0 : binary.E1;
 
-        var left = Expr(e0, inLetExprBody, wStmts);
+        var left = Expr(e0, letExprNesting, wStmts);
         ConcreteSyntaxTree right;
         if (convertE1_to_int) {
-          right = ExprAsNativeInt(e1, inLetExprBody, wStmts);
+          right = ExprAsNativeInt(e1, letExprNesting, wStmts);
         } else {
-          right = Expr(e1, inLetExprBody, wStmts);
+          right = Expr(e1, letExprNesting, wStmts);
           if (coerceE1) {
             right = CoercionIfNecessary(e1.Type, TypeForCoercion(e1.Type), e1.tok, right);
           }
@@ -671,7 +671,7 @@ namespace Microsoft.Dafny.Compilers {
       wr.Write(postOpString);
     }
 
-    private void EmitMatchExpr(MatchExpr e, bool inLetExprBody, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
+    private void EmitMatchExpr(MatchExpr e, int letExprNesting, ConcreteSyntaxTree wr, ConcreteSyntaxTree wStmts) {
       // ((System.Func<SourceType, TargetType>)((SourceType _source) => {
       //   if (source.is_Ctor0) {
       //     FormalType f0 = ((Dt_Ctor0)source._D).a0;
@@ -699,28 +699,28 @@ namespace Microsoft.Dafny.Compilers {
         var sourceType = (UserDefinedType)e.Source.Type.NormalizeExpand();
         foreach (MatchCaseExpr mc in e.Cases) {
           var wCase = MatchCasePrelude(source, sourceType, mc.Ctor, mc.Arguments, i, e.Cases.Count, w);
-          TrExprOpt(mc.Body, mc.Body.Type, wCase, wStmts, inLetExprBody: true, accumulatorVar: null);
+          TrExprOpt(mc.Body, mc.Body.Type, wCase, wStmts, letExprNesting: true, accumulatorVar: null);
           i++;
         }
       }
 
       // We end with applying the source expression to the delegate we just built
-      EmitExpr(e.Source, inLetExprBody, wArg, wStmts);
+      EmitExpr(e.Source, letExprNesting, wArg, wStmts);
     }
 
-    protected virtual void EmitNestedMatchExpr(NestedMatchExpr match, bool inLetExprBody, ConcreteSyntaxTree output, ConcreteSyntaxTree wStmts) {
+    protected virtual void EmitNestedMatchExpr(NestedMatchExpr match, int letExprNesting, ConcreteSyntaxTree output, ConcreteSyntaxTree wStmts) {
       var lambdaBody = EmitAppliedLambda(output, wStmts, match.Tok, match.Type);
-      TrOptNestedMatchExpr(match, match.Type, lambdaBody, wStmts, inLetExprBody, null);
+      TrOptNestedMatchExpr(match, match.Type, lambdaBody, wStmts, letExprNesting, null);
     }
 
     protected virtual void TrOptNestedMatchExpr(NestedMatchExpr match, Type resultType, ConcreteSyntaxTree wr,
-      ConcreteSyntaxTree wStmts, bool inLetExprBody, IVariable accumulatorVar) {
+      ConcreteSyntaxTree wStmts, int letExprNesting, IVariable accumulatorVar) {
 
       wStmts = wr.Fork();
 
       EmitNestedMatchGeneric(match, (caseIndex, caseBody) => {
         var myCase = match.Cases[caseIndex];
-        TrExprOpt(myCase.Body, myCase.Body.Type, caseBody, wStmts, inLetExprBody: true, accumulatorVar: null);
+        TrExprOpt(myCase.Body, myCase.Body.Type, caseBody, wStmts, letExprNesting: true, accumulatorVar: null);
       }, wr, true);
     }
 

--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.cs
@@ -115,6 +115,10 @@ namespace Microsoft.Dafny.Compilers {
     public void Error(ErrorId errorId, IToken tok, string msg, ConcreteSyntaxTree wr, params object[] args) {
       ReportError(errorId, Reporter, tok, msg, wr, args);
     }
+    
+    public void Warning(ErrorId errorId, IToken tok, string msg, params object[] args) {
+      Reporter.Warning(MessageSource.Compiler, errorId, tok, msg, args);
+    }
 
     protected void UnsupportedFeatureError(IToken tok, Feature feature, string message = null, ConcreteSyntaxTree wr = null, params object[] args) {
       if (!UnsupportedFeatures.Contains(feature)) {


### PR DESCRIPTION
### Description
Attempts to warn against potentially hitting #3868.

Replaces the omnipresent `inLetExprBody` boolean with a `letExprNesting` int, so we can track how many levels deep we're nesting let expressions when compiling, and warn when crossing a somewhat arbitrary threshold.

TODO:
* [ ] Figure out a way to easily suppress the warning if it's not actually an issue
* [ ] Decide whether to expose an option to control the threshold
* [ ] Flesh out the error message (relatively tricky to describe well)
* [ ] Explict test case - probably add to git-issue-3868.dfy

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
