### PR TITLE
Prevent downgrade of System.Runtime.Handles

### DIFF
--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -30,7 +30,7 @@
       <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
       <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
-      <PackageReference Include="Serilog" Version="2.12.0" />
+      <PackageReference Include="Serilog" Version="4.1.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />

--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RangeTree" Version="3.0.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
 


### PR DESCRIPTION
Fixes nightly failure on Windows: https://github.com/dafny-lang/dafny/actions/runs/12032974129/job/33593067661

### Description
- Prevent downgrade of System.Runtime.Handles by updating Serilog.Settings.Configuration which uses it

### How has this been tested?
- Could not reproduce nightly build failure locally, but I hope this will fix it

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
