### PR TITLE
docs: explicitly show implication operator `==>` when introducing it

### DIFF
--- a/docs/OnlineTutorial/guide.md
+++ b/docs/OnlineTutorial/guide.md
@@ -516,7 +516,7 @@ method Abs(x: int) returns (y: int)
 
 This expresses exactly the property we discussed before,
 that the absolute value is the same for non-negative integers. The second
-ensures is expressed via the implication operator, which basically says that
+ensures is expressed via the implication operator `==>`, which basically says that
 the left hand side implies the right in the mathematical sense (it binds more
 weakly than boolean "and" and comparisons, so the above says `0 <= x` implies `y == x`).
 The left and right sides must both be boolean expressions.


### PR DESCRIPTION
Explicitly show implication operator `==>` when introducing it in "[Getting Started with Dafny: A Guide](https://dafny.org/latest/OnlineTutorial/guide)"

### Description
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->
- Docs-only change. (Thus user-visible, but only in the documentation.)
<!-- Is this a bug fix for an issue visible in the latest release?  Mention this in the PR details and ensure a patch release is considered -->
- I assume https://dafny.org/latest/OnlineTutorial/guide is rendered from the `master` branch. If it's instead rendered from the latest release and/or additionally rendered for releases, backporting this to those releases and releasing the result in patch releases (probably together with other changes) should probably be considered, but isn't urgent.

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->
I didn't test this change, beyond viewing it in VSCodium's Markdown rendering preview (which might assume a different Markdown dialect). However I'm confident that this change should work in all Markdown dialects.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
