### PR TITLE
Feat no maybeplacebo

### DIFF
--- a/Source/DafnyCore.Test/GeneratedDafnyTest.cs
+++ b/Source/DafnyCore.Test/GeneratedDafnyTest.cs
@@ -21,6 +21,6 @@ public class GeneratedDafnyTest {
 
   [Fact]
   public void TestDefsCoverage() {
-    DefsCoverage.__default.Test(); ;
+    DefsCoverage.__default.Tests();
   }
 }

--- a/Source/DafnyCore.Test/GeneratedDafnyTest.cs
+++ b/Source/DafnyCore.Test/GeneratedDafnyTest.cs
@@ -18,4 +18,9 @@ public class GeneratedDafnyTest {
   public void TestPathSimplification() {
     FactorPathsOptimizationTest.__default.TestApply();
   }
+
+  [Fact]
+  public void TestDefsCoverage() {
+    DefsCoverage.__default.Test(); ;
+  }
 }

--- a/Source/DafnyCore.Test/GeneratedFromDafny/DefsCoverage.cs
+++ b/Source/DafnyCore.Test/GeneratedFromDafny/DefsCoverage.cs
@@ -1,0 +1,81 @@
+// Dafny program the_program compiled into C#
+// To recompile, you will need the libraries
+//     System.Runtime.Numerics.dll System.Collections.Immutable.dll
+// but the 'dotnet' tool in net6.0 should pick those up automatically.
+// Optionally, you may want to include compiler switches like
+//     /debug /nowarn:162,164,168,183,219,436,1717,1718
+
+using System;
+using System.Numerics;
+using System.Collections;
+#pragma warning disable CS0164 // This label has not been referenced
+#pragma warning disable CS0162 // Unreachable code detected
+#pragma warning disable CS1717 // Assignment made to same variable
+
+namespace DefsCoverage {
+
+  public partial class __default {
+    public static void Expect(bool x)
+    {
+      if (!(x)) {
+        throw new Dafny.HaltException("Backends/Rust/Dafny-compiler-rust-definitions.dfy(789,4): " + Dafny.Sequence<Dafny.Rune>.UnicodeFromString("expectation violation").ToVerbatimString(false));}
+    }
+    public static void Tests()
+    {
+      DefsCoverage.__default.Expect(object.Equals((Defs.AssignmentStatus.create_SurelyAssigned()).Join(Defs.AssignmentStatus.create_SurelyAssigned()), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals((Defs.AssignmentStatus.create_NotAssigned()).Join(Defs.AssignmentStatus.create_NotAssigned()), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals((Defs.AssignmentStatus.create_NotAssigned()).Join(Defs.AssignmentStatus.create_SurelyAssigned()), Defs.AssignmentStatus.create_Unknown()));
+      DefsCoverage.__default.Expect(object.Equals((Defs.AssignmentStatus.create_SurelyAssigned()).Join(Defs.AssignmentStatus.create_NotAssigned()), Defs.AssignmentStatus.create_Unknown()));
+      DefsCoverage.__default.Expect((object.Equals((Defs.AssignmentStatus.create_Unknown()).Join(Defs.AssignmentStatus.create_NotAssigned()), (Defs.AssignmentStatus.create_NotAssigned()).Join(Defs.AssignmentStatus.create_Unknown()))) && (object.Equals((Defs.AssignmentStatus.create_NotAssigned()).Join(Defs.AssignmentStatus.create_Unknown()), Defs.AssignmentStatus.create_Unknown())));
+      DefsCoverage.__default.Expect((object.Equals((Defs.AssignmentStatus.create_Unknown()).Join(Defs.AssignmentStatus.create_SurelyAssigned()), (Defs.AssignmentStatus.create_SurelyAssigned()).Join(Defs.AssignmentStatus.create_Unknown()))) && (object.Equals((Defs.AssignmentStatus.create_SurelyAssigned()).Join(Defs.AssignmentStatus.create_Unknown()), Defs.AssignmentStatus.create_Unknown())));
+      DefsCoverage.__default.Expect(object.Equals((Defs.AssignmentStatus.create_Unknown()).Join(Defs.AssignmentStatus.create_Unknown()), Defs.AssignmentStatus.create_Unknown()));
+      DefsCoverage.__default.Expect((((object.Equals((Defs.AssignmentStatus.create_SurelyAssigned()).Then(Defs.AssignmentStatus.create_Unknown()), (Defs.AssignmentStatus.create_SurelyAssigned()).Then(Defs.AssignmentStatus.create_NotAssigned()))) && (object.Equals((Defs.AssignmentStatus.create_SurelyAssigned()).Then(Defs.AssignmentStatus.create_NotAssigned()), (Defs.AssignmentStatus.create_SurelyAssigned()).Then(Defs.AssignmentStatus.create_SurelyAssigned())))) && (object.Equals((Defs.AssignmentStatus.create_SurelyAssigned()).Then(Defs.AssignmentStatus.create_SurelyAssigned()), (Defs.AssignmentStatus.create_NotAssigned()).Then(Defs.AssignmentStatus.create_SurelyAssigned())))) && (object.Equals((Defs.AssignmentStatus.create_NotAssigned()).Then(Defs.AssignmentStatus.create_SurelyAssigned()), Defs.AssignmentStatus.create_SurelyAssigned())));
+      DefsCoverage.__default.Expect((((object.Equals((Defs.AssignmentStatus.create_Unknown()).Then(Defs.AssignmentStatus.create_NotAssigned()), (Defs.AssignmentStatus.create_Unknown()).Then(Defs.AssignmentStatus.create_SurelyAssigned()))) && (object.Equals((Defs.AssignmentStatus.create_Unknown()).Then(Defs.AssignmentStatus.create_SurelyAssigned()), (Defs.AssignmentStatus.create_Unknown()).Then(Defs.AssignmentStatus.create_Unknown())))) && (object.Equals((Defs.AssignmentStatus.create_Unknown()).Then(Defs.AssignmentStatus.create_Unknown()), (Defs.AssignmentStatus.create_NotAssigned()).Then(Defs.AssignmentStatus.create_Unknown())))) && (object.Equals((Defs.AssignmentStatus.create_NotAssigned()).Then(Defs.AssignmentStatus.create_Unknown()), Defs.AssignmentStatus.create_Unknown())));
+      DefsCoverage.__default.Expect(object.Equals((Defs.AssignmentStatus.create_NotAssigned()).Then(Defs.AssignmentStatus.create_NotAssigned()), Defs.AssignmentStatus.create_NotAssigned()));
+      Dafny.ISequence<Dafny.Rune> _0_x;
+      _0_x = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("x");
+      Dafny.ISequence<Dafny.Rune> _1_y;
+      _1_y = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("y");
+      DAST._IExpression _2_z;
+      _2_z = DAST.Expression.create_Ident(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("z"));
+      Dafny.ISequence<DAST._IStatement> _3_assigns__x;
+      _3_assigns__x = Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Assign(DAST.AssignLhs.create_Ident(_0_x), DAST.Expression.create_Ident(_1_y)));
+      Dafny.ISequence<DAST._IStatement> _4_assigns__y;
+      _4_assigns__y = Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Assign(DAST.AssignLhs.create_Ident(_1_y), DAST.Expression.create_Ident(_0_x)));
+      DAST._IExpression _5_cond;
+      _5_cond = DAST.Expression.create_Ident(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("cond"));
+      Dafny.ISequence<DAST._IStatement> _6_unknown__x;
+      _6_unknown__x = Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_If(_5_cond, _3_assigns__x, _4_assigns__y));
+      Dafny.ISequence<DAST._IStatement> _7_surely__double__x;
+      _7_surely__double__x = Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_If(_5_cond, _3_assigns__x, _3_assigns__x));
+      Dafny.ISequence<DAST._IStatement> _8_call__to__x;
+      _8_call__to__x = Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Call(_2_z, DAST.CallName.create_SetBuilderAdd(), Dafny.Sequence<DAST._IType>.FromElements(), Dafny.Sequence<DAST._IExpression>.FromElements(), Std.Wrappers.Option<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>>.create_Some(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(_0_x))));
+      Dafny.ISequence<DAST._IStatement> _9_declare__x__again;
+      _9_declare__x__again = Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_DeclareVar(_0_x, DAST.Type.create_Tuple(Dafny.Sequence<DAST._IType>.FromElements()), Std.Wrappers.Option<DAST._IExpression>.create_None()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_4_assigns__y, _0_x), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_3_assigns__x, _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_3_assigns__x, _1_y), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(_3_assigns__x, _4_assigns__y), _1_y), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_6_unknown__x, _0_x), Defs.AssignmentStatus.create_Unknown()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_7_surely__double__x, _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_7_surely__double__x, _1_y), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_8_call__to__x, _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(_8_call__to__x, _1_y), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(_8_call__to__x, _4_assigns__y), _1_y), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Labeled(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("l"), _4_assigns__y)), _3_assigns__x), _1_y), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Labeled(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("l"), _3_assigns__x)), _4_assigns__y), _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Labeled(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("l"), _3_assigns__x)), _4_assigns__y), _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(_9_declare__x__again, _3_assigns__x), _0_x), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(_9_declare__x__again, _4_assigns__y), _1_y), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Return(_2_z)), _3_assigns__x), _0_x), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_EarlyReturn()), _3_assigns__x), _0_x), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_JumpTailCallStart()), _3_assigns__x), _0_x), Defs.AssignmentStatus.create_NotAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Print(_2_z)), _3_assigns__x), _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_Print(_2_z)), _3_assigns__x), _0_x), Defs.AssignmentStatus.create_SurelyAssigned()));
+      DefsCoverage.__default.Expect(object.Equals(Defs.__default.DetectAssignmentStatus(Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_While(_2_z, Dafny.Sequence<DAST._IStatement>.FromElements())), _3_assigns__x), _0_x), Defs.AssignmentStatus.create_Unknown()));
+    }
+    public static Dafny.ISequence<Dafny.Rune> IND { get {
+      return RAST.__default.IND;
+    } }
+  }
+} // end of namespace DefsCoverage

--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust-definitions.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust-definitions.dfy
@@ -179,6 +179,9 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
     predicate NeedsAsRefForBorrow(name: string) {
       name in types && types[name].NeedsAsRefForBorrow()
     }
+    predicate IsMaybePlacebo(name: string) {
+      name in types && types[name].ExtractMaybePlacebo().Some?
+    }
     function AddAssigned(name: string, tpe: R.Type): Environment
       // If we know for sure the type of name extends the Copy trait
     {
@@ -203,11 +206,14 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
         assignmentStatusKnown - {name}
       )
     }
-    function AddAssignmentStatusKnown(name: string): Environment {
+    function AddAssignmentStatus(name: string, assignmentStatus: AssignmentStatus): Environment {
       Environment(
         names,
         types,
-        assignmentStatusKnown + {name}
+        if assignmentStatus.Unknown? then
+          assignmentStatusKnown - {name}
+        else
+          assignmentStatusKnown + {name}
       )
     }
     predicate IsAssignmentStatusKnown(name: string) {
@@ -761,5 +767,80 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
       case Print(_) => DetectAssignmentStatus(stmts_remainder[1..], dafny_name)
       case _ => Unknown
     }
+  }
+}
+
+// Tests
+module {:extern "DefsCoverage"} DafnyToRustCompilerDefinitionsCoverage {
+  import opened DafnyToRustCompilerDefinitions
+  import opened DAST
+  import Strings = Std.Strings
+  import Std
+  import opened Std.Wrappers
+  import R = RAST
+  import opened DafnyCompilerRustUtils
+
+  const IND := R.IND
+  type Type = DAST.Type
+  type Formal = DAST.Formal
+
+  method Expect(x: bool)
+  {
+    expect x; // Avoids having too little coverage
+  }
+
+  method Tests() {
+    Expect(SurelyAssigned.Join(SurelyAssigned) == SurelyAssigned);
+    Expect(NotAssigned.Join(NotAssigned) == NotAssigned);
+    Expect(NotAssigned.Join(SurelyAssigned) == Unknown);
+    Expect(SurelyAssigned.Join(NotAssigned) == Unknown);
+    Expect(Unknown.Join(NotAssigned) == NotAssigned.Join(Unknown) == Unknown);
+    Expect(Unknown.Join(SurelyAssigned) == SurelyAssigned.Join(Unknown) == Unknown);
+    Expect(Unknown.Join(Unknown) == Unknown);
+    
+    Expect(SurelyAssigned.Then(Unknown)
+                   == SurelyAssigned.Then(NotAssigned)
+                   == SurelyAssigned.Then(SurelyAssigned)
+                   == NotAssigned.Then(SurelyAssigned)
+                   == SurelyAssigned);
+    Expect(Unknown.Then(NotAssigned)
+                   == Unknown.Then(SurelyAssigned)
+                   == Unknown.Then(Unknown)
+                   == NotAssigned.Then(Unknown)
+                   == Unknown);
+    Expect(NotAssigned.Then(NotAssigned)
+                   == NotAssigned);
+    
+    var x := VarName("x");
+    var y := VarName("y");
+    var z := Expression.Ident(VarName("z"));
+    var assigns_x := [Assign(AssignLhs.Ident(x), Expression.Ident(y))];
+    var assigns_y := [Assign(AssignLhs.Ident(y), Expression.Ident(x))];
+    var cond := Expression.Ident(VarName("cond"));
+    var unknown_x := [If(cond, assigns_x, assigns_y)];
+    var surely_double_x := [If(cond, assigns_x, assigns_x)];
+    var call_to_x := [Statement.Call(z, SetBuilderAdd, [], [], Some([x]))];
+    var declare_x_again := [DeclareVar(x, Type.Tuple([]), None)];
+    Expect(DetectAssignmentStatus(assigns_y, x) == NotAssigned);
+    Expect(DetectAssignmentStatus(assigns_x, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus(assigns_x, y) == NotAssigned);
+    Expect(DetectAssignmentStatus(assigns_x + assigns_y, y) == SurelyAssigned);
+    Expect(DetectAssignmentStatus(unknown_x, x) == Unknown);
+    Expect(DetectAssignmentStatus(surely_double_x, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus(surely_double_x, y) == NotAssigned);
+    Expect(DetectAssignmentStatus(call_to_x, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus(call_to_x, y) == NotAssigned);
+    Expect(DetectAssignmentStatus(call_to_x + assigns_y, y) == SurelyAssigned);
+    Expect(DetectAssignmentStatus([Labeled("l", assigns_y)] + assigns_x, y) == SurelyAssigned);
+    Expect(DetectAssignmentStatus([Labeled("l", assigns_x)] + assigns_y, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus([Labeled("l", assigns_x)] + assigns_y, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus(declare_x_again + assigns_x, x) == NotAssigned);
+    Expect(DetectAssignmentStatus(declare_x_again + assigns_y, y) == SurelyAssigned);
+    Expect(DetectAssignmentStatus([Return(z)] + assigns_x, x) == NotAssigned);
+    Expect(DetectAssignmentStatus([EarlyReturn()] + assigns_x, x) == NotAssigned);
+    Expect(DetectAssignmentStatus([JumpTailCallStart()] + assigns_x, x) == NotAssigned);
+    Expect(DetectAssignmentStatus([Print(z)] + assigns_x, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus([Print(z)] + assigns_x, x) == SurelyAssigned);
+    Expect(DetectAssignmentStatus([While(z, [])] + assigns_x, x) == Unknown);
   }
 }

--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust-definitions.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust-definitions.dfy
@@ -148,14 +148,15 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
   // fn Test(i: &mut T) is map["i" := R.BorrowedMut(...)]
   datatype Environment = Environment(
     names: seq<string>,                 // All variable names, after escape, in Rust
-    types: map<string, R.Type>
+    types: map<string, R.Type>,
+    assignmentStatusKnown: set<string> // Variables that are guaranteed to be assigned exactly once
   ) {
     function ToOwned(): Environment {
       this.(types :=
       map k <- types :: k := types[k].ToOwned())
     }
     static function Empty(): Environment {
-      Environment([], map[])
+      Environment([], map[], {})
     }
     opaque predicate CanReadWithoutClone(name: string) {
       name in types && types[name].CanReadWithoutClone()
@@ -181,23 +182,36 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
     function AddAssigned(name: string, tpe: R.Type): Environment
       // If we know for sure the type of name extends the Copy trait
     {
-      Environment(names + [name], types[name := tpe])
+      Environment(names + [name], types[name := tpe], assignmentStatusKnown - {name})
     }
     function merge(other: Environment): Environment
     {
       Environment(
         names + other.names,
-        types + other.types
+        types + other.types,
+        assignmentStatusKnown + other.assignmentStatusKnown
       )
     }
+    // Used to removed from the environment the "_is_assigned" vars used to initialize fields
     function RemoveAssigned(name: string): Environment
       requires name in names
     {
       var indexInEnv := Std.Collections.Seq.IndexOf(names, name);
       Environment(
         names[0..indexInEnv] + names[indexInEnv + 1..],
-        types - {name}
+        types - {name},
+        assignmentStatusKnown - {name}
       )
+    }
+    function AddAssignmentStatusKnown(name: string): Environment {
+      Environment(
+        names,
+        types,
+        assignmentStatusKnown + {name}
+      )
+    }
+    predicate IsAssignmentStatusKnown(name: string) {
+      name in assignmentStatusKnown
     }
   }
 
@@ -701,5 +715,51 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
                                                                                         ]))
             ))
         ]))
