### PR TITLE
Chore: Fixed non-deterministic with only one assumed timeout instead of two

### DIFF
--- a/Source/DafnyLanguageServer.Test/Diagnostics/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Diagnostics/DiagnosticsTest.cs
@@ -1005,8 +1005,10 @@ method test() {
       var documentItem = CreateTestDocument(source, "OpeningDocumentWithTimeoutReportsTimeoutDiagnostic.dfy");
       client.OpenDocument(documentItem);
       var diagnostics = await GetLastDiagnostics(documentItem);
-      Assert.Single(diagnostics);
-      Assert.Contains("timed out", diagnostics[0].Message);
+      Assert.True(diagnostics.Length == 1 || diagnostics.Length == 2); // Ack and Test sometimes time out at the same time
+      for (var i = 0; i < diagnostics.Length; i++) {
+        Assert.Contains("timed out", diagnostics[i].Message);
+      }
     }
 
     [Fact]

--- a/Source/DafnyLanguageServer.Test/Diagnostics/DiagnosticsTest.cs
+++ b/Source/DafnyLanguageServer.Test/Diagnostics/DiagnosticsTest.cs
@@ -1005,7 +1005,7 @@ method test() {
       var documentItem = CreateTestDocument(source, "OpeningDocumentWithTimeoutReportsTimeoutDiagnostic.dfy");
       client.OpenDocument(documentItem);
       var diagnostics = await GetLastDiagnostics(documentItem);
-      Assert.True(diagnostics.Length == 1 || diagnostics.Length == 2); // Ack and Test sometimes time out at the same time
+      Assert.True(diagnostics.Length is 1 or 2); // Ack and Test sometimes time out at the same time
       for (var i = 0; i < diagnostics.Length; i++) {
         Assert.Contains("timed out", diagnostics[i].Message);
       }


### PR DESCRIPTION
Fixes #5753

### Description
I ensures the flaky test does not test for a single diagnostic but for two, and if there are two the two should be timeouts.

### How has this been tested?
No tests can be performed on a flaky test but at least it looks like it should prevent the issue since that issue was diagnosed.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
