### PR TITLE
Revert "Chore: Set up nightly and prerelease for 4.9.1 (#5995)"

### DIFF
--- a/.github/workflows/check-for-workflow-run.js
+++ b/.github/workflows/check-for-workflow-run.js
@@ -30,10 +30,10 @@ module.exports = async ({github, context, core, workflow_id, sha, ...config}) =>
         `\nA run of ${runFilterDesc} is currently ${workflow_runs_in_progress[0].status}:`+
         ` ${workflow_runs_in_progress[0].html_url}, just re-run this test once it is finished.` :
         `\nAt the time of checking, no fix was underway.\n`+
-        `- Please first check https://github.com/dafny-lang/dafny/actions/workflows/nightly-build.yml. `+
+        `- Please first check https://github.com/dafny-lang/dafny/actions/workflows/nightly-build.yml . `+
         `If you see any queued or in progress run on ${runFilterDesc}, just re-run this test once it is finished.`+
         `- If not, and you are a Dafny developer, please fix the issue by creating a PR with the label [run-deep-tests], have it reviewed and merged, ` +
-        `and then trigger the workflow on ${runFilterDesc} with the URL https://github.com/dafny-lang/dafny/actions/workflows/nightly-build.yml.\n`+
+        `and then trigger the workflow on ${runFilterDesc} with the URL https://github.com/dafny-lang/dafny/actions/workflows/nightly-build.yml .\n`+
         `With such a label, you can merge a PR even if tests are not successful, but make sure the deeps one are!\n`+
         `If you do not have any clue on how to fix it, `+
         `at worst you can revert all PRs from the last successful run and indicate the authors they need to re-file`+

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,14 +28,6 @@ jobs:
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
-    secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
-
-  nightly-build-for-4-9-1:
-    if: github.repository_owner == 'dafny-lang'
-    uses: ./.github/workflows/nightly-build-reusable.yml
-    with:
-      ref: 4.9.1
       publish-prerelease: true
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
This reverts commit 041c925ba1533561651bd4c5238ba1e0d510f39a that seems to be the source of problems in the nightly.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
