### PR TITLE
Resolved a crash that would occur when using a match statement inside…

### DIFF
--- a/Source/DafnyCore/AST/Substituter.cs
+++ b/Source/DafnyCore/AST/Substituter.cs
@@ -879,7 +879,9 @@ namespace Microsoft.Dafny {
         rr.ResolvedStatements.AddRange(revealStmt.ResolvedStatements.ConvertAll(SubstStmt));
         rr.OffsetMembers = revealStmt.OffsetMembers.ToList();
         r = rr;
-      } else {
+      } else if (stmt is NestedMatchStmt nestedMatchStmt) {
+        r = SubstStmt(nestedMatchStmt.Flattened);
+      }else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
       }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/matchInAssertBy.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/matchInAssertBy.dfy
@@ -1,0 +1,12 @@
+// RUN: %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype D = D 
+function f(d:D):bool {
+  assert true by {
+    match d {
+      case _ => assert true;
+    }
+  }
+  true
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/matchInAssertBy.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/matchInAssertBy.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/docs/dev/news/5671.fix
+++ b/docs/dev/news/5671.fix
@@ -1,0 +1,1 @@
+Resolved a crash that would occur when using a match statement inside an assert by block


### PR DESCRIPTION
Fixes #5671

### Description
Resolved a crash that would occur when using a match statement inside an assert by block

### How has this been tested?
Added a CLI test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
