### PR TITLE
fix: Remove dead test generation link

### DIFF
--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -2770,12 +2770,3 @@ The following options are also commonly used:
 
 * `--verification-time-limit:<n>` (was `-timeLimit:<n>`) - limits 
   the number of seconds spent trying to verify each procedure.
-
-
-### 13.9.11. Controlling test generation {#sec-controlling-test-gen}
-
-Dafny is capable of generating unit (runtime) tests. It does so by asking the prover to solve
-for values of inputs to a method that cause the program to execute specific blocks or paths.
-A detailed description of how to do this is given in
-[a separate document](https://github.com/dafny-lang/dafny/blob/master/Source/DafnyTestGeneration/README.md).
-


### PR DESCRIPTION
### What was changed?
Removed section `13.9.11. Controlling test generation` from the user docs

This is now documented in
`#### 13.6.1.12. `dafny generate-tests` {#sec-dafny-generate-tests}`

These docs were added in #4445

### How has this been tested?
Docs change

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
