### PR TITLE
Add developer options --sprint and --pprint

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -34,7 +34,7 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
-      <PackageReference Include="Boogie.ExecutionEngine" Version="3.2.2" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="3.2.3" />
       <PackageReference Include="Tomlyn" Version="0.16.2" />
   </ItemGroup>
 

--- a/Source/DafnyCore/Options/DafnyCommands.cs
+++ b/Source/DafnyCore/Options/DafnyCommands.cs
@@ -71,6 +71,8 @@ public static class DafnyCommands {
     Snippets.ShowSnippets,
     DeveloperOptionBag.PrintOption,
     DeveloperOptionBag.ResolvedPrint,
+    DeveloperOptionBag.SplitPrint,
+    DeveloperOptionBag.PassivePrint,
     DeveloperOptionBag.BoogiePrint,
     Printer.PrintMode,
     CommonOptionBag.AllowWarnings,

--- a/Source/DafnyCore/Options/DeveloperOptionBag.cs
+++ b/Source/DafnyCore/Options/DeveloperOptionBag.cs
@@ -6,6 +6,22 @@ namespace Microsoft.Dafny;
 
 public class DeveloperOptionBag {
 
+  public static readonly Option<string> SplitPrint = new("--sprint",
+    @"
+Print Boogie splits translated from Dafny
+(use - as <file> to print to console)".TrimStart()) {
+    IsHidden = true,
+    ArgumentHelpName = "file",
+  };
+
+  public static readonly Option<string> PassivePrint = new("--pprint",
+    @"
+Print passified Boogie program translated from Dafny
+(use - as <file> to print to console)".TrimStart()) {
+    IsHidden = true,
+    ArgumentHelpName = "file",
+  };
+
   public static readonly Option<string> BoogiePrint = new("--bprint",
   @"
 Print Boogie program translated from Dafny
@@ -48,13 +64,27 @@ enabling necessary special handling.".TrimStart()) {
         options.FileTimestamp);
     });
 
+    DafnyOptions.RegisterLegacyBinding(PassivePrint, (options, f) => {
+      options.PrintPassiveFile = f;
+      options.ExpandFilename(options.PrintPassiveFile, x => options.PrintPassiveFile = x, options.LogPrefix,
+        options.FileTimestamp);
+    });
+
     DafnyOptions.RegisterLegacyBinding(BoogiePrint, (options, f) => {
       options.PrintFile = f;
       options.ExpandFilename(options.PrintFile, x => options.PrintFile = x, options.LogPrefix,
         options.FileTimestamp);
     });
 
+    DafnyOptions.RegisterLegacyBinding(SplitPrint, (options, f) => {
+      options.PrintSplitFile = f;
+      options.ExpandFilename(options.PrintSplitFile, x => options.PrintSplitFile = x, options.LogPrefix,
+        options.FileTimestamp);
+    });
+
+    DooFile.RegisterNoChecksNeeded(PassivePrint, false);
     DooFile.RegisterNoChecksNeeded(BoogiePrint, false);
+    DooFile.RegisterNoChecksNeeded(SplitPrint, false);
     DooFile.RegisterNoChecksNeeded(PrintOption, false);
     DooFile.RegisterNoChecksNeeded(ResolvedPrint, false);
     DooFile.RegisterNoChecksNeeded(Bootstrapping, false);

--- a/Source/DafnyDriver/Commands/MeasureComplexityCommand.cs
+++ b/Source/DafnyDriver/Commands/MeasureComplexityCommand.cs
@@ -20,7 +20,8 @@ static class MeasureComplexityCommand {
     VerifyCommand.FilterSymbol,
     VerifyCommand.FilterPosition,
   }.Concat(DafnyCommands.VerificationOptions).
-    Concat(DafnyCommands.ResolverOptions);
+    Concat(DafnyCommands.ResolverOptions).
+    Concat(DafnyCommands.ConsoleOutputOptions);
 
   static MeasureComplexityCommand() {
     DafnyOptions.RegisterLegacyBinding(Iterations, (o, v) => o.RandomizeVcIterations = (int)v);

--- a/Source/DafnyLanguageServer/LanguageServer.cs
+++ b/Source/DafnyLanguageServer/LanguageServer.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Dafny.LanguageServer {
         DafnyLangSymbolResolver.UseCaching,
         ProjectManager.UpdateThrottling,
         CachingProjectFileOpener.ProjectFileCacheExpiry,
+        DeveloperOptionBag.SplitPrint,
+        DeveloperOptionBag.PassivePrint,
         DeveloperOptionBag.BoogiePrint,
         CommonOptionBag.EnforceDeterminism,
         InternalDocstringRewritersPluginConfiguration.UseJavadocLikeDocstringRewriterOption,

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/measure-complexity.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/measure-complexity.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %baredafny measure-complexity --use-basename-for-filename --isolate-assertions --worst-amount 100 "%s" > %t.raw
+// RUN: %exits-with 4 %baredafny measure-complexity --show-snippets false --use-basename-for-filename --isolate-assertions --worst-amount 100 "%s" > %t.raw
 // RUN: %sed 's#\): \d+#): <redacted>#g' %t.raw > %t.raw2
 // RUN: %sed 's#are \d+#are <redacted>#g' %t.raw2 > %t
 // RUN: %diff "%s.expect" "%t"

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -61,7 +61,7 @@ index 4a8b2f89b..a308be9bf 100644
        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
        <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
--      <PackageReference Include="Boogie.ExecutionEngine" Version="3.2.2" />
+-      <PackageReference Include="Boogie.ExecutionEngine" Version="3.2.3" />
 +      <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
 +      <ProjectReference Include="..\..\boogie\Source\BaseTypes\BaseTypes.csproj" />
 +      <ProjectReference Include="..\..\boogie\Source\Core\Core.csproj" />


### PR DESCRIPTION
### Description
Add developer options --sprint and --pprint, which are useful for debugging verification at the split level

### How has this been tested?
These options map to Boogie options that are tested at the Boogie level

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
