### PR TITLE
Fix: General newtypes now support conditional equality

### DIFF
--- a/Scripts/test-dafny.sh
+++ b/Scripts/test-dafny.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Check for required environment variables
+if [ -z "$DIR" ]; then
+  echo "Error: DIR environment variable is not set."
+  exit 1
+fi
+
+if [ -z "$name" ]; then
+  echo "Error: name environment variable is not set."
+  exit 1
+fi
+
+# Set the default build flag
+NO_BUILD=${NO_BUILD:-false}
+
+# Locate files matching the specified pattern
+files=$(cd "${DIR}/Source/IntegrationTests/TestFiles/LitTests/LitTest" && find . -type f -wholename "*$name*" | grep -E '\.dfy$')
+
+if [ -z "$files" ]; then
+  echo "No files found matching pattern: $name"
+  exit 1
+else
+  count=$(echo "$files" | wc -l)
+  echo "$files"
+  echo "$count test files found."
+  for file in $files; do
+    filedir=$(dirname "$file")
+    (
+      cd "${DIR}/Source/IntegrationTests/TestFiles/LitTests/LitTest/$filedir" || exit
+      
+      build_flag=""
+      [ "$NO_BUILD" = "true" ] && build_flag="--no-build"
+
+      dotnet run $build_flag --project "${DIR}/Source/Dafny" -- ${action} "$(basename "$file")"
+    )
+  done
+fi

--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -482,11 +482,11 @@ Generate module names in the older A_mB_mC style instead of the current A.B.C sc
     resolver.moduleInfo = ModuleResolver.MergeSignature(sig, resolver.ProgramResolver.SystemModuleManager.systemNameInfo);
     Type.PushScope(resolver.moduleInfo.VisibilityScope);
     ModuleResolver.ResolveOpenedImports(resolver.moduleInfo, this, resolver.Reporter, resolver); // opened imports do not persist
-    var datatypeDependencies = new Graph<IndDatatypeDecl>();
+    var equalityDependencies = new Graph<ITentativeEqualitySupportingDeclaration>();
     var codatatypeDependencies = new Graph<CoDatatypeDecl>();
     var allDeclarations = AllDeclarationsAndNonNullTypeDecls(TopLevelDecls).ToList();
     int prevErrorCount = resolver.reporter.Count(ErrorLevel.Error);
-    resolver.ResolveTopLevelDecls_Signatures(this, sig, allDeclarations, datatypeDependencies, codatatypeDependencies);
+    resolver.ResolveTopLevelDecls_Signatures(this, sig, allDeclarations, equalityDependencies, codatatypeDependencies);
     Contract.Assert(resolver.AllTypeConstraints.Count == 0); // signature resolution does not add any type constraints
 
     resolver.scope.PushMarker();
