### PR TITLE
Reveal recursive functions

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -34,7 +34,7 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
-      <PackageReference Include="Boogie.ExecutionEngine" Version="3.2.4" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="3.2.5" />
       <PackageReference Include="Tomlyn" Version="0.16.2" />
   </ItemGroup>
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -85,6 +85,9 @@ namespace Microsoft.Dafny {
       Bpl.Program boogieProgram = ReadPrelude();
       if (boogieProgram != null) {
         sink = boogieProgram;
+        foreach (var function in boogieProgram.TopLevelDeclarations.OfType<Bpl.Function>()) {
+          function.AlwaysRevealed = true;
+        }
         predef = FindPredefinedDecls(boogieProgram);
       }
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/reveal/revealFunctions.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/reveal/revealFunctions.dfy
@@ -97,9 +97,9 @@ module M2 {
     lemma Lemma(x: nat) 
     ensures RecFunc(0) == 0
     {
+        // Because RecFunc is recursive, it uses the fuel related $LS function, 
+        // this was previously hidden by 'hide *', so that the ensures could not be proven
         hide *;
         reveal RecFunc;
-        // reveal *
-        // ^ this makes the assertion pass
     }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/reveal/revealFunctions.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/reveal/revealFunctions.dfy
@@ -85,3 +85,21 @@ method ReadsClause() {
     }
   }
 }
+
+module M1 {
+    ghost function RecFunc(x: nat): nat { 
+        if x == 0 then 0
+        else 1 + RecFunc(x - 1)
+    }
+}
+module M2 {
+    import opened M1
+    lemma Lemma(x: nat) 
+    ensures RecFunc(0) == 0
+    {
+        hide *;
+        reveal RecFunc;
+        // reveal *
+        // ^ this makes the assertion pass
+    }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/reveal/revealFunctions.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/reveal/revealFunctions.dfy.expect
@@ -2,4 +2,4 @@ revealFunctions.dfy(15,12): Error: assertion might not hold
 revealFunctions.dfy(22,12): Error: assertion might not hold
 revealFunctions.dfy(49,21): Error: assertion might not hold
 
-Dafny program verifier finished with 15 verified, 3 errors
+Dafny program verifier finished with 22 verified, 3 errors


### PR DESCRIPTION
Fixes #5763

Requires the upcoming Boogie version 3.2.5, for which this PR needs to be merged first: https://github.com/boogie-org/boogie/pull/945

### Description
- No longer allow hiding functions from the Dafny prelude by using `hide *`. This affected recursive functions because they use `$LS` which is defined in the prelude.

### How has this been tested?
- Added a CLI test-case to `revealFunctions.dfy`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
