### PR TITLE
Remove fragile logic for mapping verification tasks to Dafny symbols

### DIFF
--- a/Source/DafnyCore/AST/RangeToken.cs
+++ b/Source/DafnyCore/AST/RangeToken.cs
@@ -80,10 +80,6 @@ public class RangeToken : OriginWrapper {
 
   public override bool IsSourceToken => this != NoToken;
 
-  public BoogieRangeOrigin ToToken() {
-    return new BoogieRangeOrigin(StartToken, EndToken, null);
-  }
-
   public bool Contains(IOrigin otherToken) {
     return StartToken.Uri == otherToken.Uri &&
            StartToken.pos <= otherToken.pos &&

--- a/Source/DafnyCore/AST/Statements/Verification/AssertStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Verification/AssertStmt.cs
@@ -67,12 +67,12 @@ public class AssertStmt : PredicateStmt, ICloneable<AssertStmt>, ICanFormat {
     }
 
     if (this.HasUserAttribute("only", out var attribute)) {
-      resolver.Reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_assert_only_assumes_others.ToString(), attribute.RangeToken.ToToken(),
+      resolver.Reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_assert_only_assumes_others.ToString(), attribute.RangeToken,
         "Assertion with {:only} temporarily transforms other assertions into assumptions");
       if (attribute.Args.Count >= 1
           && attribute.Args[0] is LiteralExpr { Value: string value }
           && value != "before" && value != "after") {
-        resolver.Reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_assert_only_before_after.ToString(), attribute.Args[0].RangeToken.ToToken(),
+        resolver.Reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_assert_only_before_after.ToString(), attribute.Args[0].RangeToken,
           "{:only} only accepts \"before\" or \"after\" as an optional argument");
       }
     }

