### PR TITLE
Fix opaque block soundness bug

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -1876,6 +1876,10 @@ namespace Microsoft.Dafny {
       }
     }
 
+    public static bool ModifiesClauseIsEmpty(Specification<FrameExpression> modifiesClause) {
+      return modifiesClause.Expressions.All(e => e.E is SetDisplayExpr setDisplayExpr && !setDisplayExpr.Elements.Any());
+    }
+
     private void InsertChecksum(Method m, Boogie.Declaration decl, bool specificationOnly = false) {
       Contract.Requires(VisibleInScope(m));
       byte[] data;

--- a/Source/DafnyCore/Verifier/Statements/OpaqueBlockVerifier.cs
+++ b/Source/DafnyCore/Verifier/Statements/OpaqueBlockVerifier.cs
@@ -10,10 +10,9 @@ public static class OpaqueBlockVerifier {
   public static void EmitBoogie(BoogieGenerator generator, OpaqueBlock block, BoogieStmtListBuilder builder,
     Variables locals, BoogieGenerator.ExpressionTranslator etran, IMethodCodeContext codeContext) {
 
-    var hasModifiesClause = block.Modifies.Expressions.Any();
     var blockBuilder = new BoogieStmtListBuilder(generator, builder.Options, builder.Context);
 
-    var bodyTranslator = GetBodyTranslator(generator, block, locals, etran, hasModifiesClause, blockBuilder);
+    var bodyTranslator = GetBodyTranslator(generator, block, locals, etran, blockBuilder);
     var prevDefiniteAssignmentTrackers = generator.DefiniteAssignmentTrackers;
     generator.TrStmtList(block.Body, blockBuilder, locals, bodyTranslator, block.Origin);
     generator.DefiniteAssignmentTrackers = prevDefiniteAssignmentTrackers;
@@ -43,7 +42,7 @@ public static class OpaqueBlockVerifier {
         etran.TrAttributes(ensure.Attributes, null)));
     }
 
-    if (hasModifiesClause) {
+    if (block.Modifies.Expressions.Any()) {
       var context = new OpaqueBlockContext(codeContext, block);
       if (context is IMethodCodeContext methodCodeContext) {
         generator.CheckFrameSubset(
@@ -59,7 +58,9 @@ public static class OpaqueBlockVerifier {
     generator.PathAsideBlock(block.Tok, blockBuilder, builder);
     builder.Add(new HavocCmd(Token.NoToken, assignedVariables.Select(v => new BoogieIdentifierExpr(v.Tok, v.UniqueName)).ToList()));
 
-    if (hasModifiesClause) {
+    var effectiveModifies = block.Modifies.Expressions.Any() ? block.Modifies : codeContext.Modifies;
+    var emptyModifies = BoogieGenerator.ModifiesClauseIsEmpty(effectiveModifies);
+    if (!emptyModifies) {
       generator.ApplyModifiesEffect(block, etran, builder, block.Modifies, true, block.IsGhost);
     }
 
@@ -70,11 +71,12 @@ public static class OpaqueBlockVerifier {
   }
 
   private static BoogieGenerator.ExpressionTranslator GetBodyTranslator(BoogieGenerator generator, OpaqueBlock block, Variables locals,
-    BoogieGenerator.ExpressionTranslator etran, bool hasModifiesClause, BoogieStmtListBuilder blockBuilder) {
+    BoogieGenerator.ExpressionTranslator etran, BoogieStmtListBuilder blockBuilder) {
     BoogieGenerator.ExpressionTranslator bodyTranslator;
-    if (hasModifiesClause) {
+    if (block.Modifies.Expressions.Any()) {
       string modifyFrameName = BoogieGenerator.FrameVariablePrefix + generator.CurrentIdGenerator.FreshId("opaque#");
-      generator.DefineFrame(block.Tok, etran.ModifiesFrame(block.Tok), block.Modifies.Expressions, blockBuilder, locals, modifyFrameName);
+      generator.DefineFrame(block.Tok, etran.ModifiesFrame(block.Tok), block.Modifies.Expressions, blockBuilder, locals,
+        modifyFrameName);
       bodyTranslator = etran.WithModifiesFrame(modifyFrameName);
     } else {
       bodyTranslator = etran;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
@@ -6,14 +6,14 @@ method Foo() returns (x: int)
 {
   x := 1;
   var y := 1;
-  opaque
+  opaque 
     ensures x > 3 
   {
     x := x + y;
     x := x + 2;
   }
   assert x == 4; // error
-  x := x + 1;
+  x := x + y;
 }
 
 method StructuredCommandsIf(t: bool)
@@ -195,4 +195,25 @@ method FlattenedMatch(x: Option<int>, y: Option<int>) {
      }
    }
    assert z == 3;
+}
+
+method ModifiesFresh(w: Wrapper)
+{
+  opaque modifies {} 
+  {
+    var wrapper := new Wrapper;
+    wrapper.x := 2;
+    w.x := 3;
+  }
+}
+
+method ImplicitModifiesClause(w: Wrapper)
+  modifies w
+{
+  w.x := 2;
+  opaque
+  {
+    w.x := 3;
+  }
+  assert w.x == 2;
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
@@ -6,7 +6,7 @@ method Foo() returns (x: int)
 {
   x := 1;
   var y := 1;
-  opaque 
+  opaque
     ensures x > 3 
   {
     x := x + y;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy.expect
@@ -10,5 +10,7 @@ opaqueBlock.dfy(106,4): Error: opaque block might violate context's modifies cla
 opaqueBlock.dfy(127,12): Error: variable 'y', which is subject to definite-assignment rules, might be uninitialized here
 opaqueBlock.dfy(130,17): Error: variable 'z', which is subject to definite-assignment rules, might be uninitialized here
 opaqueBlock.dfy(142,12): Error: ensures might not hold
+opaqueBlock.dfy(206,6): Error: assignment might update an object not in the enclosing context's modifies clause
+opaqueBlock.dfy(218,13): Error: assertion might not hold
 
-Dafny program verifier finished with 3 verified, 12 errors
+Dafny program verifier finished with 3 verified, 14 errors

--- a/docs/news/fix.6006
+++ b/docs/news/fix.6006
@@ -1,0 +1,1 @@
+Fix soundness bug that could occur for opaque blocks with empty modifies clauses


### PR DESCRIPTION
Fixes #6006

### What was changed?
- Dafny now havocs the heap of an opaque block when it inherits a non-empty modifies clause from its parent

### How has this been tested?
- Extended test-case

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
