### PR TITLE
Chore: Ensure we run miri with the tests to detect undefined behavior…

### DIFF
--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Install Miri for DafnyRuntimeRust
         run: |
           rustup +nightly-x86_64-pc-windows-gnu component add miri
+          cargo miri setup
       - name: Test DafnyRuntimeRust
         run: |
           cd ./Source/DafnyRuntime/DafnyRuntimeRust

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -48,7 +48,7 @@ jobs:
           cd ./Source/DafnyCore
           make test
           make check-format
-      - name: Test DafnyRuntime (C#, Rust)
+      - name: Test DafnyRuntime C#
         run: |
           cd ./Source/DafnyRuntime
           make all
@@ -72,6 +72,9 @@ jobs:
         run: |
           cd ./Source/DafnyRuntime/DafnyRuntimeJs
           make all
+      - name: Install Miri for DafnyRuntimeRust
+        run: |
+          rustup +nightly-x86_64-pc-windows-gnu component add miri
       - name: Test DafnyRuntimeRust
         run: |
           cd ./Source/DafnyRuntime/DafnyRuntimeRust

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -74,7 +74,7 @@ jobs:
           make all
       - name: Install Miri for DafnyRuntimeRust
         run: |
-          rustup +nightly-x86_64-pc-windows-gnu component add miri
+          rustup +nightly component add miri
           cargo miri setup
       - name: Test DafnyRuntimeRust
         run: |

--- a/Source/DafnyRuntime.Tests/DafnyRuntimeRustTest/Cargo.lock
+++ b/Source/DafnyRuntime.Tests/DafnyRuntimeRustTest/Cargo.lock
@@ -10,12 +10,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "as-any"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a30a44e99a1c83ccb2a6298c563c888952a1c9134953db26876528f84c93a"
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,11 +19,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 name = "dafny_runtime"
 version = "0.1.0"
 dependencies = [
- "as-any",
  "itertools",
  "num",
  "once_cell",
- "paste",
 ]
 
 [[package]]
@@ -125,9 +117,3 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"

--- a/Source/DafnyRuntime.Tests/DafnyRuntimeRustTest/src/main.rs
+++ b/Source/DafnyRuntime.Tests/DafnyRuntimeRustTest/src/main.rs
@@ -1,4 +1,4 @@
-use dafny_runtime::{Upcast, UpcastObject};
+use dafny_runtime::{Upcast, UpcastObject, deallocate};
 
 
 
@@ -36,4 +36,6 @@ fn smoke_test() {
     let a = ::dafny_runtime::array!(1, 2, 3);
     assert_eq!(z, 3);
     assert_eq!(::dafny_runtime::read!(a)[2], 3);
+    deallocate(x);
+    deallocate(a);    
 }

--- a/Source/DafnyRuntime/DafnyRuntimeRust/Makefile
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/Makefile
@@ -17,6 +17,8 @@ check-system-module: build-system-module
 update-system-module: build-system-module
 	cp $(GENERATED_SYSTEM_MODULE_SOURCE) $(GENERATED_SYSTEM_MODULE_TARGET)
 
+# We disabled stacked borrows because MIRI fails to recognized allocated memory not yet
+# written to (like in Dafny constructors)
 test:
-	cargo test
-	(cd ../../DafnyRuntime.Tests/DafnyRuntimeRustTest; cargo test)
+	MIRIFLAGS=-Zmiri-disable-stacked-borrows cargo +nightly-x86_64-pc-windows-gnu miri test;
+	(cd ../../DafnyRuntime.Tests/DafnyRuntimeRustTest; MIRIFLAGS=-Zmiri-disable-stacked-borrows cargo +nightly-x86_64-pc-windows-gnu miri test; )


### PR DESCRIPTION
… and leaks

### How has this been tested?
The CI now ensures MIRI runs to test the runtime. It has caught two memory leaks so far, and will ensure to detect undefined behaviors as well. It's not perfect but will do a better job.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