--- a/Source/DafnyCore/JsonDiagnostics.cs
+++ b/Source/DafnyCore/JsonDiagnostics.cs
@@ -26,8 +26,8 @@ record DiagnosticMessageData(MessageSource source, ErrorLevel level, Boogie.ITok
     };
     if (tok is RangeToken rangeToken1) {
       range["end"] = SerializePosition(rangeToken1.EndToken);
-    } else if (tok is BoogieRangeOrigin rangeToken2) {
-      range["end"] = SerializePosition(rangeToken2.EndToken);
+    } else if (tok is FromDafnyNode rangeToken2) {
+      range["end"] = SerializePosition(rangeToken2.Inner.EndToken);
     }
     return range;
   }

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -2778,10 +2778,10 @@ namespace Microsoft.Dafny {
       foreach (MemberDecl member in cl.Members) {
         Contract.Assert(VisibleInScope(member));
         if (member.HasUserAttribute("only", out var attribute)) {
-          reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_member_only_assumes_other.ToString(), attribute.RangeToken.ToToken(),
+          reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_member_only_assumes_other.ToString(), attribute.RangeToken,
             "Members with {:only} temporarily disable the verification of other members in the entire file");
           if (attribute.Args.Count >= 1) {
-            reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_member_only_has_no_before_after.ToString(), attribute.Args[0].RangeToken.ToToken(),
+            reporter.Warning(MessageSource.Verifier, ResolutionErrors.ErrorId.r_member_only_has_no_before_after.ToString(), attribute.Args[0].RangeToken,
               "{:only} on members does not support arguments");
           }
         }
@@ -5894,7 +5894,7 @@ namespace Microsoft.Dafny {
               }
               if (allowMethodCall) {
                 Contract.Assert(!e.Bindings.WasResolved); // we expect that .Bindings has not yet been processed, so we use just .ArgumentBindings in the next line
-                var tok = Options.Get(Snippets.ShowSnippets) ? e.RangeToken.ToToken() : e.tok;
+                var tok = Options.Get(Snippets.ShowSnippets) ? e.RangeToken : e.tok;
                 var cRhs = new MethodCallInformation(tok, mse, e.Bindings.ArgumentBindings);
                 return cRhs;
               } else {

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -1810,7 +1810,7 @@ namespace Microsoft.Dafny {
               }
               if (allowMethodCall) {
                 Contract.Assert(!e.Bindings.WasResolved); // we expect that .Bindings has not yet been processed, so we use just .ArgumentBindings in the next line
-                var tok = resolver.Options.Get(Snippets.ShowSnippets) ? e.RangeToken.ToToken() : e.tok;
+                var tok = resolver.Options.Get(Snippets.ShowSnippets) ? e.RangeToken : e.tok;
                 e.MethodCallInfo = new MethodCallInformation(tok, mse, e.Bindings.ArgumentBindings);
                 return e.MethodCallInfo;
               } else {

--- a/Source/DafnyCore/Rewriters/RefinementTransformer.cs
+++ b/Source/DafnyCore/Rewriters/RefinementTransformer.cs
@@ -960,13 +960,13 @@ namespace Microsoft.Dafny {
         }
         var bodyProper = MergeStmtList(sbsSkeleton.BodyProper, sbsOldStmt.BodyProper, out hoverText);
         if (hoverText.Length != 0) {
-          Reporter.Info(MessageSource.RefinementTransformer, sbsSkeleton.RangeToken.ToToken(), hoverText);
+          Reporter.Info(MessageSource.RefinementTransformer, sbsSkeleton.RangeToken, hoverText);
         }
         return new DividedBlockStmt(sbsSkeleton.RangeToken, bodyInit, sbsSkeleton.SeparatorTok, bodyProper);
       } else {
         var body = MergeStmtList(skeleton.Body, oldStmt.Body, out var hoverText);
         if (hoverText.Length != 0) {
-          Reporter.Info(MessageSource.RefinementTransformer, skeleton.RangeToken.ToToken(), hoverText);
+          Reporter.Info(MessageSource.RefinementTransformer, skeleton.RangeToken, hoverText);
         }
         return new BlockStmt(skeleton.RangeToken, body);
       }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.BoogieFactory.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.BoogieFactory.cs
@@ -882,12 +882,13 @@ namespace Microsoft.Dafny {
     }
 
     public static IOrigin ToDafnyToken(bool reportRanges, Bpl.IToken boogieToken) {
-      if (boogieToken is BoogieRangeOrigin boogieRangeToken) {
-        if (!reportRanges && boogieRangeToken.Center is not null) {
-          return boogieRangeToken.Center;
-        }
-
-        return new RangeToken(boogieRangeToken.StartToken, boogieRangeToken.EndToken);
+      if (boogieToken is FromDafnyNode fromDafnyNode) {
+        return fromDafnyNode.Inner.Tok;
+        // if (!reportRanges && fromDafnyNode.Center is not null) {
+        //   return fromDafnyNode.Center;
+        // }
+        //
+        // return new RangeToken(fromDafnyNode.StartToken, fromDafnyNode.EndToken);
       }
 
       if (boogieToken is NestedOrigin nestedToken) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.DefiniteAssignment.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.DefiniteAssignment.cs
@@ -108,23 +108,24 @@ namespace Microsoft.Dafny {
     }
 
     internal IOrigin GetToken(INode node) {
-      if (flags.ReportRanges) {
-        // Filter against IHasUsages to only select declarations, not usages.
-        if (node is IHasNavigationToken declarationOrUsage && node is not IHasReferences) {
-          return new BoogieRangeOrigin(node.StartToken, node.EndToken, declarationOrUsage.NavigationToken);
-        }
-
-        return new BoogieRangeOrigin(node.StartToken, node.EndToken, node.Tok);
-      } else {
-        // The commented line is what we want, but it changes what is translated.
-        // Seems to relate to refinement and possibly RefinementToken.IsInherited and or ForceCheckToken
-        // It might be better to remove calls to RefinementToken.IsInherited from this file, and instead
-        // add generic attributes like {:verify false} in the refinement phases, so that refinement does not complicate
-        // translation,
-        //
-        // return new BoogieRangeToken(node.StartToken, node.EndToken, node.Tok);
-        return node.Tok;
-      }
+      return new FromDafnyNode(node);
+      // if (flags.ReportRanges) {
+      //   // Filter against IHasUsages to only select declarations, not usages.
+      //   if (node is IHasNavigationToken declarationOrUsage && node is not IHasReferences) {
+      //     return new BoogieRangeOrigin(node.StartToken, node.EndToken, declarationOrUsage.NavigationToken);
+      //   }
+      //
+      //   return new BoogieRangeOrigin(node.StartToken, node.EndToken, node.Tok);
+      // } else {
+      //   // The commented line is what we want, but it changes what is translated.
+      //   // Seems to relate to refinement and possibly RefinementToken.IsInherited and or ForceCheckToken
+      //   // It might be better to remove calls to RefinementToken.IsInherited from this file, and instead
+      //   // add generic attributes like {:verify false} in the refinement phases, so that refinement does not complicate
+      //   // translation,
+      //   //
+      //   // return new BoogieRangeToken(node.StartToken, node.EndToken, node.Tok);
+      //   return node.Tok;
+      // }
     }
 
     void CheckDefiniteAssignment(IdentifierExpr expr, BoogieStmtListBuilder builder) {

--- a/Source/DafnyCore/Verifier/ProofDependencyManager.cs
+++ b/Source/DafnyCore/Verifier/ProofDependencyManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Dafny {
     // condition.
     private const string idAttributeName = "id";
 
-    public void AddProofDependencyId(ICarriesAttributes boogieNode, IOrigin tok, ProofDependency dep) {
+    public void AddProofDependencyId(ICarriesAttributes boogieNode, IToken tok, ProofDependency dep) {
       var idString = GetProofDependencyId(dep);
       boogieNode.Attributes =
         new QKeyValue(tok, idAttributeName, new List<object>() { idString }, boogieNode.Attributes);

--- a/Source/DafnyDriver/CliCompilation.cs
+++ b/Source/DafnyDriver/CliCompilation.cs
@@ -234,7 +234,7 @@ public class CliCompilation {
       yield break;
     }
 
-    var canVerifies = resolution.CanVerifies?.DistinctBy(v => v.Tok).ToList();
+    var canVerifies = resolution.CanVerifies?.ToList();
 
     if (canVerifies == null) {
       yield break;
@@ -247,7 +247,7 @@ public class CliCompilation {
 
     int done = 0;
 
-    var canVerifiesPerModule = canVerifies.ToList().GroupBy(c => c.ContainingModule).ToList();
+    var canVerifiesPerModule = canVerifies.GroupBy(c => c.ContainingModule).ToList();
     foreach (var canVerifiesForModule in canVerifiesPerModule.
                OrderBy(v => v.Key.Tok.pos)) {
       var orderedCanVerifies = canVerifiesForModule.OrderBy(v => v.Tok.pos).ToList();
@@ -260,7 +260,7 @@ public class CliCompilation {
 
         var shouldVerify = await Compilation.VerifyCanVerify(canVerify, results.TaskFilter, randomSeed);
         if (!shouldVerify) {
-          canVerifies.ToList().Remove(canVerify);
+          canVerifies.Remove(canVerify);
         }
       }
 


### PR DESCRIPTION
Dafny creates a Boogie program for each Dafny module, and the verification tasks in this Boogie program need to be mapped back to Dafny symbols. Previously this was done by comparing file positions, but this is fragile since multiple Dafny symbols can have the same position, particularly when these symbols were generated. An example is when using Dafny iterators, then several methods get generated.

### Changes

- No longer use file positions to map verification tasks to Dafny symbols, but instead insert references to the Dafny symbols in the Boogie program, so these can be compared directly.

### How has this been tested?
Should be covered by the existing test-suite

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
