### PR TITLE
Parse more general decreases-to expressions

### DIFF
--- a/Source/DafnyCore/AST/Grammar/ParseErrors.cs
+++ b/Source/DafnyCore/AST/Grammar/ParseErrors.cs
@@ -142,6 +142,7 @@ public class ParseErrors {
     p_general_traits_full,
     p_decreases_without_to,
     p_binding_in_decreases_to,
+    p_ghost_in_decreases_to,
   }
 
   static ParseErrors() {

--- a/Source/DafnyCore/AST/Grammar/ParserNonGeneratedPart.cs
+++ b/Source/DafnyCore/AST/Grammar/ParserNonGeneratedPart.cs
@@ -170,6 +170,17 @@ public partial class Parser {
     return IsFunctionDecl(kind);
   }
 
+  bool IsDecreasesTo() {
+    scanner.ResetPeek();
+    if (la.kind is _decreases or _nonincreases) {
+      Token x = scanner.Peek();
+      if (x.kind == _ident && x.val == "to") {
+        return true;
+      }
+    }
+    return false;
+  }
+  
   private bool IsFunctionDecl(int kind) {
     switch (kind) {
       case _function:

--- a/Source/DafnyCore/AST/Grammar/ParserNonGeneratedPart.cs
+++ b/Source/DafnyCore/AST/Grammar/ParserNonGeneratedPart.cs
@@ -180,7 +180,7 @@ public partial class Parser {
     }
     return false;
   }
-  
+
   private bool IsFunctionDecl(int kind) {
     switch (kind) {
       case _function:

--- a/Source/DafnyCore/AST/Grammar/Printer/Printer.Expression.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer/Printer.Expression.cs
@@ -1228,7 +1228,7 @@ namespace Microsoft.Dafny {
           PrintExpr(newExpr, opBindingStrength, true, !parensNeeded && isRightmost, true, -1);
           comma = true;
         }
-        
+
         if (parensNeeded) { wr.Write(")"); }
 
       } else {

--- a/Source/DafnyCore/AST/Grammar/Printer/Printer.Expression.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer/Printer.Expression.cs
@@ -207,35 +207,35 @@ namespace Microsoft.Dafny {
       PrintExpr(expr, 0, false, true, isFollowedBySemicolon, -1, keyword);
     }
 
-    private const int BindingGroup = 0xFC;
+    private const int BindingGroup = 0xF0;
 
-    private const int BindingStrengthDecreasesTo = 0x04; // decreases to, nonincreases to
+    private const int BindingStrengthDecreasesTo = 0x10; // decreases to, nonincreases to
 
-    private const int BindingStrengthEquiv = 0x08; // <==>
+    private const int BindingStrengthEquiv = 0x20; // <==>
 
-    private const int BindingStrengthImplies = 0x10; // ==>
-    private const int BindingStrengthExplies = 0x11; // <==
+    private const int BindingStrengthImplies = 0x30; // ==>
+    private const int BindingStrengthExplies = 0x31; // <==
 
-    private const int BindingStrengthAnd = 0x20; // &&
-    private const int BindingStrengthOr = 0x21; // ||
+    private const int BindingStrengthAnd = 0x40; // &&
+    private const int BindingStrengthOr = 0x41; // ||
 
-    private const int BindingStrengthCompare = 0x30; // == != ==#[...] !=#[...] < <= >= >
+    private const int BindingStrengthCompare = 0x50; // == != ==#[...] !=#[...] < <= >= >
 
-    private const int BindingStrengthAdd = 0x40; // + -
+    private const int BindingStrengthAdd = 0x60; // + -
 
-    private const int BindingStrengthShift = 0x48; // << >>
+    private const int BindingStrengthShift = 0x70; // << >>
 
-    private const int BindingStrengthMul = 0x50; // * / %
+    private const int BindingStrengthMul = 0x80; // * / %
 
-    private const int BindingStrengthBitwiseAnd = 0x60; // &
-    private const int BindingStrengthBitwiseOr = 0x61; // |
-    private const int BindingStrengthBitwiseXor = 0x62; // ^
+    private const int BindingStrengthBitwiseAnd = 0x90; // &
+    private const int BindingStrengthBitwiseOr = 0x91; // |
+    private const int BindingStrengthBitwiseXor = 0x92; // ^
 
-    private const int BindingStrengthUnarySuffix = 0x70; // as is
+    private const int BindingStrengthUnarySuffix = 0xA0; // as is
 
-    private const int BindingStrengthUnaryPrefix = 0x80; // ! -
+    private const int BindingStrengthUnaryPrefix = 0xB0; // ! -
 
-    private const int BindingStrengthSuffix = 0x90; // X.name X.(name := ...) X(...) X[...]
+    private const int BindingStrengthSuffix = 0xC0; // X.name X.(name := ...) X(...) X[...]
 
     private bool ParensNeeded(int opBindingStrength, int contextBindingStrength, bool fragileContext) {
       int opGroupStrength = opBindingStrength & BindingGroup;

--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -3276,47 +3276,6 @@ Forall = "forall".
 Exists = "exists".
 QSep = "::".
 
-MaybeDecreasesToExpression<out Expression e, IToken lp>
-= (. List<ActualBinding> args = new();
-     List<Expression> newExprs = new();
-     Expression tmp = null;
-     IToken x = null;
-     bool allowNoChange = false;
-  .)
-  TupleArgs<args>
-  [ ( "decreases"                                                 (. allowNoChange = false; .)
-    | "nonincreases"                                              (. allowNoChange = true; .)
-    ) (. x = t; .)
-    ident
-    (. if (t.val != "to") {
-         SemErr(ErrorId.p_decreases_without_to, t, "expected 'to'");
-       }
-    .)
-    Expression<out tmp, false, false>                             (. newExprs.Add(tmp); .)
-    { ","
-      Expression<out tmp, false, false>                           (. newExprs.Add(tmp); .)
-    }
-  ]
-  (.
-      if (newExprs.Count() == 0) {
-        e = ProcessTupleArgs(args, lp);
-      } else if (args.Count() > 0 && newExprs.Count() > 0) {
-        var formals = args.Where(arg => arg.FormalParameterName != null).ToList();
-        if (formals.Any()) {
-          SemErr(ErrorId.p_binding_in_decreases_to,
-                 formals[0].FormalParameterName,
-                 "bindings are not allowed in `decreases to` expressions.");
-        }
-        var oldExprs = args.Select(arg => arg.Actual).ToList();
-        e = new DecreasesToExpr(x, oldExprs, newExprs, allowNoChange);
-        e.RangeToken = new RangeToken(oldExprs[0].tok, newExprs[newExprs.Count() - 1].tok);
-      } else {
-        // Unreachable
-        e = null;
-      }
-  .)
-  .
-
 /* The "allowLemma" argument says whether or not the expression
  * to be parsed is allowed to have the form S;E where S is a call to a lemma.
  * "allowLemma" should be passed in as "false" whenever the expression to
@@ -3334,10 +3293,15 @@ MaybeDecreasesToExpression<out Expression e, IToken lp>
  * at the top level of this expression. It is passed in as "false" only inside
  * cardinality brackets, that is, "|expr|".
  */
-Expression<out Expression e, bool allowLemma, bool allowLambda, bool allowBitwiseOps = true>
+Expression<out Expression e, bool allowLemma, bool allowLambda, bool allowBitwiseOps = true, bool allowDecreasesTo = true>
 = (. Expression e0; IToken semiToken; .)
   [ "new" (. SemErr(ErrorId.p_no_side_effects_in_expressions, t, "Calls with side-effects such as constructors are not allowed in expressions."); .) ]
   EquivExpression<out e, allowLemma, allowLambda, allowBitwiseOps>
+  [ IF(allowDecreasesTo && IsDecreasesTo())
+    DecreasesTo<out var decreasesToToken, out var allowNoChange>
+    EquivExpression<out e0, allowLemma, allowLambda, allowBitwiseOps>
+    (. e = new DecreasesToExpr(decreasesToToken, new List<Expression>() { e }, new List<Expression>() { e0 }, allowNoChange); .)
+  ]
   [ IF(SemiFollowsCall(allowLemma, e))
     /* here we parse the ";E" that is part of a "LemmaCall;E" expression (other "S;E" expressions are parsed elsewhere) */
     ";"                       (. semiToken = t; .)
@@ -3838,38 +3802,90 @@ ParensExpression<out Expression e>
 = (. IToken lp = null; IToken rp = null;
      var args = new List<ActualBinding>();
      e = dummyExpr;
+     var isDecreasesToExpr = false;
+     IToken decreasesToToken = null;
+     var allowNoChange = false;
+     List<Expression> oldExprs = null;
+     List<Expression> newExprs = null;
   .)
- "("
- (. lp = t;
- .)
-  (
-    MaybeDecreasesToExpression<out e, lp>
-    ")"                                     (. rp = t;
-                                               if (e is not DatatypeValue) {
-                                                 e = new ParensExpression(lp, e);
-                                               }
-                                            .)
-  |
-    ")"                                     (. rp = t;
-                                               e = ProcessTupleArgs(new List<ActualBinding>(), lp);
-                                            .)
-  )                                         (. e.RangeToken = new RangeToken(lp, rp); .)
+  "("                                       (. lp = t; .)
+  ( ")"                                     (. rp = t; .)
+
+  | (. isDecreasesToExpr = true;
+       oldExprs = new();
+    .)
+    DecreasesTo<out decreasesToToken, out allowNoChange>
+    DecreasesToExpressionList<out newExprs>
+    ")"                                     (. rp = t; .)
+
+  | TupleArgs<args>
+    [ (. isDecreasesToExpr = true; .)
+      DecreasesTo<out decreasesToToken, out allowNoChange>
+      (. foreach (var binding in args) {
+           if (binding.FormalParameterName != null) {
+             SemErr(ErrorId.p_binding_in_decreases_to, binding.FormalParameterName,
+               $"bindings are not allowed in `{decreasesToToken.val} to` expressions.");
+           } else if (binding.IsGhost) {
+             SemErr(ErrorId.p_ghost_in_decreases_to, binding.Actual.tok, // we don't have the token of "ghost" :(
+               $"'ghost' components are not allowed in `{decreasesToToken.val} to` expressions.");
+           }
+         }
+         oldExprs = args.Select(arg => arg.Actual).ToList();
+      .)
+      DecreasesToExpressionList<out newExprs>
+    ]
+    ")"                                     (. rp = t; .)
+  )
+
+  (. if (isDecreasesToExpr) {
+       e = new DecreasesToExpr(decreasesToToken, oldExprs, newExprs, allowNoChange);
+     } else {
+       e = ProcessTupleArgs(args, lp);
+       if (e is not DatatypeValue) { // here, a DatatypeValue is a tuple expression
+         e = new ParensExpression(lp, e);
+       }
+     }
+     e.RangeToken = new RangeToken(lp, rp);
+  .)
   .
 
-/*------------------------------------------------------------------------*/
 TupleArgs<.List<ActualBinding> args.>
 = (. ActualBinding binding; bool isGhost = false; .)
   // The IF is to distinguish between `(ghost var x := 5; x + x)` and (ghost x), both of which begin with `( ghost`.
   [ IF(la.kind == _ghost && !IsPeekVar())
-    "ghost"                             (. isGhost = true; .)
+    "ghost"                                     (. isGhost = true; .)
   ]
-  ActualBinding<out binding, isGhost>   (. args.Add(binding); .)
-  { ","                                 (. isGhost = false; .)
+  ActualBinding<out binding, isGhost, false>    (. args.Add(binding); .)
+  { ","                                         (. isGhost = false; .)
     [ IF(la.kind == _ghost && !IsPeekVar())
-      "ghost"                           (. isGhost = true; .)
+      "ghost"                                   (. isGhost = true; .)
     ]
-    ActualBinding<out binding, isGhost> (. args.Add(binding); .)
+    ActualBinding<out binding, isGhost, false>  (. args.Add(binding); .)
   }
+  .
+
+// the DecreasesTo production can be anticipated by IsDecreasesTo()
+DecreasesTo<out IToken x, out bool allowNoChange>
+= (. allowNoChange = false; .)
+  ( "decreases"
+  | "nonincreases"                (. allowNoChange = true; .)
+  )                               (. x = t; .)
+  ident
+  (. if (t.val != "to") {
+       SemErr(ErrorId.p_decreases_without_to, t, "expected 'to'");
+     }
+  .)
+  .
+
+DecreasesToExpressionList<.out List<Expression> newExprs.>
+= (. newExprs = new();
+     Expression expr;
+  .)
+  [ Expression<out expr, false, false>                   (. newExprs.Add(expr); .)
+    { ","
+      Expression<out expr, false, false>                 (. newExprs.Add(expr); .)
+    }
+  ]
   .
 
 /*------------------------------------------------------------------------*/
@@ -4458,18 +4474,18 @@ Suffix<ref Expression e>
 /*------------------------------------------------------------------------*/
 ActualBindings<.List<ActualBinding> bindings.>
 = (. ActualBinding binding; .)
-  ActualBinding<out binding>                      (. bindings.Add(binding); .)
-  { "," ActualBinding<out binding>                (. bindings.Add(binding); .)
+  ActualBinding<out binding, false, true>            (. bindings.Add(binding); .)
+  { "," ActualBinding<out binding, false, true>      (. bindings.Add(binding); .)
   }
   .
 
-ActualBinding<out ActualBinding binding, bool isGhost = false>
+ActualBinding<out ActualBinding binding, bool isGhost, bool allowDecreasesTo>
 = (. IToken id = null; Expression e; .)
   [ IF(IsBinding())
     NoUSIdentOrDigits<out id>
     ":="
   ]
-  Expression<out e, true, true>
+  Expression<out e, true, true, allowDecreasesTo: allowDecreasesTo>
   (. binding = new ActualBinding(id, e, isGhost); .)
   .
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo0.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo0.dfy
@@ -1,0 +1,86 @@
+// RUN: %exits-with 4 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method GoodInstances(x: int, y: int) {
+  assert true decreases to false;
+  assert 1 decreases to 0;
+  assert x decreases to x - 1;
+  assert (x, y decreases to x, y - 1); // the parentheses here make this into a "decreases to" expression
+  assert y > x ==> (x, (y decreases to x), y - 1) == (x, true, y - 1); // whereas this is a 3-tuple
+
+  var s := {x, y, x*y};
+  var s' := s - {x};
+  assert  (s, s, s decreases to s, s, s') ;
+  assert 0 nonincreases to 0;
+}
+
+method Nested() {
+  assert (true, (true decreases to false)) == (true, true);
+}
+
+method BadInstance1() {
+  assert 0 decreases to 1; // error
+}
+
+method BadInstance2(x: int) {
+  assert x - 1 decreases to x; // error
+}
+
+method BadInstance3(x: int, y: int) {
+  assert (x, y - 1 decreases to x, y); // error
+}
+
+method BadInstance4() {
+  assert 0 nonincreases to 1; // error
+}
+
+method BadInstance5(i: int, b: bool) {
+  assert i decreases to b; // error
+}
+
+method BadInstance6() {
+  assert 0 decreases to false; // error
+}
+
+datatype Color = Red | Green | Blue
+
+method Tuples(x: int) {
+  if
+  case true =>
+    assert (Red, Green) decreases to Red;
+  case true =>
+    assert (Red, Green) decreases to (Red, Green); // error
+  case true =>
+    assert (Red, Green) nonincreases to (Red, Green);
+  case true =>
+    assert (Red, Green) decreases to Blue; // error
+  case true =>
+    assert x decreases to (x - 1, Blue); // error
+  case true =>
+    assert (x decreases to x - 1, Blue);
+}
+
+method Empties() {
+  assert (nonincreases to);
+  assert !(decreases to);
+  assert (decreases to 2); // yes, because \top decreases to 2,\top
+  assert (2 decreases to); // error, because 2,\top does not decreases to \top
+}
+
+method M0(c: bool) returns (b: bool)
+  ensures b
+  decreases c
+{
+  if c {
+    b := M0(false);
+  } else {
+    b := true;
+  }
+}
+
+method M1(c: bool) returns (b: bool)
+  requires !c
+  ensures b decreases to c
+{
+  b := true;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo0.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo0.dfy
@@ -1,5 +1,5 @@
-// RUN: %exits-with 4 %verify "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
+// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s"
+
 
 method GoodInstances(x: int, y: int) {
   assert true decreases to false;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo0.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo0.dfy.expect
@@ -1,0 +1,12 @@
+DecreasesTo0.dfy(22,11): Error: assertion might not hold
+DecreasesTo0.dfy(26,15): Error: assertion might not hold
+DecreasesTo0.dfy(30,19): Error: assertion might not hold
+DecreasesTo0.dfy(34,11): Error: assertion might not hold
+DecreasesTo0.dfy(38,11): Error: assertion might not hold
+DecreasesTo0.dfy(42,11): Error: assertion might not hold
+DecreasesTo0.dfy(52,24): Error: assertion might not hold
+DecreasesTo0.dfy(56,24): Error: assertion might not hold
+DecreasesTo0.dfy(58,13): Error: assertion might not hold
+DecreasesTo0.dfy(67,12): Error: assertion might not hold
+
+Dafny program verifier finished with 4 verified, 10 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo1.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo1.dfy
@@ -1,5 +1,5 @@
-// RUN: %exits-with 4 %verify --show-proof-obligation-expressions "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
+// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s" -- --show-proof-obligation-expressions 
+
 method GoodInstances(x: int, y: int) {
   assert (true decreases to false);
   assert (1 decreases to 0);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo1.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo1.dfy.expect
@@ -1,8 +1,8 @@
-DecreasesTo1.dfy(19,9): Error: assertion might not hold
+DecreasesTo1.dfy(19,12): Error: assertion might not hold
  Asserted expression: 0 decreases to 1
-DecreasesTo1.dfy(23,9): Error: assertion might not hold
+DecreasesTo1.dfy(23,16): Error: assertion might not hold
  Asserted expression: x - 1 decreases to x
-DecreasesTo1.dfy(27,9): Error: assertion might not hold
+DecreasesTo1.dfy(27,19): Error: assertion might not hold
  Asserted expression: x, y - 1 decreases to x, y
 DecreasesTo1.dfy(39,34): Error: decreases clause might not decrease
  Asserted expression: n + m decreases to n + m + 1
@@ -14,11 +14,11 @@ DecreasesTo1.dfy(57,2): Error: decreases expression might not decrease
    and with the following declarations at the beginning of the loop body:
      var prev_x': int := x';
      var prev_y': int := y';
-DecreasesTo1.dfy(69,9): Error: assertion might not hold
+DecreasesTo1.dfy(69,12): Error: assertion might not hold
  Asserted expression: 0 nonincreases to 1
-DecreasesTo1.dfy(73,9): Error: assertion might not hold
+DecreasesTo1.dfy(73,12): Error: assertion might not hold
  Asserted expression: i decreases to b
-DecreasesTo1.dfy(77,9): Error: assertion might not hold
+DecreasesTo1.dfy(77,12): Error: assertion might not hold
  Asserted expression: 0 decreases to false
 
 Dafny program verifier finished with 2 verified, 9 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo1.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo1.dfy.expect
@@ -3,7 +3,7 @@ DecreasesTo1.dfy(19,12): Error: assertion might not hold
 DecreasesTo1.dfy(23,16): Error: assertion might not hold
  Asserted expression: x - 1 decreases to x
 DecreasesTo1.dfy(27,19): Error: assertion might not hold
- Asserted expression: x, y - 1 decreases to x, y
+ Asserted expression: (x, y - 1 decreases to x, y)
 DecreasesTo1.dfy(39,34): Error: decreases clause might not decrease
  Asserted expression: n + m decreases to n + m + 1
 DecreasesTo1.dfy(49,20): Error: decreases clause might not decrease

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy
@@ -20,3 +20,10 @@ method BadParse2() {
 method BadParse3() {
   assert (nonincreases 20); // parsing error
 }
+
+method BadParse4() returns (ghost b: bool) {
+  b := (Lemma(0); true decreases to Lemma(1); false); // parsing error: needs parens around (Lemma(1); false)
+}
+
+lemma Lemma(x: int) {
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy
@@ -1,15 +1,22 @@
 // RUN: %exits-with 2 %resolve "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
+// Parentheses but missing "to"
+
+method BadParse0() {
+  assert (decreases); // parsing error
+}
+
 method BadParse1() {
-  assert (1 decreases to);
+  assert (nonincreases); // parsing error
+}
+
+// Arguments and parentheses, but missing "to"
+
+method BadParse2() {
+  assert (10 decreases); // parsing error
 }
 
 method BadParse3() {
-  assert (1 decreases);
+  assert (nonincreases 20); // parsing error
 }
-
-method BadParse2() {
-  assert (decreases to);
-}
-

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy.expect
@@ -1,5 +1,9 @@
-DecreasesTo2.dfy(5,24): Error: invalid UnaryExpression
-DecreasesTo2.dfy(9,21): Error: ident expected
-DecreasesTo2.dfy(9,12): Error: expected 'to'
-DecreasesTo2.dfy(13,10): Error: invalid ParensExpression
-4 parse errors detected in DecreasesTo2.dfy
+DecreasesTo2.dfy(7,19): Error: ident expected
+DecreasesTo2.dfy(7,10): Error: expected 'to'
+DecreasesTo2.dfy(11,22): Error: ident expected
+DecreasesTo2.dfy(11,10): Error: expected 'to'
+DecreasesTo2.dfy(17,22): Error: ident expected
+DecreasesTo2.dfy(17,13): Error: expected 'to'
+DecreasesTo2.dfy(21,23): Error: ident expected
+DecreasesTo2.dfy(21,10): Error: expected 'to'
+8 parse errors detected in DecreasesTo2.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo2.dfy.expect
@@ -6,4 +6,6 @@ DecreasesTo2.dfy(17,22): Error: ident expected
 DecreasesTo2.dfy(17,13): Error: expected 'to'
 DecreasesTo2.dfy(21,23): Error: ident expected
 DecreasesTo2.dfy(21,10): Error: expected 'to'
-8 parse errors detected in DecreasesTo2.dfy
+DecreasesTo2.dfy(25,44): Error: closeparen expected
+DecreasesTo2.dfy(25,51): Error: invalid Suffix
+10 parse errors detected in DecreasesTo2.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy
@@ -2,9 +2,32 @@
 // RUN: %diff "%s.expect" "%t"
 
 method M1() {
-  assert (1 decreases to 0) && (0 decreases to 1);
+  assert (1 decreases to 0) && (0 decreases to 1); // error: second conjunct doesn't hold
 }
 
 method M2() {
-  assert (0 decreases to 1);
+  assert 0 decreases to 1; // error
+}
+
+method PrettyPrinting0(b: bool) {
+  assert b <==> (0, 1, 2 decreases to (0 nonincreases to 0), b <==> b, 6) <==> b; // error
+}
+
+method PrettyPrinting1(b: bool) {
+  assert b <==> (3 decreases to 2) <==> !b; // error
+}
+
+method PrettyPrinting2(b: bool) {
+  assert b <==> b decreases to var two := 2; two <= two; // error
+}
+
+lemma Lemma() {
+}
+
+method PrettyPrinting3(b: bool) {
+  assert (Lemma(); b) <==> (Lemma(); !b) decreases to (Lemma(); false); // error
+}
+
+method PrettyPrinting4(b: bool) {
+  assert (b decreases to (Lemma(); true), (Lemma(); true)); // error
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy
@@ -1,5 +1,5 @@
-// RUN: %exits-with 4 %verify --show-proof-obligation-expressions "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
+// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s" -- --show-proof-obligation-expressions
+
 
 method M1() {
   assert (1 decreases to 0) && (0 decreases to 1); // error: second conjunct doesn't hold

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy.expect
@@ -1,6 +1,6 @@
-DecreasesTo3.dfy(5,32): Error: assertion might not hold
+DecreasesTo3.dfy(5,31): Error: assertion might not hold
  Asserted expression: 1 decreases to 0 && 0 decreases to 1
-DecreasesTo3.dfy(9,9): Error: assertion might not hold
+DecreasesTo3.dfy(9,12): Error: assertion might not hold
  Asserted expression: 0 decreases to 1
 
 Dafny program verifier finished with 0 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo3.dfy.expect
@@ -1,6 +1,16 @@
 DecreasesTo3.dfy(5,31): Error: assertion might not hold
- Asserted expression: 1 decreases to 0 && 0 decreases to 1
-DecreasesTo3.dfy(9,12): Error: assertion might not hold
+ Asserted expression: (1 decreases to 0) && (0 decreases to 1)
+DecreasesTo3.dfy(9,11): Error: assertion might not hold
  Asserted expression: 0 decreases to 1
+DecreasesTo3.dfy(13,74): Error: assertion might not hold
+ Asserted expression: b <==> (0, 1, 2 decreases to (0 nonincreases to 0), b <==> b, 6) <==> b
+DecreasesTo3.dfy(17,35): Error: assertion might not hold
+ Asserted expression: b <==> (3 decreases to 2) <==> !b
+DecreasesTo3.dfy(21,18): Error: assertion might not hold
+ Asserted expression: b <==> b decreases to var two: int := 2; two <= two
+DecreasesTo3.dfy(28,41): Error: assertion might not hold
+ Asserted expression: (Lemma(); b) <==> (Lemma(); !b) decreases to (Lemma(); false)
+DecreasesTo3.dfy(32,12): Error: assertion might not hold
+ Asserted expression: (b decreases to (Lemma(); true), (Lemma(); true))
 
-Dafny program verifier finished with 0 verified, 2 errors
+Dafny program verifier finished with 0 verified, 7 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo4.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo4.dfy
@@ -1,6 +1,26 @@
 // RUN: %exits-with 2 %resolve "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
-//
-method M3(x: int) {
-  assert (x := 1 decreases to x - 1);
+
+method AttemptAtBinding0(x: int) {
+  assert (x := 1 decreases to x - 1); // parsing error
+}
+
+method AttemptAtBinding1(x: int) {
+  assert (0 := x decreases to x - 1); // parsing error
+}
+
+method AttemptAtBinding2(x: int) {
+  assert (000 := x nonincreases to x - 1); // parsing error
+}
+
+method AttemptAtBinding3(x: int) {
+  assert (ghost y := x decreases to x - 1); // parsing error
+}
+
+method BadUseOfGhost0(x: int) {
+  assert (ghost x decreases to x - 1); // parsing error
+}
+
+method BadUseOfGhost1(x: int) {
+  assert (x + 1, ghost x nonincreases to x - 1); // parsing error
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo4.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo4.dfy.expect
@@ -1,2 +1,7 @@
 DecreasesTo4.dfy(5,10): Error: bindings are not allowed in `decreases to` expressions.
-1 parse errors detected in DecreasesTo4.dfy
+DecreasesTo4.dfy(9,10): Error: bindings are not allowed in `decreases to` expressions.
+DecreasesTo4.dfy(13,10): Error: bindings are not allowed in `nonincreases to` expressions.
+DecreasesTo4.dfy(17,16): Error: bindings are not allowed in `decreases to` expressions.
+DecreasesTo4.dfy(21,16): Error: 'ghost' components are not allowed in `decreases to` expressions.
+DecreasesTo4.dfy(25,23): Error: 'ghost' components are not allowed in `nonincreases to` expressions.
+6 parse errors detected in DecreasesTo4.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy
@@ -1,6 +1,18 @@
-// RUN: %exits-with 2 %resolve "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
-//
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s"
+
+
 method NonGhost(x: int) {
-  expect (x - 1 decreases to x);
+  expect x - 1 decreases to x; // error: cannot use ghost expression here
 }
+
+method GhostVariable(x: int) returns (c: bool) {
+  ghost var b := x - 1 decreases to x; // b is inferred to be ghost
+  c := b; // error: cannot assign ghost to non-ghost
+}
+
+/* TODO: this currently crashes the resovler
+method InferredGhost(x: int) returns (c: bool) {
+  var b := x - 1 decreases to x; // b is inferred to be ghost
+  c := b; // error: cannot assign ghost to non-ghost
+}
+*/

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy.expect
@@ -1,2 +1,3 @@
-DecreasesTo5.dfy(5,16): Error: a `decreases to` expression is allowed only in specification and ghost contexts
-1 resolution/type errors detected in DecreasesTo5.dfy
+DecreasesTo5.dfy(5,15): Error: a `decreases to` expression is allowed only in specification and ghost contexts
+DecreasesTo5.dfy(10,7): Error: ghost variables such as b are allowed only in specification contexts. b was inferred to be ghost based on its declaration or initialization.
+2 resolution/type errors detected in DecreasesTo5.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/PrettyPrinting.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/PrettyPrinting.dfy
@@ -208,3 +208,42 @@ module SimpleNewtypeWitness {
   newtype E = A ghost witness 104
   newtype F = A witness *
 }
+
+module DecreasesTo {
+  lemma Lemma(x: int) {
+  }
+
+  datatype Record = R
+
+  ghost method ParseAndPrettyPrintTests(b: bool)
+    ensures (Lemma(0); true)
+
+    ensures (if b then Lemma(0); true else Lemma(0); true)
+    ensures if b then Lemma(0); true else (Lemma(0); true)
+
+    ensures (Lemma(0); b <==> b) // Lemma(0) comes before <==> expression
+    ensures (Lemma(0); (b <==> b)) // same as above
+    ensures ((Lemma(0); b) <==> (Lemma(1); b))
+
+    ensures (Lemma(0); true decreases to (Lemma(1); false)) // Lemma(0) comes before the entire decreases-to
+    ensures (Lemma(0); true, Lemma(1); true decreases to (Lemma(2); false)) == (true, true) // Lemma(1) comes before the entire decreases-to
+    ensures (true, Lemma(0); true decreases to (Lemma(1); false)) == (true, true) // Lemma(0) comes before the entire decreases-to
+    ensures (Lemma(0); R, Lemma(0); true) decreases to (Lemma(0); R)
+    ensures (Lemma(0); true) decreases to (Lemma(0); false)
+  {
+    while Lemma(0); false  {
+    }
+    while if b then Lemma(0); false else Lemma(0); false
+    {
+    }
+    while (Lemma(0); false decreases to (Lemma(1); false))
+    {
+    }
+    while (Lemma(0); R, Lemma(0); true) decreases to (Lemma(0); 15)
+    {
+    }
+    while (Lemma(0); true) decreases to (Lemma(0); 15)
+    {
+    }
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/PrettyPrinting.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/PrettyPrinting.dfy.expect
@@ -250,6 +250,39 @@ module SimpleNewtypeWitness {
   newtype F = A
     witness *
 }
+
+module DecreasesTo {
+  lemma Lemma(x: int)
+  {
+  }
+
+  ghost method ParseAndPrettyPrintTests(b: bool)
+    ensures (Lemma(0); true)
+    ensures if b then Lemma(0); true else (Lemma(0); true)
+    ensures if b then Lemma(0); true else (Lemma(0); true)
+    ensures (Lemma(0); b <==> b)
+    ensures (Lemma(0); b <==> b)
+    ensures (Lemma(0); b) <==> (Lemma(1); b)
+    ensures (Lemma(0); true decreases to (Lemma(1); false))
+    ensures (Lemma(0); true, Lemma(1); true decreases to (Lemma(2); false)) == (true, true)
+    ensures (true, Lemma(0); true decreases to (Lemma(1); false)) == (true, true)
+    ensures (Lemma(0); R, Lemma(0); true) decreases to (Lemma(0); R)
+    ensures (Lemma(0); true) decreases to (Lemma(0); false)
+  {
+    while Lemma(0); false {
+    }
+    while if b then Lemma(0); false else Lemma(0); false {
+    }
+    while Lemma(0); false decreases to (Lemma(1); false) {
+    }
+    while (Lemma(0); R, Lemma(0); true) decreases to (Lemma(0); 15) {
+    }
+    while (Lemma(0); true) decreases to (Lemma(0); 15) {
+    }
+  }
+
+  datatype Record = R
+}
 PrettyPrinting.dfy(20,4): Error: skeleton statements are allowed only in refining methods
 PrettyPrinting.dfy(21,4): Error: skeleton statements are allowed only in refining methods
 PrettyPrinting.dfy(75,16): Error: a possibly infinite loop is allowed only if the enclosing method is declared (with 'decreases *') to be possibly non-terminating

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/proof-obligation-desc/trait-decreases.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/proof-obligation-desc/trait-decreases.dfy.expect
@@ -1,8 +1,8 @@
 trait-decreases.dfy(11,2): Error: method's (possibly automatically generated) decreases clause must be below or equal to that in the trait
- Asserted expression: x, y nonincreases to y, x
+ Asserted expression: (x, y nonincreases to y, x)
 trait-decreases.dfy(13,2): Error: method's (possibly automatically generated) decreases clause must be below or equal to that in the trait
- Asserted expression: y, x nonincreases to y
+ Asserted expression: (y, x nonincreases to y)
 trait-decreases.dfy(15,2): Error: method's (possibly automatically generated) decreases clause must be below or equal to that in the trait
- Asserted expression: false, x nonincreases to y, x
+ Asserted expression: (false, x nonincreases to y, x)
 
 Dafny program verifier finished with 0 verified, 3 errors

--- a/docs/DafnyRef/Expressions.5.expect
+++ b/docs/DafnyRef/Expressions.5.expect
@@ -1,3 +1,3 @@
-text.dfy(2,9): Error: assertion might not hold
+text.dfy(2,11): Error: assertion might not hold
 
 Dafny program verifier finished with 0 verified, 1 error

--- a/docs/DafnyRef/Expressions.md
+++ b/docs/DafnyRef/Expressions.md
@@ -1878,11 +1878,12 @@ internal. However, it can be written as a Dafny expression using the
 `decreases to` operator.
 
 The Boolean expression `(a, ..., b decreases to a', ..., b')` encodes
-this ordering. For example, the following assertions are valid:
+this ordering. (The parentheses can be omitted if there is exactly 1 left-hand side
+and exactly 1 right-hand side.) For example, the following assertions are valid:
 <!-- %check-verify -->
 ```dafny
 method M(x: int, y: int) {
-  assert (1 decreases to 0);
+  assert 1 decreases to 0;
   assert (true, false decreases to false, true);
   assert (x, y decreases to x - 1, y);
 }
@@ -1892,12 +1893,12 @@ Conversely, the following assertion is invalid:
 <!-- %check-verify Expressions.5.expect -->
 ```dafny
 method M(x: int, y: int) {
-  assert (x decreases to x + 1);
+  assert x decreases to x + 1;
 }
 ```
 
-Currently, `decreases to` expressions must be written in parentheses to
-avoid parsing ambiguities.
+The `decreases to` operator is strict, that is, it means "strictly greater than".
+The `nonincreases to` operator is the non-strict ("greater than or equal") version of it.
 
 ## 9.39. Compile-Time Constants {#sec-compile-time-constants}
 

--- a/docs/dev/news/5891.feat
+++ b/docs/dev/news/5891.feat
@@ -1,0 +1,1 @@
+Accept `decreases to` and `nonincreaes to` expressions with 0 LHSs and/or 0 RHSs, and allow parentheses to be omitted when there is 1 LHS and 1 RHS.

--- a/docs/dev/news/5891.feat
+++ b/docs/dev/news/5891.feat
@@ -1,1 +1,1 @@
-Accept `decreases to` and `nonincreaes to` expressions with 0 LHSs and/or 0 RHSs, and allow parentheses to be omitted when there is 1 LHS and 1 RHS.
+Accept `decreases to` and `nonincreases to` expressions with 0 LHSs and/or 0 RHSs, and allow parentheses to be omitted when there is 1 LHS and 1 RHS.


### PR DESCRIPTION
This PR expands the accepted `decreases to` (and `nonincreases to`) expressions. They now accept any number of left-hand sides and any number of right-hand sides (in particular, 0 LHSs and/or 0 RHSs). While the general form requires parentheses parentheses, this PR also allows a parenthesis-free form when there is exactly 1 LHS and exactly 1 RHS.

The PR also fixes pretty printing of `decreases to` expressions.

The PR also introduces errors for any `ghost` component among the arguments of `decreases to`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
