### PR TITLE
Fix: Dafny server API for counterexamples

### DIFF
--- a/Source/DafnyLanguageServer/Handlers/Custom/CounterExampleItem.cs
+++ b/Source/DafnyLanguageServer/Handlers/Custom/CounterExampleItem.cs
@@ -4,11 +4,13 @@ using System.Collections.Generic;
 namespace Microsoft.Dafny.LanguageServer.Handlers.Custom {
   public class CounterExampleItem {
     public Position Position { get; }
+    public IDictionary<string, string> Variables { get; }
 
     public string Assumption { get; }
 
-    public CounterExampleItem(Position position, string assumption) {
+    public CounterExampleItem(Position position, IDictionary<string, string> variables, string assumption) {
       Position = position;
+      Variables = variables;
       Assumption = assumption;
     }
   }

--- a/Source/DafnyLanguageServer/Handlers/Custom/DafnyCounterExampleHandler.cs
+++ b/Source/DafnyLanguageServer/Handlers/Custom/DafnyCounterExampleHandler.cs
@@ -109,7 +109,8 @@ namespace Microsoft.Dafny.LanguageServer.Handlers.Custom {
       private CounterExampleItem GetCounterExample(PartialState state) {
         return new(
           new Position(state.GetLineId() - 1, state.GetCharId()),
-           state.AsAssumption().ToString()
+           state.AsVariableValueDictionary(),
+          state.AsAssumption().ToString()
          );
       }
     }

--- a/docs/dev/news/5847.fix
+++ b/docs/dev/news/5847.fix
@@ -1,0 +1,1 @@
+Fixed a bug preventing counterexamples from being displayed in the IDE


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->

Fixes https://github.com/dafny-lang/ide-vscode/issues/492

The language sever currently crushes when asking to display counterexamples.  This is because #5013 changed the way counterexamples are represented but the IDE still expects the old representation. This PR fixes this. The IDE will now display any constraints that equate some literal to a variable/field/function application, etc. Here are some examples:

<img width="941" alt="Screenshot 2024-10-21 at 4 39 26 PM" src="https://github.com/user-attachments/assets/c5c4c478-b649-487d-87c9-f07ed635cac9">


### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
