### PR TITLE
Tweak origins used for reporting assertion errors

### DIFF
--- a/Source/DafnyCore/AST/Statements/CalcStmt.cs
+++ b/Source/DafnyCore/AST/Statements/CalcStmt.cs
@@ -202,7 +202,7 @@ public class CalcStmt : Statement, ICloneable<CalcStmt>, ICanFormat {
   public readonly List<CalcOp/*?*/> StepOps; // StepOps[i] comes after line i
   [FilledInDuringResolution]
   public CalcOp Op;                          // main operator of the calculation (either UserSuppliedOp or (after resolution) an inferred CalcOp)
-  [FilledInDuringResolution] public readonly List<Expression> Steps;    // expressions li op l<i + 1> (last step is dummy)
+  [FilledInDuringResolution] public readonly List<Expression> Steps;    // expressions l<i> op l<i + 1> (last step is dummy)
   [FilledInDuringResolution] public Expression Result;                  // expression l0 ResultOp ln
 
   public static readonly CalcOp DefaultOp = new BinaryCalcOp(BinaryExpr.Opcode.Eq);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
@@ -816,12 +816,12 @@ namespace Microsoft.Dafny {
                 var argSubstMap = e.Function.Ins.Zip(e.Args).ToDictionary(fa => fa.First as IVariable, fa => fa.Second);
                 var directSub = new Substituter(e.Receiver, argSubstMap, e.GetTypeArgumentSubstitutions());
 
-                foreach (AttributedExpression p in e.Function.Req) {
-                  var directPrecond = directSub.Substitute(p.E);
+                foreach (AttributedExpression requires in e.Function.Req) {
+                  var directPrecond = directSub.Substitute(requires.E);
 
-                  Expression precond = Substitute(p.E, e.Receiver, substMap, e.GetTypeArgumentSubstitutions());
-                  var (errorMessage, successMessage) = CustomErrorMessage(p.Attributes);
-                  foreach (var ss in TrSplitExpr(builder.Context, precond, etran, true, out _)) {
+                  Expression precond = Substitute(requires.E, e.Receiver, substMap, e.GetTypeArgumentSubstitutions());
+                  var (errorMessage, successMessage) = CustomErrorMessage(requires.Attributes);
+                  foreach (var ss in TrSplitExpr(requires.Origin, builder.Context, precond, etran, true, out _)) {
                     if (ss.IsChecked) {
                       var tok = new NestedOrigin(GetToken(expr), ss.Tok);
                       var desc = new PreconditionSatisfied(directPrecond, errorMessage, successMessage);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.Wellformedness.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.Wellformedness.cs
@@ -46,7 +46,7 @@ public partial class BoogieGenerator {
       foreach (AttributedExpression ensures in f.Ens) {
         var functionHeight = generator.currentModule.CallGraph.GetSCCRepresentativePredecessorCount(f);
         var splits = new List<SplitExprInfo>();
-        bool splitHappened /*we actually don't care*/ = generator.TrSplitExpr(context, ensures.E, splits, true, functionHeight, true, etran);
+        bool splitHappened /*we actually don't care*/ = generator.TrSplitExpr(ensures.Origin, context, ensures.E, splits, true, functionHeight, true, etran);
         var (errorMessage, successMessage) = generator.CustomErrorMessage(ensures.Attributes);
         foreach (var s in splits) {
           if (s.IsChecked && !s.Tok.IsInherited(generator.currentModule)) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Iterators.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Iterators.cs
@@ -75,30 +75,30 @@ namespace Microsoft.Dafny {
       GenerateMethodParametersChoose(iter.Tok, iter, kind,
         true, true, false, etran, inParams, out var outParams);
 
-      var req = new List<Bpl.Requires>();
+      var reqs = new List<Bpl.Requires>();
       var mod = new List<Bpl.IdentifierExpr>();
-      var ens = new List<Bpl.Ensures>();
+      var enses = new List<Bpl.Ensures>();
       // FREE PRECONDITIONS
       if (kind == MethodTranslationKind.SpecWellformedness || kind == MethodTranslationKind.Implementation) {  // the other cases have no need for a free precondition
         // free requires mh == ModuleContextHeight && fh = FunctionContextHeight;
-        req.Add(Requires(iter.Tok, true, null, etran.HeightContext(iter), null, null, null));
+        reqs.Add(Requires(iter.Tok, true, null, etran.HeightContext(iter), null, null, null));
       }
       mod.Add(etran.HeapCastToIdentifierExpr);
 
       if (kind != MethodTranslationKind.SpecWellformedness) {
         // USER-DEFINED SPECIFICATIONS
         var comment = "user-defined preconditions";
-        foreach (var p in iter.Requires) {
-          var (errorMessage, successMessage) = CustomErrorMessage(p.Attributes);
-          if (p.Label != null && kind == MethodTranslationKind.Implementation) {
+        foreach (var req in iter.Requires) {
+          var (errorMessage, successMessage) = CustomErrorMessage(req.Attributes);
+          if (req.Label != null && kind == MethodTranslationKind.Implementation) {
             // don't include this precondition here, but record it for later use
-            p.Label.E = etran.Old.TrExpr(p.E);
+            req.Label.E = etran.Old.TrExpr(req.E);
           } else {
-            foreach (var split in TrSplitExprForMethodSpec(new BodyTranslationContext(false), p.E, etran, kind)) {
+            foreach (var split in TrSplitExprForMethodSpec(req.Origin, new BodyTranslationContext(false), req.E, etran, kind)) {
               if (kind == MethodTranslationKind.Call && split.Tok.IsInherited(currentModule)) {
                 // this precondition was inherited into this module, so just ignore it
               } else {
-                req.Add(Requires(split.Tok, split.IsOnlyFree, p.E, split.E, errorMessage, successMessage, comment));
+                reqs.Add(Requires(split.Tok, split.IsOnlyFree, req.E, split.E, errorMessage, successMessage, comment));
                 comment = null;
                 // the free here is not linked to the free on the original expression (this is free things generated in the splitting.)
               }
@@ -106,24 +106,24 @@ namespace Microsoft.Dafny {
           }
         }
         comment = "user-defined postconditions";
-        foreach (var p in iter.Ensures) {
-          foreach (var split in TrSplitExprForMethodSpec(new BodyTranslationContext(false), p.E, etran, kind)) {
+        foreach (var ens in iter.Ensures) {
+          foreach (var split in TrSplitExprForMethodSpec(ens.Origin, new BodyTranslationContext(false), ens.E, etran, kind)) {
             if (kind == MethodTranslationKind.Implementation && split.Tok.IsInherited(currentModule)) {
               // this postcondition was inherited into this module, so just ignore it
             } else {
-              ens.Add(Ensures(split.Tok, split.IsOnlyFree, p.E, split.E, null, null, comment));
+              enses.Add(Ensures(split.Tok, split.IsOnlyFree, ens.E, split.E, null, null, comment));
               comment = null;
             }
           }
         }
         foreach (BoilerplateTriple tri in GetTwoStateBoilerplate(iter.Tok, iter.Modifies.Expressions, false, iter.AllowsAllocation, etran.Old, etran, etran.Old)) {
-          ens.Add(Ensures(tri.tok, tri.IsFree, null, tri.Expr, tri.ErrorMessage, tri.SuccessMessage, tri.Comment));
+          enses.Add(Ensures(tri.tok, tri.IsFree, null, tri.Expr, tri.ErrorMessage, tri.SuccessMessage, tri.Comment));
         }
       }
 
       var name = MethodName(iter, kind);
       var proc = new Bpl.Procedure(iter.Tok, name, new List<Bpl.TypeVariable>(),
-        inParams, outParams.Values.ToList(), false, req, mod, ens, etran.TrAttributes(iter.Attributes, null));
+        inParams, outParams.Values.ToList(), false, reqs, mod, enses, etran.TrAttributes(iter.Attributes, null));
       AddVerboseNameAttribute(proc, iter.FullDafnyName, kind);
 
       currentModule = null;

--- a/Source/DafnyCore/Verifier/BoogieGenerator.SplitExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.SplitExpr.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Dafny {
     /// if its body is available in the current context and its height is less than "heightLimit" (if "heightLimit" is
     /// passed in as 0, then no functions will be inlined).
     /// </summary>
-    bool TrSplitExpr(BodyTranslationContext context, Expression expr, List<SplitExprInfo> splits, /*!*/ /*!*/
+    bool TrSplitExpr(IOrigin origin, BodyTranslationContext context, Expression expr,
+      List<SplitExprInfo> splits, /*!*/ /*!*/
       bool position, int heightLimit, bool applyInduction, ExpressionTranslator etran) {
       Contract.Requires(expr != null);
       Contract.Requires(expr.Type.IsBoolType || (expr is BoxingCastExpr && ((BoxingCastExpr)expr).E.Type.IsBoolType));
@@ -50,7 +51,7 @@ namespace Microsoft.Dafny {
         case BoxingCastExpr castExpr: {
             var bce = castExpr;
             var ss = new List<SplitExprInfo>();
-            if (TrSplitExpr(context, bce.E, ss, position, heightLimit, applyInduction, etran)) {
+            if (TrSplitExpr(origin, context, bce.E, ss, position, heightLimit, applyInduction, etran)) {
               foreach (var s in ss) {
                 splits.Add(ToSplitExprInfo(s.Kind, CondApplyBox(s.Tok, s.E, bce.FromType, bce.ToType)));
               }
@@ -61,18 +62,18 @@ namespace Microsoft.Dafny {
           }
         case ConcreteSyntaxExpression expression: {
             var e = expression;
-            return TrSplitExpr(context, e.ResolvedExpression, splits, position, heightLimit, applyInduction, etran);
+            return TrSplitExpr(origin, context, e.ResolvedExpression, splits, position, heightLimit, applyInduction, etran);
           }
         case NestedMatchExpr nestedMatchExpr:
-          return TrSplitExpr(context, nestedMatchExpr.Flattened, splits, position, heightLimit, applyInduction, etran);
+          return TrSplitExpr(origin, context, nestedMatchExpr.Flattened, splits, position, heightLimit, applyInduction, etran);
         case LetExpr letExpr: {
             var e = letExpr;
             if (!e.Exact) {
               var d = etran.LetDesugaring(e);
-              return TrSplitExpr(context, d, splits, position, heightLimit, applyInduction, etran);
+              return TrSplitExpr(origin, context, d, splits, position, heightLimit, applyInduction, etran);
             } else {
               var ss = new List<SplitExprInfo>();
-              if (TrSplitExpr(context, e.Body, ss, position, heightLimit, applyInduction, etran)) {
+              if (TrSplitExpr(origin, context, e.Body, ss, position, heightLimit, applyInduction, etran)) {
                 // We don't know where the RHSs of the let are used in the body. In particular, we don't know if a RHS
                 // will end up in a spot where TrSplitExpr would like to increase the Layer offset or not. In fact, different
                 // uses of the same let variable may end up needing different Layer constants. The following code will
@@ -96,10 +97,10 @@ namespace Microsoft.Dafny {
             if (position && e.Frame.Count > 1) {
               // split into a number of UnchangeExpr's, one for each FrameExpression
               foreach (var fe in e.Frame) {
-                var tok = new NestedOrigin(GetToken(e), fe.Tok);
+                var tok = new NestedOrigin(origin, fe.Tok);
                 Expression ee = new UnchangedExpr(tok, new List<FrameExpression> { fe }, e.At) { AtLabel = e.AtLabel };
                 ee.Type = Type.Bool;  // resolve here
-                TrSplitExpr(context, ee, splits, position, heightLimit, applyInduction, etran);
+                TrSplitExpr(origin, context, ee, splits, position, heightLimit, applyInduction, etran);
               }
               return true;
             }
@@ -110,7 +111,7 @@ namespace Microsoft.Dafny {
             var e = opExpr;
             if (e.ResolvedOp == UnaryOpExpr.ResolvedOpcode.BoolNot) {
               var ss = new List<SplitExprInfo>();
-              if (TrSplitExpr(context, e.E, ss, !position, heightLimit, applyInduction, etran)) {
+              if (TrSplitExpr(origin, context, e.E, ss, !position, heightLimit, applyInduction, etran)) {
                 foreach (var s in ss) {
                   splits.Add(ToSplitExprInfo(s.Kind, Bpl.Expr.Unary(s.E.tok, UnaryOperator.Opcode.Not, s.E)));
                 }
@@ -123,13 +124,13 @@ namespace Microsoft.Dafny {
         case BinaryExpr binaryExpr: {
             var bin = binaryExpr;
             if (position && bin.ResolvedOp == BinaryExpr.ResolvedOpcode.And) {
-              TrSplitExpr(context, bin.E0, splits, position, heightLimit, applyInduction, etran);
-              TrSplitExpr(context, bin.E1, splits, position, heightLimit, applyInduction, etran);
+              TrSplitExpr(origin, context, bin.E0, splits, position, heightLimit, applyInduction, etran);
+              TrSplitExpr(origin, context, bin.E1, splits, position, heightLimit, applyInduction, etran);
               return true;
 
             } else if (!position && bin.ResolvedOp == BinaryExpr.ResolvedOpcode.Or) {
-              TrSplitExpr(context, bin.E0, splits, position, heightLimit, applyInduction, etran);
-              TrSplitExpr(context, bin.E1, splits, position, heightLimit, applyInduction, etran);
+              TrSplitExpr(origin, context, bin.E0, splits, position, heightLimit, applyInduction, etran);
+              TrSplitExpr(origin, context, bin.E1, splits, position, heightLimit, applyInduction, etran);
               return true;
 
             } else if (bin.ResolvedOp == BinaryExpr.ResolvedOpcode.Imp) {
@@ -137,14 +138,14 @@ namespace Microsoft.Dafny {
               if (position) {
                 var lhs = etran.TrExpr(bin.E0);
                 var ss = new List<SplitExprInfo>();
-                TrSplitExpr(context, bin.E1, ss, position, heightLimit, applyInduction, etran);
+                TrSplitExpr(origin, context, bin.E1, ss, position, heightLimit, applyInduction, etran);
                 foreach (var s in ss) {
                   // as the source location in the following implication, use that of the translated "s"
                   splits.Add(ToSplitExprInfo(s.Kind, Bpl.Expr.Binary(s.E.tok, BinaryOperator.Opcode.Imp, lhs, s.E)));
                 }
               } else {
                 var ss = new List<SplitExprInfo>();
-                TrSplitExpr(context, bin.E0, ss, !position, heightLimit, applyInduction, etran);
+                TrSplitExpr(origin, context, bin.E0, ss, !position, heightLimit, applyInduction, etran);
                 var rhs = etran.TrExpr(bin.E1);
                 foreach (var s in ss) {
                   // as the source location in the following implication, use that of the translated "s"
@@ -218,8 +219,8 @@ namespace Microsoft.Dafny {
             var ssThen = new List<SplitExprInfo>();
             var ssElse = new List<SplitExprInfo>();
 
-            TrSplitExpr(context, ite.Thn, ssThen, position, heightLimit, applyInduction, etran);
-            TrSplitExpr(context, ite.Els, ssElse, position, heightLimit, applyInduction, etran);
+            TrSplitExpr(origin, context, ite.Thn, ssThen, position, heightLimit, applyInduction, etran);
+            TrSplitExpr(origin, context, ite.Els, ssElse, position, heightLimit, applyInduction, etran);
 
             var op = position ? BinaryOperator.Opcode.Imp : BinaryOperator.Opcode.And;
             var test = etran.TrExpr(ite.Test);
@@ -239,7 +240,7 @@ namespace Microsoft.Dafny {
         case MatchExpr matchExpr: {
             var e = matchExpr;
             var ite = etran.DesugarMatchExpr(e);
-            return TrSplitExpr(context, ite, splits, position, heightLimit, applyInduction, etran);
+            return TrSplitExpr(origin, context, ite, splits, position, heightLimit, applyInduction, etran);
           }
         case StmtExpr stmtExpr: {
             var e = stmtExpr;
@@ -249,14 +250,14 @@ namespace Microsoft.Dafny {
             if (position) {
               var conclusion = etran.TrExpr(e.GetStatementConclusion());
               var ss = new List<SplitExprInfo>();
-              TrSplitExpr(context, e.E, ss, position, heightLimit, applyInduction, etran);
+              TrSplitExpr(origin, context, e.E, ss, position, heightLimit, applyInduction, etran);
               foreach (var s in ss) {
                 // as the source location in the following implication, use that of the translated "s"
                 splits.Add(ToSplitExprInfo(s.Kind, Bpl.Expr.Binary(s.E.tok, BinaryOperator.Opcode.Imp, conclusion, s.E)));
               }
             } else {
               var ss = new List<SplitExprInfo>();
-              TrSplitExpr(context, e.GetStatementConclusion(), ss, !position, heightLimit, applyInduction, etran);
+              TrSplitExpr(origin, context, e.GetStatementConclusion(), ss, !position, heightLimit, applyInduction, etran);
               var rhs = etran.TrExpr(e.E);
               foreach (var s in ss) {
                 // as the source location in the following implication, use that of the translated "s"
@@ -267,18 +268,18 @@ namespace Microsoft.Dafny {
           }
         case OldExpr oldExpr: {
             var e = oldExpr;
-            return TrSplitExpr(context, e.E, splits, position, heightLimit, applyInduction, etran.OldAt(e.AtLabel));
+            return TrSplitExpr(origin, context, e.E, splits, position, heightLimit, applyInduction, etran.OldAt(e.AtLabel));
           }
         case FunctionCallExpr callExpr when position: {
             var fexp = callExpr;
-            if (TrSplitFunctionCallExpr(context, callExpr, splits, heightLimit, applyInduction, etran, fexp)) {
+            if (TrSplitFunctionCallExpr(origin, context, callExpr, splits, heightLimit, applyInduction, etran, fexp)) {
               return true;
             }
 
             break;
           }
         case QuantifierExpr quantifierExpr when quantifierExpr.SplitQuantifier != null:
-          return TrSplitExpr(context, quantifierExpr.SplitQuantifierExpression, splits, position, heightLimit, applyInduction, etran);
+          return TrSplitExpr(origin, context, quantifierExpr.SplitQuantifierExpression, splits, position, heightLimit, applyInduction, etran);
         default: {
             if (((position && expr is ForallExpr) || (!position && expr is ExistsExpr))) {
               var e = (QuantifierExpr)expr;
@@ -473,7 +474,7 @@ namespace Microsoft.Dafny {
       }
     }
 
-    private bool TrSplitFunctionCallExpr(BodyTranslationContext context,
+    private bool TrSplitFunctionCallExpr(IOrigin origin, BodyTranslationContext context,
       Expression expr, List<SplitExprInfo> splits, int heightLimit,
       bool applyInduction, ExpressionTranslator etran, FunctionCallExpr fexp) {
       var f = fexp.Function;
@@ -533,7 +534,7 @@ namespace Microsoft.Dafny {
 
             // recurse on body
             var ss = new List<SplitExprInfo>();
-            TrSplitExpr(context, typeSpecializedBody, ss, true, functionHeight, applyInduction, etran);
+            TrSplitExpr(origin, context, typeSpecializedBody, ss, true, functionHeight, applyInduction, etran);
             var needsTokenAdjust = TrSplitNeedsTokenAdjustment(typeSpecializedBody);
             foreach (var s in ss) {
               if (s.IsChecked) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
@@ -1522,7 +1522,8 @@ public partial class BoogieGenerator {
           if (witnessExpr != null) {
             witnessExpr.SetTok(result.Tok);
             var desc = new WitnessCheck(witnessString, witnessExpr);
-            SplitAndAssertExpression(returnBuilder, witnessExpr, etran, context, desc);
+            var origin = new SourceOrigin(witnessExpr.StartToken, witnessExpr.EndToken);
+            SplitAndAssertExpression(origin, returnBuilder, witnessExpr, etran, context, desc);
           }
         });
       codeContext = ghostCodeContext;
@@ -1539,7 +1540,8 @@ public partial class BoogieGenerator {
         if (witnessExpr != null) {
           witnessExpr.SetTok(decl.Tok);
           var desc = new WitnessCheck(witnessString, witnessExpr);
-          SplitAndAssertExpression(witnessCheckBuilder, witnessExpr, etran, context, desc);
+          var origin = new SourceOrigin(witnessExpr.StartToken, witnessExpr.EndToken);
+          SplitAndAssertExpression(origin, witnessCheckBuilder, witnessExpr, etran, context, desc);
         }
       }
     }
@@ -1564,11 +1566,11 @@ public partial class BoogieGenerator {
     Reset();
   }
 
-  private void SplitAndAssertExpression(BoogieStmtListBuilder witnessCheckBuilder, Expression witnessExpr,
+  private void SplitAndAssertExpression(IOrigin origin, BoogieStmtListBuilder witnessCheckBuilder, Expression witnessExpr,
     ExpressionTranslator etran, BodyTranslationContext context, WitnessCheck desc) {
     witnessCheckBuilder.Add(new Bpl.AssumeCmd(witnessExpr.Tok, etran.CanCallAssumption(witnessExpr)));
 
-    var ss = TrSplitExpr(context, witnessExpr, etran, true, out var splitHappened);
+    var ss = TrSplitExpr(origin, context, witnessExpr, etran, true, out var splitHappened);
     if (!splitHappened) {
       witnessCheckBuilder.Add(Assert(witnessExpr.Tok, etran.TrExpr(witnessExpr), desc, context));
     } else {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -4469,25 +4469,25 @@ namespace Microsoft.Dafny {
       return dafnyOptions.DisableNLarith;
     }
 
-    List<SplitExprInfo> /*!*/ TrSplitExpr(BodyTranslationContext context, Expression expr, ExpressionTranslator etran, bool applyInduction,
+    List<SplitExprInfo> /*!*/ TrSplitExpr(IOrigin origin, BodyTranslationContext context, Expression expr, ExpressionTranslator etran, bool applyInduction,
       out bool splitHappened) {
       Contract.Requires(expr != null);
       Contract.Requires(etran != null);
       Contract.Ensures(Contract.Result<List<SplitExprInfo>>() != null);
 
       var splits = new List<SplitExprInfo>();
-      splitHappened = TrSplitExpr(context, expr, splits, true, int.MaxValue, applyInduction, etran);
+      splitHappened = TrSplitExpr(origin, context, expr, splits, true, int.MaxValue, applyInduction, etran);
       return splits;
     }
 
-    List<SplitExprInfo> TrSplitExprForMethodSpec(BodyTranslationContext context, Expression expr, ExpressionTranslator etran, MethodTranslationKind kind) {
+    List<SplitExprInfo> TrSplitExprForMethodSpec(IOrigin origin, BodyTranslationContext context, Expression expr, ExpressionTranslator etran, MethodTranslationKind kind) {
       Contract.Requires(expr != null);
       Contract.Requires(etran != null);
       Contract.Ensures(Contract.Result<List<SplitExprInfo>>() != null);
 
       var splits = new List<SplitExprInfo>();
       var applyInduction = kind == MethodTranslationKind.Implementation;
-      TrSplitExpr(context, expr, splits, true, int.MaxValue, applyInduction, etran);
+      TrSplitExpr(origin, context, expr, splits, true, int.MaxValue, applyInduction, etran);
       return splits;
     }
 

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
@@ -528,7 +528,7 @@ public partial class BoogieGenerator {
 
       // check that postconditions hold
       foreach (var ens in forallStmt.Ens) {
-        foreach (var split in TrSplitExpr(definedness.Context, ens.E, etran, true, out var splitHappened)) {
+        foreach (var split in TrSplitExpr(ens.Origin, definedness.Context, ens.E, etran, true, out var splitHappened)) {
           if (split.IsChecked) {
             definedness.Add(Assert(split.Tok, split.E, new ForallPostcondition(ens.E), definedness.Context));
           }

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrLoop.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrLoop.cs
@@ -239,10 +239,10 @@ public partial class BoogieGenerator {
       invDefinednessBuilder.Add(TrAssumeCmdWithDependencies(etran, loopInv.E.Tok, loopInv.E, "loop invariant"));
 
       invariants.Add(TrAssumeCmd(loopInv.E.Tok, BplImp(w, etran.CanCallAssumption(loopInv.E))));
-      var ss = TrSplitExpr(builder.Context, loopInv.E, etran, false, out var splitHappened);
+      var ss = TrSplitExpr(loopInv.Origin, builder.Context, loopInv.E, etran, false, out var splitHappened);
       if (!splitHappened) {
         var wInv = BplImp(w, etran.TrExpr(loopInv.E));
-        invariants.Add(Assert(loopInv.E.Tok, wInv, new LoopInvariant(loopInv.E, errorMessage, successMessage), builder.Context));
+        invariants.Add(Assert(loopInv.Origin, wInv, new LoopInvariant(loopInv.E, errorMessage, successMessage), builder.Context));
       } else {
         foreach (var split in ss) {
           var wInv = Bpl.Expr.Binary(split.E.tok, BinaryOperator.Opcode.Imp, w, split.E);

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrPredicateStatement.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrPredicateStatement.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Dafny {
       ExpressionTranslator etran, BoogieStmtListBuilder proofBuilder) {
 
       var (errorMessage, successMessage) = CustomErrorMessage(stmt.Attributes);
-      var splits = TrSplitExpr(proofBuilder.Context, stmt.Expr, etran, true, out var splitHappened);
+      var splits = TrSplitExpr(stmt.Origin, proofBuilder.Context, stmt.Expr, etran, true, out var splitHappened);
       if (!splitHappened) {
         var desc = new AssertStatementDescription(stmt, errorMessage, successMessage);
         proofBuilder.Add(Assert(stmt.Origin, etran.TrExpr(stmt.Expr), desc, stmt.Tok, proofBuilder.Context,
@@ -155,9 +155,9 @@ namespace Microsoft.Dafny {
       } else {
         foreach (var split in splits) {
           if (split.IsChecked) {
-            var tok = split.E.tok;
+            var origin = split.E.tok;
             var desc = new AssertStatementDescription(stmt, errorMessage, successMessage);
-            proofBuilder.Add(AssertAndForget(proofBuilder.Context, ToDafnyToken(flags.ReportRanges, tok), split.E, desc, stmt.Tok,
+            proofBuilder.Add(AssertAndForget(proofBuilder.Context, ToDafnyToken(flags.ReportRanges, origin), split.E, desc, stmt.Tok,
               etran.TrAttributes(stmt.Attributes, null))); // attributes go on every split
           }
         }

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
@@ -118,18 +118,18 @@ public partial class BoogieGenerator {
         );
       var fieldSub = new SpecialFieldSubstituter(fieldSubstMap);
 
-      foreach (var p in iter.YieldEnsures) {
-        var ss = TrSplitExpr(builder.Context, p.E, yeEtran, true, out var splitHappened);
+      foreach (var ensures in iter.YieldEnsures) {
+        var ss = TrSplitExpr(ensures.Origin, builder.Context, ensures.E, yeEtran, true, out var splitHappened);
         foreach (var split in ss) {
           if (split.Tok.IsInherited(currentModule)) {
             // this postcondition was inherited into this module, so just ignore it
           } else if (split.IsChecked) {
             var yieldToken = new NestedOrigin(s.Tok, split.Tok);
-            var desc = new YieldEnsures(fieldSub.Substitute(p.E));
+            var desc = new YieldEnsures(fieldSub.Substitute(ensures.E));
             builder.Add(AssertAndForget(builder.Context, yieldToken, split.E, desc, stmt.Tok, null));
           }
         }
-        builder.Add(TrAssumeCmdWithDependencies(yeEtran, stmt.Tok, p.E, "yield ensures clause"));
+        builder.Add(TrAssumeCmdWithDependencies(yeEtran, stmt.Tok, ensures.E, "yield ensures clause"));
       }
       YieldHavoc(iter.Tok, iter, builder, etran);
       builder.AddCaptureState(s);
@@ -570,15 +570,21 @@ public partial class BoogieGenerator {
             }
           }
           TrStmt_CheckWellformed(CalcStmt.Rhs(stmt.Steps[i]), b, locals, etran, false);
-          var ss = TrSplitExpr(builder.Context, stmt.Steps[i], etran, true, out var splitHappened);
+          // For calc statement expression, there is not always an explicit operator,
+          // so there is no obvious place to use as a center for each expression.
+          // We will use the start of the expression as its center.
+          // An alternative would be to use the preceding ; in case of an implicit operator
+          var origin = stmt.Lines[i + 1].Origin;
+          var leftCenterOrigin = new OverrideCenter(origin, origin.StartToken);
+          var ss = TrSplitExpr(leftCenterOrigin, builder.Context, stmt.Steps[i], etran, true, out var splitHappened);
           // assert step:
           AddComment(b, stmt, "assert line" + i.ToString() + " " + (stmt.StepOps[i] ?? stmt.Op).ToString() + " line" + (i + 1).ToString());
           if (!splitHappened) {
-            b.Add(AssertAndForget(b.Context, stmt.Lines[i + 1].Tok, etran.TrExpr(stmt.Steps[i]), new CalculationStep(stmt.Steps[i], stmt.Hints[i])));
+            b.Add(AssertAndForget(b.Context, leftCenterOrigin, etran.TrExpr(stmt.Steps[i]), new CalculationStep(stmt.Steps[i], stmt.Hints[i])));
           } else {
             foreach (var split in ss) {
               if (split.IsChecked) {
-                b.Add(AssertAndForget(b.Context, stmt.Lines[i + 1].Tok, split.E, new CalculationStep(stmt.Steps[i], stmt.Hints[i])));
+                b.Add(AssertAndForget(b.Context, split.Tok, split.E, new CalculationStep(stmt.Steps[i], stmt.Hints[i])));
               }
             }
           }


### PR DESCRIPTION
### What was changed?
When asserting a condition, do not use just condition's origin as an origin for that condition, but also the context in which it occurs, for example include the ensures, requires or assert keyword

### How has this been tested?
- Updated existing tests

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