@@ -495,7 +495,7 @@ Generate module names in the older A_mB_mC style instead of the current A.B.C sc
     resolver.scope.PopMarker();
 
     if (resolver.reporter.Count(ErrorLevel.Error) == prevErrorCount) {
-      resolver.ResolveTopLevelDecls_Core(allDeclarations, datatypeDependencies, codatatypeDependencies,
+      resolver.ResolveTopLevelDecls_Core(allDeclarations, equalityDependencies, codatatypeDependencies,
         exportSetName == null ? Name : $"{Name} export {exportSetName}", exportSetName != null);
     }
 

--- a/Source/DafnyCore/AST/TypeDeclarations/IndDatatypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/IndDatatypeDecl.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Microsoft.Dafny;
 
-public class IndDatatypeDecl : DatatypeDecl {
+public class IndDatatypeDecl : DatatypeDecl, ITentativeEqualitySupportingDeclaration {
   public override string WhatKind { get { return "datatype"; } }
   [FilledInDuringResolution] public DatatypeCtor GroundingCtor; // set during resolution (possibly to null)
 
@@ -29,8 +29,14 @@ public class IndDatatypeDecl : DatatypeDecl {
     }
   }
 
-  public enum ES { NotYetComputed, Never, ConsultTypeArguments }
-  public ES EqualitySupport = ES.NotYetComputed;
+  public ITentativeEqualitySupportingDeclaration.ES EqualitySupport { get; set; } = ITentativeEqualitySupportingDeclaration.ES.NotYetComputed;
+
+  List<TypeParameter> ITentativeEqualitySupportingDeclaration.TypeParameters {
+    get => TypeArgs;
+  }
+
+  ModuleDefinition ITentativeEqualitySupportingDeclaration.EnclosingModuleDefinition =>
+    EnclosingModuleDefinition;
 
   public IndDatatypeDecl(RangeToken rangeOrigin, Name name, ModuleDefinition module, List<TypeParameter> typeArgs,
     [Captured] List<DatatypeCtor> ctors, List<Type> parentTraits, List<MemberDecl> members, Attributes attributes, bool isRefining)

--- a/Source/DafnyCore/AST/TypeDeclarations/NewtypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/NewtypeDecl.cs
@@ -5,7 +5,7 @@ using System.Numerics;
 
 namespace Microsoft.Dafny;
 
-public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, RedirectingTypeDecl, IHasDocstring, ICanVerify {
+public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, RedirectingTypeDecl, ITentativeEqualitySupportingDeclaration, IHasDocstring, ICanVerify {
   public override string WhatKind { get { return "newtype"; } }
   public override bool CanBeRevealed() { return true; }
   public PreType BasePreType;
@@ -96,16 +96,13 @@ public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, Redirect
   public TopLevelDecl AsTopLevelDecl => this;
   public TypeDeclSynonymInfo SynonymInfo { get; set; }
 
-  public TypeParameter.EqualitySupportValue EqualitySupport {
-    get {
-      if (this.BaseType.SupportsEquality) {
-        return TypeParameter.EqualitySupportValue.Required;
-      } else {
-        return TypeParameter.EqualitySupportValue.Unspecified;
-      }
-    }
-  }
+  public ITentativeEqualitySupportingDeclaration.ES EqualitySupport { get; set; } = ITentativeEqualitySupportingDeclaration.ES.NotYetComputed;
 
+  List<TypeParameter> ITentativeEqualitySupportingDeclaration.TypeParameters {
+    get => TypeArgs;
+  }
+  ModuleDefinition ITentativeEqualitySupportingDeclaration.EnclosingModuleDefinition =>
+    EnclosingModuleDefinition;
   string RedirectingTypeDecl.Name { get { return Name; } }
   IOrigin RedirectingTypeDecl.tok { get { return tok; } }
   Attributes RedirectingTypeDecl.Attributes { get { return Attributes; } }

--- a/Source/DafnyCore/AST/TypeDeclarations/TentativeEqualitySupportingDeclaration.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/TentativeEqualitySupportingDeclaration.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Dafny;
+
+public interface ITentativeEqualitySupportingDeclaration {
+  public enum ES { NotYetComputed, Never, ConsultTypeArguments }
+  public ES EqualitySupport { get; set; }
+  public List<TypeParameter> TypeParameters { get; }
+  public ModuleDefinition EnclosingModuleDefinition { get; }
+}

--- a/Source/DafnyCore/AST/TypeDeclarations/TupleTypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/TupleTypeDecl.cs
@@ -49,7 +49,7 @@ public class TupleTypeDecl : IndDatatypeDecl {
         TypeParametersUsedInConstructionByGroundingCtor[i] = !argumentGhostness[i];
       }
     }
-    this.EqualitySupport = argumentGhostness.Contains(true) ? ES.Never : ES.ConsultTypeArguments;
+    this.EqualitySupport = argumentGhostness.Contains(true) ? ITentativeEqualitySupportingDeclaration.ES.Never : ITentativeEqualitySupportingDeclaration.ES.ConsultTypeArguments;
 
     // Resolve parent type information - not currently possible for tuples to have any parent traits
     ParentTypeInformation = new InheritanceInformationClass();

--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -790,6 +790,17 @@ public abstract class Type : TokenNode {
       return udt?.ResolvedClass as IndDatatypeDecl;
     }
   }
+
+  public ITentativeEqualitySupportingDeclaration AsTentativeEqualitySupportingDeclaration {
+    get {
+      ITentativeEqualitySupportingDeclaration eqDecl = AsIndDatatype;
+      if (eqDecl == null) {
+        eqDecl = AsNewtype;
+      }
+
+      return eqDecl;
+    }
+  }
   public bool IsCoDatatype => AsCoDatatype != null;
 
   public CoDatatypeDecl AsCoDatatype {

--- a/Source/DafnyCore/Resolver/CheckTypeCharacteristics_Visitor.cs
+++ b/Source/DafnyCore/Resolver/CheckTypeCharacteristics_Visitor.cs
@@ -406,6 +406,18 @@ class CheckTypeCharacteristics_Visitor : ResolverTopDownVisitor<bool> {
     if (tp != null) {
       return string.Format(" (perhaps try declaring {2} '{0}' on line {1} as '{0}(==)', which says it can only be instantiated with a type that supports equality)", tp.Name, tp.tok.line, tp.WhatKind);
     }
+
+    if (argType.AsTentativeEqualitySupportingDeclaration is { EqualitySupport: ITentativeEqualitySupportingDeclaration.ES.ConsultTypeArguments } decl && argType is { TypeArgs: var typeArgs }) {
+      var i = 0;
+      foreach (var tParam in decl.TypeParameters) {
+        if (tParam.NecessaryForEqualitySupportOfSurroundingInductiveDatatype && !typeArgs[i].SupportsEquality) {
+          if (TypeEqualityErrorMessageHint(typeArgs[i]) is var message and not "") {
+            return message;
+          }
+        }
+        i++;
+      }
+    }
     return "";
   }
 }

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -2832,7 +2832,7 @@ namespace Microsoft.Dafny {
     /// <summary>
     /// Assumes type parameters have already been pushed
     /// </summary>
-    void ResolveCtorTypes(DatatypeDecl/*!*/ dt, Graph<IndDatatypeDecl/*!*/>/*!*/ dependencies, Graph<CoDatatypeDecl/*!*/>/*!*/ coDependencies) {
+    void ResolveCtorTypes(DatatypeDecl/*!*/ dt, Graph<ITentativeEqualitySupportingDeclaration/*!*/>/*!*/ dependencies, Graph<CoDatatypeDecl/*!*/>/*!*/ coDependencies) {
       Contract.Requires(dt != null);
       Contract.Requires(dependencies != null);
       Contract.Requires(coDependencies != null);
@@ -2849,7 +2849,7 @@ namespace Microsoft.Dafny {
           var idt = (IndDatatypeDecl)dt;
           dependencies.AddVertex(idt);
           foreach (Formal p in ctor.Formals) {
-            AddDatatypeDependencyEdge(idt, p.Type, dependencies);
+            AddEqualityDependencyEdge(idt, p.Type, dependencies);
           }
         } else {
           // The dependencies of interest among codatatypes are just the top-level types of parameters.
@@ -2874,17 +2874,16 @@ namespace Microsoft.Dafny {
       }
     }
 
-    void AddDatatypeDependencyEdge(IndDatatypeDecl dt, Type tp, Graph<IndDatatypeDecl> dependencies) {
-      Contract.Requires(dt != null);
+    void AddEqualityDependencyEdge(ITentativeEqualitySupportingDeclaration decl, Type tp, Graph<ITentativeEqualitySupportingDeclaration> dependencies) {
+      Contract.Requires(decl != null);
       Contract.Requires(tp != null);
       Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(cce.NonNullElements(dependencies));
 
       tp = tp.NormalizeExpand();
-      var dependee = tp.AsIndDatatype;
-      if (dependee != null && dt.EnclosingModuleDefinition == dependee.EnclosingModuleDefinition) {
-        dependencies.AddEdge(dt, dependee);
+      if (tp.AsTentativeEqualitySupportingDeclaration is { } dependee && decl.EnclosingModuleDefinition == dependee.EnclosingModuleDefinition) {
+        dependencies.AddEdge(decl, dependee);
         foreach (var ta in ((UserDefinedType)tp).TypeArgs) {
-          AddDatatypeDependencyEdge(dt, ta, dependencies);
+          AddEqualityDependencyEdge(decl, ta, dependencies);
         }
       }
     }

--- a/Source/DafnyCore/Resolver/ProgramResolver.cs
+++ b/Source/DafnyCore/Resolver/ProgramResolver.cs
@@ -167,7 +167,7 @@ public class ProgramResolver {
 
     systemModuleResolver.ResolveTopLevelDecls_Core(
       ModuleDefinition.AllDeclarationsAndNonNullTypeDecls(systemModuleClassesWithNonNullTypes).ToList(),
-      new Graph<IndDatatypeDecl>(), new Graph<CoDatatypeDecl>(), SystemModuleManager.SystemModule.Name, false);
+      new Graph<ITentativeEqualitySupportingDeclaration>(), new Graph<CoDatatypeDecl>(), SystemModuleManager.SystemModule.Name, false);
 
     return systemModuleResolver.moduleClassMembers;
   }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5972.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5972.dfy.expect
@@ -1,3 +1,3 @@
-git-issue-5972.dfy(19,9): Error: == can only be applied to expressions of types that support equality (got M<int, A>)
-git-issue-5972.dfy(37,9): Error: == can only be applied to expressions of types that support equality (got S<A>)
+git-issue-5972.dfy(19,9): Error: == can only be applied to expressions of types that support equality (got M<int, A>) (perhaps try declaring type parameter 'A' on line 6 as 'A(==)', which says it can only be instantiated with a type that supports equality)
+git-issue-5972.dfy(37,9): Error: == can only be applied to expressions of types that support equality (got S<A>) (perhaps try declaring type parameter 'A' on line 24 as 'A(==)', which says it can only be instantiated with a type that supports equality)
 2 resolution/type errors detected in git-issue-5972.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy
@@ -1,0 +1,59 @@
+// RUN: %exits-with 2 %baredafny verify %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// RUN: %exits-with 2 %baredafny verify --type-system-refresh --general-newtypes %args "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+newtype M<U> = m: map<int, U> | true
+
+method CompareAnything<A>(f: A, g: A) returns (b: bool) 
+   ensures b <==> f == g
+{
+  var m1 := map[0 := f] as M<A>;
+  var m2 := map[0 := g] as M<A>;
+  assert m1 == m2 <==> f == g by {
+    if f == g {
+      assert m1 == m2;
+    }
+    if m1 == m2 {
+      assert m1[0] == m2[0];
+    }
+  }
+  return m1 == m2;
+}
+
+newtype S<T> = s: seq<T> | true
+
+method CompareAnythingS<A>(f: A, g: A) returns (b: bool) 
+   ensures b <==> f == g
+{
+  var m1 := [f] as S<A>;
+  var m2 := [g] as S<A>;
+  assert m1 == m2 <==> f == g by {
+    if f == g {
+      assert m1 == m2;
+    }
+    if m1 == m2 {
+      assert m1[0] == m2[0];
+    }
+  }
+  return m1 == m2;
+}
+
+codatatype Stream = Stream(head: int, tail: Stream)
+{
+  static function From(i: int): Stream {
+    Stream(i, From(i + 1))
+  }
+}
+
+method Main() {
+  var s1 := Stream.From(0);
+  var s2 := Stream.From(0);
+  var b := CompareAnything(s1, s2);
+  var b2 := CompareAnythingS(s1, s2);
+  if !b || !b2 {
+    assert false;
+    print 1/0;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy
@@ -1,6 +1,3 @@
-// RUN: %exits-with 2 %baredafny verify %args "%s" > "%t"
-// RUN: %diff "%s.expect" "%t"
-
 // RUN: %exits-with 2 %baredafny verify --type-system-refresh --general-newtypes %args "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-5978.dfy.expect
@@ -1,2 +1,3 @@
-
-Dafny program verifier finished with TODO verified, TODO errors
+git-issue-5978.dfy(19,9): Error: == can only be applied to expressions of types that support equality (got M<A>) (perhaps try declaring type parameter 'A' on line 6 as 'A(==)', which says it can only be instantiated with a type that supports equality)
+git-issue-5978.dfy(37,9): Error: == can only be applied to expressions of types that support equality (got S<A>) (perhaps try declaring type parameter 'A' on line 24 as 'A(==)', which says it can only be instantiated with a type that supports equality)
+2 resolution/type errors detected in git-issue-5978.dfy

--- a/docs/dev/news/5978.fix
+++ b/docs/dev/news/5978.fix
@@ -1,0 +1,1 @@
+General newtypes now support conditional equality


### PR DESCRIPTION
This PR fixes #5978

## Why it failed

At the beginning newtypes were only used for numeric-like types, so they did not have type parameters and always supported equality.
When newtypes became general, they obtained type parameters, and a soundness issue appeared.
Indeed, datatypes can be either determine to never support equality, or support equality if their type arguments supports equality when the corresponding type parameter requires equality for the datatype to support equality.
Newtypes, on the other hand, only had two kinds of equality support: Always, and unspecified. Unfortunately, unspecified was mapped to `SupportEquality: true` in `Type.cs`
Newtypes are like a datatype with a single constructor with a single field. Hence, they follow the same rules for determining equality, which requires them to be part of the same graph when computing equality dependencies.

## How this was solved.

Newtypes and inductive type declarations are now both abstracted under the same interface, and dependencies previously on datatypes are now on this interface. I updated all algorithms accordingly
I took the opportunity to enhance the error message by a recursive traversal of the type in search of the first type parameter whose equality support resulted in the whole type not supporting equality.

## How it was tested

Added the test git-issue-5978.dfy

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>