+  }
+
+  // Overapproximate but sound static analysis domain for assignment of a variable
+  datatype AssignmentStatus = NotAssigned | SurelyAssigned | Unknown {
+    // After a if, typically. What we know if either of the assignment status is taken
+    function Join(other: AssignmentStatus): AssignmentStatus {
+      if SurelyAssigned? && other.SurelyAssigned? then SurelyAssigned
+      else if NotAssigned? && other.NotAssigned? then NotAssigned
+      else Unknown
+    }
+    function Then(other: AssignmentStatus): AssignmentStatus {
+      if SurelyAssigned? then SurelyAssigned
+      else if NotAssigned? then other
+      else Unknown // It's not as simple. If there are are two paths leading to one being assigned, the other not,
+      // Rust won't be albe to figure out the rules
+    }
+  }
+
+  // What could be problematic is the presence of branches in the assignment
+  // and one branch where a value is not assigned at all.
+  // If return false, we don't know if it's assigned or not
+  function DetectAssignmentStatus(stmts_remainder: seq<Statement>, dafny_name: VarName): AssignmentStatus {
+    if |stmts_remainder| == 0 then NotAssigned else
+    var stmt := stmts_remainder[0];
+    match stmt {
+      case Assign(Ident(assign_name), _) =>
+        if assign_name == dafny_name then SurelyAssigned else
+        DetectAssignmentStatus(stmts_remainder[1..], dafny_name)
+      case If(cond, thn, els) =>
+        DetectAssignmentStatus(thn, dafny_name).Join(DetectAssignmentStatus(els, dafny_name))
+      case Call(on, callName, typeArgs, args, outs) =>
+        if outs.Some? && dafny_name in outs.value then
+          SurelyAssigned
+        else
+          DetectAssignmentStatus(stmts_remainder[1..], dafny_name)
+      case Labeled(_, stmts) =>
+        DetectAssignmentStatus(stmts, dafny_name).Then(DetectAssignmentStatus(stmts_remainder[1..], dafny_name))
+      case DeclareVar(name, _, _) =>
+        if name == dafny_name then
+          NotAssigned // Shadowed
+        else
+          DetectAssignmentStatus(stmts_remainder[1..], dafny_name)
+      case Return(_) | EarlyReturn() | JumpTailCallStart() => NotAssigned
+      case Print(_) => DetectAssignmentStatus(stmts_remainder[1..], dafny_name)
+      case _ => Unknown
+    }
   }
 }

--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust-definitions.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust-definitions.dfy
@@ -735,7 +735,7 @@ module {:extern "Defs"} DafnyToRustCompilerDefinitions {
       if SurelyAssigned? then SurelyAssigned
       else if NotAssigned? then other
       else Unknown // It's not as simple. If there are are two paths leading to one being assigned, the other not,
-      // Rust won't be albe to figure out the rules
+           // Rust won't be albe to figure out the rules
     }
   }
 
@@ -797,20 +797,20 @@ module {:extern "DefsCoverage"} DafnyToRustCompilerDefinitionsCoverage {
     Expect(Unknown.Join(NotAssigned) == NotAssigned.Join(Unknown) == Unknown);
     Expect(Unknown.Join(SurelyAssigned) == SurelyAssigned.Join(Unknown) == Unknown);
     Expect(Unknown.Join(Unknown) == Unknown);
-    
+
     Expect(SurelyAssigned.Then(Unknown)
-                   == SurelyAssigned.Then(NotAssigned)
-                   == SurelyAssigned.Then(SurelyAssigned)
-                   == NotAssigned.Then(SurelyAssigned)
-                   == SurelyAssigned);
+        == SurelyAssigned.Then(NotAssigned)
+        == SurelyAssigned.Then(SurelyAssigned)
+        == NotAssigned.Then(SurelyAssigned)
+        == SurelyAssigned);
     Expect(Unknown.Then(NotAssigned)
-                   == Unknown.Then(SurelyAssigned)
-                   == Unknown.Then(Unknown)
-                   == NotAssigned.Then(Unknown)
-                   == Unknown);
+        == Unknown.Then(SurelyAssigned)
+        == Unknown.Then(Unknown)
+        == NotAssigned.Then(Unknown)
+        == Unknown);
     Expect(NotAssigned.Then(NotAssigned)
-                   == NotAssigned);
-    
+           == NotAssigned);
+
     var x := VarName("x");
     var y := VarName("y");
     var z := Expression.Ident(VarName("z"));

--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
@@ -2142,7 +2142,7 @@ module {:extern "DCOMP"} DafnyToRustCompiler {
         case Call(on, name, typeArgs, args, maybeOutVars) => {
           assume {:axiom} Expression.Call(on, name, typeArgs, args) < stmt;
           generated, readIdents := GenOwnedCallPart(Expression.Call(on, name, typeArgs, args), on, selfIdent, name, typeArgs, args, env);
-          
+
           newEnv := env;
           if maybeOutVars.Some? && |maybeOutVars.value| == 1 {
             var outVar := escapeVar(maybeOutVars.value[0]);

--- a/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
+++ b/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
@@ -1969,7 +1969,7 @@ namespace DCOMP {
         {
         }
       after_match1: ;
-        _32_env = Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(_34_preAssignNames, _1_paramNames), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Merge(_35_preAssignTypes, _2_paramTypes));
+        _32_env = Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(_34_preAssignNames, _1_paramNames), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Merge(_35_preAssignTypes, _2_paramTypes), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements());
         RAST._IExpr _50_body;
         Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _51___v20;
         Defs._IEnvironment _52___v21;
@@ -1982,7 +1982,7 @@ namespace DCOMP {
         _52___v21 = _out8;
         _31_fBody = Std.Wrappers.Option<RAST._IExpr>.create_Some((_33_preBody).Then(_50_body));
       } else {
-        _32_env = Defs.Environment.create(_1_paramNames, _2_paramTypes);
+        _32_env = Defs.Environment.create(_1_paramNames, _2_paramTypes, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements());
         _31_fBody = Std.Wrappers.Option<RAST._IExpr>.create_None();
       }
       s = RAST.ImplMember.create_FnDecl(_21_visibility, RAST.Fn.create(_7_fnName, _25_typeParams, _0_params, Std.Wrappers.Option<RAST._IType>.create_Some((((new BigInteger((_18_retTypeArgs).Count)) == (BigInteger.One)) ? ((_18_retTypeArgs).Select(BigInteger.Zero)) : (RAST.Type.create_TupleType(_18_retTypeArgs)))), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""), _31_fBody));
@@ -2012,61 +2012,67 @@ namespace DCOMP {
             DAST._IType _5_optType = _source0.dtor_typ;
             Std.Wrappers._IOption<DAST._IExpression> maybeValue0 = _source0.dtor_maybeValue;
             if (maybeValue0.is_None) {
-              if (((_1_i) + (BigInteger.One)) < (new BigInteger((_2_stmts).Count))) {
-                DAST._IStatement _source1 = (_2_stmts).Select((_1_i) + (BigInteger.One));
-                {
-                  if (_source1.is_Assign) {
-                    DAST._IAssignLhs lhs0 = _source1.dtor_lhs;
-                    if (lhs0.is_Ident) {
-                      Dafny.ISequence<Dafny.Rune> _6_name2 = lhs0.dtor_ident;
-                      DAST._IExpression _7_rhs = _source1.dtor_value;
-                      if (object.Equals(_6_name2, _4_name)) {
-                        _2_stmts = Dafny.Sequence<DAST._IStatement>.Concat(Dafny.Sequence<DAST._IStatement>.Concat((_2_stmts).Subsequence(BigInteger.Zero, _1_i), Dafny.Sequence<DAST._IStatement>.FromElements(DAST.Statement.create_DeclareVar(_4_name, _5_optType, Std.Wrappers.Option<DAST._IExpression>.create_Some(_7_rhs)))), (_2_stmts).Drop((_1_i) + (new BigInteger(2))));
-                        _3_stmt = (_2_stmts).Select(_1_i);
-                      }
-                      goto after_match1;
-                    }
-                  }
-                }
-                {
-                }
-              after_match1: ;
-              }
+              Defs._IAssignmentStatus _6_laterAssignmentStatus;
+              _6_laterAssignmentStatus = Defs.__default.DetectAssignmentStatus((_2_stmts).Drop((_1_i) + (BigInteger.One)), _4_name);
+              newEnv = (newEnv).AddAssignmentStatus(Defs.__default.escapeVar(_4_name), _6_laterAssignmentStatus);
               goto after_match0;
+            }
+          }
+        }
+        {
+          if (_source0.is_DeclareVar) {
+            Dafny.ISequence<Dafny.Rune> _7_name = _source0.dtor_name;
+            DAST._IType _8_optType = _source0.dtor_typ;
+            Std.Wrappers._IOption<DAST._IExpression> maybeValue1 = _source0.dtor_maybeValue;
+            if (maybeValue1.is_Some) {
+              DAST._IExpression value0 = maybeValue1.dtor_value;
+              if (value0.is_InitializationValue) {
+                DAST._IType _9_typ = value0.dtor_typ;
+                RAST._IType _10_tpe;
+                RAST._IType _out0;
+                _out0 = (this).GenType(_9_typ, Defs.GenTypeContext.@default());
+                _10_tpe = _out0;
+                Dafny.ISequence<Dafny.Rune> _11_varName;
+                _11_varName = Defs.__default.escapeVar(_7_name);
+                Defs._IAssignmentStatus _12_laterAssignmentStatus;
+                _12_laterAssignmentStatus = Defs.__default.DetectAssignmentStatus((_2_stmts).Drop((_1_i) + (BigInteger.One)), _7_name);
+                newEnv = (newEnv).AddAssignmentStatus(_11_varName, _12_laterAssignmentStatus);
+                goto after_match0;
+              }
             }
           }
         }
         {
         }
       after_match0: ;
-        RAST._IExpr _8_stmtExpr;
-        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _9_recIdents;
-        Defs._IEnvironment _10_newEnv2;
-        RAST._IExpr _out0;
-        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out1;
-        Defs._IEnvironment _out2;
-        (this).GenStmt(_3_stmt, selfIdent, newEnv, (isLast) && ((_1_i) == ((new BigInteger((_2_stmts).Count)) - (BigInteger.One))), earlyReturn, out _out0, out _out1, out _out2);
-        _8_stmtExpr = _out0;
-        _9_recIdents = _out1;
-        _10_newEnv2 = _out2;
-        newEnv = _10_newEnv2;
-        DAST._IStatement _source2 = _3_stmt;
+        RAST._IExpr _13_stmtExpr;
+        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _14_recIdents;
+        Defs._IEnvironment _15_newEnv2;
+        RAST._IExpr _out1;
+        Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out2;
+        Defs._IEnvironment _out3;
+        (this).GenStmt(_3_stmt, selfIdent, newEnv, (isLast) && ((_1_i) == ((new BigInteger((_2_stmts).Count)) - (BigInteger.One))), earlyReturn, out _out1, out _out2, out _out3);
+        _13_stmtExpr = _out1;
+        _14_recIdents = _out2;
+        _15_newEnv2 = _out3;
+        newEnv = _15_newEnv2;
+        DAST._IStatement _source1 = _3_stmt;
         {
-          if (_source2.is_DeclareVar) {
-            Dafny.ISequence<Dafny.Rune> _11_name = _source2.dtor_name;
+          if (_source1.is_DeclareVar) {
+            Dafny.ISequence<Dafny.Rune> _16_name = _source1.dtor_name;
             {
-              _0_declarations = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_0_declarations, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(Defs.__default.escapeVar(_11_name)));
+              _0_declarations = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_0_declarations, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(Defs.__default.escapeVar(_16_name)));
             }
-            goto after_match2;
+            goto after_match1;
           }
         }
         {
         }
-      after_match2: ;
-        readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_9_recIdents, _0_declarations));
-        generated = (generated).Then(_8_stmtExpr);
+      after_match1: ;
+        readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_14_recIdents, _0_declarations));
+        generated = (generated).Then(_13_stmtExpr);
         _1_i = (_1_i) + (BigInteger.One);
-        if ((_8_stmtExpr).is_Return) {
+        if ((_13_stmtExpr).is_Return) {
           goto after_0;
         }
       continue_0: ;
@@ -2206,14 +2212,14 @@ namespace DCOMP {
           BigInteger _hi0 = new BigInteger((_12_indices).Count);
           for (BigInteger _18_i = BigInteger.Zero; _18_i < _hi0; _18_i++) {
             RAST._IExpr _19_idx;
-            Defs._IOwnership _20___v30;
+            Defs._IOwnership _20___v29;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _21_recIdentsIdx;
             RAST._IExpr _out6;
             Defs._IOwnership _out7;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out8;
             (this).GenExpr((_12_indices).Select(_18_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out6, out _out7, out _out8);
             _19_idx = _out6;
-            _20___v30 = _out7;
+            _20___v29 = _out7;
             _21_recIdentsIdx = _out8;
             Dafny.ISequence<Dafny.Rune> _22_varName;
             _22_varName = Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("__idx"), Std.Strings.__default.OfNat(_18_i));
@@ -2315,14 +2321,14 @@ namespace DCOMP {
       }
       {
         RAST._IExpr _12_onExpr;
-        Defs._IOwnership _13___v35;
+        Defs._IOwnership _13___v34;
         Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _14_recIdents;
         RAST._IExpr _out18;
         Defs._IOwnership _out19;
         Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out20;
         (this).GenExpr(@on, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out18, out _out19, out _out20);
         _12_onExpr = _out18;
-        _13___v35 = _out19;
+        _13___v34 = _out19;
         _14_recIdents = _out20;
         readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _14_recIdents);
         Dafny.ISequence<Dafny.Rune> _15_renderedName;
@@ -2402,15 +2408,15 @@ namespace DCOMP {
               _5_isAssignedVar = Defs.__default.AddAssignedPrefix(_3_fieldName);
               if (((newEnv).dtor_names).Contains(_5_isAssignedVar)) {
                 RAST._IExpr _6_rhs;
-                Defs._IOwnership _7___v45;
-                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _8___v46;
+                Defs._IOwnership _7___v44;
+                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _8___v45;
                 RAST._IExpr _out1;
                 Defs._IOwnership _out2;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out3;
                 (this).GenExpr(DAST.Expression.create_InitializationValue(((_2_field).dtor_formal).dtor_typ), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out1, out _out2, out _out3);
                 _6_rhs = _out1;
-                _7___v45 = _out2;
-                _8___v46 = _out3;
+                _7___v44 = _out2;
+                _8___v45 = _out3;
                 readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_5_isAssignedVar));
                 Dafny.ISequence<Dafny.Rune> _9_update__if__uninit;
                 if ((_2_field).dtor_isConstant) {
@@ -2443,32 +2449,42 @@ namespace DCOMP {
               bool _15_hasCopySemantics;
               _15_hasCopySemantics = (_13_tpe).CanReadWithoutClone();
               if (((_12_expression).is_InitializationValue) && (!(_15_hasCopySemantics))) {
-                generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _14_varName, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(((((RAST.__default.MaybePlaceboPath).AsExpr()).ApplyType1(_13_tpe)).FSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("new"))).Apply0()));
-                readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
-                newEnv = (env).AddAssigned(_14_varName, RAST.__default.MaybePlaceboType(_13_tpe));
-              } else {
-                RAST._IExpr _16_expr = RAST.Expr.Default();
-                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _17_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty;
-                if (((_12_expression).is_InitializationValue) && ((_13_tpe).IsObjectOrPointer())) {
-                  _16_expr = (_13_tpe).ToNullExpr();
-                  _17_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+                if ((env).IsAssignmentStatusKnown(_14_varName)) {
+                  RAST._IType _16_tpe;
+                  RAST._IType _out5;
+                  _out5 = (this).GenType(_11_typ, Defs.GenTypeContext.@default());
+                  _16_tpe = _out5;
+                  generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _14_varName, Std.Wrappers.Option<RAST._IType>.create_Some(_16_tpe), Std.Wrappers.Option<RAST._IExpr>.create_None());
+                  readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+                  newEnv = (env).AddAssigned(_14_varName, _16_tpe);
                 } else {
-                  Defs._IOwnership _18_exprOwnership = Defs.Ownership.Default();
-                  RAST._IExpr _out5;
-                  Defs._IOwnership _out6;
-                  Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out7;
-                  (this).GenExpr(_12_expression, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out5, out _out6, out _out7);
-                  _16_expr = _out5;
-                  _18_exprOwnership = _out6;
-                  _17_recIdents = _out7;
+                  generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _14_varName, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(((((RAST.__default.MaybePlaceboPath).AsExpr()).ApplyType1(_13_tpe)).FSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("new"))).Apply0()));
+                  readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+                  newEnv = (env).AddAssigned(_14_varName, RAST.__default.MaybePlaceboType(_13_tpe));
                 }
-                readIdents = _17_recIdents;
+              } else {
+                RAST._IExpr _17_expr = RAST.Expr.Default();
+                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _18_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty;
+                if (((_12_expression).is_InitializationValue) && ((_13_tpe).IsObjectOrPointer())) {
+                  _17_expr = (_13_tpe).ToNullExpr();
+                  _18_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+                } else {
+                  Defs._IOwnership _19_exprOwnership = Defs.Ownership.Default();
+                  RAST._IExpr _out6;
+                  Defs._IOwnership _out7;
+                  Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out8;
+                  (this).GenExpr(_12_expression, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out6, out _out7, out _out8);
+                  _17_expr = _out6;
+                  _19_exprOwnership = _out7;
+                  _18_recIdents = _out8;
+                }
+                readIdents = _18_recIdents;
                 if ((_12_expression).is_NewUninitArray) {
                   _13_tpe = (_13_tpe).TypeAtInitialization();
                 } else {
                   _13_tpe = _13_tpe;
                 }
-                generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _14_varName, Std.Wrappers.Option<RAST._IType>.create_Some(_13_tpe), Std.Wrappers.Option<RAST._IExpr>.create_Some(_16_expr));
+                generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _14_varName, Std.Wrappers.Option<RAST._IType>.create_Some(_13_tpe), Std.Wrappers.Option<RAST._IExpr>.create_Some(_17_expr));
                 newEnv = (env).AddAssigned(_14_varName, _13_tpe);
               }
             }
