### PR TITLE
fix: Frame and termination checks are now subject to by-proofs of method calls

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/CallBy.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/CallBy.dfy
@@ -65,3 +65,15 @@ greatest lemma F(x: int)
   F(x-2) by { ProveP(); }
   assert P(); // should fail
 }
+
+method H(x: int, y: int, s: set<object>, t: set<object>)
+  requires y % 2 == 0
+  modifies s
+  decreases x
+{
+  H(y, x, t, t) by {
+    assume x % 2 == 0; // to prove the precondition of the call
+    assume t <= s; // to prove the modifies clause of the call
+    assume 0 <= y < x; // to prove termination of the call
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/CallBy.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/CallBy.dfy.expect
@@ -5,4 +5,4 @@ CallBy.dfy(50,10): Error: assertion might not hold
 CallBy.dfy(56,10): Error: assertion might not hold
 CallBy.dfy(66,10): Error: assertion might not hold
 
-Dafny program verifier finished with 3 verified, 6 errors
+Dafny program verifier finished with 5 verified, 6 errors


### PR DESCRIPTION
Fixes #5734