### PR TITLE
--ignore-warnings flag for test generation

### DIFF
--- a/Source/DafnyCore/TestGenerationOptions.cs
+++ b/Source/DafnyCore/TestGenerationOptions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Dafny {
     public const string TestInlineAttribute = "testInline";
     public const string TestEntryAttribute = "testEntry";
     public bool WarnDeadCode = false;
+
+    public bool IgnoreWarnings = false;
     public enum Modes { None, Block, InlinedBlock, Path };
     public Modes Mode = Modes.None;
     public uint SeqLengthLimit = 0;

--- a/Source/DafnyDriver/Commands/GenerateTestsCommand.cs
+++ b/Source/DafnyDriver/Commands/GenerateTestsCommand.cs
@@ -18,6 +18,7 @@ static class GenerateTestsCommand {
   public static IEnumerable<Option> Options {
     get {
       return new Option[] {
+        IgnoreWarnings,
         LoopUnroll,
         SequenceLengthLimit,
         BoogieOptionBag.SolverLog,
@@ -123,6 +124,9 @@ Path - Generate tests targeting path-coverage.");
     dafnyOptions.TestGenOptions.Mode = mode;
   }
 
+  public static readonly Option<bool> IgnoreWarnings = new("--ignore-warnings",
+    "Ignore warnings in error messages.");
+
   public static readonly Option<uint> SequenceLengthLimit = new("--length-limit",
     "Add an axiom that sets the length of all sequences to be no greater than <n>. 0 (default) indicates no limit.");
 
@@ -140,6 +144,9 @@ Path - Generate tests targeting path-coverage.");
   public static readonly Option<bool> ForcePrune = new("--force-prune",
     "Enable axiom pruning that Dafny uses to speed up verification. This may negatively affect the quality of tests.");
   static GenerateTestsCommand() {
+    DafnyOptions.RegisterLegacyBinding(IgnoreWarnings, (options, value) => {
+      options.TestGenOptions.IgnoreWarnings = value;
+    });
     DafnyOptions.RegisterLegacyBinding(LoopUnroll, (options, value) => {
       options.LoopUnrollCount = value;
     });
@@ -161,5 +168,6 @@ Path - Generate tests targeting path-coverage.");
     DooFile.RegisterNoChecksNeeded(PrintBpl, false);
     DooFile.RegisterNoChecksNeeded(ExpectedCoverageReport, false);
     DooFile.RegisterNoChecksNeeded(ForcePrune, false);
+    DooFile.RegisterNoChecksNeeded(IgnoreWarnings, false);
   }
 }

--- a/Source/DafnyDriver/Commands/GenerateTestsCommand.cs
+++ b/Source/DafnyDriver/Commands/GenerateTestsCommand.cs
@@ -125,7 +125,7 @@ Path - Generate tests targeting path-coverage.");
   }
 
   public static readonly Option<bool> IgnoreWarnings = new("--ignore-warnings",
-    "Ignore warnings in error messages.");
+    "Ignore warnings when generating tests.");
 
   public static readonly Option<uint> SequenceLengthLimit = new("--length-limit",
     "Add an axiom that sets the length of all sequences to be no greater than <n>. 0 (default) indicates no limit.");

--- a/Source/DafnyTestGeneration.Test/Setup.cs
+++ b/Source/DafnyTestGeneration.Test/Setup.cs
@@ -42,6 +42,7 @@ namespace DafnyTestGeneration.Test {
       options.TestGenOptions.SeqLengthLimit = 3;
       options.TestGenOptions.Mode = TestGenerationOptions.Modes.Block;
       options.TestGenOptions.WarnDeadCode = false;
+      options.TestGenOptions.IgnoreWarnings = false;
       options.TimeLimit = 10;
       foreach (var optionSetting in optionSettings) {
         optionSetting(options);

--- a/Source/DafnyTestGeneration/FirstPass.cs
+++ b/Source/DafnyTestGeneration/FirstPass.cs
@@ -76,7 +76,7 @@ public class FirstPass {
         errorReporter.Error(MessageSource.TestGeneration, errorId, error.Token, error.Message);
       }
     }
-    if (Warnings.Count() != 0) {
+    if (Warnings.Count() != 0 && !options.TestGenOptions.IgnoreWarnings) {
       errorReporter.Warning(MessageSource.TestGeneration, "", program.StartToken,
         $"Test generation returned {Warnings.Count()} warnings:");
       foreach (var warning in Warnings) {


### PR DESCRIPTION
### Description
Introduces a `ignore-warnings` flag to `dafny generate-tests`. 

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

### How has this been tested?

This is a temporary workaround for https://github.com/dafny-lang/dafny/issues/5607. Run below `nat.dfy` with `dafny generate-tests InlinedBlock nat.dfy --ignore-warnings=true`
```
module M {
method {:testEntry} plus_one(n: nat)
{
}
}
```


<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
