### PR TITLE
Handle native string correctly with `SeqWithoutIsStrInference` for python code generation

### DIFF
--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.WriteLine($"import {moduleName}");
       }
       wr.NewBlockPy("try:")
-        .WriteLine($"dafnyArgs = [{DafnyRuntimeModule}.Seq(a) for a in sys.argv]")
+        .WriteLine($"dafnyArgs = [{DafnyRuntimeModule}.SeqWithoutIsStrInference(map({DafnyRuntimeModule}.CodePoint, a)) for a in sys.argv]")
         .WriteLine($"{mainMethod.EnclosingClass.GetFullCompileName(Options)}.{(IssueCreateStaticMain(mainMethod) ? "StaticMain" : IdName(mainMethod))}(dafnyArgs)");
       wr.NewBlockPy($"except {DafnyRuntimeModule}.HaltException as e:")
         .WriteLine($"{DafnyRuntimeModule}.print(\"[Program halted] \" + e.message + \"\\n\")")

--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -84,9 +84,15 @@ namespace Microsoft.Dafny.Compilers {
       if (moduleName != DafnyDefaultModule) {
         wr.WriteLine($"import {moduleName}");
       }
-      wr.NewBlockPy("try:")
-        .WriteLine($"dafnyArgs = [{DafnyRuntimeModule}.SeqWithoutIsStrInference(map({DafnyRuntimeModule}.CodePoint, a)) for a in sys.argv]")
+      if (UnicodeCharEnabled) {
+        wr.NewBlockPy("try:")
+          .WriteLine($"dafnyArgs = [{DafnyRuntimeModule}.SeqWithoutIsStrInference(map({DafnyRuntimeModule}.CodePoint, a)) for a in sys.argv]")
+          .WriteLine($"{mainMethod.EnclosingClass.GetFullCompileName(Options)}.{(IssueCreateStaticMain(mainMethod) ? "StaticMain" : IdName(mainMethod))}(dafnyArgs)");
+      } else {
+        wr.NewBlockPy("try:")
+        .WriteLine($"dafnyArgs = [{DafnyRuntimeModule}.Seq(a) for a in sys.argv]")
         .WriteLine($"{mainMethod.EnclosingClass.GetFullCompileName(Options)}.{(IssueCreateStaticMain(mainMethod) ? "StaticMain" : IdName(mainMethod))}(dafnyArgs)");
+      }
       wr.NewBlockPy($"except {DafnyRuntimeModule}.HaltException as e:")
         .WriteLine($"{DafnyRuntimeModule}.print(\"[Program halted] \" + e.message + \"\\n\")")
         .WriteLine("sys.exit(1)");

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy
@@ -1,0 +1,9 @@
+// RUN: %exits-with 0 %verify "%s"
+
+method Main(args: seq<string>) 
+{
+  expect 1 < |args|;
+  print Foo(args[1], "World"), "\n";
+}
+
+datatype Foo = Foo(t: string, x: string)

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy
@@ -1,4 +1,6 @@
-// RUN: %testDafnyForEachCompiler "%s"
+// NONUNIFORM: %testDafnyForEachCompiler doesn't support main arguments :(
+// RUN: %run -t:py "%s" Hello > %t
+// RUN: %diff "%s.expect" "%t"
 
 method Main(args: seq<string>) 
 {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 0 %verify "%s"
+// RUN: %testDafnyForEachCompiler "%s"
 
 method Main(args: seq<string>) 
 {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5184/git-issue-5184.dfy.expect
@@ -1,0 +1,3 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+Foo.Foo("Hello", "World")


### PR DESCRIPTION
### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->
Fixes #5184

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
Tested with original test case in the issue.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
