### PR TITLE
fix: Don’t require —standard-libraries matches across doo files

### DIFF
--- a/Source/DafnyCore/Options/CommonOptionBag.cs
+++ b/Source/DafnyCore/Options/CommonOptionBag.cs
@@ -609,7 +609,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
     OptionRegistry.RegisterGlobalOption(AllowWarnings, OptionCompatibility.OptionLibraryImpliesLocalWarning);
     OptionRegistry.RegisterGlobalOption(AllowDeprecation, OptionCompatibility.OptionLibraryImpliesLocalWarning);
     OptionRegistry.RegisterGlobalOption(WarnShadowing, OptionCompatibility.OptionLibraryImpliesLocalWarning);
-    OptionRegistry.RegisterGlobalOption(UseStandardLibraries, OptionCompatibility.OptionLibraryImpliesLocalError);
+    OptionRegistry.RegisterGlobalOption(UseStandardLibraries, OptionCompatibility.NoOpOptionCheck);
     OptionRegistry.RegisterOption(WarnAsErrors, OptionScope.Cli);
     OptionRegistry.RegisterOption(ProgressOption, OptionScope.Cli);
     OptionRegistry.RegisterOption(LogLocation, OptionScope.Cli);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy
@@ -3,12 +3,12 @@
 // which led to duplicate definitions.
 
 // RUN: %build %s -t:lib --standard-libraries:true --output="%S/Output/useStandardLibraries.doo" &> "%t"
-// RUN: %run %S/Output/useStandardLibraries.doo &>> %t
+// RUN: %resolve %S/Output/useStandardLibraries.doo &>> %t
 // RUN: %diff "%s.expect" "%t"
 
 import opened Std.Wrappers
 import opened Std.Collections.Seq
 
 method Main() {
-  print IndexOfOption([1, 1, 2, 3, 5, 8, 13, 21], 5), "\n";
+  assert IndexOfOption([1, 1, 2, 3, 5, 8, 13, 21], 5) == Some(4);
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy
@@ -1,0 +1,14 @@
+// Regression test for including the standard libraries in a doo file.
+// This used to break because we incorrectly required --standard-libraries to be set when consuming too,
+// which led to duplicate definitions.
+
+// RUN: %build %s -t:lib --standard-libraries:true --output="%S/Output/useStandardLibraries.doo" &> "%t"
+// RUN: %run %S/Output/useStandardLibraries.doo &>> %t
+// RUN: %diff "%s.expect" "%t"
+
+import opened Std.Wrappers
+import opened Std.Collections.Seq
+
+method Main() {
+  print IndexOfOption([1, 1, 2, 3, 5, 8, 13, 21], 5), "\n";
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy.expect
@@ -1,0 +1,5 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+Wrappers.Option.Some(4)

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/useStandardLibraries.dfy.expect
@@ -1,5 +1,4 @@
 
-Dafny program verifier finished with 0 verified, 0 errors
+Dafny program verifier finished with 1 verified, 0 errors
 
-Dafny program verifier finished with 0 verified, 0 errors
-Wrappers.Option.Some(4)
+Dafny program verifier did not attempt verification


### PR DESCRIPTION
### What was changed?
`--standard-libraries` is registered as an option that has to match when consuming a doo file, but this is incorrect because passing it again leads to duplicate definitions.

### How has this been tested?
`useStandardLibraries.dfy`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
