### PR TITLE
Fix issue #5892

### DIFF
--- a/Source/DafnyCore/Resolver/ExpressionTester.cs
+++ b/Source/DafnyCore/Resolver/ExpressionTester.cs
@@ -648,6 +648,8 @@ public class ExpressionTester {
     } else if (expr is MultiSetFormingExpr) {
       var e = (MultiSetFormingExpr)expr;
       return UsesSpecFeatures(e.E);
+    } else if (expr is DecreasesToExpr) {
+      return true;
     } else {
       Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy
@@ -10,9 +10,7 @@ method GhostVariable(x: int) returns (c: bool) {
   c := b; // error: cannot assign ghost to non-ghost
 }
 
-/* TODO: this currently crashes the resovler
 method InferredGhost(x: int) returns (c: bool) {
   var b := x - 1 decreases to x; // b is inferred to be ghost
   c := b; // error: cannot assign ghost to non-ghost
 }
-*/

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/DecreasesTo5.dfy.expect
@@ -1,3 +1,4 @@
 DecreasesTo5.dfy(5,15): Error: a `decreases to` expression is allowed only in specification and ghost contexts
 DecreasesTo5.dfy(10,7): Error: ghost variables such as b are allowed only in specification contexts. b was inferred to be ghost based on its declaration or initialization.
-2 resolution/type errors detected in DecreasesTo5.dfy
+DecreasesTo5.dfy(15,7): Error: ghost variables such as b are allowed only in specification contexts. b was inferred to be ghost based on its declaration or initialization.
+3 resolution/type errors detected in DecreasesTo5.dfy


### PR DESCRIPTION
### Description

Add a case for `DecreasesToExpr` in `UsesSpecFeatures` to avoid a crash in the resolver.

Fixes #5892.

### How has this been tested?

Uncommented the test mentioned in #5892 in `dafny0/DecreasesTo5.dfy`, and updated `dafny0/DecreasesTo5.dfy.expect` to match.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
