### PR TITLE
Chore: Faster Rust tests.

### DIFF
--- a/Source/DafnyCore/Generic/IO.cs
+++ b/Source/DafnyCore/Generic/IO.cs
@@ -1,0 +1,39 @@
+using System.IO;
+
+namespace Microsoft.Dafny;
+
+public class IO {
+  public static void CopyDirectory(string sourceDir, string destinationDir, bool recursive = true, bool force = true) {
+    // Get information about the source directory
+    var dir = new DirectoryInfo(sourceDir);
+
+    // Check if the source directory exists
+    if (!dir.Exists) {
+      throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+    }
+
+    // Cache directories before we start copying
+    DirectoryInfo[] dirs = dir.GetDirectories();
+
+    // Create the destination directory
+    Directory.CreateDirectory(destinationDir);
+
+    // Get the files in the source directory and copy to the destination directory
+    foreach (FileInfo file in dir.GetFiles()) {
+      string targetFilePath = Path.Combine(destinationDir, file.Name);
+      if (force && File.Exists(targetFilePath)) {
+        File.Delete(targetFilePath);
+      }
+
+      file.CopyTo(targetFilePath);
+    }
+
+    // If recursive and copying subdirectories, recursively call this method
+    if (recursive) {
+      foreach (DirectoryInfo subDir in dirs) {
+        string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+        CopyDirectory(subDir.FullName, newDestinationDir, true, force);
+      }
+    }
+  }
+}

--- a/Source/XUnitExtensions/Lit/CpCommand.cs
+++ b/Source/XUnitExtensions/Lit/CpCommand.cs
@@ -45,8 +45,9 @@ namespace XUnitExtensions.Lit {
       var dir = new DirectoryInfo(sourceDir);
 
       // Check if the source directory exists
-      if (!dir.Exists)
+      if (!dir.Exists) {
         throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+      }
 
       // Cache directories before we start copying
       DirectoryInfo[] dirs = dir.GetDirectories();


### PR DESCRIPTION
### Description

Previously, every single invocation of "cargo build" resulted in the creation of 100Mb of artifacts, many of which were downloaded from the internet.
I had figured out that, by reusing the "target" directory from a sibling test, even unrelated, I completely removed the need to download dependencies from the internet, and also it compiled substantially faster on my machine.


### How has this been tested?
All existing Rust tests should pass

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
