### PR TITLE
Delete test for legacy CLI that tests ambiguous behavior

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3549a.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3549a.dfy
@@ -1,2 +1,0 @@
-// RUN: %exits-with 1 %baredafny "" 2> "%t"
-// RUN: %diff "%s.expect" "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3549a.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-3549a.dfy.expect
@@ -1,1 +1,0 @@
-Invalid filename: The value cannot be an empty string. (Parameter 'path')


### PR DESCRIPTION
Should fix failing nightly: https://github.com/dafny-lang/dafny/actions/runs/12711494070/job/35434956978

### What was changed?
The Dafny legacy CLI shows part of a .NET error message as part of it UI. This can not be tested well since the specific error message is not defined as part of .NET, and can be different across .NET versions and platforms.

On Windows it returns:
`Invalid filename: The value cannot be an empty string. (Parameter 'path')`
On other platforms it is:
`Invalid filename: The path is empty. (Parameter 'path')`

Instead of fixing the legacy CLI to remove the ambiguity, I'm removing the test for that ambiguous behavior since the old CLI is deprecated.

### How has this been tested?
Removed a test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
