### PR TITLE
fix: Crash when compiling an empty source file while including testing code

### DIFF
--- a/Source/DafnyCore/AST/Statements/Assignment/AssignStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/AssignStmt.cs
@@ -17,13 +17,15 @@ public class AssignStmt : Statement, ICloneable<AssignStmt> {
 
   public override IToken Tok {
     get {
-      var previous = Rhs.StartToken.Prev;
-      // If there was a single assignment, report on the operator.
-      var singleAssignment = previous.val == ":=";
-      // If there was an implicit return assignment, report on the return.
-      var implicitAssignment = previous.val == "return";
-      if (singleAssignment || implicitAssignment) {
-        return previous;
+      if (Rhs.StartToken.Prev is not null) {
+        var previous = Rhs.StartToken.Prev;
+        // If there was a single assignment, report on the operator.
+        var singleAssignment = previous.val == ":=";
+        // If there was an implicit return assignment, report on the return.
+        var implicitAssignment = previous.val == "return";
+        if (singleAssignment || implicitAssignment) {
+          return previous;
+        }
       }
       return Rhs.StartToken;
     }

--- a/Source/DafnyCore/Rewriters/RunAllTestsMainMethod.cs
+++ b/Source/DafnyCore/Rewriters/RunAllTestsMainMethod.cs
@@ -93,7 +93,7 @@ public class RunAllTestsMainMethod : IRewriter {
   /// }
   /// </summary>
   internal override void PostResolve(Program program) {
-    var tok = program.GetStartOfFirstFileToken();
+    var tok = program.GetStartOfFirstFileToken() ?? Token.NoToken;
     List<Statement> mainMethodStatements = new();
     var idGenerator = new FreshIdGenerator();
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5637.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5637.dfy
@@ -1,0 +1,2 @@
+// RUN: %translate cs --include-test-runner --allow-warnings %s > "%t"
+// RUN: %diff "%s.expect" "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5637.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5637.dfy.expect
@@ -1,0 +1,7 @@
+git-issue-5637.dfy(1,0): Warning: File contains no code
+  |
+1 | // RUN: %translate cs --include-test-runner --allow-warnings %s > "%t"
+  | ^
+
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/docs/dev/news/5638.fix
+++ b/docs/dev/news/5638.fix
@@ -1,0 +1,1 @@
+Crash when compiling an empty source file while including testing code


### PR DESCRIPTION
Fixes #5637.
