### PR TITLE
Chore: Fix 'no active test'

### DIFF
--- a/Source/DafnyCore.Test/WriterFromOutputHelper.cs
+++ b/Source/DafnyCore.Test/WriterFromOutputHelper.cs
@@ -25,17 +25,29 @@ public class WriterFromOutputHelper : TextWriter {
   public override Encoding Encoding => Encoding.Default;
 
   public override void WriteLine(string? value) {
-    output.WriteLine(buffer + value);
+    try {
+      output.WriteLine(buffer + value);
+    } catch {
+      // ignored
+    }
     buffer.Clear();
   }
 
   public override void WriteLine(string format, params object?[] arg) {
-    output.WriteLine(buffer + format, arg);
+    try {
+      output.WriteLine(buffer + format, arg);
+    } catch {
+      // ignored
+    }
     buffer.Clear();
   }
 
   public override void Flush() {
-    output.WriteLine(buffer.ToString());
+    try {
+      output.WriteLine(buffer.ToString());
+    } catch {
+      // ignored
+    }
     base.Flush();
   }
 }

--- a/Source/DafnyCore.Test/WriterFromOutputHelper.cs
+++ b/Source/DafnyCore.Test/WriterFromOutputHelper.cs
@@ -28,7 +28,7 @@ public class WriterFromOutputHelper : TextWriter {
     try {
       output.WriteLine(buffer + value);
     } catch {
-      // ignored
+      // ignored because of https://github.com/dafny-lang/dafny/issues/5723
     }
     buffer.Clear();
   }
@@ -37,7 +37,7 @@ public class WriterFromOutputHelper : TextWriter {
     try {
       output.WriteLine(buffer + format, arg);
     } catch {
-      // ignored
+      // ignored because of https://github.com/dafny-lang/dafny/issues/5723
     }
     buffer.Clear();
   }
@@ -46,7 +46,7 @@ public class WriterFromOutputHelper : TextWriter {
     try {
       output.WriteLine(buffer.ToString());
     } catch {
-      // ignored
+      // ignored because of https://github.com/dafny-lang/dafny/issues/5723
     }
     base.Flush();
   }


### PR DESCRIPTION
Fixes #5723, likely fixes #5713 and fixes #5759

### Description
The CI fails every other run because of some unknown "there is no currently active test"
Based on this discussion:
https://github.com/xunit/xunit/issues/2146
it seems we should try/catch writing to the output channel, which this PR implements

### How has this been tested?
The CI should not fail on this PR, and if needed, we can increase assurance that this PR solves the problem correctly.
To ensure the catching code is not deleted, the comment mentions the issue it is fixing.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
