### PR TITLE
fix: Forbid recursive function uses in decreases clauses

### DIFF
--- a/Source/DafnyCore/Resolver/ExtremeLemmaChecks_Visitor.cs
+++ b/Source/DafnyCore/Resolver/ExtremeLemmaChecks_Visitor.cs
@@ -11,26 +11,24 @@ class ExtremeLemmaChecks_Visitor : ResolverBottomUpVisitor {
     this.context = context;
   }
   protected override void VisitOneStmt(Statement stmt) {
-    if (stmt is CallStmt) {
-      var s = (CallStmt)stmt;
-      if (s.Method is ExtremeLemma || s.Method is PrefixLemma) {
+    if (stmt is CallStmt callStmt) {
+      if (callStmt.Method is ExtremeLemma or PrefixLemma) {
         // all is cool
       } else {
         // the call goes from an extreme lemma context to a non-extreme-lemma callee
-        if (ModuleDefinition.InSameSCC(context, s.Method)) {
+        if (ModuleDefinition.InSameSCC(context, callStmt.Method)) {
           // we're looking at a recursive call (to a non-extreme-lemma)
-          resolver.reporter.Error(MessageSource.Resolver, s.Origin, "a recursive call from a {0} can go only to other {0}s and prefix lemmas", context.WhatKind);
+          resolver.reporter.Error(MessageSource.Resolver, callStmt.Origin, "a recursive call from a {0} can go only to other {0}s and prefix lemmas", context.WhatKind);
         }
       }
     }
   }
   protected override void VisitOneExpr(Expression expr) {
-    if (expr is FunctionCallExpr) {
-      var e = (FunctionCallExpr)expr;
+    if (expr is FunctionCallExpr callExpr) {
       // the call goes from a greatest lemma context to a non-greatest-lemma callee
-      if (ModuleDefinition.InSameSCC(context, e.Function)) {
+      if (ModuleDefinition.InSameSCC(context, callExpr.Function)) {
         // we're looking at a recursive call (to a non-greatest-lemma)
-        resolver.reporter.Error(MessageSource.Resolver, e.Origin, "a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas");
+        resolver.reporter.Error(MessageSource.Resolver, callExpr.Origin, "a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas");
       }
     }
   }

--- a/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
+++ b/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.Contracts;
+
+namespace Microsoft.Dafny;
+
+class FunctionEntanglementChecks_Visitor : ResolverBottomUpVisitor {
+  private readonly ICallable context;
+  public bool DoDecreasesChecks;
+  public FunctionEntanglementChecks_Visitor(ModuleResolver resolver, ICallable context)
+    : base(resolver) {
+    Contract.Requires(resolver != null);
+    Contract.Requires(context != null);
+    this.context = context;
+  }
+
+  protected override void VisitOneExpr(Expression expr) {
+    if (!DoDecreasesChecks && expr is MemberSelectExpr { Member: Function fn }) {
+      if (ModuleDefinition.InSameSCC(context, fn)) {
+        resolver.reporter.Error(MessageSource.Resolver, expr.Origin,
+          "cannot use naked function in recursive setting. Possible solution: eta expansion.");
+      }
+    }
+  }
+}

--- a/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
+++ b/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
@@ -19,5 +19,19 @@ class FunctionEntanglementChecks_Visitor : ResolverBottomUpVisitor {
           "cannot use naked function in recursive setting. Possible solution: eta expansion.");
       }
     }
+
+    if (DoDecreasesChecks && expr is FunctionCallExpr callExpr) {
+      if (ModuleDefinition.InSameSCC(context, callExpr.Function)) {
+        string msg;
+        if (context == callExpr.Function) {
+          msg = "a decreases clause is not allowed to call the enclosing function";
+        } else {
+          msg = $"the decreases clause of {context.WhatKind} '{context.NameRelativeToModule}' is not allowed to call '{callExpr.Function}', " +
+                "because they are mutually recursive";
+        }
+
+        resolver.reporter.Error(MessageSource.Resolver, callExpr.Origin, msg);
+      }
+    }
   }
 }

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1262,6 +1262,13 @@ namespace Microsoft.Dafny {
         FillInPostConditionsAndBodiesOfPrefixLemmas(declarations);
       }
 
+      // A function is not allowed to be used naked in its own SCC. Also, a function is not allowed to be used
+      // in any way inside a "decreases" clause its its own SCC.
+      foreach (var function in ModuleDefinition.AllFunctions(declarations)) {
+        var visitor = new FunctionEntanglementChecks_Visitor(this, function);
+        visitor.Visit(function);
+      }
+
       // An inductive datatype is allowed to be defined as an empty type. For example, in
       //     predicate P(x: int) { false }
       //     type Subset = x: int | P(x) witness *

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1267,6 +1267,8 @@ namespace Microsoft.Dafny {
       foreach (var function in ModuleDefinition.AllFunctions(declarations)) {
         var visitor = new FunctionEntanglementChecks_Visitor(this, function);
         visitor.Visit(function);
+        visitor.DoDecreasesChecks = true;
+        visitor.Visit(function.Decreases.Expressions);
       }
 
       // An inductive datatype is allowed to be defined as an empty type. For example, in

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
@@ -332,7 +332,6 @@ namespace Microsoft.Dafny {
           }
         case MemberSelectExpr selectExpr: {
             MemberSelectExpr e = selectExpr;
-            CheckFunctionSelectWF("naked function", builder, etran, e, " Possible solution: eta expansion.");
             CheckWellformed(e.Obj, wfOptions, locals, builder, etran);
             if (e.Obj.Type.IsRefType) {
               if (inBodyInitContext && Expression.AsThis(e.Obj) != null && !e.Member.IsInstanceIndependentConstant) {
@@ -681,8 +680,6 @@ namespace Microsoft.Dafny {
               CheckWellformed(e.Receiver, wfOptions, locals, builder, etran);
               if (!e.Function.IsStatic && !(e.Receiver is ThisExpr) && !e.Receiver.Type.IsArrowType) {
                 CheckNonNull(callExpr.Origin, e.Receiver, builder, etran, wfOptions.AssertKv);
-              } else if (e.Receiver.Type.IsArrowType) {
-                CheckFunctionSelectWF("function specification", builder, etran, e.Receiver, "");
               }
               if (!e.Function.IsStatic && !etran.UsesOldHeap) {
                 // the argument can't be assumed to be allocated for the old heap

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -2447,13 +2447,6 @@ namespace Microsoft.Dafny {
       }
     }
 
-    void CheckFunctionSelectWF(string what, BoogieStmtListBuilder builder, ExpressionTranslator etran, Expression e, string hint) {
-      if (e is MemberSelectExpr sel && sel.Member is Function fn) {
-        Bpl.Expr assertion = !InVerificationScope(fn) ? Bpl.Expr.True : Bpl.Expr.Not(etran.HeightContext(fn));
-        builder.Add(Assert(GetToken(e), assertion, new ValidInRecursion(what, hint), builder.Context));
-      }
-    }
-
     void CloneVariableAsBoundVar(IOrigin tok, IVariable iv, string prefix, out BoundVar bv, out IdentifierExpr ie) {
       Contract.Requires(tok != null);
       Contract.Requires(iv != null);

--- a/Source/DafnyCore/Verifier/ProofObligationDescription.cs
+++ b/Source/DafnyCore/Verifier/ProofObligationDescription.cs
@@ -1423,26 +1423,6 @@ public class ForRangeAssignable : ProofObligationDescription {
   }
 }
 
-public class ValidInRecursion : ProofObligationDescription {
-  public override string SuccessDescription =>
-    $"{what} is valid in recursive setting";
-
-  public override string FailureDescription =>
-    $"cannot use {what} in recursive setting.{hint ?? ""}";
-
-  public override string ShortDescription => "valid in recursion";
-
-  public override bool ProvedOutsideUserCode => true;
-
-  private readonly string what;
-  private readonly string hint;
-
-  public ValidInRecursion(string what, string hint) {
-    this.what = what;
-    this.hint = hint;
-  }
-}
-
 public class IsNonRecursive : ProofObligationDescription {
   public override string SuccessDescription =>
     "default value is non-recursive";

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy
@@ -31,11 +31,11 @@
 /// anonymous functions (“lambdas”) modularly: every time a lambda is created,
 /// as with `(fun () -> parentheses' ())`, Dafny checks that the function can be
 /// called in any context.  To see why, consider the function `Apply` below and
-/// the following two uses of it:
+/// the following two uses of it (see also parser_combinators_error.dfy):
 
 function Apply(f: () -> int): int { f() }
 
-function F0(): int { Apply(F0) }
+// function F0(): int { Apply(F0) } // cannot use F0 naked here (see parser_combinators_error.dfy)
 function F1(): int { Apply(() => F1()) }
 
 /// Dafny rejects `F0` because it does not allow using “naked” recursive

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy.expect
@@ -1,7 +1,6 @@
-parser_combinators.dfy(38,27): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 parser_combinators.dfy(39,33): Error: cannot prove termination; try supplying a decreases clause
 
-Dafny program verifier finished with 8 verified, 2 errors
+Dafny program verifier finished with 8 verified, 1 error
 
 Dafny program verifier did not attempt verification
 "((()))": 3 nested parentheses

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy
@@ -1,0 +1,42 @@
+// RUN: %exits-with 2 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function F(x: int): int
+  decreases G(x) // error: decreases clause cannot use mutually recursive function
+{
+  G(x) - 1
+}
+
+function G(x: int): int
+  decreases F(x) // error: decreases clause cannot use mutually recursive function
+{
+  F(x)
+}
+
+function K(x: nat): int
+  decreases if x == 0 then 0 else 1 + K(x - 1) // error: decreases clause is not allowed to call enclosing function
+{
+  if x == 0 then 200 else 1 + K(x - 1)
+}
+
+function Id(x: int): int {
+  IdBuddy(x)
+}
+
+function IdBuddy(x: int): int
+  decreases x, 0
+{
+  if x <= 0 then x else
+    var id := Id; // error: cannot use Id naked here
+    id(x - 1)
+}
+
+ghost function H(x: int): int {
+  if H != (H) then 0 else 3 // error (x2): cannot use H naked here
+}
+
+datatype Dt = Dt {
+  ghost function J(x: int): int {
+    if (this).J == J then 0 else 3 // error (x2): cannot use J naked here
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy.expect
@@ -1,0 +1,9 @@
+git-issue-6043.dfy(5,12): Error: the decreases clause of function 'F' is not allowed to call 'G', because they are mutually recursive
+git-issue-6043.dfy(11,12): Error: the decreases clause of function 'G' is not allowed to call 'F', because they are mutually recursive
+git-issue-6043.dfy(17,38): Error: a decreases clause is not allowed to call the enclosing function
+git-issue-6043.dfy(30,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(35,5): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(35,11): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(40,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(40,19): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+8 resolution/type errors detected in git-issue-6043.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy
@@ -61,3 +61,37 @@ method AllocationTest(oldcell: Cell)
     case true =>  assert old(k(y, b)) < 50;  // error: argument y is not allocated in old state
   }
 }
+
+module TwoStateFunctions {
+  method Apply(ghost f: int -> int, x: int) returns (ghost y: int)
+    ensures y == f(x)
+  {
+    y := f(x);
+  }
+
+  class Cell {
+    var data: int
+
+    twostate function F(x: int): int {
+      old(data) + x
+    }
+  }
+
+  method Caller(c: Cell)
+    requires c.data == 9
+    modifies c
+  {
+    c.data := c.data + 1;
+    label L:
+    assert c.F(11) == 20;
+
+    var y := Apply(c.F, 11);
+    assert y == 20;
+
+    assert c.F@L(11) == 21;
+    y := Apply(u => c.F@L(u), 11);
+    assert y == 21;
+
+    assert c.F(100) == 0; // error
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy.expect
@@ -1,6 +1,7 @@
+Apply.dfy(95,4): Error: assertion might not hold
 Apply.dfy(46,23): Error: function could not be proved to be allocated in the state in which the function is invoked
 Apply.dfy(57,31): Error: argument could not be proved to be allocated in the state in which the function is invoked
 Apply.dfy(58,31): Error: argument could not be proved to be allocated in the state in which the function is invoked
 Apply.dfy(61,31): Error: argument could not be proved to be allocated in the state in which the function is invoked
 
-Dafny program verifier finished with 4 verified, 4 errors
+Dafny program verifier finished with 7 verified, 5 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s" -- --allow-deprecation
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s"
 
 
 module Functions {
@@ -19,86 +19,52 @@ module Functions {
 
 module Requires {
   ghost function t(x: nat): nat
-    requires !t.requires(x);  // error: use of naked function in its own SCC
+    requires !t.requires(x)  // error: use of naked function in its own SCC
   { x }
 
   ghost function g(x: nat): nat
-    requires !(g).requires(x);  // error: use of naked function in its own SCC
+    requires !(g).requires(x)  // error: use of naked function in its own SCC
   { x }
 
   ghost function D(x: int): int  // used so termination errors don't mask other errors
-  ghost function g2(x: int): int decreases D(x) { h(x) }  // error: precondition violation
+  ghost function g2(x: int): int decreases D(x) { h(x) }
   ghost function h(x: int): int
-    requires !g2.requires(x);  // error: use of naked function in its own SCC
+    requires !g2.requires(x)  // error: use of naked function in its own SCC
   { x }
 }
 
 module Reads {
   ghost function t(x: nat): nat
-    reads t.reads(x);
+    reads t.reads(x)
   { x }
 
   ghost function g(x: nat): nat
-    reads (g).reads(x);
+    reads (g).reads(x)
   { x }
 
   ghost function g2(x: int): int
   { h(x) }
 
   ghost function h(x: int): int
-    reads g2.reads(x);
+    reads g2.reads(x)
   { x }
 }
 
 module ReadsGenerics {
   class Cl<A> {
     ghost function t<B>(a: A, b: B): (A, B)
-      reads t.reads(a, b);
+      reads t.reads(a, b)
     { (a, b) }
 
     ghost function g<B>(a: A, b: B): (A, B)
-      reads (g).reads(a, b);
+      reads (g).reads(a, b)
     { (a, b) }
 
     ghost function g2<B>(a: A, b: B): (A, B)
     { h(a, b) }
 
     ghost function h<B>(a: A, b: B): (A, B)
-      reads g2.reads(a, b);
+      reads g2.reads(a, b)
     { (a, b) }
-  }
-}
-
-module TwoStateFunctions {
-  method Apply(ghost f: int -> int, x: int) returns (ghost y: int)
-    ensures y == f(x)
-  {
-    y := f(x);
-  }
-
-  class Cell {
-    var data: int
-
-    twostate function F(x: int): int {
-      old(data) + x
-    }
-  }
-
-  method Caller(c: Cell)
-    requires c.data == 9
-    modifies c
-  {
-    c.data := c.data + 1;
-    label L:
-    assert c.F(11) == 20;
-
-    var y := Apply(c.F, 11);
-    assert y == 20;
-
-    assert c.F@L(11) == 21;
-    y := Apply(u => c.F@L(u), 11);
-    assert y == 21;
-
-    assert c.F(100) == 0; // error
   }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy.expect
@@ -3,16 +3,11 @@ Naked.dfy(12,7): Error: cannot use naked function in recursive setting. Possible
 Naked.dfy(17,58): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(22,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(26,15): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-Naked.dfy(30,50): Error: function precondition could not be proved
-Naked.dfy(32,13): Related location: this proposition could not be proved
 Naked.dfy(32,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(38,10): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(42,11): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-Naked.dfy(46,4): Error: cannot prove termination; try supplying a decreases clause
 Naked.dfy(49,10): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(56,12): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(60,13): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(67,12): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-Naked.dfy(102,4): Error: assertion might not hold
-
-Dafny program verifier finished with 5 verified, 15 errors
+12 resolution/type errors detected in Naked.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
+// RUN: %exits-with 2 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 ghost function fact(n: int): int

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy.expect
@@ -1,5 +1,3 @@
 naked-function-in-recursive-setting.dfy(4,15): Info: auto-accumulator tail recursive
-naked-function-in-recursive-setting.dfy(4,15): Info: decreases n
 naked-function-in-recursive-setting.dfy(10,11): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-
-Dafny program verifier finished with 0 verified, 1 error
+1 resolution/type errors detected in naked-function-in-recursive-setting.dfy


### PR DESCRIPTION
Fixes #6043 

This PR changes two verification checks into resolution checks:

* use of a function in a `decreases` clause in the function's SCC
* use of naked functions inside an SCC

The first of these was omitted in the recent `CanCall` PR. Hence, this PR fixes that regression.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
