### PR TITLE
fix: Don’t prematurely assume properties of “this” in constructors

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -650,7 +650,7 @@ namespace Microsoft.Dafny {
         CheckWellformed(p, wfOptions, localVariables, builder, etran);
       }
 
-      if (!(m is TwoStateLemma)) {
+      if (m is not TwoStateLemma) {
         var modifies = m.Mod;
         var allowsAllocation = m.AllowsAllocation;
 
@@ -674,7 +674,7 @@ namespace Microsoft.Dafny {
           builder.Add(TrAssumeCmd(m.tok, wh));
         }
       }
-      // mark the end of the modifles/out-parameter havocking with a CaptureState; make its location be the first ensures clause, if any (and just
+      // mark the end of the modifies/out-parameter havocking with a CaptureState; make its location be the first ensures clause, if any (and just
       // omit the CaptureState if there's no ensures clause)
       if (m.Ens.Count != 0) {
         builder.AddCaptureState(m.Ens[0].E.tok, false, "post-state");

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -665,6 +665,14 @@ namespace Microsoft.Dafny {
           outH.Add(new Boogie.IdentifierExpr(b.tok, b));
         }
         builder.Add(new Boogie.HavocCmd(m.tok, outH));
+        if (m is Constructor) {
+          var receiverType = ModuleResolver.GetReceiverType(m.tok, m);
+          var receiver = new Bpl.IdentifierExpr(m.tok, "this", TrType(receiverType));
+          var wh = BplAnd(
+            ReceiverNotNull(receiver),
+            GetWhereClause(m.tok, receiver, receiverType, etran, IsAllocType.ISALLOC));
+          builder.Add(TrAssumeCmd(m.tok, wh));
+        }
       }
       // mark the end of the modifles/out-parameter havocking with a CaptureState; make its location be the first ensures clause, if any (and just
       // omit the CaptureState if there's no ensures clause)

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -2828,10 +2828,9 @@ namespace Microsoft.Dafny {
 
         Bpl.Expr wh;
         var receiver = new Bpl.IdentifierExpr(tok, "this", TrType(receiverType));
-        if (m is Constructor && kind == MethodTranslationKind.Implementation) {
-          wh = BplAnd(
-            ReceiverNotNull(receiver),
-            GetWhereClause(tok, receiver, receiverType, etran, IsAllocType.NEVERALLOC));
+        if (m is Constructor && kind is MethodTranslationKind.Implementation or MethodTranslationKind.SpecWellformedness) {
+          // For constructors, the typical "where" condition is added in an assumption in the body, rather than in the parameter declaration itself
+          wh = null;
         } else {
           wh = BplAnd(
             ReceiverNotNull(receiver),

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
@@ -762,12 +762,14 @@ public partial class BoogieGenerator {
     if (includeHavoc) {
       // havoc $nw;
       builder.Add(new Bpl.HavocCmd(tok, new List<Bpl.IdentifierExpr> { nw }));
-      // assume $nw != null && $Is($nw, type);
-      var nwNotNull = Bpl.Expr.Neq(nw, Predef.Null);
-      // drop the $Is conjunct if the type is "object", because "new object" allocates an object of an arbitrary type
-      var rightType = type.IsObjectQ ? Bpl.Expr.True : MkIs(nw, type);
-      builder.Add(TrAssumeCmd(tok, BplAnd(nwNotNull, rightType)));
     }
+
+    // assume $nw != null && $Is($nw, type);
+    var nwNotNull = Bpl.Expr.Neq(nw, Predef.Null);
+    // drop the $Is conjunct if the type is "object", because "new object" allocates an object of an arbitrary type
+    var rightType = type.IsObjectQ ? Bpl.Expr.True : MkIs(nw, type);
+    builder.Add(TrAssumeCmd(tok, BplAnd(nwNotNull, rightType)));
+
     // assume !$Heap[$nw, alloc];
     var notAlloc = Bpl.Expr.Not(etran.IsAlloced(tok, nw));
     builder.Add(TrAssumeCmd(tok, notAlloc));

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
@@ -754,11 +754,10 @@ public partial class BoogieGenerator {
     Contract.Requires(type != null);
     Contract.Requires(builder != null);
     Contract.Requires(etran != null);
-    var udt = type as UserDefinedType;
-    if (udt != null && udt.ResolvedClass is NonNullTypeDecl) {
-      var nnt = (NonNullTypeDecl)udt.ResolvedClass;
+    if (type is UserDefinedType { ResolvedClass: NonNullTypeDecl nnt }) {
       type = nnt.RhsWithArgument(type.TypeArgs);
     }
+
     if (includeHavoc) {
       // havoc $nw;
       builder.Add(new Bpl.HavocCmd(tok, new List<Bpl.IdentifierExpr> { nw }));

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5136.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5136.dfy
@@ -1,0 +1,98 @@
+// RUN: %exits-with 4 %verify --type-system-refresh --general-traits=datatype "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+type Empty = x: int | false witness *
+
+class TestEmpty {
+  const x: Empty
+
+  constructor ()
+    ensures false
+  {
+    x := 2; // error: RHS does not satisfy type constraint for Empty
+    new;
+  }
+  constructor BadPrecondition(u: int)
+    requires 10 / u == 2 // error: division by 0
+    decreases *
+  {
+    for i := 0 to * {
+    }
+    new;
+  }
+
+  constructor BadPostcondition(u: int)
+    // The following expression is fine, because the assumption generated between the well-formedness checks of the pre- and postconditions
+    // should allow the verifier to derive false.
+    ensures x as int is Empty && 10 / u == 2
+    decreases *
+  {
+    for i := 0 to * {
+    }
+    new;
+  }
+
+  constructor Star() {
+    x := *;
+    new; // error: x is subject to definite assignment, but a ":= *" does not count for a possibly empty type
+  }
+
+}
+
+// Repeat the class above, but with "var x" instead of "const x"
+class TestEmptyWithVar {
+  var x: Empty
+
+  constructor ()
+    ensures false
+  {
+    x := 2; // error: RHS does not satisfy type constraint for Empty
+    new;
+  }
+
+  constructor BadPrecondition(u: int)
+    requires 10 / u == 2 // error: division by 0
+    decreases *
+  {
+    for i := 0 to * {
+    }
+    new;
+  }
+
+  constructor BadPostcondition(u: int)
+    // The following expression is fine, because the assumption generated between the well-formedness checks of the pre- and postconditions
+    // should allow the verifier to derive false.
+    ensures x as int is Empty && 10 / u == 2
+    decreases *
+  {
+    for i := 0 to * {
+    }
+    new;
+  }
+
+  constructor Star() {
+    x := *;
+    new; // error: x is subject to definite assignment, but a ":= *" does not count for a possibly empty type
+  }
+}
+
+method CallEm()
+  ensures false
+{
+  if
+  case true =>
+    var tc := new TestEmpty();
+  case true =>
+    var tv := new TestEmptyWithVar();
+  case true =>
+    var tc := new TestEmpty.Star();
+    assert tc.x as int is Empty;
+  case true =>
+    var tv := new TestEmptyWithVar.Star();
+    assert tv.x as int is Empty;
+}
+
+method Main() {
+  CallEm();
+  print 10 / 0, "\n";
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5136.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5136.dfy.expect
@@ -1,0 +1,8 @@
+git-issue-5136.dfy(12,9): Error: value does not satisfy the subset constraints of 'Empty'
+git-issue-5136.dfy(16,16): Error: possible division by zero
+git-issue-5136.dfy(37,4): Error: field 'x', which is subject to definite-assignment rules, might be uninitialized at this point in the constructor body
+git-issue-5136.dfy(49,9): Error: value does not satisfy the subset constraints of 'Empty'
+git-issue-5136.dfy(54,16): Error: possible division by zero
+git-issue-5136.dfy(75,4): Error: field 'x', which is subject to definite-assignment rules, might be uninitialized at this point in the constructor body
+
+Dafny program verifier finished with 8 verified, 6 errors

--- a/docs/dev/news/5876.fix
+++ b/docs/dev/news/5876.fix
@@ -1,0 +1,1 @@
+Fix soundness issue where the verifier had assumed properties of `this` already during the first phase of a constructor


### PR DESCRIPTION
This PR fixes a soundness issue where, previously, type properties of `this` were assumed already in the first phase of `constructor`s. Now they are assumed at the time of the `new;`.

Fixes #5136

### Description

The details of the fix are as described in issue #5136.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
