### PR TITLE
Chore: Printing of Object<string> will now display the string.

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
@@ -3403,7 +3403,8 @@ impl<T: ?Sized + UpcastObject<dyn Any>> Debug for Object<T> {
 }
 impl <T: ?Sized + UpcastObject<dyn Any>> DafnyPrint for Object<T> {
     fn fmt_print(&self, f: &mut Formatter<'_>, _in_seq: bool) -> std::fmt::Result {
-        let option_string = UpcastObject::<dyn Any>::upcast(self.as_ref()).as_ref().downcast_ref::<String>().cloned();
+        let obj_any = UpcastObject::<dyn Any>::upcast(self.as_ref());
+        let option_string = obj_any.as_ref().downcast_ref::<String>();
         match option_string {
             Some(s) => write!(f, "{}", s),
             None => write!(f, "<object>"),

--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/tests/mod.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/tests/mod.rs
@@ -856,4 +856,13 @@ mod tests {
         let s2 = crate::dafny_runtime_conversions::object::dafny_class_to_struct(x);
         assert_eq!(s2.message, "Hello, World!");
     }
+
+    #[test]
+    fn test_native_string_upcast_raw() {
+        let message = "Hello, World!".to_string();
+        let object = Object::new(message.clone());
+        let object_any: Object<dyn Any> = UpcastObject::<dyn Any>::upcast(object.as_ref());
+        let resulting_message = format!("{:?}", object_any);
+        assert_eq!(resulting_message, message);
+    }
 }


### PR DESCRIPTION
This PR makes it possible to wrap Rust's native string in `Object<>` while printing will print them correctly. I added a test in DafnyRuntimeRust

This PR might break external code which created `Object<>` of things that Dafny did not support originally, but I'm not aware of any other external code that was making use of that. Moreover, there is a workaround by creating the appropriate `Upcast` trait.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
