### PR TITLE
Fix: Object::from_ref no longer forgetting to increment the strong count

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
@@ -3508,7 +3508,8 @@ impl <T: ?Sized> AsRef<T> for Object<T> {
 fn increment_strong_count<T: ?Sized>(data: *const T) {
     // SAFETY: This method is called only on values that were constructed from an Rc
     unsafe {
-       Rc::increment_strong_count(data);
+        // Black box avoids the compiler wrongly inferring that increment strong count does nothing since the data it was applied to can be traced to be borrowed
+       ::std::hint::black_box(Rc::increment_strong_count(data));
     }
 }
 

--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
@@ -3515,22 +3515,17 @@ fn increment_strong_count<T: ?Sized>(data: *const T) {
 
 impl <T: ?Sized> Object<T> {
     // SAFETY: This function needs to be called from a reference obtained by calling read!(o) on an object
+    // We never inline this function, otherwise the compiler might figure out a way to remove the increment_strong_count
+    #[inline(never)]    
     pub fn from_ref(r: &T) -> Object<T> {
         let pt = r as *const T as *const UnsafeCell<T>;
         // SAFETY: Not guaranteed unfortunately. But looking at the sources of from_raw as of today 10/24/2024
         // it will will correctly rebuilt the Rc
         let rebuilt = unsafe { Rc::from_raw(pt) };
         let previous_strong_count = Rc::strong_count(&rebuilt);
-        let rebuilt_pt = Rc::into_raw(rebuilt);
-        // If applied on pt directly, without inline(never) and opaque, we have found that
-        // this sentence used to be skipped by the compiler.
-        // All this code is there to ensure this line is not skipped, and if it is, we simply panic
-        // instead of returning invalid code
-        crate::increment_strong_count(rebuilt_pt);
-        // SAFETY: rebuilt_pt was obtained from Rc::into_raw
-        let rebuilt = unsafe { Rc::from_raw(rebuilt_pt) };
+        ::std::hint::black_box(crate::increment_strong_count(pt));
         let new_strong_count = Rc::strong_count(&rebuilt);
-        assert!(new_strong_count == previous_strong_count + 1); // Will panic if not
+        assert_eq!(new_strong_count, previous_strong_count + 1); // Will panic if not
         Object(Some(rebuilt))
     }
 }


### PR DESCRIPTION
Fixes #5851
This PR adds the following safety checks
* If the strong count is not updated, we will panic instead of silently returning a Rc pointer that would cause dangling pointers if dropped. Adding these checks helped me reproduce the soundness issue all the time locally, but obviously did not fix it. I'm keeping it there just in case.
* Itmakes the strong count increment opaque to the compiler, so that it should prevent optimizations that would skip the strong count from increasing. It also makes it opaque at the call site. This did not prevent the compiler from optimizing it away unfortunately in at least one experiment, but I'll keep it just in case it's was another lurking issue.
* Added `#[inline(never)]` to the function from_ref did fix the soundness issue.
* I tried the following but it did not do anything, so not implementing: Instead of incrementing the strong count from the pointer obtained by `&T`, it increments the strong count from the pointer obtained by the extracted `Rc<T>` by doing it the normal way

An alternative to avoid all this hassle would be to pass `self: &Rc<Self>` instead of `self: &Self`, which is what the branch https://github.com/dafny-lang/dafny/tree/fix-object-safety-rust does, but `&Rc` does not make traits object-safe, which means we can't yet use them in the code. I tried also passing a second arguments so that we directly have a `Rc<>` and don't need to recover it from the &T, but `this: Rc<Self>` again makes the trait not object-safe, and `this: Rc<dyn Any>` causes an issue because we can't create this argument when what we have is only the trait, and trait upcast to Any is currently unsound in Rust. This PR is the best workaround I found so far.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
