### PR TITLE
fix: Include arguments to Go external constructor

### DIFF
--- a/Source/DafnyCore/Backends/GoLang/GoCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/GoLang/GoCodeGenerator.cs
@@ -2236,8 +2236,11 @@ namespace Microsoft.Dafny.Compilers {
       if (cl is TraitDecl { IsObjectTrait: true }) {
         wr.Write("_dafny.New_Object()");
       } else {
+        var ctor = (Constructor)initCall?.Method; // correctness of cast follows from precondition of "EmitNew"
+        var sep = "";
         wr.Write("{0}(", TypeName_Initializer(type, wr, tok));
         EmitTypeDescriptorsActuals(TypeArgumentInstantiation.ListFromClass(cl, type.TypeArgs), tok, wr);
+        wr.Write(ConstructorArguments(initCall, wStmts, ctor, sep));
         wr.Write(")");
       }
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors-externs/Class.java
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors-externs/Class.java
@@ -2,7 +2,7 @@ package Library;
 
 import java.math.BigInteger;
 
-public class Class extends _ExternBase_Class {
+public class Class {
     private final BigInteger n;
 
     public Class(BigInteger n) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors-externs/Library.go
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors-externs/Library.go
@@ -17,12 +17,6 @@ func (obj *Class) Get() dafny.Int {
 	return obj.n
 }
 
-// have to implement this because the Go backend can't mix Dafny and Go code :-\
-
-func (obj *Class) Print() {
-	fmt.Printf("My value is %d\n", obj.n)
-}
-
 type CompanionStruct_Class_ struct{}
 var Companion_Class_ = CompanionStruct_Class_{}
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors-externs/Library.py
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors-externs/Library.py
@@ -17,8 +17,3 @@ class Class:
 
     def Get(self):
         return self.n
-
-    def Print(self):
-        _dafny.print(_dafny.string_of(_dafny.Seq("My value is ")))
-        _dafny.print(_dafny.string_of((self).Get()))
-        _dafny.print(_dafny.string_of(_dafny.Seq("\n")))

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors.dfy
@@ -1,15 +1,16 @@
 // RUN: %run --target cs "%s" --input %S/ExternCtors-externs/Library.cs > "%t"
 // RUN: %run --target java "%s" --input %S/ExternCtors-externs/Class.java >> "%t"
 // RUN: %run --target py "%s" --input %S/ExternCtors-externs/Library.py >> "%t"
+// RUN: %run --target go "%s" --input %S/ExternCtors-externs/Library.go >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
-// FIXME: Extern constructors are currently broken in Go and JavaScript,
-// so they are omitted
+// FIXME: Extern constructors are currently broken in JavaScript,
+// so that is omitted
 
 method Main() {
   Library.Class.SayHi();
   var obj := new Library.Class(42);
-  obj.Print();
+  print "My value is ", obj.Get(), "\n";
 }
 
 module {:extern "Library"} Library {
@@ -17,8 +18,6 @@ module {:extern "Library"} Library {
     constructor {:extern} (n: int)
     static method {:extern} SayHi()
     function {:extern} Get() : int
-    method Print() {
-      print "My value is ", Get(), "\n";
-    }
   }
 }
+

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/ExternCtors.dfy.expect
@@ -10,3 +10,7 @@ My value is 42
 Dafny program verifier finished with 1 verified, 0 errors
 Hello!
 My value is 42
+
+Dafny program verifier finished with 1 verified, 0 errors
+Hello!
+My value is 42


### PR DESCRIPTION
### Description
The Go backend was not passing arguments when invoking an `{:extern}` constructor.

### How has this been tested?
Enabled Go in the existing `ExternCtors.dfy` test case, and refactored it to not require support for classes with both Dafny- and extern-implemented declarations (which is a separate feature).

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
