### PR TITLE
Fuzzing on forks

### DIFF
--- a/.github/workflows/compfuzzci_fuzz.yaml
+++ b/.github/workflows/compfuzzci_fuzz.yaml
@@ -1,15 +1,19 @@
 # This workflow is triggered on PR being opened, synced, reopened, closed.
 # It dispatches workflow on CompFuzzCI repository, where fuzzing of the PR is handled.
+# For problems or suggestions, contact karnbongkot.boonriong23@imperial.ac.uk
 
-name: Fuzzing on PR (excluding forks)
+name: Fuzzing on PR
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
   
 jobs:
   FuzzOnPR:
-    if: github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.repo.owner.login == 'dafny-lang'
+    if: github.event.pull_request.base.ref == 'master' &&
+        (github.event.pull_request.author_association == 'COLLABORATOR' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CompFuzzCI
@@ -23,9 +27,10 @@ jobs:
                   workflow_id: 'fuzz.yaml',
                   ref: 'main',
                   inputs: {
-                      commit: '${{ github.event.pull_request.head.sha }}',
-                      main_commit: '${{github.event.pull_request.base.sha}}',
+                      pr: '${{github.event.pull_request.number}}',
+                      author: '${{github.event.pull_request.user.login}}',
                       branch: '${{github.event.pull_request.head.ref}}',
+                      head_sha: '${{github.event.pull_request.head.sha}}',
                       duration: '3600',
                       instance: '2'
                   }


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->
I have modified the fuzzing workflow to handle PR from forks. Fuzzing will only be triggered on PR created by verified contributors to prevent potential security risks.
**ALL WILL BE FUZZED** mwahaha

This change also fix the following annoying issues:
- Reporting bugs already caught by CI: Fuzzing will now be delayed and only run if all CI checks have passed. This is implemented outside of the workflow, the PR will not be blocked.
- Reporting non-bugs in Rust: Added pattern matching to ignore error that comes from not yet implemented features in Dafny-to-Rust. (sorry Mikael!)


### How has this been tested?
Tested on my own dummy repo
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