@@ -2478,20 +2494,32 @@ namespace DCOMP {
       }
       {
         if (_source0.is_DeclareVar) {
-          Dafny.ISequence<Dafny.Rune> _19_name = _source0.dtor_name;
-          DAST._IType _20_typ = _source0.dtor_typ;
+          Dafny.ISequence<Dafny.Rune> _20_name = _source0.dtor_name;
+          DAST._IType _21_typ = _source0.dtor_typ;
           Std.Wrappers._IOption<DAST._IExpression> maybeValue1 = _source0.dtor_maybeValue;
           if (maybeValue1.is_None) {
             {
-              DAST._IStatement _21_newStmt;
-              _21_newStmt = DAST.Statement.create_DeclareVar(_19_name, _20_typ, Std.Wrappers.Option<DAST._IExpression>.create_Some(DAST.Expression.create_InitializationValue(_20_typ)));
-              RAST._IExpr _out8;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out9;
-              Defs._IEnvironment _out10;
-              (this).GenStmt(_21_newStmt, selfIdent, env, isLast, earlyReturn, out _out8, out _out9, out _out10);
-              generated = _out8;
-              readIdents = _out9;
-              newEnv = _out10;
+              Dafny.ISequence<Dafny.Rune> _22_varName;
+              _22_varName = Defs.__default.escapeVar(_20_name);
+              if ((env).IsAssignmentStatusKnown(_22_varName)) {
+                RAST._IType _23_tpe;
+                RAST._IType _out9;
+                _out9 = (this).GenType(_21_typ, Defs.GenTypeContext.@default());
+                _23_tpe = _out9;
+                generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _22_varName, Std.Wrappers.Option<RAST._IType>.create_Some(_23_tpe), Std.Wrappers.Option<RAST._IExpr>.create_None());
+                readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
+                newEnv = (env).AddAssigned(_22_varName, _23_tpe);
+              } else {
+                DAST._IStatement _24_newStmt;
+                _24_newStmt = DAST.Statement.create_DeclareVar(_20_name, _21_typ, Std.Wrappers.Option<DAST._IExpression>.create_Some(DAST.Expression.create_InitializationValue(_21_typ)));
+                RAST._IExpr _out10;
+                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out11;
+                Defs._IEnvironment _out12;
+                (this).GenStmt(_24_newStmt, selfIdent, env, isLast, earlyReturn, out _out10, out _out11, out _out12);
+                generated = _out10;
+                readIdents = _out11;
+                newEnv = _out12;
+              }
             }
             goto after_match0;
           }
@@ -2499,124 +2527,124 @@ namespace DCOMP {
       }
       {
         if (_source0.is_Assign) {
-          DAST._IAssignLhs _22_lhs = _source0.dtor_lhs;
-          DAST._IExpression _23_expression = _source0.dtor_value;
+          DAST._IAssignLhs _25_lhs = _source0.dtor_lhs;
+          DAST._IExpression _26_expression = _source0.dtor_value;
           {
-            RAST._IExpr _24_exprGen;
-            Defs._IOwnership _25___v47;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _26_exprIdents;
-            RAST._IExpr _out11;
-            Defs._IOwnership _out12;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out13;
-            (this).GenExpr(_23_expression, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out11, out _out12, out _out13);
-            _24_exprGen = _out11;
-            _25___v47 = _out12;
-            _26_exprIdents = _out13;
-            if ((_22_lhs).is_Ident) {
-              Dafny.ISequence<Dafny.Rune> _27_rustId;
-              _27_rustId = Defs.__default.escapeVar((_22_lhs).dtor_ident);
-              Std.Wrappers._IOption<RAST._IType> _28_tpe;
-              _28_tpe = (env).GetType(_27_rustId);
-              if (((_28_tpe).is_Some) && ((((_28_tpe).dtor_value).ExtractMaybePlacebo()).is_Some)) {
-                _24_exprGen = RAST.__default.MaybePlacebo(_24_exprGen);
+            RAST._IExpr _27_exprGen;
+            Defs._IOwnership _28___v46;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _29_exprIdents;
+            RAST._IExpr _out13;
+            Defs._IOwnership _out14;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out15;
+            (this).GenExpr(_26_expression, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out13, out _out14, out _out15);
+            _27_exprGen = _out13;
+            _28___v46 = _out14;
+            _29_exprIdents = _out15;
+            if ((_25_lhs).is_Ident) {
+              Dafny.ISequence<Dafny.Rune> _30_rustId;
+              _30_rustId = Defs.__default.escapeVar((_25_lhs).dtor_ident);
+              Std.Wrappers._IOption<RAST._IType> _31_tpe;
+              _31_tpe = (env).GetType(_30_rustId);
+              if (((_31_tpe).is_Some) && ((((_31_tpe).dtor_value).ExtractMaybePlacebo()).is_Some)) {
+                _27_exprGen = RAST.__default.MaybePlacebo(_27_exprGen);
               }
             }
-            if (((_22_lhs).is_Index) && (((_22_lhs).dtor_expr).is_Ident)) {
-              Dafny.ISequence<Dafny.Rune> _29_rustId;
-              _29_rustId = Defs.__default.escapeVar(((_22_lhs).dtor_expr).dtor_name);
-              Std.Wrappers._IOption<RAST._IType> _30_tpe;
-              _30_tpe = (env).GetType(_29_rustId);
-              if (((_30_tpe).is_Some) && ((((_30_tpe).dtor_value).ExtractMaybeUninitArrayElement()).is_Some)) {
-                _24_exprGen = RAST.__default.MaybeUninitNew(_24_exprGen);
+            if (((_25_lhs).is_Index) && (((_25_lhs).dtor_expr).is_Ident)) {
+              Dafny.ISequence<Dafny.Rune> _32_rustId;
+              _32_rustId = Defs.__default.escapeVar(((_25_lhs).dtor_expr).dtor_name);
+              Std.Wrappers._IOption<RAST._IType> _33_tpe;
+              _33_tpe = (env).GetType(_32_rustId);
+              if (((_33_tpe).is_Some) && ((((_33_tpe).dtor_value).ExtractMaybeUninitArrayElement()).is_Some)) {
+                _27_exprGen = RAST.__default.MaybeUninitNew(_27_exprGen);
               }
             }
-            RAST._IExpr _31_lhsGen;
-            bool _32_needsIIFE;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _33_recIdents;
-            Defs._IEnvironment _34_resEnv;
-            RAST._IExpr _out14;
-            bool _out15;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out16;
-            Defs._IEnvironment _out17;
-            (this).GenAssignLhs(_22_lhs, _24_exprGen, selfIdent, env, out _out14, out _out15, out _out16, out _out17);
-            _31_lhsGen = _out14;
-            _32_needsIIFE = _out15;
-            _33_recIdents = _out16;
-            _34_resEnv = _out17;
-            generated = _31_lhsGen;
-            newEnv = _34_resEnv;
-            if (_32_needsIIFE) {
+            RAST._IExpr _34_lhsGen;
+            bool _35_needsIIFE;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _36_recIdents;
+            Defs._IEnvironment _37_resEnv;
+            RAST._IExpr _out16;
+            bool _out17;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out18;
+            Defs._IEnvironment _out19;
+            (this).GenAssignLhs(_25_lhs, _27_exprGen, selfIdent, env, out _out16, out _out17, out _out18, out _out19);
+            _34_lhsGen = _out16;
+            _35_needsIIFE = _out17;
+            _36_recIdents = _out18;
+            _37_resEnv = _out19;
+            generated = _34_lhsGen;
+            newEnv = _37_resEnv;
+            if (_35_needsIIFE) {
               generated = RAST.Expr.create_Block(generated);
             }
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_33_recIdents, _26_exprIdents);
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(_36_recIdents, _29_exprIdents);
           }
           goto after_match0;
         }
       }
       {
         if (_source0.is_If) {
-          DAST._IExpression _35_cond = _source0.dtor_cond;
-          Dafny.ISequence<DAST._IStatement> _36_thnDafny = _source0.dtor_thn;
-          Dafny.ISequence<DAST._IStatement> _37_elsDafny = _source0.dtor_els;
+          DAST._IExpression _38_cond = _source0.dtor_cond;
+          Dafny.ISequence<DAST._IStatement> _39_thnDafny = _source0.dtor_thn;
+          Dafny.ISequence<DAST._IStatement> _40_elsDafny = _source0.dtor_els;
           {
-            RAST._IExpr _38_cond;
-            Defs._IOwnership _39___v48;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _40_recIdents;
-            RAST._IExpr _out18;
-            Defs._IOwnership _out19;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out20;
-            (this).GenExpr(_35_cond, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out18, out _out19, out _out20);
-            _38_cond = _out18;
-            _39___v48 = _out19;
-            _40_recIdents = _out20;
-            Dafny.ISequence<Dafny.Rune> _41_condString;
-            _41_condString = (_38_cond)._ToString(Defs.__default.IND);
-            readIdents = _40_recIdents;
-            RAST._IExpr _42_thn;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _43_thnIdents;
-            Defs._IEnvironment _44_thnEnv;
-            RAST._IExpr _out21;
+            RAST._IExpr _41_cond;
+            Defs._IOwnership _42___v47;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _43_recIdents;
+            RAST._IExpr _out20;
+            Defs._IOwnership _out21;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out22;
-            Defs._IEnvironment _out23;
-            (this).GenStmts(_36_thnDafny, selfIdent, env, isLast, earlyReturn, out _out21, out _out22, out _out23);
-            _42_thn = _out21;
-            _43_thnIdents = _out22;
-            _44_thnEnv = _out23;
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _43_thnIdents);
-            RAST._IExpr _45_els;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _46_elsIdents;
-            Defs._IEnvironment _47_elsEnv;
-            RAST._IExpr _out24;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out25;
-            Defs._IEnvironment _out26;
-            (this).GenStmts(_37_elsDafny, selfIdent, env, isLast, earlyReturn, out _out24, out _out25, out _out26);
-            _45_els = _out24;
-            _46_elsIdents = _out25;
-            _47_elsEnv = _out26;
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _46_elsIdents);
+            (this).GenExpr(_38_cond, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out20, out _out21, out _out22);
+            _41_cond = _out20;
+            _42___v47 = _out21;
+            _43_recIdents = _out22;
+            Dafny.ISequence<Dafny.Rune> _44_condString;
+            _44_condString = (_41_cond)._ToString(Defs.__default.IND);
+            readIdents = _43_recIdents;
+            RAST._IExpr _45_thn;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _46_thnIdents;
+            Defs._IEnvironment _47_thnEnv;
+            RAST._IExpr _out23;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out24;
+            Defs._IEnvironment _out25;
+            (this).GenStmts(_39_thnDafny, selfIdent, env, isLast, earlyReturn, out _out23, out _out24, out _out25);
+            _45_thn = _out23;
+            _46_thnIdents = _out24;
+            _47_thnEnv = _out25;
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _46_thnIdents);
+            RAST._IExpr _48_els;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _49_elsIdents;
+            Defs._IEnvironment _50_elsEnv;
+            RAST._IExpr _out26;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out27;
+            Defs._IEnvironment _out28;
+            (this).GenStmts(_40_elsDafny, selfIdent, env, isLast, earlyReturn, out _out26, out _out27, out _out28);
+            _48_els = _out26;
+            _49_elsIdents = _out27;
+            _50_elsEnv = _out28;
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _49_elsIdents);
             newEnv = env;
-            generated = RAST.Expr.create_IfExpr(_38_cond, _42_thn, _45_els);
+            generated = RAST.Expr.create_IfExpr(_41_cond, _45_thn, _48_els);
           }
           goto after_match0;
         }
       }
       {
         if (_source0.is_Labeled) {
-          Dafny.ISequence<Dafny.Rune> _48_lbl = _source0.dtor_lbl;
-          Dafny.ISequence<DAST._IStatement> _49_body = _source0.dtor_body;
+          Dafny.ISequence<Dafny.Rune> _51_lbl = _source0.dtor_lbl;
+          Dafny.ISequence<DAST._IStatement> _52_body = _source0.dtor_body;
           {
-            RAST._IExpr _50_body;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _51_bodyIdents;
-            Defs._IEnvironment _52_env2;
-            RAST._IExpr _out27;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out28;
-            Defs._IEnvironment _out29;
-            (this).GenStmts(_49_body, selfIdent, env, isLast, earlyReturn, out _out27, out _out28, out _out29);
-            _50_body = _out27;
-            _51_bodyIdents = _out28;
-            _52_env2 = _out29;
-            readIdents = _51_bodyIdents;
-            generated = RAST.Expr.create_Labelled(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("label_"), _48_lbl), RAST.Expr.create_Loop(Std.Wrappers.Option<RAST._IExpr>.create_None(), RAST.Expr.create_StmtExpr(_50_body, RAST.Expr.create_Break(Std.Wrappers.Option<Dafny.ISequence<Dafny.Rune>>.create_None()))));
+            RAST._IExpr _53_body;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _54_bodyIdents;
+            Defs._IEnvironment _55_env2;
+            RAST._IExpr _out29;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out30;
+            Defs._IEnvironment _out31;
+            (this).GenStmts(_52_body, selfIdent, env, isLast, earlyReturn, out _out29, out _out30, out _out31);
+            _53_body = _out29;
+            _54_bodyIdents = _out30;
+            _55_env2 = _out31;
+            readIdents = _54_bodyIdents;
+            generated = RAST.Expr.create_Labelled(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("label_"), _51_lbl), RAST.Expr.create_Loop(Std.Wrappers.Option<RAST._IExpr>.create_None(), RAST.Expr.create_StmtExpr(_53_body, RAST.Expr.create_Break(Std.Wrappers.Option<Dafny.ISequence<Dafny.Rune>>.create_None()))));
             newEnv = env;
           }
           goto after_match0;
@@ -2624,91 +2652,91 @@ namespace DCOMP {
       }
       {
         if (_source0.is_While) {
-          DAST._IExpression _53_cond = _source0.dtor_cond;
-          Dafny.ISequence<DAST._IStatement> _54_body = _source0.dtor_body;
+          DAST._IExpression _56_cond = _source0.dtor_cond;
+          Dafny.ISequence<DAST._IStatement> _57_body = _source0.dtor_body;
           {
-            RAST._IExpr _55_cond;
-            Defs._IOwnership _56___v49;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _57_recIdents;
-            RAST._IExpr _out30;
-            Defs._IOwnership _out31;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out32;
-            (this).GenExpr(_53_cond, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out30, out _out31, out _out32);
-            _55_cond = _out30;
-            _56___v49 = _out31;
-            _57_recIdents = _out32;
-            readIdents = _57_recIdents;
-            RAST._IExpr _58_bodyExpr;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _59_bodyIdents;
-            Defs._IEnvironment _60_bodyEnv;
-            RAST._IExpr _out33;
+            RAST._IExpr _58_cond;
+            Defs._IOwnership _59___v48;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _60_recIdents;
+            RAST._IExpr _out32;
+            Defs._IOwnership _out33;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out34;
-            Defs._IEnvironment _out35;
-            (this).GenStmts(_54_body, selfIdent, env, false, earlyReturn, out _out33, out _out34, out _out35);
-            _58_bodyExpr = _out33;
-            _59_bodyIdents = _out34;
-            _60_bodyEnv = _out35;
+            (this).GenExpr(_56_cond, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out32, out _out33, out _out34);
+            _58_cond = _out32;
+            _59___v48 = _out33;
+            _60_recIdents = _out34;
+            readIdents = _60_recIdents;
+            RAST._IExpr _61_bodyExpr;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _62_bodyIdents;
+            Defs._IEnvironment _63_bodyEnv;
+            RAST._IExpr _out35;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out36;
+            Defs._IEnvironment _out37;
+            (this).GenStmts(_57_body, selfIdent, env, false, earlyReturn, out _out35, out _out36, out _out37);
+            _61_bodyExpr = _out35;
+            _62_bodyIdents = _out36;
+            _63_bodyEnv = _out37;
             newEnv = env;
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _59_bodyIdents);
-            generated = RAST.Expr.create_Loop(Std.Wrappers.Option<RAST._IExpr>.create_Some(_55_cond), _58_bodyExpr);
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _62_bodyIdents);
+            generated = RAST.Expr.create_Loop(Std.Wrappers.Option<RAST._IExpr>.create_Some(_58_cond), _61_bodyExpr);
           }
           goto after_match0;
         }
       }
       {
         if (_source0.is_Foreach) {
-          Dafny.ISequence<Dafny.Rune> _61_boundName = _source0.dtor_boundName;
-          DAST._IType _62_boundType = _source0.dtor_boundType;
-          DAST._IExpression _63_overExpr = _source0.dtor_over;
-          Dafny.ISequence<DAST._IStatement> _64_body = _source0.dtor_body;
+          Dafny.ISequence<Dafny.Rune> _64_boundName = _source0.dtor_boundName;
+          DAST._IType _65_boundType = _source0.dtor_boundType;
+          DAST._IExpression _66_overExpr = _source0.dtor_over;
+          Dafny.ISequence<DAST._IStatement> _67_body = _source0.dtor_body;
           {
-            RAST._IExpr _65_over;
-            Defs._IOwnership _66___v50;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _67_recIdents;
-            RAST._IExpr _out36;
-            Defs._IOwnership _out37;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out38;
-            (this).GenExpr(_63_overExpr, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out36, out _out37, out _out38);
-            _65_over = _out36;
-            _66___v50 = _out37;
-            _67_recIdents = _out38;
-            if (((_63_overExpr).is_MapBoundedPool) || ((_63_overExpr).is_SetBoundedPool)) {
-              _65_over = ((_65_over).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("cloned"))).Apply0();
+            RAST._IExpr _68_over;
+            Defs._IOwnership _69___v49;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _70_recIdents;
+            RAST._IExpr _out38;
+            Defs._IOwnership _out39;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out40;
+            (this).GenExpr(_66_overExpr, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out38, out _out39, out _out40);
+            _68_over = _out38;
+            _69___v49 = _out39;
+            _70_recIdents = _out40;
+            if (((_66_overExpr).is_MapBoundedPool) || ((_66_overExpr).is_SetBoundedPool)) {
+              _68_over = ((_68_over).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("cloned"))).Apply0();
             }
-            RAST._IType _68_boundTpe;
-            RAST._IType _out39;
-            _out39 = (this).GenType(_62_boundType, Defs.GenTypeContext.@default());
-            _68_boundTpe = _out39;
-            readIdents = _67_recIdents;
-            Dafny.ISequence<Dafny.Rune> _69_boundRName;
-            _69_boundRName = Defs.__default.escapeVar(_61_boundName);
-            RAST._IExpr _70_bodyExpr;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _71_bodyIdents;
-            Defs._IEnvironment _72_bodyEnv;
-            RAST._IExpr _out40;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out41;
-            Defs._IEnvironment _out42;
-            (this).GenStmts(_64_body, selfIdent, (env).AddAssigned(_69_boundRName, _68_boundTpe), false, earlyReturn, out _out40, out _out41, out _out42);
-            _70_bodyExpr = _out40;
-            _71_bodyIdents = _out41;
-            _72_bodyEnv = _out42;
-            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _71_bodyIdents), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_69_boundRName));
+            RAST._IType _71_boundTpe;
+            RAST._IType _out41;
+            _out41 = (this).GenType(_65_boundType, Defs.GenTypeContext.@default());
+            _71_boundTpe = _out41;
+            readIdents = _70_recIdents;
+            Dafny.ISequence<Dafny.Rune> _72_boundRName;
+            _72_boundRName = Defs.__default.escapeVar(_64_boundName);
+            RAST._IExpr _73_bodyExpr;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _74_bodyIdents;
+            Defs._IEnvironment _75_bodyEnv;
+            RAST._IExpr _out42;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out43;
+            Defs._IEnvironment _out44;
+            (this).GenStmts(_67_body, selfIdent, (env).AddAssigned(_72_boundRName, _71_boundTpe), false, earlyReturn, out _out42, out _out43, out _out44);
+            _73_bodyExpr = _out42;
+            _74_bodyIdents = _out43;
+            _75_bodyEnv = _out44;
+            readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _74_bodyIdents), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_72_boundRName));
             newEnv = env;
