### PR TITLE
Publish nightly prereleases from release-4.8.0

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,6 +28,14 @@ jobs:
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
+    secrets:
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+
+  nightly-build-for-4-8:
+    if: github.repository_owner == 'dafny-lang'
+    uses: ./.github/workflows/nightly-build-reusable.yml
+    with:
+      ref: release-4.8.0
       publish-prerelease: true
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
### Description

Temporary change to do nightly builds from the `release-4.8.0` branch. Will be reverted after 4.8.0 is released.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
