### PR TITLE
Fix bad generated Java code when using --legacy-data-constructors

### DIFF
--- a/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
@@ -1925,7 +1925,7 @@ namespace Microsoft.Dafny.Compilers {
       var wDefaultTypeArguments = new ConcreteSyntaxTree();
       var defaultMethodTypeDescriptorCount = 0;
       var usedTypeArgs = UsedTypeParameters(dt);
-      ConcreteSyntaxTree wDefault;
+      IConcreteSyntaxTree wDefault;
       ConcreteSyntaxTree wLegacyDefault = null;
       wr.WriteLine();
       if (dt.TypeArgs.Count == 0) {

--- a/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
@@ -1925,7 +1925,7 @@ namespace Microsoft.Dafny.Compilers {
       var wDefaultTypeArguments = new ConcreteSyntaxTree();
       var defaultMethodTypeDescriptorCount = 0;
       var usedTypeArgs = UsedTypeParameters(dt);
-      IConcreteSyntaxTree wDefault;
+      ConcreteSyntaxTree wDefault;
       ConcreteSyntaxTree wLegacyDefault = null;
       wr.WriteLine();
       if (dt.TypeArgs.Count == 0) {
@@ -1967,12 +1967,11 @@ namespace Microsoft.Dafny.Compilers {
         EmitDatatypeValue(dt, groundingCtor,
           dt.TypeArgs.ConvertAll(tp => (Type)new UserDefinedType(dt.tok, tp)),
           dt is CoDatatypeDecl, $"{wDefaultTypeArguments}", args, wDefault);
+      }
 
-        if (dt.TypeArgs.Any() && Options.Get(JavaBackend.LegacyDataConstructors)) {
-          var nullTypeDescriptorArgs = Enumerable.Repeat("null", defaultMethodTypeDescriptorCount).Comma();
-          EmitDatatypeValue(dt, groundingCtor,
-            dt.TypeArgs.ConvertAll(tp => (Type)new UserDefinedType(dt.tok, tp)),
-            dt is CoDatatypeDecl, nullTypeDescriptorArgs, args, wLegacyDefault);
+      if (wLegacyDefault != null) {
+        foreach (var node in wDefault.Nodes) {
+          wLegacyDefault.Append(node);
         }
       }
 

--- a/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
+++ b/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
@@ -20,12 +20,8 @@ namespace Microsoft.Dafny {
       return ConcreteSyntaxTree.Create($"({canRender})");
     }
   }
-
-  interface IConcreteSyntaxTree {
-    IConcreteSyntaxTree Write(string value);
-  }
   
-  public class ConcreteSyntaxTree : ICanRender, IConcreteSyntaxTree {
+  public class ConcreteSyntaxTree : ICanRender {
     public ConcreteSyntaxTree(int relativeIndent = 0) {
       RelativeIndentLevel = relativeIndent;
     }
@@ -62,7 +58,7 @@ namespace Microsoft.Dafny {
       return node;
     }
 
-    public IConcreteSyntaxTree Write(string value) {
+    public ConcreteSyntaxTree Write(string value) {
       _nodes.Add(new LineSegment(value));
       return this;
     }

--- a/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
+++ b/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Dafny {
       return ConcreteSyntaxTree.Create($"({canRender})");
     }
   }
-  
+
   public class ConcreteSyntaxTree : ICanRender {
     public ConcreteSyntaxTree(int relativeIndent = 0) {
       RelativeIndentLevel = relativeIndent;

--- a/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
+++ b/Source/DafnyCore/ConcreteSyntax/ConcreteSyntaxTree.cs
@@ -21,7 +21,11 @@ namespace Microsoft.Dafny {
     }
   }
 
-  public class ConcreteSyntaxTree : ICanRender {
+  interface IConcreteSyntaxTree {
+    IConcreteSyntaxTree Write(string value);
+  }
+  
+  public class ConcreteSyntaxTree : ICanRender, IConcreteSyntaxTree {
     public ConcreteSyntaxTree(int relativeIndent = 0) {
       RelativeIndentLevel = relativeIndent;
     }
@@ -58,7 +62,7 @@ namespace Microsoft.Dafny {
       return node;
     }
 
-    public ConcreteSyntaxTree Write(string value) {
+    public IConcreteSyntaxTree Write(string value) {
       _nodes.Add(new LineSegment(value));
       return this;
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/separate-compilation/Inputs/producer/timesTwo.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/separate-compilation/Inputs/producer/timesTwo.dfy
@@ -10,6 +10,9 @@ module {:options "--function-syntax:4"} LibraryModule {
   // Record type
   datatype Pair<+T, +U> = Pair(first: T, second: U)
 
+  datatype NestedTypeConstructorRecord<+T> = First(value: Pair<T, T>)
+  datatype NestedTypeConstructorClass<+T> = First2(value: Pair<T, T>) | Second2(value: Pair<T, T>)
+
   datatype NoTypeArgs = Success2 | Failure2
 
 }


### PR DESCRIPTION
### Description
- Fix bad generated Java code when using --legacy-data-constructors

### How has this been tested?
- Updated existing test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