-            generated = RAST.Expr.create_For(_69_boundRName, _65_over, _70_bodyExpr);
+            generated = RAST.Expr.create_For(_72_boundRName, _68_over, _73_bodyExpr);
           }
           goto after_match0;
         }
       }
       {
         if (_source0.is_Break) {
-          Std.Wrappers._IOption<Dafny.ISequence<Dafny.Rune>> _73_toLabel = _source0.dtor_toLabel;
+          Std.Wrappers._IOption<Dafny.ISequence<Dafny.Rune>> _76_toLabel = _source0.dtor_toLabel;
           {
-            Std.Wrappers._IOption<Dafny.ISequence<Dafny.Rune>> _source1 = _73_toLabel;
+            Std.Wrappers._IOption<Dafny.ISequence<Dafny.Rune>> _source1 = _76_toLabel;
             {
               if (_source1.is_Some) {
-                Dafny.ISequence<Dafny.Rune> _74_lbl = _source1.dtor_value;
+                Dafny.ISequence<Dafny.Rune> _77_lbl = _source1.dtor_value;
                 {
-                  generated = RAST.Expr.create_Break(Std.Wrappers.Option<Dafny.ISequence<Dafny.Rune>>.create_Some(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("label_"), _74_lbl)));
+                  generated = RAST.Expr.create_Break(Std.Wrappers.Option<Dafny.ISequence<Dafny.Rune>>.create_Some(Dafny.Sequence<Dafny.Rune>.Concat(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("label_"), _77_lbl)));
                 }
                 goto after_match1;
               }
@@ -2727,72 +2755,72 @@ namespace DCOMP {
       }
       {
         if (_source0.is_TailRecursive) {
-          Dafny.ISequence<DAST._IStatement> _75_body = _source0.dtor_body;
+          Dafny.ISequence<DAST._IStatement> _78_body = _source0.dtor_body;
           {
             generated = (this).InitEmptyExpr();
-            Defs._IEnvironment _76_oldEnv;
-            _76_oldEnv = env;
+            Defs._IEnvironment _79_oldEnv;
+            _79_oldEnv = env;
             if (!object.Equals(selfIdent, Defs.SelfInfo.create_NoSelf())) {
-              RAST._IExpr _77_selfClone;
-              Defs._IOwnership _78___v51;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _79___v52;
-              RAST._IExpr _out43;
-              Defs._IOwnership _out44;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out45;
-              (this).GenIdent((selfIdent).dtor_rSelfName, selfIdent, Defs.Environment.Empty(), Defs.Ownership.create_OwnershipOwned(), out _out43, out _out44, out _out45);
-              _77_selfClone = _out43;
-              _78___v51 = _out44;
-              _79___v52 = _out45;
-              generated = (generated).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this"), Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(_77_selfClone)));
-              if (((_76_oldEnv).dtor_names).Contains((selfIdent).dtor_rSelfName)) {
-                _76_oldEnv = (_76_oldEnv).RemoveAssigned((selfIdent).dtor_rSelfName);
+              RAST._IExpr _80_selfClone;
+              Defs._IOwnership _81___v50;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _82___v51;
+              RAST._IExpr _out45;
+              Defs._IOwnership _out46;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out47;
+              (this).GenIdent((selfIdent).dtor_rSelfName, selfIdent, Defs.Environment.Empty(), Defs.Ownership.create_OwnershipOwned(), out _out45, out _out46, out _out47);
+              _80_selfClone = _out45;
+              _81___v50 = _out46;
+              _82___v51 = _out47;
+              generated = (generated).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this"), Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(_80_selfClone)));
+              if (((_79_oldEnv).dtor_names).Contains((selfIdent).dtor_rSelfName)) {
+                _79_oldEnv = (_79_oldEnv).RemoveAssigned((selfIdent).dtor_rSelfName);
               }
             }
-            RAST._IExpr _80_loopBegin;
-            _80_loopBegin = RAST.Expr.create_RawExpr(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""));
+            RAST._IExpr _83_loopBegin;
+            _83_loopBegin = RAST.Expr.create_RawExpr(Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""));
             newEnv = env;
-            BigInteger _hi1 = new BigInteger(((_76_oldEnv).dtor_names).Count);
-            for (BigInteger _81_paramI = BigInteger.Zero; _81_paramI < _hi1; _81_paramI++) {
-              Dafny.ISequence<Dafny.Rune> _82_param;
-              _82_param = ((_76_oldEnv).dtor_names).Select(_81_paramI);
-              if ((_82_param).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_accumulator"))) {
+            BigInteger _hi1 = new BigInteger(((_79_oldEnv).dtor_names).Count);
+            for (BigInteger _84_paramI = BigInteger.Zero; _84_paramI < _hi1; _84_paramI++) {
+              Dafny.ISequence<Dafny.Rune> _85_param;
+              _85_param = ((_79_oldEnv).dtor_names).Select(_84_paramI);
+              if ((_85_param).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_accumulator"))) {
                 goto continue_4_0;
               }
-              RAST._IExpr _83_paramInit;
-              Defs._IOwnership _84___v53;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _85___v54;
-              RAST._IExpr _out46;
-              Defs._IOwnership _out47;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out48;
-              (this).GenIdent(_82_param, selfIdent, _76_oldEnv, Defs.Ownership.create_OwnershipOwned(), out _out46, out _out47, out _out48);
-              _83_paramInit = _out46;
-              _84___v53 = _out47;
-              _85___v54 = _out48;
-              Dafny.ISequence<Dafny.Rune> _86_recVar;
-              _86_recVar = Dafny.Sequence<Dafny.Rune>.Concat(Defs.__default.TailRecursionPrefix, Std.Strings.__default.OfNat(_81_paramI));
-              generated = (generated).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _86_recVar, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(_83_paramInit)));
-              if (((_76_oldEnv).dtor_types).Contains(_82_param)) {
-                RAST._IType _87_declaredType;
-                _87_declaredType = (Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Select((_76_oldEnv).dtor_types,_82_param)).ToOwned();
-                newEnv = (newEnv).AddAssigned(_82_param, _87_declaredType);
-                newEnv = (newEnv).AddAssigned(_86_recVar, _87_declaredType);
+              RAST._IExpr _86_paramInit;
+              Defs._IOwnership _87___v52;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _88___v53;
+              RAST._IExpr _out48;
+              Defs._IOwnership _out49;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out50;
+              (this).GenIdent(_85_param, selfIdent, _79_oldEnv, Defs.Ownership.create_OwnershipOwned(), out _out48, out _out49, out _out50);
+              _86_paramInit = _out48;
+              _87___v52 = _out49;
+              _88___v53 = _out50;
+              Dafny.ISequence<Dafny.Rune> _89_recVar;
+              _89_recVar = Dafny.Sequence<Dafny.Rune>.Concat(Defs.__default.TailRecursionPrefix, Std.Strings.__default.OfNat(_84_paramI));
+              generated = (generated).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), _89_recVar, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(_86_paramInit)));
+              if (((_79_oldEnv).dtor_types).Contains(_85_param)) {
+                RAST._IType _90_declaredType;
+                _90_declaredType = (Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Select((_79_oldEnv).dtor_types,_85_param)).ToOwned();
+                newEnv = (newEnv).AddAssigned(_85_param, _90_declaredType);
+                newEnv = (newEnv).AddAssigned(_89_recVar, _90_declaredType);
               }
-              _80_loopBegin = (_80_loopBegin).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), _82_param, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(RAST.Expr.create_Identifier(_86_recVar))));
+              _83_loopBegin = (_83_loopBegin).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), _85_param, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(RAST.Expr.create_Identifier(_89_recVar))));
             continue_4_0: ;
             }
           after_4_0: ;
