### PR TITLE
Use a specific version of System.Runtime.Handles

### DIFF
--- a/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
 
     <!-- The following packages are referenced explicitely since Serilog references older versions than required (nuget prevents the downgrade). -->
     <PackageReference Include="System.Collections" Version="4.3.0" />


### PR DESCRIPTION
### Description
Use a specific version of System.Runtime.Handles

### How has this been tested?
Will turn on `run-deep-tests` to see if this fixes CI on Windows.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
