### PR TITLE
Fix: Rust traits downcast now clone their arguments

### DIFF
--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
@@ -2943,8 +2943,8 @@ module {:extern "DCOMP"} DafnyToRustCompiler {
         if resultingOwnership == OwnershipBorrowed {
           // we need the value to be owned for conversion
           r := BorrowedToOwned(r, env);
-          resultingOwnership := OwnershipOwned;
         }
+        resultingOwnership := OwnershipOwned;
         r := R.dafny_runtime
         .MSel(downcast).AsExpr().Apply([r, R.ExprFromType(toTpeGen)]);
         r, resultingOwnership := FromOwnership(r, OwnershipOwned, expectedOwnership);

--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
@@ -2920,6 +2920,7 @@ module {:extern "DCOMP"} DafnyToRustCompiler {
       env: Environment,
       expectedOwnership: Ownership
     ) returns (r: R.Expr, resultingOwnership: Ownership)
+      requires exprOwnership != OwnershipAutoBorrowed
       modifies this
       ensures OwnershipGuarantee(expectedOwnership, resultingOwnership)
     {
@@ -2943,8 +2944,8 @@ module {:extern "DCOMP"} DafnyToRustCompiler {
         if resultingOwnership == OwnershipBorrowed {
           // we need the value to be owned for conversion
           r := BorrowedToOwned(r, env);
+          resultingOwnership := OwnershipOwned;
         }
-        resultingOwnership := OwnershipOwned;
         r := R.dafny_runtime
         .MSel(downcast).AsExpr().Apply([r, R.ExprFromType(toTpeGen)]);
         r, resultingOwnership := FromOwnership(r, OwnershipOwned, expectedOwnership);

--- a/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
+++ b/Source/DafnyCore/Backends/Rust/Dafny-compiler-rust.dfy
@@ -2924,20 +2924,27 @@ module {:extern "DCOMP"} DafnyToRustCompiler {
       ensures OwnershipGuarantee(expectedOwnership, resultingOwnership)
     {
       r := expr;
+      resultingOwnership := exprOwnership;
       var fromTpeGen := GenType(fromTpe, GenTypeContext.default());
       var toTpeGen := GenType(toTpe, GenTypeContext.default());
       var upcastConverter := UpcastConversionLambda(fromTpe, fromTpeGen, toTpe, toTpeGen, map[]);
       if upcastConverter.Success? {
         var conversionLambda := upcastConverter.value;
-        if exprOwnership == OwnershipBorrowed {
+        if resultingOwnership == OwnershipBorrowed {
           // we need the value to be owned for conversion
           r := BorrowedToOwned(r, env);
+          resultingOwnership := OwnershipOwned;
         }
         r := conversionLambda.Apply1(r);
-        r, resultingOwnership := FromOwnership(r, OwnershipOwned, expectedOwnership);
+        r, resultingOwnership := FromOwnership(r, resultingOwnership, expectedOwnership);
       } else if IsDowncastConversion(fromTpeGen, toTpeGen) {
         assert toTpeGen.IsObjectOrPointer();
         toTpeGen := toTpeGen.ObjectOrPointerUnderlying();
+        if resultingOwnership == OwnershipBorrowed {
+          // we need the value to be owned for conversion
+          r := BorrowedToOwned(r, env);
+          resultingOwnership := OwnershipOwned;
+        }
         r := R.dafny_runtime
         .MSel(downcast).AsExpr().Apply([r, R.ExprFromType(toTpeGen)]);
         r, resultingOwnership := FromOwnership(r, OwnershipOwned, expectedOwnership);

--- a/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
+++ b/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
@@ -4210,8 +4210,8 @@ namespace DCOMP {
         _1_toTpeGen = (_1_toTpeGen).ObjectOrPointerUnderlying();
         if (object.Equals(resultingOwnership, Defs.Ownership.create_OwnershipBorrowed())) {
           r = (this).BorrowedToOwned(r, env);
+          resultingOwnership = Defs.Ownership.create_OwnershipOwned();
         }
-        resultingOwnership = Defs.Ownership.create_OwnershipOwned();
         r = (((RAST.__default.dafny__runtime).MSel((this).downcast)).AsExpr()).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(r, RAST.Expr.create_ExprFromType(_1_toTpeGen)));
         RAST._IExpr _out4;
         Defs._IOwnership _out5;

--- a/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
+++ b/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
@@ -4182,6 +4182,7 @@ namespace DCOMP {
       r = RAST.Expr.Default();
       resultingOwnership = Defs.Ownership.Default();
       r = expr;
+      resultingOwnership = exprOwnership;
       RAST._IType _0_fromTpeGen;
       RAST._IType _out0;
       _out0 = (this).GenType(fromTpe, Defs.GenTypeContext.@default());
@@ -4195,17 +4196,22 @@ namespace DCOMP {
       if ((_2_upcastConverter).is_Success) {
         RAST._IExpr _3_conversionLambda;
         _3_conversionLambda = (_2_upcastConverter).dtor_value;
-        if (object.Equals(exprOwnership, Defs.Ownership.create_OwnershipBorrowed())) {
+        if (object.Equals(resultingOwnership, Defs.Ownership.create_OwnershipBorrowed())) {
           r = (this).BorrowedToOwned(r, env);
+          resultingOwnership = Defs.Ownership.create_OwnershipOwned();
         }
         r = (_3_conversionLambda).Apply1(r);
         RAST._IExpr _out2;
         Defs._IOwnership _out3;
-        (this).FromOwnership(r, Defs.Ownership.create_OwnershipOwned(), expectedOwnership, out _out2, out _out3);
+        (this).FromOwnership(r, resultingOwnership, expectedOwnership, out _out2, out _out3);
         r = _out2;
         resultingOwnership = _out3;
       } else if ((this).IsDowncastConversion(_0_fromTpeGen, _1_toTpeGen)) {
         _1_toTpeGen = (_1_toTpeGen).ObjectOrPointerUnderlying();
+        if (object.Equals(resultingOwnership, Defs.Ownership.create_OwnershipBorrowed())) {
+          r = (this).BorrowedToOwned(r, env);
+          resultingOwnership = Defs.Ownership.create_OwnershipOwned();
+        }
         r = (((RAST.__default.dafny__runtime).MSel((this).downcast)).AsExpr()).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(r, RAST.Expr.create_ExprFromType(_1_toTpeGen)));
         RAST._IExpr _out4;
         Defs._IOwnership _out5;

--- a/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
+++ b/Source/DafnyCore/GeneratedFromDafny/DCOMP.cs
@@ -4210,8 +4210,8 @@ namespace DCOMP {
         _1_toTpeGen = (_1_toTpeGen).ObjectOrPointerUnderlying();
         if (object.Equals(resultingOwnership, Defs.Ownership.create_OwnershipBorrowed())) {
           r = (this).BorrowedToOwned(r, env);
-          resultingOwnership = Defs.Ownership.create_OwnershipOwned();
         }
+        resultingOwnership = Defs.Ownership.create_OwnershipOwned();
         r = (((RAST.__default.dafny__runtime).MSel((this).downcast)).AsExpr()).Apply(Dafny.Sequence<RAST._IExpr>.FromElements(r, RAST.Expr.create_ExprFromType(_1_toTpeGen)));
         RAST._IExpr _out4;
         Defs._IOwnership _out5;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/traits.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/traits.dfy
@@ -127,6 +127,9 @@ module All {
     r := Some(true);
   }
 
+  method AcceptSubtraitIntInt(t: SubTrait<int, int>) {
+  }
+
   datatype ObjectContainer = ObjectContainer(y: Y<int>)
 
   method ParameterBorrows(y: Y<int>, o: ObjectContainer) { // y is borrowed
@@ -136,8 +139,18 @@ module All {
     ConsumeBorrows(y2 as SubTrait<int, int>);
     ConsumeBorrows(y2 as SubTrait<int, int>);
   }
+
   method ConsumeBorrows(y: SubTrait<int, int>) {
 
+  }
+  trait TraitNoArgs {}
+  class ClassNoArgs extends TraitNoArgs {
+    var x: int
+    constructor() {
+      x := 0;
+    }
+  }
+  method ConsumeClassNoArgs(a: ClassNoArgs) {
   }
 
   method Main() {
@@ -145,9 +158,14 @@ module All {
     expect rts == Some(true);
 
     var y := new Y<int>(7);
+    var yOwned := y;
     expect y.GetDFunc() == 2;
-    var z: SubTrait<int, int> := y as SubTrait<int, int>;
+    AcceptSubtraitIntInt(yOwned);
+    AcceptSubtraitIntInt(yOwned);
+    var z: SubTrait<int, int> := yOwned as SubTrait<int, int>;
+    var z2: SubTrait<int, int> := yOwned as SubTrait<int, int>;
     var w: SuperTrait := z;
+    var w2: SuperTrait := z;
     var p: SuperTrait := y;
     /*var zy := z as Y<int>;
     var wy := w as Y<int>;
@@ -171,6 +189,18 @@ module All {
     expect f == 42;
     expect y as object == w as object;
     expect y as object == p as object;
+    expect yOwned as object == w as object;
+    expect yOwned as object == p as object;
+    var a := new ClassNoArgs();
+    var aOwned := a;
+    var o: TraitNoArgs := a as TraitNoArgs;
+    expect o is ClassNoArgs;
+    ConsumeClassNoArgs(o);
+    ConsumeClassNoArgs(o);
+    var oo: object := o as object;
+    expect oo is ClassNoArgs;
+    ConsumeClassNoArgs(oo as ClassNoArgs);
+    ConsumeClassNoArgs(oo as ClassNoArgs);
     var objects := {y as object, w as object, p as object};
     expect |objects| == 1;
     var q := y as NoMemberTrait;


### PR DESCRIPTION
Fixes #5992

### What was changed?
When upcasting/downcasting, we often need a cloned reference. However, until recently, the references were cloned only if the call site required an owned referenced. Recently, references were borrowed and the borrow converted to a clone only if the ownership of the reference was necessary. However, this was implemented for Upcast, not downcast. Hence, if the same reference needed multiple downcasts, the generated Rust code would fail.

This PR fixes that by reusing the cloning code for upcasting but for downcasting as well.

### How has this been tested?
Modified comp/rust/traits.dfy to account for two test cases that were failing for a user.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
