### PR TITLE
Chore: Platform-agnostic python commands

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimePython/Makefile
+++ b/Source/DafnyRuntime/DafnyRuntimePython/Makefile
@@ -20,16 +20,16 @@ update-system-module: build-system-module
 
 setup-venv:
 	python -m venv --clear $(VIRTUALENV)
-	$(VIRTUALENV)/bin/pip install --upgrade build twine
+	python -m pip install --upgrade build twine
 
 clean-package:
 	rm -rf dist/ *.egg-info/
 
 build-package:
-	$(VIRTUALENV)/bin/python -m build
+	python -m build
 
 upload-package-testpypi:
-	$(VIRTUALENV)/bin/python -m twine upload --repository testpypi dist/*
+	python -m twine upload --repository testpypi dist/*
 
 upload-package-pypi:
-	$(VIRTUALENV)/bin/python -m twine upload dist/*
+	python -m twine upload dist/*


### PR DESCRIPTION
This PR removes venv/bin so that executing python is straightforward on Windows.

### How has this been tested?
I'm testing this script to release the DafnyRuntimePython 4.9.0 on Windows

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