-            RAST._IExpr _88_bodyExpr;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _89_bodyIdents;
-            Defs._IEnvironment _90_bodyEnv;
-            RAST._IExpr _out49;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out50;
-            Defs._IEnvironment _out51;
-            (this).GenStmts(_75_body, ((!object.Equals(selfIdent, Defs.SelfInfo.create_NoSelf())) ? (Defs.SelfInfo.create_ThisTyped(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this"), (selfIdent).dtor_dafnyType)) : (Defs.SelfInfo.create_NoSelf())), newEnv, false, earlyReturn, out _out49, out _out50, out _out51);
-            _88_bodyExpr = _out49;
-            _89_bodyIdents = _out50;
-            _90_bodyEnv = _out51;
-            readIdents = _89_bodyIdents;
-            generated = (generated).Then(RAST.Expr.create_Labelled(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("TAIL_CALL_START"), RAST.Expr.create_Loop(Std.Wrappers.Option<RAST._IExpr>.create_None(), (_80_loopBegin).Then(_88_bodyExpr))));
+            RAST._IExpr _91_bodyExpr;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _92_bodyIdents;
+            Defs._IEnvironment _93_bodyEnv;
+            RAST._IExpr _out51;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out52;
+            Defs._IEnvironment _out53;
+            (this).GenStmts(_78_body, ((!object.Equals(selfIdent, Defs.SelfInfo.create_NoSelf())) ? (Defs.SelfInfo.create_ThisTyped(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this"), (selfIdent).dtor_dafnyType)) : (Defs.SelfInfo.create_NoSelf())), newEnv, false, earlyReturn, out _out51, out _out52, out _out53);
+            _91_bodyExpr = _out51;
+            _92_bodyIdents = _out52;
+            _93_bodyEnv = _out53;
+            readIdents = _92_bodyIdents;
+            generated = (generated).Then(RAST.Expr.create_Labelled(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("TAIL_CALL_START"), RAST.Expr.create_Loop(Std.Wrappers.Option<RAST._IExpr>.create_None(), (_83_loopBegin).Then(_91_bodyExpr))));
           }
           goto after_match0;
         }
@@ -2809,43 +2837,44 @@ namespace DCOMP {
       }
       {
         if (_source0.is_Call) {
-          DAST._IExpression _91_on = _source0.dtor_on;
-          DAST._ICallName _92_name = _source0.dtor_callName;
-          Dafny.ISequence<DAST._IType> _93_typeArgs = _source0.dtor_typeArgs;
-          Dafny.ISequence<DAST._IExpression> _94_args = _source0.dtor_args;
-          Std.Wrappers._IOption<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _95_maybeOutVars = _source0.dtor_outs;
+          DAST._IExpression _94_on = _source0.dtor_on;
+          DAST._ICallName _95_name = _source0.dtor_callName;
+          Dafny.ISequence<DAST._IType> _96_typeArgs = _source0.dtor_typeArgs;
+          Dafny.ISequence<DAST._IExpression> _97_args = _source0.dtor_args;
+          Std.Wrappers._IOption<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _98_maybeOutVars = _source0.dtor_outs;
           {
-            RAST._IExpr _out52;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out53;
-            (this).GenOwnedCallPart(_91_on, selfIdent, _92_name, _93_typeArgs, _94_args, env, out _out52, out _out53);
-            generated = _out52;
-            readIdents = _out53;
-            if (((_95_maybeOutVars).is_Some) && ((new BigInteger(((_95_maybeOutVars).dtor_value).Count)) == (BigInteger.One))) {
-              Dafny.ISequence<Dafny.Rune> _96_outVar;
-              _96_outVar = Defs.__default.escapeVar(((_95_maybeOutVars).dtor_value).Select(BigInteger.Zero));
-              if (!((env).CanReadWithoutClone(_96_outVar))) {
+            RAST._IExpr _out54;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out55;
+            (this).GenOwnedCallPart(_94_on, selfIdent, _95_name, _96_typeArgs, _97_args, env, out _out54, out _out55);
+            generated = _out54;
+            readIdents = _out55;
+            newEnv = env;
+            if (((_98_maybeOutVars).is_Some) && ((new BigInteger(((_98_maybeOutVars).dtor_value).Count)) == (BigInteger.One))) {
+              Dafny.ISequence<Dafny.Rune> _99_outVar;
+              _99_outVar = Defs.__default.escapeVar(((_98_maybeOutVars).dtor_value).Select(BigInteger.Zero));
+              if ((env).IsMaybePlacebo(_99_outVar)) {
                 generated = RAST.__default.MaybePlacebo(generated);
               }
-              generated = RAST.__default.AssignVar(_96_outVar, generated);
-            } else if (((_95_maybeOutVars).is_None) || ((new BigInteger(((_95_maybeOutVars).dtor_value).Count)).Sign == 0)) {
+              generated = RAST.__default.AssignVar(_99_outVar, generated);
+            } else if (((_98_maybeOutVars).is_None) || ((new BigInteger(((_98_maybeOutVars).dtor_value).Count)).Sign == 0)) {
             } else {
-              Dafny.ISequence<Dafny.Rune> _97_tmpVar;
-              _97_tmpVar = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_x");
-              RAST._IExpr _98_tmpId;
-              _98_tmpId = RAST.Expr.create_Identifier(_97_tmpVar);
-              generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), _97_tmpVar, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(generated));
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _99_outVars;
-              _99_outVars = (_95_maybeOutVars).dtor_value;
-              BigInteger _hi2 = new BigInteger((_99_outVars).Count);
-              for (BigInteger _100_outI = BigInteger.Zero; _100_outI < _hi2; _100_outI++) {
-                Dafny.ISequence<Dafny.Rune> _101_outVar;
-                _101_outVar = Defs.__default.escapeVar((_99_outVars).Select(_100_outI));
-                RAST._IExpr _102_rhs;
-                _102_rhs = (_98_tmpId).Sel(Std.Strings.__default.OfNat(_100_outI));
-                if (!((env).CanReadWithoutClone(_101_outVar))) {
-                  _102_rhs = RAST.__default.MaybePlacebo(_102_rhs);
+              Dafny.ISequence<Dafny.Rune> _100_tmpVar;
+              _100_tmpVar = Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_x");
+              RAST._IExpr _101_tmpId;
+              _101_tmpId = RAST.Expr.create_Identifier(_100_tmpVar);
+              generated = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), _100_tmpVar, Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(generated));
+              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _102_outVars;
+              _102_outVars = (_98_maybeOutVars).dtor_value;
+              BigInteger _hi2 = new BigInteger((_102_outVars).Count);
+              for (BigInteger _103_outI = BigInteger.Zero; _103_outI < _hi2; _103_outI++) {
+                Dafny.ISequence<Dafny.Rune> _104_outVar;
+                _104_outVar = Defs.__default.escapeVar((_102_outVars).Select(_103_outI));
+                RAST._IExpr _105_rhs;
+                _105_rhs = (_101_tmpId).Sel(Std.Strings.__default.OfNat(_103_outI));
+                if ((env).IsMaybePlacebo(_104_outVar)) {
+                  _105_rhs = RAST.__default.MaybePlacebo(_105_rhs);
                 }
-                generated = (generated).Then(RAST.__default.AssignVar(_101_outVar, _102_rhs));
+                generated = (generated).Then(RAST.__default.AssignVar(_104_outVar, _105_rhs));
               }
             }
             newEnv = env;
@@ -2855,23 +2884,23 @@ namespace DCOMP {
       }
       {
         if (_source0.is_Return) {
-          DAST._IExpression _103_exprDafny = _source0.dtor_expr;
+          DAST._IExpression _106_exprDafny = _source0.dtor_expr;
           {
-            RAST._IExpr _104_expr;
-            Defs._IOwnership _105___v55;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _106_recIdents;
-            RAST._IExpr _out54;
-            Defs._IOwnership _out55;
-            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out56;
-            (this).GenExpr(_103_exprDafny, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out54, out _out55, out _out56);
-            _104_expr = _out54;
-            _105___v55 = _out55;
-            _106_recIdents = _out56;
-            readIdents = _106_recIdents;
+            RAST._IExpr _107_expr;
+            Defs._IOwnership _108___v54;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _109_recIdents;
+            RAST._IExpr _out56;
+            Defs._IOwnership _out57;
+            Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out58;
+            (this).GenExpr(_106_exprDafny, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out56, out _out57, out _out58);
+            _107_expr = _out56;
+            _108___v54 = _out57;
+            _109_recIdents = _out58;
+            readIdents = _109_recIdents;
             if (isLast) {
-              generated = _104_expr;
+              generated = _107_expr;
             } else {
-              generated = RAST.Expr.create_Return(Std.Wrappers.Option<RAST._IExpr>.create_Some(_104_expr));
+              generated = RAST.Expr.create_Return(Std.Wrappers.Option<RAST._IExpr>.create_Some(_107_expr));
             }
             newEnv = env;
           }
@@ -2889,27 +2918,27 @@ namespace DCOMP {
               }
             }
             {
-              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _107_rustIdents = _source2.dtor_value;
-              Dafny.ISequence<RAST._IExpr> _108_tupleArgs;
-              _108_tupleArgs = Dafny.Sequence<RAST._IExpr>.FromElements();
-              BigInteger _hi3 = new BigInteger((_107_rustIdents).Count);
-              for (BigInteger _109_i = BigInteger.Zero; _109_i < _hi3; _109_i++) {
-                RAST._IExpr _110_rIdent;
-                Defs._IOwnership _111___v56;
-                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _112___v57;
-                RAST._IExpr _out57;
-                Defs._IOwnership _out58;
-                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out59;
-                (this).GenIdent((_107_rustIdents).Select(_109_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out57, out _out58, out _out59);
-                _110_rIdent = _out57;
-                _111___v56 = _out58;
-                _112___v57 = _out59;
-                _108_tupleArgs = Dafny.Sequence<RAST._IExpr>.Concat(_108_tupleArgs, Dafny.Sequence<RAST._IExpr>.FromElements(_110_rIdent));
+              Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _110_rustIdents = _source2.dtor_value;
+              Dafny.ISequence<RAST._IExpr> _111_tupleArgs;
+              _111_tupleArgs = Dafny.Sequence<RAST._IExpr>.FromElements();
+              BigInteger _hi3 = new BigInteger((_110_rustIdents).Count);
+              for (BigInteger _112_i = BigInteger.Zero; _112_i < _hi3; _112_i++) {
+                RAST._IExpr _113_rIdent;
+                Defs._IOwnership _114___v55;
+                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _115___v56;
+                RAST._IExpr _out59;
+                Defs._IOwnership _out60;
+                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out61;
+                (this).GenIdent((_110_rustIdents).Select(_112_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out59, out _out60, out _out61);
+                _113_rIdent = _out59;
+                _114___v55 = _out60;
+                _115___v56 = _out61;
+                _111_tupleArgs = Dafny.Sequence<RAST._IExpr>.Concat(_111_tupleArgs, Dafny.Sequence<RAST._IExpr>.FromElements(_113_rIdent));
               }
-              if ((new BigInteger((_108_tupleArgs).Count)) == (BigInteger.One)) {
-                generated = RAST.Expr.create_Return(Std.Wrappers.Option<RAST._IExpr>.create_Some((_108_tupleArgs).Select(BigInteger.Zero)));
+              if ((new BigInteger((_111_tupleArgs).Count)) == (BigInteger.One)) {
+                generated = RAST.Expr.create_Return(Std.Wrappers.Option<RAST._IExpr>.create_Some((_111_tupleArgs).Select(BigInteger.Zero)));
               } else {
-                generated = RAST.Expr.create_Return(Std.Wrappers.Option<RAST._IExpr>.create_Some(RAST.Expr.create_Tuple(_108_tupleArgs)));
+                generated = RAST.Expr.create_Return(Std.Wrappers.Option<RAST._IExpr>.create_Some(RAST.Expr.create_Tuple(_111_tupleArgs)));
               }
             }
           after_match2: ;
@@ -2930,20 +2959,20 @@ namespace DCOMP {
         }
       }
       {
-        DAST._IExpression _113_e = _source0.dtor_Print_a0;
+        DAST._IExpression _116_e = _source0.dtor_Print_a0;
         {
-          RAST._IExpr _114_printedExpr;
-          Defs._IOwnership _115_recOwnership;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _116_recIdents;
-          RAST._IExpr _out60;
-          Defs._IOwnership _out61;
-          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out62;
-          (this).GenExpr(_113_e, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out60, out _out61, out _out62);
-          _114_printedExpr = _out60;
-          _115_recOwnership = _out61;
-          _116_recIdents = _out62;
-          generated = (RAST.Expr.create_Identifier(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!"))).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(RAST.Expr.create_LiteralString(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{}"), false, false), (((RAST.__default.dafny__runtime).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("DafnyPrintWrapper"))).AsExpr()).Apply1(_114_printedExpr)));
-          readIdents = _116_recIdents;
+          RAST._IExpr _117_printedExpr;
+          Defs._IOwnership _118_recOwnership;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _119_recIdents;
+          RAST._IExpr _out62;
+          Defs._IOwnership _out63;
+          Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out64;
+          (this).GenExpr(_116_e, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out62, out _out63, out _out64);
+          _117_printedExpr = _out62;
+          _118_recOwnership = _out63;
+          _119_recIdents = _out64;
+          generated = (RAST.Expr.create_Identifier(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("print!"))).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(RAST.Expr.create_LiteralString(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("{}"), false, false), (((RAST.__default.dafny__runtime).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("DafnyPrintWrapper"))).AsExpr()).Apply1(_117_printedExpr)));
+          readIdents = _119_recIdents;
           newEnv = env;
         }
       }
@@ -3299,24 +3328,24 @@ namespace DCOMP {
         _10_expectedRightOwnership = Defs.Ownership.create_OwnershipOwned();
       }
       RAST._IExpr _11_left;
-      Defs._IOwnership _12___v58;
+      Defs._IOwnership _12___v57;
       Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _13_recIdentsL;
       RAST._IExpr _out0;
       Defs._IOwnership _out1;
       Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out2;
       (this).GenExpr(_4_lExpr, selfIdent, env, _9_expectedLeftOwnership, out _out0, out _out1, out _out2);
       _11_left = _out0;
-      _12___v58 = _out1;
+      _12___v57 = _out1;
       _13_recIdentsL = _out2;
       RAST._IExpr _14_right;
-      Defs._IOwnership _15___v59;
+      Defs._IOwnership _15___v58;
       Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _16_recIdentsR;
       RAST._IExpr _out3;
       Defs._IOwnership _out4;
       Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out5;
       (this).GenExpr(_5_rExpr, selfIdent, env, _10_expectedRightOwnership, out _out3, out _out4, out _out5);
       _14_right = _out3;
-      _15___v59 = _out4;
+      _15___v58 = _out4;
       _16_recIdentsR = _out5;
       DAST._IBinOp _source0 = _0_op;
       {
@@ -4331,14 +4360,14 @@ namespace DCOMP {
           }
         }
         RAST._IExpr _4_argExpr;
-        Defs._IOwnership _5___v76;
+        Defs._IOwnership _5___v75;
         Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _6_argIdents;
         RAST._IExpr _out1;
         Defs._IOwnership _out2;
         Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out3;
         (this).GenExpr((args).Select(_1_i), selfIdent, env, _2_argOwnership, out _out1, out _out2, out _out3);
         _4_argExpr = _out1;
-        _5___v76 = _out2;
+        _5___v75 = _out2;
         _6_argIdents = _out3;
         argExprs = Dafny.Sequence<RAST._IExpr>.Concat(argExprs, Dafny.Sequence<RAST._IExpr>.FromElements(_4_argExpr));
         readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _6_argIdents);
@@ -4536,14 +4565,14 @@ namespace DCOMP {
             BigInteger _hi1 = new BigInteger((_9_values).Count);
             for (BigInteger _11_i = BigInteger.Zero; _11_i < _hi1; _11_i++) {
               RAST._IExpr _12_recursiveGen;
-              Defs._IOwnership _13___v86;
+              Defs._IOwnership _13___v85;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _14_recIdents;
               RAST._IExpr _out16;
               Defs._IOwnership _out17;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out18;
               (this).GenExpr((_9_values).Select(_11_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out16, out _out17, out _out18);
               _12_recursiveGen = _out16;
-              _13___v86 = _out17;
+              _13___v85 = _out17;
               _14_recIdents = _out18;
               _10_exprs = Dafny.Sequence<RAST._IExpr>.Concat(_10_exprs, Dafny.Sequence<RAST._IExpr>.FromElements(_12_recursiveGen));
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _14_recIdents);
@@ -4592,14 +4621,14 @@ namespace DCOMP {
             BigInteger _hi3 = new BigInteger((_17_args).Count);
             for (BigInteger _22_i = BigInteger.Zero; _22_i < _hi3; _22_i++) {
               RAST._IExpr _23_recursiveGen;
-              Defs._IOwnership _24___v87;
+              Defs._IOwnership _24___v86;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _25_recIdents;
               RAST._IExpr _out23;
               Defs._IOwnership _out24;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out25;
               (this).GenExpr((_17_args).Select(_22_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out23, out _out24, out _out25);
               _23_recursiveGen = _out23;
-              _24___v87 = _out24;
+              _24___v86 = _out24;
               _25_recIdents = _out25;
               _21_arguments = Dafny.Sequence<RAST._IExpr>.Concat(_21_arguments, Dafny.Sequence<RAST._IExpr>.FromElements(_23_recursiveGen));
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _25_recIdents);
@@ -4637,14 +4666,14 @@ namespace DCOMP {
               BigInteger _hi4 = new BigInteger((_26_dims).Count);
               for (BigInteger _30_i = BigInteger.Zero; _30_i < _hi4; _30_i++) {
                 RAST._IExpr _31_recursiveGen;
-                Defs._IOwnership _32___v88;
+                Defs._IOwnership _32___v87;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _33_recIdents;
                 RAST._IExpr _out30;
                 Defs._IOwnership _out31;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out32;
                 (this).GenExpr((_26_dims).Select(_30_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out30, out _out31, out _out32);
                 _31_recursiveGen = _out30;
-                _32___v88 = _out31;
+                _32___v87 = _out31;
                 _33_recIdents = _out32;
                 _29_dimExprs = Dafny.Sequence<RAST._IExpr>.Concat(_29_dimExprs, Dafny.Sequence<RAST._IExpr>.FromElements(RAST.__default.IntoUsize(_31_recursiveGen)));
                 readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _33_recIdents);
@@ -4671,14 +4700,14 @@ namespace DCOMP {
           DAST._IExpression _35_underlying = _source0.dtor_value;
           {
             RAST._IExpr _36_recursiveGen;
-            Defs._IOwnership _37___v89;
+            Defs._IOwnership _37___v88;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _38_recIdents;
             RAST._IExpr _out35;
             Defs._IOwnership _out36;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out37;
             (this).GenExpr(_35_underlying, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out35, out _out36, out _out37);
             _36_recursiveGen = _out35;
-            _37___v89 = _out36;
+            _37___v88 = _out36;
             _38_recIdents = _out37;
             r = (((RAST.__default.dafny__runtime).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("int!"))).AsExpr()).Apply1(_36_recursiveGen);
             readIdents = _38_recIdents;
@@ -4701,14 +4730,14 @@ namespace DCOMP {
             _out40 = (this).GenType(_40_typ, Defs.GenTypeContext.@default());
             _41_tpe = _out40;
             RAST._IExpr _42_recursiveGen;
-            Defs._IOwnership _43___v90;
+            Defs._IOwnership _43___v89;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _44_recIdents;
             RAST._IExpr _out41;
             Defs._IOwnership _out42;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out43;
             (this).GenExpr(_39_underlying, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out41, out _out42, out _out43);
             _42_recursiveGen = _out41;
-            _43___v90 = _out42;
+            _43___v89 = _out42;
             _44_recIdents = _out43;
             readIdents = _44_recIdents;
             if ((_41_tpe).IsObjectOrPointer()) {
@@ -4774,14 +4803,14 @@ namespace DCOMP {
               DAST._IExpression _58_value = _let_tmp_rhs0.dtor__1;
               if (_50_isCo) {
                 RAST._IExpr _59_recursiveGen;
-                Defs._IOwnership _60___v91;
+                Defs._IOwnership _60___v90;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _61_recIdents;
                 RAST._IExpr _out50;
                 Defs._IOwnership _out51;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out52;
                 (this).GenExpr(_58_value, selfIdent, Defs.Environment.Empty(), Defs.Ownership.create_OwnershipOwned(), out _out50, out _out51, out _out52);
                 _59_recursiveGen = _out50;
-                _60___v91 = _out51;
+                _60___v90 = _out51;
                 _61_recIdents = _out52;
                 readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _61_recIdents);
                 RAST._IExpr _62_allReadCloned;
@@ -4804,14 +4833,14 @@ namespace DCOMP {
                 _55_assignments = Dafny.Sequence<RAST._IAssignIdentifier>.Concat(_55_assignments, Dafny.Sequence<RAST._IAssignIdentifier>.FromElements(RAST.AssignIdentifier.create(Defs.__default.escapeVar(_57_name), _64_wasAssigned)));
               } else {
                 RAST._IExpr _65_recursiveGen;
-                Defs._IOwnership _66___v92;
+                Defs._IOwnership _66___v91;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _67_recIdents;
                 RAST._IExpr _out53;
                 Defs._IOwnership _out54;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out55;
                 (this).GenExpr(_58_value, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out53, out _out54, out _out55);
                 _65_recursiveGen = _out53;
-                _66___v92 = _out54;
+                _66___v91 = _out54;
                 _67_recIdents = _out55;
                 _55_assignments = Dafny.Sequence<RAST._IAssignIdentifier>.Concat(_55_assignments, Dafny.Sequence<RAST._IAssignIdentifier>.FromElements(RAST.AssignIdentifier.create(Defs.__default.escapeVar(_57_name), _65_recursiveGen)));
                 readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _67_recIdents);
@@ -4851,24 +4880,24 @@ namespace DCOMP {
           DAST._IExpression _69_expr = _source0.dtor_elem;
           {
             RAST._IExpr _70_recursiveGen;
-            Defs._IOwnership _71___v96;
+            Defs._IOwnership _71___v95;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _72_recIdents;
             RAST._IExpr _out61;
             Defs._IOwnership _out62;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out63;
             (this).GenExpr(_69_expr, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out61, out _out62, out _out63);
             _70_recursiveGen = _out61;
-            _71___v96 = _out62;
+            _71___v95 = _out62;
             _72_recIdents = _out63;
             RAST._IExpr _73_lengthGen;
-            Defs._IOwnership _74___v97;
+            Defs._IOwnership _74___v96;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _75_lengthIdents;
             RAST._IExpr _out64;
             Defs._IOwnership _out65;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out66;
             (this).GenExpr(_68_length, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out64, out _out65, out _out66);
             _73_lengthGen = _out64;
-            _74___v97 = _out65;
+            _74___v96 = _out65;
             _75_lengthIdents = _out66;
             r = RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_initializer"), Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(_70_recursiveGen));
             RAST._IExpr _76_range;
@@ -4907,14 +4936,14 @@ namespace DCOMP {
             _82_args = Dafny.Sequence<RAST._IExpr>.FromElements();
             while ((_81_i) < (new BigInteger((_78_exprs).Count))) {
               RAST._IExpr _83_recursiveGen;
-              Defs._IOwnership _84___v98;
+              Defs._IOwnership _84___v97;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _85_recIdents;
               RAST._IExpr _out70;
               Defs._IOwnership _out71;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out72;
               (this).GenExpr((_78_exprs).Select(_81_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out70, out _out71, out _out72);
               _83_recursiveGen = _out70;
-              _84___v98 = _out71;
+              _84___v97 = _out71;
               _85_recIdents = _out72;
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _85_recIdents);
               _82_args = Dafny.Sequence<RAST._IExpr>.Concat(_82_args, Dafny.Sequence<RAST._IExpr>.FromElements(_83_recursiveGen));
@@ -4945,14 +4974,14 @@ namespace DCOMP {
             _88_i = BigInteger.Zero;
             while ((_88_i) < (new BigInteger((_86_exprs).Count))) {
               RAST._IExpr _89_recursiveGen;
-              Defs._IOwnership _90___v99;
+              Defs._IOwnership _90___v98;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _91_recIdents;
               RAST._IExpr _out75;
               Defs._IOwnership _out76;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out77;
               (this).GenExpr((_86_exprs).Select(_88_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out75, out _out76, out _out77);
               _89_recursiveGen = _out75;
-              _90___v99 = _out76;
+              _90___v98 = _out76;
               _91_recIdents = _out77;
               _87_generatedValues = Dafny.Sequence<RAST._IExpr>.Concat(_87_generatedValues, Dafny.Sequence<RAST._IExpr>.FromElements(_89_recursiveGen));
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _91_recIdents);
@@ -4980,14 +5009,14 @@ namespace DCOMP {
             _94_i = BigInteger.Zero;
             while ((_94_i) < (new BigInteger((_92_exprs).Count))) {
               RAST._IExpr _95_recursiveGen;
-              Defs._IOwnership _96___v100;
+              Defs._IOwnership _96___v99;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _97_recIdents;
               RAST._IExpr _out80;
               Defs._IOwnership _out81;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out82;
               (this).GenExpr((_92_exprs).Select(_94_i), selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out80, out _out81, out _out82);
               _95_recursiveGen = _out80;
-              _96___v100 = _out81;
+              _96___v99 = _out81;
               _97_recIdents = _out82;
               _93_generatedValues = Dafny.Sequence<RAST._IExpr>.Concat(_93_generatedValues, Dafny.Sequence<RAST._IExpr>.FromElements(_95_recursiveGen));
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _97_recIdents);
@@ -5009,14 +5038,14 @@ namespace DCOMP {
           DAST._IExpression _98_expr = _source0.dtor_ToMultiset_a0;
           {
             RAST._IExpr _99_recursiveGen;
-            Defs._IOwnership _100___v101;
+            Defs._IOwnership _100___v100;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _101_recIdents;
             RAST._IExpr _out85;
             Defs._IOwnership _out86;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out87;
             (this).GenExpr(_98_expr, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out85, out _out86, out _out87);
             _99_recursiveGen = _out85;
-            _100___v101 = _out86;
+            _100___v100 = _out86;
             _101_recIdents = _out87;
             r = ((_99_recursiveGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("as_dafny_multiset"))).Apply0();
             readIdents = _101_recIdents;
@@ -5041,24 +5070,24 @@ namespace DCOMP {
             _104_i = BigInteger.Zero;
             while ((_104_i) < (new BigInteger((_102_mapElems).Count))) {
               RAST._IExpr _105_recursiveGenKey;
-              Defs._IOwnership _106___v102;
+              Defs._IOwnership _106___v101;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _107_recIdentsKey;
               RAST._IExpr _out90;
               Defs._IOwnership _out91;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out92;
               (this).GenExpr(((_102_mapElems).Select(_104_i)).dtor__0, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out90, out _out91, out _out92);
               _105_recursiveGenKey = _out90;
-              _106___v102 = _out91;
+              _106___v101 = _out91;
               _107_recIdentsKey = _out92;
               RAST._IExpr _108_recursiveGenValue;
-              Defs._IOwnership _109___v103;
+              Defs._IOwnership _109___v102;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _110_recIdentsValue;
               RAST._IExpr _out93;
               Defs._IOwnership _out94;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out95;
               (this).GenExpr(((_102_mapElems).Select(_104_i)).dtor__1, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out93, out _out94, out _out95);
               _108_recursiveGenValue = _out93;
-              _109___v103 = _out94;
+              _109___v102 = _out94;
               _110_recIdentsValue = _out95;
               _103_generatedValues = Dafny.Sequence<_System._ITuple2<RAST._IExpr, RAST._IExpr>>.Concat(_103_generatedValues, Dafny.Sequence<_System._ITuple2<RAST._IExpr, RAST._IExpr>>.FromElements(_System.Tuple2<RAST._IExpr, RAST._IExpr>.create(_105_recursiveGenKey, _108_recursiveGenValue)));
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _107_recIdentsKey), _110_recIdentsValue);
@@ -5093,14 +5122,14 @@ namespace DCOMP {
           DAST._IExpression _116_value = _source0.dtor_value;
           {
             RAST._IExpr _117_exprR;
-            Defs._IOwnership _118___v104;
+            Defs._IOwnership _118___v103;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _119_exprIdents;
             RAST._IExpr _out98;
             Defs._IOwnership _out99;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out100;
             (this).GenExpr(_114_expr, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out98, out _out99, out _out100);
             _117_exprR = _out98;
-            _118___v104 = _out99;
+            _118___v103 = _out99;
             _119_exprIdents = _out100;
             RAST._IExpr _120_indexR;
             Defs._IOwnership _121_indexOwnership;
@@ -5141,14 +5170,14 @@ namespace DCOMP {
           DAST._IExpression _128_value = _source0.dtor_value;
           {
             RAST._IExpr _129_exprR;
-            Defs._IOwnership _130___v105;
+            Defs._IOwnership _130___v104;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _131_exprIdents;
             RAST._IExpr _out109;
             Defs._IOwnership _out110;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out111;
             (this).GenExpr(_126_expr, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out109, out _out110, out _out111);
             _129_exprR = _out109;
-            _130___v105 = _out110;
+            _130___v104 = _out110;
             _131_exprIdents = _out111;
             RAST._IExpr _132_indexR;
             Defs._IOwnership _133_indexOwnership;
@@ -5229,14 +5258,14 @@ namespace DCOMP {
           DAST._IExpression _143_f = _source0.dtor_els;
           {
             RAST._IExpr _144_cond;
-            Defs._IOwnership _145___v106;
+            Defs._IOwnership _145___v105;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _146_recIdentsCond;
             RAST._IExpr _out126;
             Defs._IOwnership _out127;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out128;
             (this).GenExpr(_141_cond, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out126, out _out127, out _out128);
             _144_cond = _out126;
-            _145___v106 = _out127;
+            _145___v105 = _out127;
             _146_recIdentsCond = _out128;
             RAST._IExpr _147_fExpr;
             Defs._IOwnership _148_fOwned;
@@ -5249,14 +5278,14 @@ namespace DCOMP {
             _148_fOwned = _out130;
             _149_recIdentsF = _out131;
             RAST._IExpr _150_tExpr;
-            Defs._IOwnership _151___v107;
+            Defs._IOwnership _151___v106;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _152_recIdentsT;
             RAST._IExpr _out132;
             Defs._IOwnership _out133;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out134;
             (this).GenExpr(_142_t, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out132, out _out133, out _out134);
             _150_tExpr = _out132;
-            _151___v107 = _out133;
+            _151___v106 = _out133;
             _152_recIdentsT = _out134;
             r = RAST.Expr.create_IfExpr(_144_cond, _150_tExpr, _147_fExpr);
             RAST._IExpr _out135;
@@ -5278,14 +5307,14 @@ namespace DCOMP {
             DAST.Format._IUnaryOpFormat _154_format = _source0.dtor_format1;
             {
               RAST._IExpr _155_recursiveGen;
-              Defs._IOwnership _156___v108;
+              Defs._IOwnership _156___v107;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _157_recIdents;
               RAST._IExpr _out137;
               Defs._IOwnership _out138;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out139;
               (this).GenExpr(_153_e, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out137, out _out138, out _out139);
               _155_recursiveGen = _out137;
-              _156___v108 = _out138;
+              _156___v107 = _out138;
               _157_recIdents = _out139;
               r = RAST.Expr.create_UnaryOp(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("!"), _155_recursiveGen, _154_format);
               RAST._IExpr _out140;
@@ -5308,14 +5337,14 @@ namespace DCOMP {
             DAST.Format._IUnaryOpFormat _159_format = _source0.dtor_format1;
             {
               RAST._IExpr _160_recursiveGen;
-              Defs._IOwnership _161___v109;
+              Defs._IOwnership _161___v108;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _162_recIdents;
               RAST._IExpr _out142;
               Defs._IOwnership _out143;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out144;
               (this).GenExpr(_158_e, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out142, out _out143, out _out144);
               _160_recursiveGen = _out142;
-              _161___v109 = _out143;
+              _161___v108 = _out143;
               _162_recIdents = _out144;
               r = RAST.Expr.create_UnaryOp(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("!"), _160_recursiveGen, _159_format);
               RAST._IExpr _out145;
@@ -5380,14 +5409,14 @@ namespace DCOMP {
           bool _171_native = _source0.dtor_native;
           {
             RAST._IExpr _172_recursiveGen;
-            Defs._IOwnership _173___v114;
+            Defs._IOwnership _173___v113;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _174_recIdents;
             RAST._IExpr _out155;
             Defs._IOwnership _out156;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out157;
             (this).GenExpr(_168_expr, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out155, out _out156, out _out157);
             _172_recursiveGen = _out155;
-            _173___v114 = _out156;
+            _173___v113 = _out156;
             _174_recIdents = _out157;
             RAST._IType _175_arrayType;
             RAST._IType _out158;
@@ -5429,14 +5458,14 @@ namespace DCOMP {
           DAST._IExpression _177_expr = _source0.dtor_expr;
           {
             RAST._IExpr _178_recursiveGen;
-            Defs._IOwnership _179___v115;
+            Defs._IOwnership _179___v114;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _180_recIdents;
             RAST._IExpr _out162;
             Defs._IOwnership _out163;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out164;
             (this).GenExpr(_177_expr, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out162, out _out163, out _out164);
             _178_recursiveGen = _out162;
-            _179___v115 = _out163;
+            _179___v114 = _out163;
             _180_recIdents = _out164;
             readIdents = _180_recIdents;
             r = ((_178_recursiveGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("keys"))).Apply0();
@@ -5455,14 +5484,14 @@ namespace DCOMP {
           DAST._IExpression _181_expr = _source0.dtor_expr;
           {
             RAST._IExpr _182_recursiveGen;
-            Defs._IOwnership _183___v116;
+            Defs._IOwnership _183___v115;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _184_recIdents;
             RAST._IExpr _out167;
             Defs._IOwnership _out168;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out169;
             (this).GenExpr(_181_expr, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out167, out _out168, out _out169);
             _182_recursiveGen = _out167;
-            _183___v116 = _out168;
+            _183___v115 = _out168;
             _184_recIdents = _out169;
             readIdents = _184_recIdents;
             r = ((_182_recursiveGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("values"))).Apply0();
@@ -5481,14 +5510,14 @@ namespace DCOMP {
           DAST._IExpression _185_expr = _source0.dtor_expr;
           {
             RAST._IExpr _186_recursiveGen;
-            Defs._IOwnership _187___v117;
+            Defs._IOwnership _187___v116;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _188_recIdents;
             RAST._IExpr _out172;
             Defs._IOwnership _out173;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out174;
             (this).GenExpr(_185_expr, selfIdent, env, Defs.Ownership.create_OwnershipAutoBorrowed(), out _out172, out _out173, out _out174);
             _186_recursiveGen = _out172;
-            _187___v117 = _out173;
+            _187___v116 = _out173;
             _188_recIdents = _out174;
             readIdents = _188_recIdents;
             r = ((_186_recursiveGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("items"))).Apply0();
@@ -5560,15 +5589,15 @@ namespace DCOMP {
               Dafny.ISequence<Dafny.Rune> _209_name = _let_tmp_rhs1.dtor__0;
               RAST._IType _210_ty = _let_tmp_rhs1.dtor__1;
               RAST._IExpr _211_rIdent;
-              Defs._IOwnership _212___v118;
-              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _213___v119;
+              Defs._IOwnership _212___v117;
+              Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _213___v118;
               RAST._IExpr _out181;
               Defs._IOwnership _out182;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out183;
               (this).GenIdent(_209_name, selfIdent, _199_lEnv, (((!(_193_isConstant)) && ((_210_ty).CanReadWithoutClone())) ? (Defs.Ownership.create_OwnershipOwned()) : (Defs.Ownership.create_OwnershipBorrowed())), out _out181, out _out182, out _out183);
               _211_rIdent = _out181;
-              _212___v118 = _out182;
-              _213___v119 = _out183;
+              _212___v117 = _out182;
+              _213___v118 = _out183;
               _207_onExprArgs = Dafny.Sequence<RAST._IExpr>.Concat(_207_onExprArgs, Dafny.Sequence<RAST._IExpr>.FromElements(_211_rIdent));
             }
             _206_body = (_206_body).Apply(_207_onExprArgs);
@@ -5859,14 +5888,14 @@ namespace DCOMP {
                 DAST._IExpression _258_l = _source5.dtor_value;
                 {
                   RAST._IExpr _259_lExpr;
-                  Defs._IOwnership _260___v122;
+                  Defs._IOwnership _260___v121;
                   Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _261_recIdentsL;
                   RAST._IExpr _out217;
                   Defs._IOwnership _out218;
                   Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out219;
                   (this).GenExpr(_258_l, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out217, out _out218, out _out219);
                   _259_lExpr = _out217;
-                  _260___v122 = _out218;
+                  _260___v121 = _out218;
                   _261_recIdentsL = _out219;
                   _257_arguments = Dafny.Sequence<RAST._IExpr>.Concat(_257_arguments, Dafny.Sequence<RAST._IExpr>.FromElements(_259_lExpr));
                   readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _261_recIdentsL);
@@ -5883,14 +5912,14 @@ namespace DCOMP {
                 DAST._IExpression _262_h = _source6.dtor_value;
                 {
                   RAST._IExpr _263_hExpr;
-                  Defs._IOwnership _264___v123;
+                  Defs._IOwnership _264___v122;
                   Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _265_recIdentsH;
                   RAST._IExpr _out220;
                   Defs._IOwnership _out221;
                   Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out222;
                   (this).GenExpr(_262_h, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out220, out _out221, out _out222);
                   _263_hExpr = _out220;
-                  _264___v123 = _out221;
+                  _264___v122 = _out221;
                   _265_recIdentsH = _out222;
                   _257_arguments = Dafny.Sequence<RAST._IExpr>.Concat(_257_arguments, Dafny.Sequence<RAST._IExpr>.FromElements(_263_hExpr));
                   readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _265_recIdentsH);
@@ -6017,17 +6046,17 @@ namespace DCOMP {
               _284_paramTypesMap = Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Update(_284_paramTypesMap, _286_name, ((_282_params).Select(_285_i)).dtor_tpe);
             }
             Defs._IEnvironment _287_subEnv;
-            _287_subEnv = ((env).ToOwned()).merge(Defs.Environment.create(_283_paramNames, _284_paramTypesMap));
+            _287_subEnv = ((env).ToOwned()).merge(Defs.Environment.create(_283_paramNames, _284_paramTypesMap, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements()));
             RAST._IExpr _288_recursiveGen;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _289_recIdents;
-            Defs._IEnvironment _290___v125;
+            Defs._IEnvironment _290___v124;
             RAST._IExpr _out235;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out236;
             Defs._IEnvironment _out237;
             (this).GenStmts(_281_body, ((!object.Equals(selfIdent, Defs.SelfInfo.create_NoSelf())) ? (Defs.SelfInfo.create_ThisTyped(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this"), (selfIdent).dtor_dafnyType)) : (Defs.SelfInfo.create_NoSelf())), _287_subEnv, true, Std.Wrappers.Option<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>>.create_None(), out _out235, out _out236, out _out237);
             _288_recursiveGen = _out235;
             _289_recIdents = _out236;
-            _290___v125 = _out237;
+            _290___v124 = _out237;
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements();
             _289_recIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_289_recIdents, Dafny.Helpers.Id<Func<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>, Dafny.ISet<Dafny.ISequence<Dafny.Rune>>>>((_291_paramNames) => ((System.Func<Dafny.ISet<Dafny.ISequence<Dafny.Rune>>>)(() => {
               var _coll0 = new System.Collections.Generic.List<Dafny.ISequence<Dafny.Rune>>();
@@ -6053,15 +6082,15 @@ namespace DCOMP {
             after__ASSIGN_SUCH_THAT_1: ;
               if ((!object.Equals(selfIdent, Defs.SelfInfo.create_NoSelf())) && ((_294_next).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this")))) {
                 RAST._IExpr _295_selfCloned;
-                Defs._IOwnership _296___v126;
-                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _297___v127;
+                Defs._IOwnership _296___v125;
+                Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _297___v126;
                 RAST._IExpr _out238;
                 Defs._IOwnership _out239;
                 Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out240;
                 (this).GenIdent(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("self"), selfIdent, Defs.Environment.Empty(), Defs.Ownership.create_OwnershipOwned(), out _out238, out _out239, out _out240);
                 _295_selfCloned = _out238;
-                _296___v126 = _out239;
-                _297___v127 = _out240;
+                _296___v125 = _out239;
+                _297___v126 = _out240;
                 _293_allReadCloned = (_293_allReadCloned).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_MUT(), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("_this"), Std.Wrappers.Option<RAST._IType>.create_None(), Std.Wrappers.Option<RAST._IExpr>.create_Some(_295_selfCloned)));
               } else if (!((_283_paramNames).Contains(_294_next))) {
                 RAST._IExpr _298_copy;
@@ -6123,20 +6152,20 @@ namespace DCOMP {
               _out245 = (this).GenType((((_300_values).Select(_311_i)).dtor__0).dtor_typ, Defs.GenTypeContext.@default());
               _312_typeGen = _out245;
               RAST._IExpr _313_valueGen;
-              Defs._IOwnership _314___v128;
+              Defs._IOwnership _314___v127;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _315_recIdents;
               RAST._IExpr _out246;
               Defs._IOwnership _out247;
               Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out248;
               (this).GenExpr(((_300_values).Select(_311_i)).dtor__1, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out246, out _out247, out _out248);
               _313_valueGen = _out246;
-              _314___v128 = _out247;
+              _314___v127 = _out247;
               _315_recIdents = _out248;
               r = (r).Then(RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), Defs.__default.escapeVar((((_300_values).Select(_311_i)).dtor__0).dtor_name), Std.Wrappers.Option<RAST._IType>.create_Some(_312_typeGen), Std.Wrappers.Option<RAST._IExpr>.create_Some(_313_valueGen)));
               readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, _315_recIdents);
             }
             Defs._IEnvironment _316_newEnv;
-            _316_newEnv = Defs.Environment.create(_303_paramNames, _306_paramTypes);
+            _316_newEnv = Defs.Environment.create(_303_paramNames, _306_paramTypes, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements());
             RAST._IExpr _317_recGen;
             Defs._IOwnership _318_recOwned;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _319_recIdents;
@@ -6167,14 +6196,14 @@ namespace DCOMP {
           DAST._IExpression _323_iifeBody = _source0.dtor_iifeBody;
           {
             RAST._IExpr _324_valueGen;
-            Defs._IOwnership _325___v129;
+            Defs._IOwnership _325___v128;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _326_recIdents;
             RAST._IExpr _out254;
             Defs._IOwnership _out255;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out256;
             (this).GenExpr(_322_value, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out254, out _out255, out _out256);
             _324_valueGen = _out254;
-            _325___v129 = _out255;
+            _325___v128 = _out255;
             _326_recIdents = _out256;
             readIdents = _326_recIdents;
             RAST._IType _327_valueTypeGen;
@@ -6184,14 +6213,14 @@ namespace DCOMP {
             Dafny.ISequence<Dafny.Rune> _328_iifeVar;
             _328_iifeVar = Defs.__default.escapeVar(_320_name);
             RAST._IExpr _329_bodyGen;
-            Defs._IOwnership _330___v130;
+            Defs._IOwnership _330___v129;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _331_bodyIdents;
             RAST._IExpr _out258;
             Defs._IOwnership _out259;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out260;
             (this).GenExpr(_323_iifeBody, selfIdent, (env).AddAssigned(_328_iifeVar, _327_valueTypeGen), Defs.Ownership.create_OwnershipOwned(), out _out258, out _out259, out _out260);
             _329_bodyGen = _out258;
-            _330___v130 = _out259;
+            _330___v129 = _out259;
             _331_bodyIdents = _out260;
             readIdents = Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union(readIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference(_331_bodyIdents, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(_328_iifeVar)));
             r = RAST.Expr.create_Block((RAST.Expr.create_DeclareVar(RAST.DeclareType.create_CONST(), _328_iifeVar, Std.Wrappers.Option<RAST._IType>.create_Some(_327_valueTypeGen), Std.Wrappers.Option<RAST._IExpr>.create_Some(_324_valueGen))).Then(_329_bodyGen));
@@ -6211,14 +6240,14 @@ namespace DCOMP {
           Dafny.ISequence<DAST._IExpression> _333_args = _source0.dtor_args;
           {
             RAST._IExpr _334_funcExpr;
-            Defs._IOwnership _335___v131;
+            Defs._IOwnership _335___v130;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _336_recIdents;
             RAST._IExpr _out263;
             Defs._IOwnership _out264;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out265;
             (this).GenExpr(_332_func, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out263, out _out264, out _out265);
             _334_funcExpr = _out263;
-            _335___v131 = _out264;
+            _335___v130 = _out264;
             _336_recIdents = _out265;
             readIdents = _336_recIdents;
             Dafny.ISequence<RAST._IExpr> _337_rArgs;
@@ -6256,14 +6285,14 @@ namespace DCOMP {
           Dafny.ISequence<Dafny.Rune> _344_variant = _source0.dtor_variant;
           {
             RAST._IExpr _345_exprGen;
-            Defs._IOwnership _346___v132;
+            Defs._IOwnership _346___v131;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _347_recIdents;
             RAST._IExpr _out271;
             Defs._IOwnership _out272;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out273;
             (this).GenExpr(_342_on, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out271, out _out272, out _out273);
             _345_exprGen = _out271;
-            _346___v132 = _out272;
+            _346___v131 = _out272;
             _347_recIdents = _out273;
             RAST._IExpr _348_variantExprPath;
             RAST._IExpr _out274;
@@ -6344,14 +6373,14 @@ namespace DCOMP {
           DAST._IExpression _357_of = _source0.dtor_of;
           {
             RAST._IExpr _358_exprGen;
-            Defs._IOwnership _359___v133;
+            Defs._IOwnership _359___v132;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _360_recIdents;
             RAST._IExpr _out287;
             Defs._IOwnership _out288;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out289;
             (this).GenExpr(_357_of, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out287, out _out288, out _out289);
             _358_exprGen = _out287;
-            _359___v133 = _out288;
+            _359___v132 = _out288;
             _360_recIdents = _out289;
             r = ((_358_exprGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("iter"))).Apply0();
             RAST._IExpr _out290;
@@ -6371,14 +6400,14 @@ namespace DCOMP {
           bool _362_includeDuplicates = _source0.dtor_includeDuplicates;
           {
             RAST._IExpr _363_exprGen;
-            Defs._IOwnership _364___v134;
+            Defs._IOwnership _364___v133;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _365_recIdents;
             RAST._IExpr _out292;
             Defs._IOwnership _out293;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out294;
             (this).GenExpr(_361_of, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out292, out _out293, out _out294);
             _363_exprGen = _out292;
-            _364___v134 = _out293;
+            _364___v133 = _out293;
             _365_recIdents = _out294;
             r = ((_363_exprGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("iter"))).Apply0();
             if (!(_362_includeDuplicates)) {
@@ -6401,14 +6430,14 @@ namespace DCOMP {
           bool _367_includeDuplicates = _source0.dtor_includeDuplicates;
           {
             RAST._IExpr _368_exprGen;
-            Defs._IOwnership _369___v135;
+            Defs._IOwnership _369___v134;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _370_recIdents;
             RAST._IExpr _out297;
             Defs._IOwnership _out298;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out299;
             (this).GenExpr(_366_of, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out297, out _out298, out _out299);
             _368_exprGen = _out297;
-            _369___v135 = _out298;
+            _369___v134 = _out298;
             _370_recIdents = _out299;
             r = ((_368_exprGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("iter"))).Apply0();
             if (!(_367_includeDuplicates)) {
@@ -6430,14 +6459,14 @@ namespace DCOMP {
           DAST._IExpression _371_of = _source0.dtor_of;
           {
             RAST._IExpr _372_exprGen;
-            Defs._IOwnership _373___v136;
+            Defs._IOwnership _373___v135;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _374_recIdents;
             RAST._IExpr _out302;
             Defs._IOwnership _out303;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out304;
             (this).GenExpr(_371_of, selfIdent, env, Defs.Ownership.create_OwnershipBorrowed(), out _out302, out _out303, out _out304);
             _372_exprGen = _out302;
-            _373___v136 = _out303;
+            _373___v135 = _out303;
             _374_recIdents = _out304;
             r = ((((_372_exprGen).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("keys"))).Apply0()).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("iter"))).Apply0();
             readIdents = _374_recIdents;
@@ -6455,14 +6484,14 @@ namespace DCOMP {
           DAST._IExpression _375_of = _source0.dtor_of;
           {
             RAST._IExpr _376_exprGen;
-            Defs._IOwnership _377___v137;
+            Defs._IOwnership _377___v136;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _378_recIdents;
             RAST._IExpr _out307;
             Defs._IOwnership _out308;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out309;
             (this).GenExpr(_375_of, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out307, out _out308, out _out309);
             _376_exprGen = _out307;
-            _377___v137 = _out308;
+            _377___v136 = _out308;
             _378_recIdents = _out309;
             r = ((((RAST.__default.std).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("iter"))).AsExpr()).FSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("once"))).Apply1(_376_exprGen);
             readIdents = _378_recIdents;
@@ -6483,24 +6512,24 @@ namespace DCOMP {
           bool _382_up = _source0.dtor_up;
           {
             RAST._IExpr _383_lo;
-            Defs._IOwnership _384___v138;
+            Defs._IOwnership _384___v137;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _385_recIdentsLo;
             RAST._IExpr _out312;
             Defs._IOwnership _out313;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out314;
             (this).GenExpr(_380_lo, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out312, out _out313, out _out314);
             _383_lo = _out312;
-            _384___v138 = _out313;
+            _384___v137 = _out313;
             _385_recIdentsLo = _out314;
             RAST._IExpr _386_hi;
-            Defs._IOwnership _387___v139;
+            Defs._IOwnership _387___v138;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _388_recIdentsHi;
             RAST._IExpr _out315;
             Defs._IOwnership _out316;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out317;
             (this).GenExpr(_381_hi, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out315, out _out316, out _out317);
             _386_hi = _out315;
-            _387___v139 = _out316;
+            _387___v138 = _out316;
             _388_recIdentsHi = _out317;
             if (_382_up) {
               r = (((RAST.__default.dafny__runtime).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("integer_range"))).AsExpr()).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(_383_lo, _386_hi));
@@ -6531,14 +6560,14 @@ namespace DCOMP {
           bool _391_up = _source0.dtor_up;
           {
             RAST._IExpr _392_start;
-            Defs._IOwnership _393___v140;
+            Defs._IOwnership _393___v139;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _394_recIdentStart;
             RAST._IExpr _out321;
             Defs._IOwnership _out322;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out323;
             (this).GenExpr(_390_start, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out321, out _out322, out _out323);
             _392_start = _out321;
-            _393___v140 = _out322;
+            _393___v139 = _out322;
             _394_recIdentStart = _out323;
             if (_391_up) {
               r = (((RAST.__default.dafny__runtime).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("integer_range_unbounded"))).AsExpr()).Apply1(_392_start);
@@ -6612,14 +6641,14 @@ namespace DCOMP {
           _out333 = (this).GenType(_401_elemType, Defs.GenTypeContext.@default());
           _405_tpe = _out333;
           RAST._IExpr _406_collectionGen;
-          Defs._IOwnership _407___v141;
+          Defs._IOwnership _407___v140;
           Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _408_recIdents;
           RAST._IExpr _out334;
           Defs._IOwnership _out335;
           Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out336;
           (this).GenExpr(_402_collection, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out334, out _out335, out _out336);
           _406_collectionGen = _out334;
-          _407___v141 = _out335;
+          _407___v140 = _out335;
           _408_recIdents = _out336;
           Dafny.ISequence<DAST._IAttribute> _409_extraAttributes;
           _409_extraAttributes = Dafny.Sequence<DAST._IAttribute>.FromElements();
@@ -6642,14 +6671,14 @@ namespace DCOMP {
             Dafny.ISequence<DAST._IFormal> _417_dt__update_hparams_h0 = _411_newFormals;
             _415_newLambda = DAST.Expression.create_Lambda(_417_dt__update_hparams_h0, (_416_dt__update__tmp_h1).dtor_retType, (_416_dt__update__tmp_h1).dtor_body);
             RAST._IExpr _418_lambdaGen;
-            Defs._IOwnership _419___v142;
+            Defs._IOwnership _419___v141;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _420_recLambdaIdents;
             RAST._IExpr _out337;
             Defs._IOwnership _out338;
             Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out339;
             (this).GenExpr(_415_newLambda, selfIdent, env, Defs.Ownership.create_OwnershipOwned(), out _out337, out _out338, out _out339);
             _418_lambdaGen = _out337;
-            _419___v142 = _out338;
+            _419___v141 = _out338;
             _420_recLambdaIdents = _out339;
             Dafny.ISequence<Dafny.Rune> _421_fn;
             if (_403_is__forall) {
@@ -6756,15 +6785,15 @@ namespace DCOMP {
   "));
       }
       RAST._IExpr _0_call;
-      Defs._IOwnership _1___v143;
-      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _2___v144;
+      Defs._IOwnership _1___v142;
+      Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _2___v143;
       RAST._IExpr _out0;
       Defs._IOwnership _out1;
       Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _out2;
       (this).GenExpr(companion, Defs.SelfInfo.create_NoSelf(), Defs.Environment.Empty(), Defs.Ownership.create_OwnershipOwned(), out _out0, out _out1, out _out2);
       _0_call = _out0;
-      _1___v143 = _out1;
-      _2___v144 = _out2;
+      _1___v142 = _out1;
+      _2___v143 = _out2;
       _0_call = (_0_call).FSel(mainMethodName);
       if (hasArgs) {
         _0_call = (_0_call).Apply1(RAST.__default.Borrow(RAST.Expr.create_Identifier(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("dafny_args"))));

--- a/Source/DafnyCore/GeneratedFromDafny/Defs.cs
+++ b/Source/DafnyCore/GeneratedFromDafny/Defs.cs
@@ -531,6 +531,89 @@ namespace Defs {
     {
       return RAST.ModDecl.create_ImplDecl(RAST.Impl.create_ImplFor(rTypeParamsDecls, (((RAST.__default.std).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("cmp"))).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("PartialOrd"))).AsType(), newtypeType, Dafny.Sequence<RAST._IImplMember>.FromElements(RAST.ImplMember.create_FnDecl(RAST.Visibility.create_PRIV(), RAST.Fn.create(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("partial_cmp"), Dafny.Sequence<RAST._ITypeParamDecl>.FromElements(), Dafny.Sequence<RAST._IFormal>.FromElements(RAST.Formal.selfBorrowed, RAST.Formal.create(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("other"), RAST.__default.SelfBorrowed)), Std.Wrappers.Option<RAST._IType>.create_Some(((((RAST.__default.std).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("option"))).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("Option"))).AsType()).Apply1((((RAST.__default.std).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("cmp"))).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("Ordering"))).AsType())), Dafny.Sequence<Dafny.Rune>.UnicodeFromString(""), Std.Wrappers.Option<RAST._IExpr>.create_Some((((((RAST.__default.std).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("cmp"))).MSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("PartialOrd"))).AsExpr()).FSel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("partial_cmp"))).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(RAST.__default.Borrow((RAST.__default.self).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("0"))), RAST.__default.Borrow((RAST.Expr.create_Identifier(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("other"))).Sel(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("0")))))))))));
     }
+    public static Defs._IAssignmentStatus DetectAssignmentStatus(Dafny.ISequence<DAST._IStatement> stmts__remainder, Dafny.ISequence<Dafny.Rune> dafny__name)
+    {
+      if ((new BigInteger((stmts__remainder).Count)).Sign == 0) {
+        return Defs.AssignmentStatus.create_NotAssigned();
+      } else {
+        DAST._IStatement _0_stmt = (stmts__remainder).Select(BigInteger.Zero);
+        DAST._IStatement _source0 = _0_stmt;
+        {
+          if (_source0.is_Assign) {
+            DAST._IAssignLhs lhs0 = _source0.dtor_lhs;
+            if (lhs0.is_Ident) {
+              Dafny.ISequence<Dafny.Rune> _1_assign__name = lhs0.dtor_ident;
+              if (object.Equals(_1_assign__name, dafny__name)) {
+                return Defs.AssignmentStatus.create_SurelyAssigned();
+              } else {
+                return Defs.__default.DetectAssignmentStatus((stmts__remainder).Drop(BigInteger.One), dafny__name);
+              }
+            }
+          }
+        }
+        {
+          if (_source0.is_If) {
+            DAST._IExpression _2_cond = _source0.dtor_cond;
+            Dafny.ISequence<DAST._IStatement> _3_thn = _source0.dtor_thn;
+            Dafny.ISequence<DAST._IStatement> _4_els = _source0.dtor_els;
+            return (Defs.__default.DetectAssignmentStatus(_3_thn, dafny__name)).Join(Defs.__default.DetectAssignmentStatus(_4_els, dafny__name));
+          }
+        }
+        {
+          if (_source0.is_Call) {
+            DAST._IExpression _5_on = _source0.dtor_on;
+            DAST._ICallName _6_callName = _source0.dtor_callName;
+            Dafny.ISequence<DAST._IType> _7_typeArgs = _source0.dtor_typeArgs;
+            Dafny.ISequence<DAST._IExpression> _8_args = _source0.dtor_args;
+            Std.Wrappers._IOption<Dafny.ISequence<Dafny.ISequence<Dafny.Rune>>> _9_outs = _source0.dtor_outs;
+            if (((_9_outs).is_Some) && (((_9_outs).dtor_value).Contains(dafny__name))) {
+              return Defs.AssignmentStatus.create_SurelyAssigned();
+            } else {
+              return Defs.__default.DetectAssignmentStatus((stmts__remainder).Drop(BigInteger.One), dafny__name);
+            }
+          }
+        }
+        {
+          if (_source0.is_Labeled) {
+            Dafny.ISequence<DAST._IStatement> _10_stmts = _source0.dtor_body;
+            return (Defs.__default.DetectAssignmentStatus(_10_stmts, dafny__name)).Then(Defs.__default.DetectAssignmentStatus((stmts__remainder).Drop(BigInteger.One), dafny__name));
+          }
+        }
+        {
+          if (_source0.is_DeclareVar) {
+            Dafny.ISequence<Dafny.Rune> _11_name = _source0.dtor_name;
+            if (object.Equals(_11_name, dafny__name)) {
+              return Defs.AssignmentStatus.create_NotAssigned();
+            } else {
+              return Defs.__default.DetectAssignmentStatus((stmts__remainder).Drop(BigInteger.One), dafny__name);
+            }
+          }
+        }
+        {
+          bool disjunctiveMatch0 = false;
+          if (_source0.is_Return) {
+            disjunctiveMatch0 = true;
+          }
+          if (_source0.is_EarlyReturn) {
+            disjunctiveMatch0 = true;
+          }
+          if (_source0.is_JumpTailCallStart) {
+            disjunctiveMatch0 = true;
+          }
+          if (disjunctiveMatch0) {
+            return Defs.AssignmentStatus.create_NotAssigned();
+          }
+        }
+        {
+          if (_source0.is_Print) {
+            return Defs.__default.DetectAssignmentStatus((stmts__remainder).Drop(BigInteger.One), dafny__name);
+          }
+        }
+        {
+          return Defs.AssignmentStatus.create_Unknown();
+        }
+      }
+    }
     public static Dafny.ISet<Dafny.ISequence<Dafny.Rune>> reserved__rust { get {
       return Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("as"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("async"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("await"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("break"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("const"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("continue"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("crate"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("dyn"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("else"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("enum"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("extern"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("false"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("fn"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("for"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("if"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("impl"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("in"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("let"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("loop"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("match"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("mod"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("move"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("mut"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("pub"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("ref"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("return"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("static"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("struct"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("super"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("trait"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("true"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("type"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("union"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unsafe"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("use"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("where"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("while"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("Keywords"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("The"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("abstract"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("become"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("box"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("do"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("final"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("macro"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("override"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("priv"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("try"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("typeof"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("unsized"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("virtual"), Dafny.Sequence<Dafny.Rune>.UnicodeFromString("yield"));
     } }
@@ -696,6 +779,7 @@ namespace Defs {
     bool is_Environment { get; }
     Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_names { get; }
     Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> dtor_types { get; }
+    Dafny.ISet<Dafny.ISequence<Dafny.Rune>> dtor_assignmentStatusKnown { get; }
     _IEnvironment DowncastClone();
     Defs._IEnvironment ToOwned();
     bool CanReadWithoutClone(Dafny.ISequence<Dafny.Rune> name);
@@ -705,30 +789,36 @@ namespace Defs {
     bool IsBorrowedMut(Dafny.ISequence<Dafny.Rune> name);
     bool IsBoxed(Dafny.ISequence<Dafny.Rune> name);
     bool NeedsAsRefForBorrow(Dafny.ISequence<Dafny.Rune> name);
+    bool IsMaybePlacebo(Dafny.ISequence<Dafny.Rune> name);
     Defs._IEnvironment AddAssigned(Dafny.ISequence<Dafny.Rune> name, RAST._IType tpe);
     Defs._IEnvironment merge(Defs._IEnvironment other);
     Defs._IEnvironment RemoveAssigned(Dafny.ISequence<Dafny.Rune> name);
+    Defs._IEnvironment AddAssignmentStatus(Dafny.ISequence<Dafny.Rune> name, Defs._IAssignmentStatus assignmentStatus);
+    bool IsAssignmentStatusKnown(Dafny.ISequence<Dafny.Rune> name);
   }
   public class Environment : _IEnvironment {
     public readonly Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> _names;
     public readonly Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> _types;
-    public Environment(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> names, Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> types) {
+    public readonly Dafny.ISet<Dafny.ISequence<Dafny.Rune>> _assignmentStatusKnown;
+    public Environment(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> names, Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> types, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> assignmentStatusKnown) {
       this._names = names;
       this._types = types;
+      this._assignmentStatusKnown = assignmentStatusKnown;
     }
     public _IEnvironment DowncastClone() {
       if (this is _IEnvironment dt) { return dt; }
-      return new Environment(_names, _types);
+      return new Environment(_names, _types, _assignmentStatusKnown);
     }
     public override bool Equals(object other) {
       var oth = other as Defs.Environment;
-      return oth != null && object.Equals(this._names, oth._names) && object.Equals(this._types, oth._types);
+      return oth != null && object.Equals(this._names, oth._names) && object.Equals(this._types, oth._types) && object.Equals(this._assignmentStatusKnown, oth._assignmentStatusKnown);
     }
     public override int GetHashCode() {
       ulong hash = 5381;
       hash = ((hash << 5) + hash) + 0;
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._names));
       hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._types));
+      hash = ((hash << 5) + hash) + ((ulong)Dafny.Helpers.GetHashCode(this._assignmentStatusKnown));
       return (int) hash;
     }
     public override string ToString() {
@@ -737,10 +827,12 @@ namespace Defs {
       s += Dafny.Helpers.ToString(this._names);
       s += ", ";
       s += Dafny.Helpers.ToString(this._types);
+      s += ", ";
+      s += Dafny.Helpers.ToString(this._assignmentStatusKnown);
       s += ")";
       return s;
     }
-    private static readonly Defs._IEnvironment theDefault = create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Empty, Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Empty);
+    private static readonly Defs._IEnvironment theDefault = create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Empty, Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Empty, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Empty);
     public static Defs._IEnvironment Default() {
       return theDefault;
     }
@@ -748,11 +840,11 @@ namespace Defs {
     public static Dafny.TypeDescriptor<Defs._IEnvironment> _TypeDescriptor() {
       return _TYPE;
     }
-    public static _IEnvironment create(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> names, Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> types) {
-      return new Environment(names, types);
+    public static _IEnvironment create(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> names, Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> types, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> assignmentStatusKnown) {
+      return new Environment(names, types, assignmentStatusKnown);
     }
-    public static _IEnvironment create_Environment(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> names, Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> types) {
-      return create(names, types);
+    public static _IEnvironment create_Environment(Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> names, Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> types, Dafny.ISet<Dafny.ISequence<Dafny.Rune>> assignmentStatusKnown) {
+      return create(names, types, assignmentStatusKnown);
     }
     public bool is_Environment { get { return true; } }
     public Dafny.ISequence<Dafny.ISequence<Dafny.Rune>> dtor_names {
@@ -763,6 +855,11 @@ namespace Defs {
     public Dafny.IMap<Dafny.ISequence<Dafny.Rune>,RAST._IType> dtor_types {
       get {
         return this._types;
+      }
+    }
+    public Dafny.ISet<Dafny.ISequence<Dafny.Rune>> dtor_assignmentStatusKnown {
+      get {
+        return this._assignmentStatusKnown;
       }
     }
     public Defs._IEnvironment ToOwned() {
@@ -777,10 +874,10 @@ namespace Defs {
         }
         return Dafny.Map<Dafny.ISequence<Dafny.Rune>,RAST._IType>.FromCollection(_coll0);
       }))();
-      return Defs.Environment.create((_0_dt__update__tmp_h0).dtor_names, _1_dt__update_htypes_h0);
+      return Defs.Environment.create((_0_dt__update__tmp_h0).dtor_names, _1_dt__update_htypes_h0, (_0_dt__update__tmp_h0).dtor_assignmentStatusKnown);
     }
     public static Defs._IEnvironment Empty() {
-      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.FromElements());
+      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.FromElements(), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements());
     }
     public bool CanReadWithoutClone(Dafny.ISequence<Dafny.Rune> name) {
       return (((this).dtor_types).Contains(name)) && ((Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Select((this).dtor_types,name)).CanReadWithoutClone());
@@ -807,16 +904,26 @@ namespace Defs {
     public bool NeedsAsRefForBorrow(Dafny.ISequence<Dafny.Rune> name) {
       return (((this).dtor_types).Contains(name)) && ((Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Select((this).dtor_types,name)).NeedsAsRefForBorrow());
     }
+    public bool IsMaybePlacebo(Dafny.ISequence<Dafny.Rune> name) {
+      return (((this).dtor_types).Contains(name)) && (((Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Select((this).dtor_types,name)).ExtractMaybePlacebo()).is_Some);
+    }
     public Defs._IEnvironment AddAssigned(Dafny.ISequence<Dafny.Rune> name, RAST._IType tpe)
     {
-      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat((this).dtor_names, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(name)), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Update((this).dtor_types, name, tpe));
+      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat((this).dtor_names, Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.FromElements(name)), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Update((this).dtor_types, name, tpe), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference((this).dtor_assignmentStatusKnown, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(name)));
     }
     public Defs._IEnvironment merge(Defs._IEnvironment other) {
-      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat((this).dtor_names, (other).dtor_names), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Merge((this).dtor_types, (other).dtor_types));
+      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat((this).dtor_names, (other).dtor_names), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Merge((this).dtor_types, (other).dtor_types), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union((this).dtor_assignmentStatusKnown, (other).dtor_assignmentStatusKnown));
     }
     public Defs._IEnvironment RemoveAssigned(Dafny.ISequence<Dafny.Rune> name) {
       BigInteger _0_indexInEnv = Std.Collections.Seq.__default.IndexOf<Dafny.ISequence<Dafny.Rune>>((this).dtor_names, name);
-      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(((this).dtor_names).Subsequence(BigInteger.Zero, _0_indexInEnv), ((this).dtor_names).Drop((_0_indexInEnv) + (BigInteger.One))), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Subtract((this).dtor_types, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(name)));
+      return Defs.Environment.create(Dafny.Sequence<Dafny.ISequence<Dafny.Rune>>.Concat(((this).dtor_names).Subsequence(BigInteger.Zero, _0_indexInEnv), ((this).dtor_names).Drop((_0_indexInEnv) + (BigInteger.One))), Dafny.Map<Dafny.ISequence<Dafny.Rune>, RAST._IType>.Subtract((this).dtor_types, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(name)), Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference((this).dtor_assignmentStatusKnown, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(name)));
+    }
+    public Defs._IEnvironment AddAssignmentStatus(Dafny.ISequence<Dafny.Rune> name, Defs._IAssignmentStatus assignmentStatus)
+    {
+      return Defs.Environment.create((this).dtor_names, (this).dtor_types, (((assignmentStatus).is_Unknown) ? (Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Difference((this).dtor_assignmentStatusKnown, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(name))) : (Dafny.Set<Dafny.ISequence<Dafny.Rune>>.Union((this).dtor_assignmentStatusKnown, Dafny.Set<Dafny.ISequence<Dafny.Rune>>.FromElements(name)))));
+    }
+    public bool IsAssignmentStatusKnown(Dafny.ISequence<Dafny.Rune> name) {
+      return ((this).dtor_assignmentStatusKnown).Contains(name);
     }
   }
 
@@ -1369,6 +1476,128 @@ namespace Defs {
       s += "(";
       s += this._reason.ToVerbatimString(true);
       s += ")";
+      return s;
+    }
+  }
+
+  public interface _IAssignmentStatus {
+    bool is_NotAssigned { get; }
+    bool is_SurelyAssigned { get; }
+    bool is_Unknown { get; }
+    _IAssignmentStatus DowncastClone();
+    Defs._IAssignmentStatus Join(Defs._IAssignmentStatus other);
+    Defs._IAssignmentStatus Then(Defs._IAssignmentStatus other);
+  }
+  public abstract class AssignmentStatus : _IAssignmentStatus {
+    public AssignmentStatus() {
+    }
+    private static readonly Defs._IAssignmentStatus theDefault = create_NotAssigned();
+    public static Defs._IAssignmentStatus Default() {
+      return theDefault;
+    }
+    private static readonly Dafny.TypeDescriptor<Defs._IAssignmentStatus> _TYPE = new Dafny.TypeDescriptor<Defs._IAssignmentStatus>(Defs.AssignmentStatus.Default());
+    public static Dafny.TypeDescriptor<Defs._IAssignmentStatus> _TypeDescriptor() {
+      return _TYPE;
+    }
+    public static _IAssignmentStatus create_NotAssigned() {
+      return new AssignmentStatus_NotAssigned();
+    }
+    public static _IAssignmentStatus create_SurelyAssigned() {
+      return new AssignmentStatus_SurelyAssigned();
+    }
+    public static _IAssignmentStatus create_Unknown() {
+      return new AssignmentStatus_Unknown();
+    }
+    public bool is_NotAssigned { get { return this is AssignmentStatus_NotAssigned; } }
+    public bool is_SurelyAssigned { get { return this is AssignmentStatus_SurelyAssigned; } }
+    public bool is_Unknown { get { return this is AssignmentStatus_Unknown; } }
+    public static System.Collections.Generic.IEnumerable<_IAssignmentStatus> AllSingletonConstructors {
+      get {
+        yield return AssignmentStatus.create_NotAssigned();
+        yield return AssignmentStatus.create_SurelyAssigned();
+        yield return AssignmentStatus.create_Unknown();
+      }
+    }
+    public abstract _IAssignmentStatus DowncastClone();
+    public Defs._IAssignmentStatus Join(Defs._IAssignmentStatus other) {
+      if (((this).is_SurelyAssigned) && ((other).is_SurelyAssigned)) {
+        return Defs.AssignmentStatus.create_SurelyAssigned();
+      } else if (((this).is_NotAssigned) && ((other).is_NotAssigned)) {
+        return Defs.AssignmentStatus.create_NotAssigned();
+      } else {
+        return Defs.AssignmentStatus.create_Unknown();
+      }
+    }
+    public Defs._IAssignmentStatus Then(Defs._IAssignmentStatus other) {
+      if ((this).is_SurelyAssigned) {
+        return Defs.AssignmentStatus.create_SurelyAssigned();
+      } else if ((this).is_NotAssigned) {
+        return other;
+      } else {
+        return Defs.AssignmentStatus.create_Unknown();
+      }
+    }
+  }
+  public class AssignmentStatus_NotAssigned : AssignmentStatus {
+    public AssignmentStatus_NotAssigned() : base() {
+    }
+    public override _IAssignmentStatus DowncastClone() {
+      if (this is _IAssignmentStatus dt) { return dt; }
+      return new AssignmentStatus_NotAssigned();
+    }
+    public override bool Equals(object other) {
+      var oth = other as Defs.AssignmentStatus_NotAssigned;
+      return oth != null;
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 0;
+      return (int) hash;
+    }
+    public override string ToString() {
+      string s = "DafnyToRustCompilerDefinitions.AssignmentStatus.NotAssigned";
+      return s;
+    }
+  }
+  public class AssignmentStatus_SurelyAssigned : AssignmentStatus {
+    public AssignmentStatus_SurelyAssigned() : base() {
+    }
+    public override _IAssignmentStatus DowncastClone() {
+      if (this is _IAssignmentStatus dt) { return dt; }
+      return new AssignmentStatus_SurelyAssigned();
+    }
+    public override bool Equals(object other) {
+      var oth = other as Defs.AssignmentStatus_SurelyAssigned;
+      return oth != null;
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 1;
+      return (int) hash;
+    }
+    public override string ToString() {
+      string s = "DafnyToRustCompilerDefinitions.AssignmentStatus.SurelyAssigned";
+      return s;
+    }
+  }
+  public class AssignmentStatus_Unknown : AssignmentStatus {
+    public AssignmentStatus_Unknown() : base() {
+    }
+    public override _IAssignmentStatus DowncastClone() {
+      if (this is _IAssignmentStatus dt) { return dt; }
+      return new AssignmentStatus_Unknown();
+    }
+    public override bool Equals(object other) {
+      var oth = other as Defs.AssignmentStatus_Unknown;
+      return oth != null;
+    }
+    public override int GetHashCode() {
+      ulong hash = 5381;
+      hash = ((hash << 5) + hash) + 2;
+      return (int) hash;
+    }
+    public override string ToString() {
+      string s = "DafnyToRustCompilerDefinitions.AssignmentStatus.Unknown";
       return s;
     }
   }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/nomaybeplacebos.check
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/nomaybeplacebos.check
@@ -1,0 +1,1 @@
+// CHECK-NOT: .*MaybePlacebo.*

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/nomaybeplacebos.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/nomaybeplacebos.dfy
@@ -1,0 +1,13 @@
+// NONUNIFORM: Test of the output of the Rust translation
+// RUN: %baredafny translate rs "%s" > "%t"
+// RUN: %OutputCheck --file-to-check "%S/nomaybeplacebos-rust/src/nomaybeplacebos.rs" "%S/nomaybeplacebos.check"
+
+
+method Test(i: int) returns (j: int) {
+  j := i;
+}
+
+method Main() {
+  var j := Test(1);
+  var k := Test(j);
+}


### PR DESCRIPTION
### Description
Given the following dafny file
```dfy
method Test(i: int) returns (j: int) {
  j := i;
}

method Main() {
  var j := Test(1);
  var k := Test(j);
}
```
the Dafny to Rust code generator used to produce this:
```rs
    pub fn Test(i: &DafnyInt) -> DafnyInt {
      let mut j = MaybePlacebo::<DafnyInt>::new();
      j = MaybePlacebo::from(i.clone());
      return j.read();
    }
    pub fn Main(_noArgsParameter: &Sequence<Sequence<DafnyChar>>) -> () {
      let mut j = MaybePlacebo::<DafnyInt>::new();
      let mut _out0 = MaybePlacebo::<DafnyInt>::new();
      _out0 = MaybePlacebo::from(_default::Test(&int!(1)));
      j = MaybePlacebo::from(_out0.read());
      let mut k = MaybePlacebo::<DafnyInt>::new();
      let mut _out1 = MaybePlacebo::<DafnyInt>::new();
      _out1 = MaybePlacebo::from(_default::Test(&j.read()));
      k = MaybePlacebo::from(_out1.read());
      return ();
    }
```
While Dafny lets users declare a variable while assigning it conditionally, Rust does not support this pattern as it needs to know if the variable was assigned so that it can deallocate it. The current solution supports all cases. It uses `MaybePlacebo`, a synonym of the Option type, so that we can declare a placebo holder even if the type does not implement the `Default trait` (looking at you, functions).
However, this encoding is still tracking a boolean, and furthermore, it makes the code harder to read and debug.

With this PR, Dafny performs static analysis of assignments, determine that the variables will be surely assigned, and is able to determine at the declaration of the yet undefined variable if it's going to be surely assigned or surely not assigned. In either case, it removes the MaybePlacebo wrapper. This works for output variables of method calls, as well as variables declared but not defined.

```rs
    pub fn Test(i: &DafnyInt) -> DafnyInt {
      let mut j: DafnyInt = i.clone();
      return j.clone();
    }
    pub fn Main(_noArgsParameter: &Sequence<Sequence<DafnyChar>>) -> () {
      let mut j: DafnyInt;
      let mut _out0: DafnyInt = _default::Test(&int!(1));
      j = _out0.clone();
      let mut k: DafnyInt;
      let mut _out1: DafnyInt = _default::Test(&j);
      k = _out1.clone();
      return ();
    }
```
There are still a few clones and one day we might be able to get rid of the intermediate variable, but this is out of scope for this PR.

### How has this been tested?
- The test above has been added
- The behavior of determining assignment status has a thorough new test executed from `DafnyCore.Test`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
