### PR TITLE
Don't complain about determinism for traits

### DIFF
--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1479,16 +1479,16 @@ namespace Microsoft.Dafny {
       // ----------------------------------------------------------------------------
 
       foreach (TopLevelDecl d in declarations) {
-        if (d is ClassLikeDecl classLikeDecl) {
-          var classIsExtern = !Options.DisallowExterns && Attributes.Contains(classLikeDecl.Attributes, "extern");
+        if (d is ClassDecl classDecl) {
+          var classIsExtern = !Options.DisallowExterns && Attributes.Contains(classDecl.Attributes, "extern");
           if (Options.ForbidNondeterminism &&
               !classIsExtern &&
-              !classLikeDecl.Members.Exists(member => member is Constructor) &&
-              classLikeDecl.Members.Exists(member => member is Field && !(member is ConstantField { Rhs: not null }))) {
+              !classDecl.Members.Exists(member => member is Constructor) &&
+              classDecl.Members.Exists(member => member is Field && !(member is ConstantField { Rhs: not null }))) {
             // This check should be moved to the resolver once we have a language construct to indicate the type is imported
             // Instead of the extern attribute
             Reporter.Error(MessageSource.Resolver, GeneratorErrors.ErrorId.c_constructorless_class_forbidden,
-              classLikeDecl.tok,
+              classDecl.tok,
               "since fields are initialized arbitrarily, constructor-less classes are forbidden by the --enforce-determinism option");
           }
         }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ForbidNondeterminismResolve.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ForbidNondeterminismResolve.dfy
@@ -143,3 +143,7 @@ ghost method M2(c: C)
   }
   modify c;  // error: nondeterministic
 }
+
+trait t { // no error: traits can't have constructors
+  var f: real
+}


### PR DESCRIPTION
### Description

After #5632, Dafny started complaining about traits lacking constructors (which they can't have) when `--enforce-determinism` was enabled. This changes back to the previous behavior of warning only about classes without constructors.

### How has this been tested?

Updated `dafny0/ForbidNondeterminismResolve.dfy` to include a trait declaration.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
