### PR TITLE
Fix concurrency bug in reported file version

### DIFF
--- a/Source/DafnyCore.Test/DafnyProjectTest.cs
+++ b/Source/DafnyCore.Test/DafnyProjectTest.cs
@@ -6,7 +6,7 @@ public class DafnyProjectTest {
   [Fact]
   public void Equality() {
     var randomFileName = Path.GetTempFileName();
-    var first = new DafnyProject(new Uri(randomFileName, UriKind.Absolute), null,
+    var first = new DafnyProject(null, new Uri(randomFileName, UriKind.Absolute), null,
       new[] { "a", "a2" }.ToHashSet(),
       new[] { "b", "b2" }.ToHashSet(), new Dictionary<string, object>() {
         { "c", "d" },
@@ -14,7 +14,7 @@ public class DafnyProjectTest {
       }
     );
 
-    var second = new DafnyProject(new Uri(randomFileName, UriKind.Absolute), null,
+    var second = new DafnyProject(null, new Uri(randomFileName, UriKind.Absolute), null,
       new[] { "a2", "a" }.ToHashSet(),
       new[] { "b2", "b" }.ToHashSet(),
       new Dictionary<string, object>() {

--- a/Source/DafnyCore.Test/DooFileTest.cs
+++ b/Source/DafnyCore.Test/DooFileTest.cs
@@ -36,8 +36,8 @@ public class DooFileTest {
     var rootUri = new Uri(fullFilePath);
     Microsoft.Dafny.Type.ResetScopes();
     var errorReporter = new ConsoleErrorReporter(options);
-    var program = await new ProgramParser().Parse(dafnyProgramText, rootUri, errorReporter);
+    var parseResult = await new ProgramParser().Parse(dafnyProgramText, rootUri, errorReporter);
     Assert.Equal(0, errorReporter.ErrorCount);
-    return program;
+    return parseResult.Program;
   }
 }

--- a/Source/DafnyCore/AST/Grammar/IFileSystem.cs
+++ b/Source/DafnyCore/AST/Grammar/IFileSystem.cs
@@ -8,8 +8,10 @@ using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 
 namespace Microsoft.Dafny;
 
+public record FileSnapshot(TextReader Reader, int? Version);
+
 public interface IFileSystem {
-  TextReader ReadFile(Uri uri);
+  FileSnapshot ReadFile(Uri uri);
 
   public bool Exists(Uri path);
   DirectoryInfoBase GetDirectoryInfoBase(string root);
@@ -22,9 +24,9 @@ public class InMemoryFileSystem : IFileSystem {
     this.files = files;
   }
 
-  public TextReader ReadFile(Uri uri) {
+  public FileSnapshot ReadFile(Uri uri) {
     if (files.TryGetValue(uri, out var entry)) {
-      return new StringReader(entry);
+      return new FileSnapshot(new StringReader(entry), null);
     }
 
     return OnDiskFileSystem.Instance.ReadFile(uri);
@@ -47,8 +49,8 @@ public class OnDiskFileSystem : IFileSystem {
   private OnDiskFileSystem() {
   }
 
-  public TextReader ReadFile(Uri uri) {
-    return new StreamReader(uri.LocalPath);
+  public FileSnapshot ReadFile(Uri uri) {
+    return new FileSnapshot(new StreamReader(uri.LocalPath), null);
   }
 
   public bool Exists(Uri path) {

--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -23,7 +23,7 @@ public class DafnyFile {
   public bool ShouldNotVerify { get; private set; }
   public bool ShouldNotCompile { get; private set; }
   public DafnyOptions FileOptions { get; private set; }
-  public Func<TextReader> GetContent { get; set; }
+  public Func<FileSnapshot> GetContent { get; set; }
   public Uri Uri { get; private set; }
   public IToken? Origin { get; }
 
@@ -156,7 +156,8 @@ public class DafnyFile {
   }
 
   public static DafnyFile HandleStandardInput(DafnyOptions options, IToken origin) {
-    return new DafnyFile(DafnyFileExtension, "<stdin>", "<stdin>", () => options.Input, new Uri("stdin:///"), origin, options) {
+    return new DafnyFile(DafnyFileExtension, "<stdin>", "<stdin>",
+      () => new FileSnapshot(options.Input, null), new Uri("stdin:///"), origin, options) {
       ShouldNotCompile = false,
       ShouldNotVerify = false,
     };
@@ -188,7 +189,7 @@ public class DafnyFile {
     }
 
     return new DafnyFile(".dll", canonicalPath, baseName,
-      () => new StringReader(sourceText), uri, origin, parseOptions) {
+      () => new FileSnapshot(new StringReader(sourceText), null), uri, origin, parseOptions) {
       ShouldNotCompile = true,
       ShouldNotVerify = true,
     };
@@ -242,14 +243,14 @@ public class DafnyFile {
     // the DooFile class should encapsulate the serialization logic better
     // and expose a Program instead of the program text.
     yield return new DafnyFile(DooFile.Extension, Canonicalize(uri.LocalPath).LocalPath, Path.GetFileName(uri.LocalPath),
-      () => new StringReader(dooFile.ProgramText), uri, origin, validDooOptions) {
+      () => new FileSnapshot(new StringReader(dooFile.ProgramText), null), uri, origin, validDooOptions) {
       ShouldNotCompile = asLibrary,
       ShouldNotVerify = true,
     };
   }
 
   protected DafnyFile(string extension, string canonicalPath, string baseName,
-    Func<TextReader> getContent, Uri uri, IToken? origin, DafnyOptions fileOptions) {
+    Func<FileSnapshot> getContent, Uri uri, IToken? origin, DafnyOptions fileOptions) {
     Extension = extension;
     CanonicalPath = canonicalPath;
     BaseName = baseName;

--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Dafny {
         _ => throw new ArgumentOutOfRangeException()
       };
 
-      var program = await new ProgramParser().ParseFiles(programName, files, reporter, CancellationToken.None);
+      var parseResult = await new ProgramParser().ParseFiles(programName, files, reporter, CancellationToken.None);
+      var program = parseResult.Program;
       var errorCount = program.Reporter.ErrorCount;
       if (errorCount != 0) {
         return (program, $"{errorCount} parse errors detected in {program.Name}");

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -59,84 +59,85 @@ public class DafnyProject : IEquatable<DafnyProject> {
 
   public static async Task<DafnyProject> Open(IFileSystem fileSystem, Uri uri, IToken uriOrigin,
     bool defaultIncludes = true, bool serverNameCheck = true) {
-
-    var emptyProject = new DafnyProject(null, uri, null, new HashSet<string>(), new HashSet<string>(),
-      new Dictionary<string, object>());
-
     DafnyProject result;
     try {
       var fileSnapshot = fileSystem.ReadFile(uri);
       using var textReader = fileSnapshot.Reader;
       var text = await textReader.ReadToEndAsync();
-      var model = Toml.ToModel<DafnyProjectFile>(text, null, new TomlModelOptions());
-      var directory = Path.GetDirectoryName(uri.LocalPath)!;
+      try {
+        var model = Toml.ToModel<DafnyProjectFile>(text, null, new TomlModelOptions());
+        var directory = Path.GetDirectoryName(uri.LocalPath)!;
 
-      result = new DafnyProject(fileSnapshot.Version, uri, model.Base == null ? null : new Uri(Path.GetFullPath(model.Base, directory!)),
-        model.Includes?.Select(p => Path.GetFullPath(p, directory)).ToHashSet() ?? new HashSet<string>(),
-        model.Excludes?.Select(p => Path.GetFullPath(p, directory)).ToHashSet() ?? new HashSet<string>(),
-        model.Options ?? new Dictionary<string, object>());
+        result = new DafnyProject(fileSnapshot.Version, uri, model.Base == null ? null : new Uri(Path.GetFullPath(model.Base, directory!)),
+          model.Includes?.Select(p => Path.GetFullPath(p, directory)).ToHashSet() ?? new HashSet<string>(),
+          model.Excludes?.Select(p => Path.GetFullPath(p, directory)).ToHashSet() ?? new HashSet<string>(),
+          model.Options ?? new Dictionary<string, object>());
 
-      if (result.Base != null) {
-        var baseProject = await Open(fileSystem, result.Base, new Token {
-          Uri = uri,
-          line = 1,
-          col = 1
-        }, false, false);
-        baseProject.Errors.CopyDiagnostics(result.Errors);
-        foreach (var include in baseProject.Includes) {
-          if (!result.Excludes.Contains(include)) {
-            result.Includes.Add(include);
+        if (result.Base != null) {
+          var baseProject = await Open(fileSystem, result.Base, new Token {
+            Uri = uri,
+            line = 1,
+            col = 1
+          }, false, false);
+          baseProject.Errors.CopyDiagnostics(result.Errors);
+          foreach (var include in baseProject.Includes) {
+            if (!result.Excludes.Contains(include)) {
+              result.Includes.Add(include);
+            }
+          }
+
+          foreach (var include in baseProject.Excludes) {
+            if (!result.Includes.Contains(include)) {
+              result.Excludes.Add(include);
+            }
+          }
+
+          foreach (var option in baseProject.Options) {
+            if (!result.Options.ContainsKey(option.Key)) {
+              result.Options.Add(option.Key, option.Value);
+            }
           }
         }
-
-        foreach (var include in baseProject.Excludes) {
-          if (!result.Includes.Contains(include)) {
-            result.Excludes.Add(include);
-          }
+        if (defaultIncludes && model.Includes == null && !result.Includes.Any()) {
+          result.Includes.Add("**/*.dfy");
         }
-
-        foreach (var option in baseProject.Options) {
-          if (!result.Options.ContainsKey(option.Key)) {
-            result.Options.Add(option.Key, option.Value);
-          }
-        }
-      }
-      if (defaultIncludes && model.Includes == null && !result.Includes.Any()) {
-        result.Includes.Add("**/*.dfy");
-      }
-    } catch (IOException e) {
-      result = emptyProject;
-      result.Errors.Error(MessageSource.Project, uriOrigin, e.Message);
-    } catch (TomlException tomlException) {
-      var propertyNotFoundRegex = new Regex(
-        @$"\((\d+),(\d+)\) : error : The property `(\w+)` was not found on object type {typeof(DafnyProject).FullName}");
-      var propertyNotFoundMatch = propertyNotFoundRegex.Match(tomlException.Message);
-      if (propertyNotFoundMatch.Success) {
-        var line = int.Parse(propertyNotFoundMatch.Groups[1].Value);
-        var column = int.Parse(propertyNotFoundMatch.Groups[2].Value);
-        var property = propertyNotFoundMatch.Groups[3].Value;
-        result = emptyProject;
-        var token = new Token(line, column) {
-          Uri = uri
-        };
-        result.Errors.Error(MessageSource.Project, token,
-          $"Dafny project files do not have the property {property}");
-      } else {
-        var genericRegex = new Regex(@$"\((\d+),(\d+)\) : error : (.*)");
-        var genericMatch = genericRegex.Match(tomlException.Message);
-        if (genericMatch.Success) {
-          var line = int.Parse(genericMatch.Groups[1].Value);
-          var column = int.Parse(genericMatch.Groups[2].Value);
-          var message = genericMatch.Groups[3].Value;
-          result = emptyProject;
+      } catch (TomlException tomlException) {
+        var propertyNotFoundRegex = new Regex(
+          @$"\((\d+),(\d+)\) : error : The property `(\w+)` was not found on object type {typeof(DafnyProject).FullName}");
+        var propertyNotFoundMatch = propertyNotFoundRegex.Match(tomlException.Message);
+        if (propertyNotFoundMatch.Success) {
+          var line = int.Parse(propertyNotFoundMatch.Groups[1].Value);
+          var column = int.Parse(propertyNotFoundMatch.Groups[2].Value);
+          var property = propertyNotFoundMatch.Groups[3].Value;
+          result = new DafnyProject(fileSnapshot.Version, uri, null, new HashSet<string>(), new HashSet<string>(),
+            new Dictionary<string, object>());
           var token = new Token(line, column) {
             Uri = uri
           };
-          result.Errors.Error(MessageSource.Project, token, message);
+          result.Errors.Error(MessageSource.Project, token,
+            $"Dafny project files do not have the property {property}");
         } else {
-          throw new Exception("Could not parse Tomlyn error");
+          var genericRegex = new Regex(@$"\((\d+),(\d+)\) : error : (.*)");
+          var genericMatch = genericRegex.Match(tomlException.Message);
+          if (genericMatch.Success) {
+            var line = int.Parse(genericMatch.Groups[1].Value);
+            var column = int.Parse(genericMatch.Groups[2].Value);
+            var message = genericMatch.Groups[3].Value;
+            result = new DafnyProject(fileSnapshot.Version, uri, null, new HashSet<string>(), new HashSet<string>(),
+              new Dictionary<string, object>());
+            var token = new Token(line, column) {
+              Uri = uri
+            };
+            result.Errors.Error(MessageSource.Project, token, message);
+          } else {
+            throw new Exception("Could not parse Tomlyn error");
+          }
         }
       }
+    } catch (IOException e) {
+      result = new DafnyProject(null, uri, null, new HashSet<string>(), new HashSet<string>(),
+        new Dictionary<string, object>());
+      result.Errors.Error(MessageSource.Project, uriOrigin, e.Message);
     }
 
     if (serverNameCheck && Path.GetFileName(uri.LocalPath) != FileName) {

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using DafnyCore;
 using DafnyCore.Options;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Tomlyn;
@@ -64,7 +63,7 @@ public class DafnyProject : IEquatable<DafnyProject> {
 
     DafnyProject result;
     try {
-      using var textReader = fileSystem.ReadFile(uri);
+      using var textReader = fileSystem.ReadFile(uri).Reader;
       var text = await textReader.ReadToEndAsync();
       var model = Toml.ToModel<DafnyProjectFile>(text, null, new TomlModelOptions());
       var directory = Path.GetDirectoryName(uri.LocalPath)!;

--- a/Source/DafnyCore/Pipeline/Compilation.cs
+++ b/Source/DafnyCore/Pipeline/Compilation.cs
@@ -223,13 +223,14 @@ public class Compilation : IDisposable {
       return null;
     }
 
-    transformedProgram = await documentLoader.ParseAsync(this, cancellationSource.Token);
+    var parseResult = await documentLoader.ParseAsync(this, cancellationSource.Token);
+    transformedProgram = parseResult.Program;
     transformedProgram.HasParseErrors = HasErrors;
 
     var cloner = new Cloner(true);
     programAfterParsing = new Program(cloner, transformedProgram);
 
-    updates.OnNext(new FinishedParsing(programAfterParsing));
+    updates.OnNext(new FinishedParsing(parseResult with { Program = programAfterParsing }));
     logger.LogDebug(
       $"Passed parsedCompilation to documentUpdates.OnNext, resolving ParsedCompilation task for version {Input.Version}.");
     return programAfterParsing;

--- a/Source/DafnyCore/Pipeline/Events/FinishedParsing.cs
+++ b/Source/DafnyCore/Pipeline/Events/FinishedParsing.cs
@@ -4,4 +4,4 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Dafny;
 
-public record FinishedParsing(Program Program) : ICompilationEvent;
+public record FinishedParsing(ProgramParseResult ParseResult) : ICompilationEvent;

--- a/Source/DafnyCore/Pipeline/IDafnyParser.cs
+++ b/Source/DafnyCore/Pipeline/IDafnyParser.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Dafny {
   /// Any implementation has to guarantee thread-safety of its public members.
   /// </remarks>
   public interface IDafnyParser {
-    Task<Program> Parse(Compilation compilation, CancellationToken cancellationToken);
+    Task<ProgramParseResult> Parse(Compilation compilation, CancellationToken cancellationToken);
   }
 }

--- a/Source/DafnyCore/Pipeline/ITextDocumentLoader.cs
+++ b/Source/DafnyCore/Pipeline/ITextDocumentLoader.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Dafny {
-  public record ProgramParseResult(Program Program, IReadOnlyDictionary<Uri, int> VersionedFiles);
+  public record ProgramParseResult(Program Program, Dictionary<Uri, int> VersionedFiles);
 
   /// <summary>
   /// Implementations are responsible to load a specified language server document and generate

--- a/Source/DafnyCore/Pipeline/ITextDocumentLoader.cs
+++ b/Source/DafnyCore/Pipeline/ITextDocumentLoader.cs
@@ -1,15 +1,20 @@
 ﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Dafny {
+  public record ProgramParseResult(Program Program, IReadOnlyDictionary<Uri, int> VersionedFiles);
+
   /// <summary>
   /// Implementations are responsible to load a specified language server document and generate
   /// a dafny document out of it.
   /// </summary>
   public interface ITextDocumentLoader {
 
-    Task<Program> ParseAsync(Compilation compilation, CancellationToken cancellationToken);
+    Task<ProgramParseResult> ParseAsync(Compilation compilation, CancellationToken cancellationToken);
 
     Task<ResolutionResult?> ResolveAsync(Compilation compilation,
       Program program,

--- a/Source/DafnyCore/Pipeline/TextDocumentLoader.cs
+++ b/Source/DafnyCore/Pipeline/TextDocumentLoader.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Dafny {
       this.symbolResolver = symbolResolver;
     }
 
-    public async Task<Program> ParseAsync(Compilation compilation, CancellationToken cancellationToken) {
+    public async Task<ProgramParseResult> ParseAsync(Compilation compilation, CancellationToken cancellationToken) {
 #pragma warning disable CS1998
       return await await DafnyMain.LargeStackFactory.StartNew(
         () => parser.Parse(compilation, cancellationToken), cancellationToken

--- a/Source/DafnyCore/Rewriters/InductionHeuristic.cs
+++ b/Source/DafnyCore/Rewriters/InductionHeuristic.cs
@@ -170,7 +170,7 @@ public static class InductionHeuristic {
       return false;
     } else {
       // in all other cases, reset the prominence status and recurse on the subexpressions
-      foreach (var exp in expr.SubExpressions) {
+      foreach (var exp in expr!.SubExpressions) {
         if (VarOccursInArgumentToRecursiveFunction(options, exp, n, subExprIsProminent)) {
           return true;
         }

--- a/Source/DafnyCore/Snippets.cs
+++ b/Source/DafnyCore/Snippets.cs
@@ -49,7 +49,7 @@ public class Snippets {
         // Note: This is not guaranteed to be the same file that Dafny parsed. To ensure that, Dafny should keep
         // an in-memory version of each file it parses.
         var file = DafnyFile.HandleDafnyFile(OnDiskFileSystem.Instance, new ErrorReporterSink(options), options, uri, Token.NoToken);
-        using var reader = file.GetContent();
+        using var reader = file.GetContent().Reader;
         lines = Util.Lines(reader).ToList();
       } catch (Exception) {
         lines = new List<string>();

--- a/Source/DafnyDriver/CliCompilation.cs
+++ b/Source/DafnyDriver/CliCompilation.cs
@@ -127,7 +127,7 @@ public class CliCompilation {
           dafnyDiagnostic.ErrorId, dafnyDiagnostic.Token, dafnyDiagnostic.Message);
       } else if (ev is FinishedParsing finishedParsing) {
         if (errorCount > 0) {
-          var programName = finishedParsing.Program.Name;
+          var programName = finishedParsing.ParseResult.Program.Name;
           Options.OutputWriter.WriteLine($"{errorCount} parse errors detected in {programName}");
         }
       } else if (ev is FinishedResolution finishedResolution) {

--- a/Source/DafnyDriver/CliCompilation.cs
+++ b/Source/DafnyDriver/CliCompilation.cs
@@ -37,7 +37,7 @@ public class CliCompilation {
     if (options.DafnyProject == null) {
       var firstFile = options.CliRootSourceUris.FirstOrDefault();
       var uri = firstFile ?? new Uri(Directory.GetCurrentDirectory());
-      options.DafnyProject = new DafnyProject(uri, null, new HashSet<string>() { uri.LocalPath }, new HashSet<string>(),
+      options.DafnyProject = new DafnyProject(null, uri, null, new HashSet<string>() { uri.LocalPath }, new HashSet<string>(),
         new Dictionary<string, object>()) {
         ImplicitFromCli = true
       };

--- a/Source/DafnyDriver/Commands/FormatCommand.cs
+++ b/Source/DafnyDriver/Commands/FormatCommand.cs
@@ -96,9 +96,9 @@ Use '--print' to output the content of the formatted files instead of overwritin
       }
 
       var content = dafnyFile.GetContent();
-      var originalText = await content.ReadToEndAsync();
-      content.Close(); // Manual closing because we want to overwrite
-      dafnyFile.GetContent = () => new StringReader(originalText);
+      var originalText = await content.Reader.ReadToEndAsync();
+      content.Reader.Close(); // Manual closing because we want to overwrite
+      dafnyFile.GetContent = () => content with { Reader = new StringReader(originalText) };
       // Might not be totally optimized but let's do that for now
       var (dafnyProgram, err) = await DafnyMain.Parse(new List<DafnyFile> { dafnyFile }, programName, options);
       if (err != null) {

--- a/Source/DafnyDriver/CoverageReporter.cs
+++ b/Source/DafnyDriver/CoverageReporter.cs
@@ -339,7 +339,7 @@ public class CoverageReporter {
     var files = await DafnyFile.CreateAndValidate(OnDiskFileSystem.Instance,
         new ConsoleErrorReporter(options), options, uri, Token.Cli).ToListAsync();
     var dafnyFile = files[0];
-    var source = await dafnyFile.GetContent().ReadToEndAsync();
+    var source = await dafnyFile.GetContent().Reader.ReadToEndAsync();
     var lines = source.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
     var characterLabels = new CoverageLabel[lines.Length][];
     for (int i = 0; i < lines.Length; i++) {

--- a/Source/DafnyLanguageServer.Test/Unit/CompilationManagerTest.cs
+++ b/Source/DafnyLanguageServer.Test/Unit/CompilationManagerTest.cs
@@ -19,7 +19,7 @@ public class CompilationManagerTest {
       new Mock<ITextDocumentLoader>().Object,
       new Mock<IProgramVerifier>().Object,
       null!, new CompilationInput(dafnyOptions, 0,
-        new DafnyProject(new Uri(Directory.GetCurrentDirectory()), null, new HashSet<string>())));
+        new DafnyProject(null, new Uri(Directory.GetCurrentDirectory()), null, new HashSet<string>())));
     compilationManager.CancelPendingUpdates();
     await Assert.ThrowsAsync<TaskCanceledException>(() => compilationManager.ParsedProgram);
   }

--- a/Source/DafnyLanguageServer.Test/Util/DiagnosticsReceiver.cs
+++ b/Source/DafnyLanguageServer.Test/Util/DiagnosticsReceiver.cs
@@ -40,7 +40,9 @@ public class DiagnosticsReceiver : TestNotificationReceiver<PublishDiagnosticsPa
     TextDocumentItem textDocumentItem = null) {
     var result = await AwaitNextNotificationAsync(cancellationToken);
     if (textDocumentItem != null) {
-      AssertM.Equal(textDocumentItem.Version, result.Version,
+      // Before parsing finishes, the version can be null even for open files.
+      var resultVersion = result.Version ?? textDocumentItem.Version;
+      AssertM.Equal(textDocumentItem.Version, resultVersion,
         $"received incorrect version, diagnostics were: [{string.Join(", ", result.Diagnostics)}]");
       Assert.Equal(textDocumentItem.Uri, result.Uri);
     }

--- a/Source/DafnyLanguageServer.Test/Various/ExceptionTests.cs
+++ b/Source/DafnyLanguageServer.Test/Various/ExceptionTests.cs
@@ -117,7 +117,7 @@ public class ExceptionTests : ClientBasedLanguageServerTest {
       this.loader = loader;
     }
 
-    public Task<Program> ParseAsync(Compilation compilation, CancellationToken cancellationToken) {
+    public Task<ProgramParseResult> ParseAsync(Compilation compilation, CancellationToken cancellationToken) {
       return loader.ParseAsync(compilation, cancellationToken);
     }
 

--- a/Source/DafnyLanguageServer/Language/CachingParser.cs
+++ b/Source/DafnyLanguageServer/Language/CachingParser.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Dafny.LanguageServer.Language;
 
 public class CachingParser : ProgramParser {
-  private readonly PruneIfNotUsedSinceLastPruneCache<byte[], DfyParseResult> parseCache = new(new HashEquality());
+  private readonly PruneIfNotUsedSinceLastPruneCache<byte[], DfyParseFileResult> parseCache = new(new HashEquality());
   private readonly TelemetryPublisherBase telemetryPublisher;
 
   public CachingParser(ILogger<ProgramParser> logger,
@@ -21,7 +21,7 @@ public class CachingParser : ProgramParser {
     this.telemetryPublisher = telemetryPublisher;
   }
 
-  public override Task<Program> ParseFiles(string programName, IReadOnlyList<DafnyFile> files,
+  public override Task<ProgramParseResult> ParseFiles(string programName, IReadOnlyList<DafnyFile> files,
     ErrorReporter errorReporter,
     CancellationToken cancellationToken) {
     return parseCache.ProfileAndPruneCache(() =>
@@ -29,9 +29,10 @@ public class CachingParser : ProgramParser {
       logger, telemetryPublisher, programName, "parsing", cancellationToken);
   }
 
-  protected override DfyParseResult ParseFile(DafnyOptions options, Func<TextReader> getReader,
+  protected override DfyParseFileResult ParseFile(DafnyOptions options, Func<FileSnapshot> getReader,
     Uri uri, CancellationToken cancellationToken) {
-    using var reader = getReader();
+    var fileSnapshot = getReader();
+    using var reader = fileSnapshot.Reader;
 
     // Add NUL delimiter to avoid collisions (otherwise hash("A" + "BC") == hash("AB" + "C"))
     var uriBytes = Encoding.UTF8.GetBytes(uri + "\0");
@@ -39,7 +40,7 @@ public class CachingParser : ProgramParser {
     var (newReader, hash) = ComputeHashFromReader(uriBytes, reader, HashAlgorithm.Create("SHA256")!);
     if (!parseCache.TryGet(hash, out var result)) {
       logger.LogDebug($"Parse cache miss for {uri}");
-      result = base.ParseFile(options, () => newReader, uri, cancellationToken);
+      result = base.ParseFile(options, () => fileSnapshot with { Reader = newReader }, uri, cancellationToken);
       parseCache.Set(hash, result);
     } else {
       logger.LogDebug($"Parse cache hit for {uri}");

--- a/Source/DafnyLanguageServer/Language/CachingParser.cs
+++ b/Source/DafnyLanguageServer/Language/CachingParser.cs
@@ -50,7 +50,8 @@ public class CachingParser : ProgramParser {
     // We should cache an immutable version of the AST instead: https://github.com/dafny-lang/dafny/issues/4086
     var cloner = new Cloner(true, false);
     var clonedResult = result! with {
-      Module = new FileModuleDefinition(cloner, result.Module)
+      Module = new FileModuleDefinition(cloner, result.Module),
+      Version = fileSnapshot.Version
     };
     return clonedResult;
   }

--- a/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
+++ b/Source/DafnyLanguageServer/Language/DafnyLangParser.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         : new ProgramParser(innerParserLogger, fileSystem);
     }
 
-    public async Task<Program> Parse(Compilation compilation, CancellationToken cancellationToken) {
+    public async Task<ProgramParseResult> Parse(Compilation compilation, CancellationToken cancellationToken) {
       await mutex.WaitAsync(cancellationToken);
 
       var rootFiles = await compilation.RootFiles;

--- a/Source/DafnyLanguageServer/Workspace/LanguageServerFilesystem.cs
+++ b/Source/DafnyLanguageServer/Workspace/LanguageServerFilesystem.cs
@@ -38,7 +38,7 @@ public class LanguageServerFilesystem : IFileSystem {
     string existingText = "";
     try {
       if (OnDiskFileSystem.Instance.Exists(uri)) {
-        using var fileStream = OnDiskFileSystem.Instance.ReadFile(uri);
+        using var fileStream = OnDiskFileSystem.Instance.ReadFile(uri).Reader;
         existingText = fileStream.ReadToEnd();
       }
     } catch (IOException) {
@@ -64,7 +64,6 @@ public class LanguageServerFilesystem : IFileSystem {
     } catch (ArgumentOutOfRangeException) {
       return false;
     }
-    entry.Buffer = mergedBuffer;
 
     // According to the LSP specification, document versions should increase monotonically but may be non-consecutive.
     // See: https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md?plain=1#L1195
@@ -76,7 +75,9 @@ public class LanguageServerFilesystem : IFileSystem {
         $"the updates of document {documentUri} are out-of-order: {oldVer} -> {newVersion}");
     }
 
-    entry.Version = newVersion!.Value;
+    // We assume no concurrent mutating calls to IFileSysten, in particular to OpenDocument and UpdateDocument
+    // Otherwise we'd have to lock around these calls.
+    openFiles[uri] = new Entry(mergedBuffer, newVersion!.Value);
     return true;
   }
 
@@ -97,9 +98,9 @@ public class LanguageServerFilesystem : IFileSystem {
     return null;
   }
 
-  public TextReader ReadFile(Uri uri) {
+  public FileSnapshot ReadFile(Uri uri) {
     if (openFiles.TryGetValue(uri, out var entry)) {
-      return new StringReader(entry.Buffer.Text);
+      return new FileSnapshot(new StringReader(entry.Buffer.Text), entry.Version);
     }
 
     return OnDiskFileSystem.Instance.ReadFile(uri);
@@ -114,18 +115,5 @@ public class LanguageServerFilesystem : IFileSystem {
     var inMemory = new InMemoryDirectoryInfoFromDotNet8(root, inMemoryFiles);
 
     return new CombinedDirectoryInfo(new[] { inMemory, OnDiskFileSystem.Instance.GetDirectoryInfoBase(root) });
-  }
-
-  /// <summary>
-  /// Return the version of a particular file.
-  /// When the client sends file updates, it includes a new version for this file, which we store and return here.
-  /// File version are important to the client because it can use them to do client side migration of positions.
-  /// </summary>
-  public int? GetVersion(Uri uri) {
-    if (openFiles.TryGetValue(uri, out var file)) {
-      return file.Version;
-    }
-
-    return null;
   }
 }

--- a/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
+++ b/Source/DafnyLanguageServer/Workspace/ProjectManagerDatabase.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
 
     public static DafnyProject ImplicitProject(Uri uri) {
       var implicitProject = new DafnyProject(
+        null,
         uri, null,
         new[] { uri.LocalPath }.ToHashSet(),
         new HashSet<string>(),

--- a/Source/DafnyPipeline.Test/FormatterBaseTest.cs
+++ b/Source/DafnyPipeline.Test/FormatterBaseTest.cs
@@ -62,7 +62,8 @@ namespace DafnyPipeline.Test {
         var reporter = new BatchErrorReporter(options);
         Microsoft.Dafny.Type.ResetScopes();
 
-        var dafnyProgram = await new ProgramParser().Parse(programNotIndented, uri, reporter);
+        var parseResult = await new ProgramParser().Parse(programNotIndented, uri, reporter);
+        var dafnyProgram = parseResult.Program;
 
         if (reporter.HasErrors) {
           var error = reporter.AllMessagesByLevel[ErrorLevel.Error][0];
@@ -125,7 +126,7 @@ namespace DafnyPipeline.Test {
         // Verify that the formatting is stable.
         Microsoft.Dafny.Type.ResetScopes();
         var newReporter = new BatchErrorReporter(options);
-        dafnyProgram = await new ProgramParser().Parse(reprinted, uri, newReporter);
+        dafnyProgram = (await new ProgramParser().Parse(reprinted, uri, newReporter)).Program;
 
         Assert.Equal(initErrorCount, reporter.ErrorCount + newReporter.ErrorCount);
         firstToken = dafnyProgram.GetFirstTokenForUri(uri);

--- a/Source/DafnyPipeline.Test/ImplicitAssertionTest.cs
+++ b/Source/DafnyPipeline.Test/ImplicitAssertionTest.cs
@@ -148,7 +148,8 @@ method Test(m: map<int, int>, x: int) {
     options = options ?? new DafnyOptions(TextReader.Null, TextWriter.Null, TextWriter.Null);
     var uri = new Uri("virtual:///virtual");
     BatchErrorReporter reporter = new BatchErrorReporter(options);
-    var dafnyProgram = await new ProgramParser().Parse(program, uri, reporter);
+    var parseResult = await new ProgramParser().Parse(program, uri, reporter);
+    var dafnyProgram = parseResult.Program;
     if (reporter.HasErrors) {
       var error = reporter.AllMessagesByLevel[ErrorLevel.Error][0];
       Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");

--- a/Source/DafnyServer/DafnyHelper.cs
+++ b/Source/DafnyServer/DafnyHelper.cs
@@ -46,12 +46,12 @@ namespace Microsoft.Dafny {
       reporter = new ConsoleErrorReporter(options);
       var fs = new InMemoryFileSystem(ImmutableDictionary<Uri, string>.Empty.Add(uri, source));
       var file = DafnyFile.HandleDafnyFile(fs, reporter, reporter.Options, uri, Token.NoToken, false);
-      var program = await new ProgramParser().ParseFiles(fname, new[] { file },
+      var parseResult = await new ProgramParser().ParseFiles(fname, new[] { file },
         reporter, CancellationToken.None);
 
       var success = !reporter.HasErrors;
       if (success) {
-        dafnyProgram = program;
+        dafnyProgram = parseResult.Program;
       }
       return success;
     }

--- a/Source/DafnyTestGeneration/Utils.cs
+++ b/Source/DafnyTestGeneration/Utils.cs
@@ -89,14 +89,14 @@ namespace DafnyTestGeneration {
 
       var fs = new InMemoryFileSystem(ImmutableDictionary<Uri, string>.Empty.Add(uri, source));
       var dafnyFile = DafnyFile.HandleDafnyFile(fs, reporter, reporter.Options, uri, Token.NoToken, false);
-      var program = await new ProgramParser().ParseFiles(uri.LocalPath,
+      var parseResult = await new ProgramParser().ParseFiles(uri.LocalPath,
         new[] { dafnyFile }, reporter, cancellationToken);
 
       if (!resolve) {
-        return program;
+        return parseResult.Program;
       }
-      await new ProgramResolver(program).Resolve(cancellationToken);
-      return program;
+      await new ProgramResolver(parseResult.Program).Resolve(cancellationToken);
+      return parseResult.Program;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dafny-lang/dafny/issues/5901 and possibly other failing tests

### Description
- For any files open in the editor, record the editor's version number when that file is read, and store this version number throughout compilation so it can be used when emitting notifications for this compilation.

### How has this been tested?
- The change in behavior only occurs for a particular race condition, which is difficult to trigger, so I have not added tests.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
