### PR TITLE
Remove function-context-height variable in Boogie encoding

### DIFF
--- a/Source/DafnyCore/DafnyPrelude.bpl
+++ b/Source/DafnyCore/DafnyPrelude.bpl
@@ -481,14 +481,6 @@ axiom (forall o: ORDINAL, m,n: int ::
     (m - n <= 0 ==> ORD#Plus(ORD#Minus(o, ORD#FromNat(m)), ORD#FromNat(n)) == ORD#Plus(o, ORD#FromNat(n-m))));
 
 // ---------------------------------------------------------------
-// -- Axiom contexts ---------------------------------------------
-// ---------------------------------------------------------------
-
-// used to make sure function axioms are not used while their consistency is being checked
-const $ModuleContextHeight: int;
-const $FunctionContextHeight: int;
-
-// ---------------------------------------------------------------
 // -- Layers of function encodings -------------------------------
 // ---------------------------------------------------------------
 

--- a/Source/DafnyCore/Prelude/PreludeCore.bpl
+++ b/Source/DafnyCore/Prelude/PreludeCore.bpl
@@ -481,14 +481,6 @@ axiom (forall o: ORDINAL, m,n: int ::
     (m - n <= 0 ==> ORD#Plus(ORD#Minus(o, ORD#FromNat(m)), ORD#FromNat(n)) == ORD#Plus(o, ORD#FromNat(n-m))));
 
 // ---------------------------------------------------------------
-// -- Axiom contexts ---------------------------------------------
-// ---------------------------------------------------------------
-
-// used to make sure function axioms are not used while their consistency is being checked
-const $ModuleContextHeight: int;
-const $FunctionContextHeight: int;
-
-// ---------------------------------------------------------------
 // -- Layers of function encodings -------------------------------
 // ---------------------------------------------------------------
 

--- a/Source/DafnyCore/Resolver/ExtremeLemmaChecks_Visitor.cs
+++ b/Source/DafnyCore/Resolver/ExtremeLemmaChecks_Visitor.cs
@@ -11,26 +11,24 @@ class ExtremeLemmaChecks_Visitor : ResolverBottomUpVisitor {
     this.context = context;
   }
   protected override void VisitOneStmt(Statement stmt) {
-    if (stmt is CallStmt) {
-      var s = (CallStmt)stmt;
-      if (s.Method is ExtremeLemma || s.Method is PrefixLemma) {
+    if (stmt is CallStmt callStmt) {
+      if (callStmt.Method is ExtremeLemma or PrefixLemma) {
         // all is cool
       } else {
         // the call goes from an extreme lemma context to a non-extreme-lemma callee
-        if (ModuleDefinition.InSameSCC(context, s.Method)) {
+        if (ModuleDefinition.InSameSCC(context, callStmt.Method)) {
           // we're looking at a recursive call (to a non-extreme-lemma)
-          resolver.reporter.Error(MessageSource.Resolver, s.Origin, "a recursive call from a {0} can go only to other {0}s and prefix lemmas", context.WhatKind);
+          resolver.reporter.Error(MessageSource.Resolver, callStmt.Origin, "a recursive call from a {0} can go only to other {0}s and prefix lemmas", context.WhatKind);
         }
       }
     }
   }
   protected override void VisitOneExpr(Expression expr) {
-    if (expr is FunctionCallExpr) {
-      var e = (FunctionCallExpr)expr;
+    if (expr is FunctionCallExpr callExpr) {
       // the call goes from a greatest lemma context to a non-greatest-lemma callee
-      if (ModuleDefinition.InSameSCC(context, e.Function)) {
+      if (ModuleDefinition.InSameSCC(context, callExpr.Function)) {
         // we're looking at a recursive call (to a non-greatest-lemma)
-        resolver.reporter.Error(MessageSource.Resolver, e.Origin, "a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas");
+        resolver.reporter.Error(MessageSource.Resolver, callExpr.Origin, "a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas");
       }
     }
   }

--- a/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
+++ b/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.Contracts;
+
+namespace Microsoft.Dafny;
+
+class FunctionEntanglementChecks_Visitor : ResolverBottomUpVisitor {
+  private readonly ICallable context;
+  public bool DoDecreasesChecks;
+  public FunctionEntanglementChecks_Visitor(ModuleResolver resolver, ICallable context)
+    : base(resolver) {
+    Contract.Requires(resolver != null);
+    Contract.Requires(context != null);
+    this.context = context;
+  }
+
+  protected override void VisitOneExpr(Expression expr) {
+    if (!DoDecreasesChecks && expr is MemberSelectExpr { Member: Function fn }) {
+      if (ModuleDefinition.InSameSCC(context, fn)) {
+        resolver.reporter.Error(MessageSource.Resolver, expr.Origin,
+          "cannot use naked function in recursive setting. Possible solution: eta expansion.");
+      }
+    }
+  }
+}

--- a/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
+++ b/Source/DafnyCore/Resolver/FunctionEntanglementChecks_Visitor.cs
@@ -19,5 +19,19 @@ class FunctionEntanglementChecks_Visitor : ResolverBottomUpVisitor {
           "cannot use naked function in recursive setting. Possible solution: eta expansion.");
       }
     }
+
+    if (DoDecreasesChecks && expr is FunctionCallExpr callExpr) {
+      if (ModuleDefinition.InSameSCC(context, callExpr.Function)) {
+        string msg;
+        if (context == callExpr.Function) {
+          msg = "a decreases clause is not allowed to call the enclosing function";
+        } else {
+          msg = $"the decreases clause of {context.WhatKind} '{context.NameRelativeToModule}' is not allowed to call '{callExpr.Function}', " +
+                "because they are mutually recursive";
+        }
+
+        resolver.reporter.Error(MessageSource.Resolver, callExpr.Origin, msg);
+      }
+    }
   }
 }

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1262,6 +1262,13 @@ namespace Microsoft.Dafny {
         FillInPostConditionsAndBodiesOfPrefixLemmas(declarations);
       }
 
+      // A function is not allowed to be used naked in its own SCC. Also, a function is not allowed to be used
+      // in any way inside a "decreases" clause its its own SCC.
+      foreach (var function in ModuleDefinition.AllFunctions(declarations)) {
+        var visitor = new FunctionEntanglementChecks_Visitor(this, function);
+        visitor.Visit(function);
+      }
+
       // An inductive datatype is allowed to be defined as an empty type. For example, in
       //     predicate P(x: int) { false }
       //     type Subset = x: int | P(x) witness *

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1267,6 +1267,8 @@ namespace Microsoft.Dafny {
       foreach (var function in ModuleDefinition.AllFunctions(declarations)) {
         var visitor = new FunctionEntanglementChecks_Visitor(this, function);
         visitor.Visit(function);
+        visitor.DoDecreasesChecks = true;
+        visitor.Visit(function.Decreases.Expressions);
       }
 
       // An inductive datatype is allowed to be defined as an empty type. For example, in

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -290,20 +290,6 @@ namespace Microsoft.Dafny {
         }
       }
 
-      public Boogie.IdentifierExpr FunctionContextHeight() {
-        Contract.Ensures(Contract.Result<Boogie.IdentifierExpr>().Type != null);
-        return new Boogie.IdentifierExpr(Token.NoToken, "$FunctionContextHeight", Boogie.Type.Int);
-      }
-
-      public Boogie.Expr HeightContext(ICallable m) {
-        Contract.Requires(m != null);
-        // free requires fh == FunctionContextHeight;
-        var module = m.EnclosingModule;
-        Boogie.Expr context =
-          Boogie.Expr.Eq(Boogie.Expr.Literal(module.CallGraph.GetSCCRepresentativePredecessorCount(m)), FunctionContextHeight());
-        return context;
-      }
-
       public Expression GetSubstitutedBody(LetExpr e) {
         Contract.Requires(e != null);
         Contract.Requires(e.Exact);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
@@ -332,7 +332,6 @@ namespace Microsoft.Dafny {
           }
         case MemberSelectExpr selectExpr: {
             MemberSelectExpr e = selectExpr;
-            CheckFunctionSelectWF("naked function", builder, etran, e, " Possible solution: eta expansion.");
             CheckWellformed(e.Obj, wfOptions, locals, builder, etran);
             if (e.Obj.Type.IsRefType) {
               if (inBodyInitContext && Expression.AsThis(e.Obj) != null && !e.Member.IsInstanceIndependentConstant) {
@@ -681,8 +680,6 @@ namespace Microsoft.Dafny {
               CheckWellformed(e.Receiver, wfOptions, locals, builder, etran);
               if (!e.Function.IsStatic && !(e.Receiver is ThisExpr) && !e.Receiver.Type.IsArrowType) {
                 CheckNonNull(callExpr.Origin, e.Receiver, builder, etran, wfOptions.AssertKv);
-              } else if (e.Receiver.Type.IsArrowType) {
-                CheckFunctionSelectWF("function specification", builder, etran, e.Receiver, "");
               }
               if (!e.Function.IsStatic && !etran.UsesOldHeap) {
                 // the argument can't be assumed to be allocated for the old heap

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Fields.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Fields.cs
@@ -188,8 +188,6 @@ namespace Microsoft.Dafny {
 
       // the procedure itself
       var req = new List<Bpl.Requires>();
-      // free requires mh == ModuleContextHeight && fh == TypeContextHeight;
-      req.Add(FreeRequires(decl.Origin, etran.HeightContext(decl), null));
       foreach (var typeBoundAxiom in TypeBoundAxioms(decl.Origin, decl.EnclosingClass.TypeArgs)) {
         req.Add(FreeRequires(decl.Origin, typeBoundAxiom, null));
       }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.Wellformedness.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.Wellformedness.cs
@@ -372,13 +372,9 @@ public partial class BoogieGenerator {
 
     private List<Bpl.Requires> GetWellformednessProcedureRequires(Function f, ExpressionTranslator etran) {
       var requires = new List<Bpl.Requires>();
-      // free requires mh == ModuleContextHeight && fh == FunctionContextHeight;
-      requires.Add(generator.FreeRequires(f.Origin, etran.HeightContext(f), null));
-
       foreach (var typeBoundAxiom in generator.TypeBoundAxioms(f.Origin, Concat(f.EnclosingClass.TypeArgs, f.TypeArgs))) {
         requires.Add(generator.Requires(f.Origin, true, null, typeBoundAxiom, null, null, null));
       }
-
       return requires;
     }
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Iterators.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Iterators.cs
@@ -79,10 +79,6 @@ namespace Microsoft.Dafny {
       var mod = new List<Bpl.IdentifierExpr>();
       var ens = new List<Bpl.Ensures>();
       // FREE PRECONDITIONS
-      if (kind == MethodTranslationKind.SpecWellformedness || kind == MethodTranslationKind.Implementation) {  // the other cases have no need for a free precondition
-        // free requires mh == ModuleContextHeight && fh = FunctionContextHeight;
-        req.Add(FreeRequires(iter.Origin, etran.HeightContext(iter), null));
-      }
       mod.Add(etran.HeapCastToIdentifierExpr);
 
       if (kind != MethodTranslationKind.SpecWellformedness) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -222,19 +222,14 @@ namespace Microsoft.Dafny {
       Contract.Requires(is_array == (f == null));
       Contract.Requires(sink != null && Predef != null);
 
-      Bpl.Expr heightAntecedent = Bpl.Expr.True;
       if (f is ConstantField cf) {
         AddWellformednessCheck(cf);
-        if (InVerificationScope(cf)) {
-          var etran = new ExpressionTranslator(this, Predef, f.Origin, null);
-          heightAntecedent = Bpl.Expr.Lt(Bpl.Expr.Literal(cf.EnclosingModule.CallGraph.GetSCCRepresentativePredecessorCount(cf)), etran.FunctionContextHeight());
-        }
       }
 
       if (f is ConstantField && f.IsStatic) {
-        AddStaticConstFieldAllocationAxiom(fieldDeclaration, f, c, heightAntecedent);
+        AddStaticConstFieldAllocationAxiom(fieldDeclaration, f, c);
       } else {
-        AddInstanceFieldAllocationAxioms(fieldDeclaration, f, c, is_array, heightAntecedent);
+        AddInstanceFieldAllocationAxioms(fieldDeclaration, f, c, is_array);
       }
     }
 
@@ -245,7 +240,7 @@ namespace Microsoft.Dafny {
     ///     // If "c" is an array declaration, then the bound variables also include the index variables "ii" and "h[o, f]" has the form "h[o, Index(ii)]".
     ///     // If "f" is readonly, then "h[o, f]" has the form "f(o)" (for special fields) or "f(G,o)" (for programmer-declared const fields),
     ///     // so "h" and $IsHeap(h) are omitted.
-    ///     axiom fh < FunctionContextHeight ==>
+    ///     axiom
     ///       (forall o: ref, h: Heap, G : Ty ::
     ///         { h[o, f], TClassA(G) }
     ///         $IsHeap(h) &&
@@ -255,7 +250,7 @@ namespace Microsoft.Dafny {
     ///
     ///     // allocation axiom:
     ///     // As above for "G" and "ii", but "h" is included no matter what.
-    ///     axiom fh < FunctionContextHeight ==>
+    ///     axiom
     ///       (forall o: ref, h: Heap, G : Ty ::
     ///         { h[o, f], TClassA(G) }
     ///         $IsHeap(h) &&
@@ -264,8 +259,7 @@ namespace Microsoft.Dafny {
     ///         ==>
     ///         $IsAlloc(h[o, f], TT(PP), h));
     /// </summary>
-    private void AddInstanceFieldAllocationAxioms(Bpl.Declaration fieldDeclaration, Field f, TopLevelDeclWithMembers c,
-      bool is_array, Expr heightAntecedent) {
+    private void AddInstanceFieldAllocationAxioms(Bpl.Declaration fieldDeclaration, Field f, TopLevelDeclWithMembers c, bool is_array) {
       var bvsTypeAxiom = new List<Bpl.Variable>();
       var bvsAllocationAxiom = new List<Bpl.Variable>();
 
@@ -382,7 +376,7 @@ namespace Microsoft.Dafny {
       }
 
       Bpl.Expr ax = BplForall(bvsTypeAxiom, tr, BplImp(ante, is_hf));
-      AddOtherDefinition(fieldDeclaration, new Bpl.Axiom(c.Origin, BplImp(heightAntecedent, ax), $"{c}.{f}: Type axiom"));
+      AddOtherDefinition(fieldDeclaration, new Bpl.Axiom(c.Origin, ax, $"{c}.{f}: Type axiom"));
 
       if (isalloc_hf != null) {
         if (!is_array && !f.IsMutable) {
@@ -407,7 +401,7 @@ namespace Microsoft.Dafny {
         tr = new Bpl.Trigger(c.Origin, true, t_es);
 
         ax = BplForall(bvsAllocationAxiom, tr, BplImp(ante, isalloc_hf));
-        AddOtherDefinition(fieldDeclaration, new Boogie.Axiom(c.Origin, BplImp(heightAntecedent, ax), $"{c}.{f}: Allocation axiom"));
+        AddOtherDefinition(fieldDeclaration, new Boogie.Axiom(c.Origin, ax, $"{c}.{f}: Allocation axiom"));
       }
     }
 
@@ -415,7 +409,7 @@ namespace Microsoft.Dafny {
     /// For a static (necessarily "const") field "f" in a class "c(G)", the expression corresponding to "h[o, f]" or "f(G,o)" above is "f(G)",
     /// so generate:
     ///     // type axiom:
-    ///     axiom fh < FunctionContextHeight ==>
+    ///     axiom
     ///       (forall G : Ty ::
     ///         { f(G) }
     ///         $Is(f(G), TT(PP)));
@@ -423,7 +417,7 @@ namespace Microsoft.Dafny {
     ///     axiom $Is(f(G), TT);
     ///
     ///     // allocation axiom:
-    ///     axiom fh < FunctionContextHeight ==>
+    ///     axiom
     ///       (forall h: Heap, G : Ty ::
     ///         { $IsAlloc(f(G), TT(PP), h) }
     ///         $IsHeap(h)
@@ -432,15 +426,15 @@ namespace Microsoft.Dafny {
     ///
     ///
     /// The axioms above could be optimised to something along the lines of:
-    ///     axiom fh < FunctionContextHeight ==>
+    ///     axiom
     ///       (forall o: ref, h: Heap ::
     ///         { h[o, f] }
     ///         $IsHeap(h) && o != null && Tag(dtype(o)) = TagClass
     ///         ==>
     ///         (h[o, alloc] ==> $IsAlloc(h[o, f], TT(TClassA_Inv_i(dtype(o)),..), h)) &&
     ///         $Is(h[o, f], TT(TClassA_Inv_i(dtype(o)),..), h);
-    /// <summary>
-    private void AddStaticConstFieldAllocationAxiom(Boogie.Declaration fieldDeclaration, Field f, TopLevelDeclWithMembers c, Expr heightAntecedent) {
+    /// </summary>
+    private void AddStaticConstFieldAllocationAxiom(Boogie.Declaration fieldDeclaration, Field f, TopLevelDeclWithMembers c) {
 
       var bvsTypeAxiom = new List<Bpl.Variable>();
       var bvsAllocationAxiom = new List<Bpl.Variable>();
@@ -452,7 +446,7 @@ namespace Microsoft.Dafny {
       var oDotF = new Boogie.NAryExpr(c.Origin, new Boogie.FunctionCall(GetReadonlyField(f)), tyexprs);
       var is_hf = MkIs(oDotF, f.Type); // $Is(h[o, f], ..)
       Boogie.Expr ax = bvsTypeAxiom.Count == 0 ? is_hf : BplForall(bvsTypeAxiom, BplTrigger(oDotF), is_hf);
-      var isAxiom = new Boogie.Axiom(c.Origin, BplImp(heightAntecedent, ax), $"{c}.{f}: Type axiom");
+      var isAxiom = new Boogie.Axiom(c.Origin, ax, $"{c}.{f}: Type axiom");
       AddOtherDefinition(fieldDeclaration, isAxiom);
 
       {
@@ -461,7 +455,7 @@ namespace Microsoft.Dafny {
         var isGoodHeap = FunctionCall(c.Origin, BuiltinFunction.IsGoodHeap, null, h);
         var isalloc_hf = MkIsAlloc(oDotF, f.Type, h); // $IsAlloc(h[o, f], ..)
         ax = BplForall(bvsAllocationAxiom, BplTrigger(isalloc_hf), BplImp(isGoodHeap, isalloc_hf));
-        var isAllocAxiom = new Boogie.Axiom(c.Origin, BplImp(heightAntecedent, ax), $"{c}.{f}: Allocation axiom");
+        var isAllocAxiom = new Boogie.Axiom(c.Origin, ax, $"{c}.{f}: Allocation axiom");
         sink.AddTopLevelDeclaration(isAllocAxiom);
       }
     }
@@ -1000,8 +994,6 @@ namespace Microsoft.Dafny {
       }
       // the procedure itself
       var req = new List<Boogie.Requires>();
-      // free requires fh == FunctionContextHeight;
-      req.Add(FreeRequires(f.Origin, etran.HeightContext(f), null));
       if (f is TwoStateFunction) {
         // free requires prevHeap == Heap && HeapSucc(prevHeap, currHeap) && IsHeap(currHeap)
         var a0 = Boogie.Expr.Eq(prevHeap, ordinaryEtran.HeapExpr);
@@ -1449,9 +1441,8 @@ namespace Microsoft.Dafny {
       // The axiom
       Boogie.Expr ax = BplForall(f.Origin, new List<Boogie.TypeVariable>(), forallFormals, null, tr,
         BplImp(ante, BplAnd(canCallImp, synonyms)));
-      var activate = AxiomActivation(overridingFunction, etran);
       var comment = $"override axiom for {f.FullSanitizedName} in {overridingFunction.EnclosingClass.WhatKind} {overridingFunction.EnclosingClass.FullSanitizedName}";
-      return new Boogie.Axiom(f.Origin, BplImp(activate, ax), comment);
+      return new Boogie.Axiom(f.Origin, ax, comment);
     }
 
     /// <summary>
@@ -1784,8 +1775,6 @@ namespace Microsoft.Dafny {
         var req = new List<Boogie.Requires>();
         // FREE PRECONDITIONS
         if (kind == MethodTranslationKind.SpecWellformedness || kind == MethodTranslationKind.Implementation || kind == MethodTranslationKind.OverrideCheck) {  // the other cases have no need for a free precondition
-          // free requires mh == ModuleContextHeight && fh == FunctionContextHeight;
-          req.Add(FreeRequires(m.Origin, etran.HeightContext(m), null));
           if (m is TwoStateLemma) {
             // free requires prevHeap == Heap && HeapSucc(prevHeap, currHeap) && IsHeap(currHeap)
             var a0 = Boogie.Expr.Eq(prevHeap, ordinaryEtran.HeapExpr);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
@@ -1487,8 +1487,6 @@ public partial class BoogieGenerator {
 
     // the procedure itself
     var req = new List<Bpl.Requires>();
-    // free requires mh == ModuleContextHeight && fh == TypeContextHeight;
-    req.Add(FreeRequires(decl.Tok, etran.HeightContext(decl), null));
     // modifies $Heap
     var mod = new List<Bpl.IdentifierExpr> {
         etran.HeapCastToIdentifierExpr,

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -2447,13 +2447,6 @@ namespace Microsoft.Dafny {
       }
     }
 
-    void CheckFunctionSelectWF(string what, BoogieStmtListBuilder builder, ExpressionTranslator etran, Expression e, string hint) {
-      if (e is MemberSelectExpr sel && sel.Member is Function fn) {
-        Bpl.Expr assertion = !InVerificationScope(fn) ? Bpl.Expr.True : Bpl.Expr.Not(etran.HeightContext(fn));
-        builder.Add(Assert(GetToken(e), assertion, new ValidInRecursion(what, hint), builder.Context));
-      }
-    }
-
     void CloneVariableAsBoundVar(IOrigin tok, IVariable iv, string prefix, out BoundVar bv, out IdentifierExpr ie) {
       Contract.Requires(tok != null);
       Contract.Requires(iv != null);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -1564,22 +1564,6 @@ namespace Microsoft.Dafny {
       return (olderParameterCount, olderCondition);
     }
 
-    Bpl.Expr AxiomActivation(Function f, ExpressionTranslator etran, bool strict = false) {
-      Contract.Requires(f != null);
-      Contract.Requires(etran != null);
-      Contract.Requires(VisibleInScope(f));
-      if (InVerificationScope(f)) {
-        if (strict) {
-          return Bpl.Expr.Lt(Bpl.Expr.Literal(forModule.CallGraph.GetSCCRepresentativePredecessorCount(f)), etran.FunctionContextHeight());
-        } else {
-          return Bpl.Expr.Le(Bpl.Expr.Literal(forModule.CallGraph.GetSCCRepresentativePredecessorCount(f)), etran.FunctionContextHeight());
-        }
-      } else {
-        return Bpl.Expr.True;
-      }
-    }
-
-
     Bpl.Type TrReceiverType(MemberDecl f) {
       Contract.Requires(f != null);
       return TrType(ModuleResolver.GetReceiverType(f.Origin, f));

--- a/Source/DafnyCore/Verifier/Datatypes/BoogieGenerator.DataTypes.cs
+++ b/Source/DafnyCore/Verifier/Datatypes/BoogieGenerator.DataTypes.cs
@@ -825,8 +825,6 @@ namespace Microsoft.Dafny {
 
       // the procedure itself
       var req = new List<Bpl.Requires>();
-      // free requires mh == ModuleContextHeight && fh == TypeContextHeight;
-      req.Add(Requires(ctor.Origin, true, null, etran.HeightContext(ctor.EnclosingDatatype), null, null, null));
       var heapVar = new Bpl.IdentifierExpr(ctor.Origin, "$Heap", false);
       var varlist = new List<Bpl.IdentifierExpr> { heapVar };
       var proc = new Bpl.Procedure(ctor.Origin, "CheckWellformed" + NameSeparator + ctor.FullName, new List<Bpl.TypeVariable>(),

--- a/Source/DafnyCore/Verifier/ProofObligationDescription.cs
+++ b/Source/DafnyCore/Verifier/ProofObligationDescription.cs
@@ -1423,26 +1423,6 @@ public class ForRangeAssignable : ProofObligationDescription {
   }
 }
 
-public class ValidInRecursion : ProofObligationDescription {
-  public override string SuccessDescription =>
-    $"{what} is valid in recursive setting";
-
-  public override string FailureDescription =>
-    $"cannot use {what} in recursive setting.{hint ?? ""}";
-
-  public override string ShortDescription => "valid in recursion";
-
-  public override bool ProvedOutsideUserCode => true;
-
-  private readonly string what;
-  private readonly string hint;
-
-  public ValidInRecursion(string what, string hint) {
-    this.what = what;
-    this.hint = hint;
-  }
-}
-
 public class IsNonRecursive : ProofObligationDescription {
   public override string SuccessDescription =>
     "default value is non-recursive";

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/HigherOrderIntrinsicSpecification/ReadPreconditionBypass4.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/HigherOrderIntrinsicSpecification/ReadPreconditionBypass4.dfy.expect
@@ -1,6 +1,4 @@
 ReadPreconditionBypass4.dfy(30,2): Error: assertion might not hold
-ReadPreconditionBypass4.dfy(31,2): Error: assertion might not hold
 ReadPreconditionBypass4.dfy(44,2): Error: assertion might not hold
-ReadPreconditionBypass4.dfy(45,2): Error: assertion might not hold
 
-Dafny program verifier finished with 2 verified, 4 errors
+Dafny program verifier finished with 2 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/CoinductiveProofs.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/CoinductiveProofs.dfy.expect
@@ -31,5 +31,5 @@ CoinductiveProofs.dfy(208,21): Related location: this is the postcondition that 
 CoinductiveProofs.dfy(4,23): Related location: this proposition could not be proved
 
 Dafny program verifier finished with 23 verified, 12 errors
-Total resources used is 749841
-Max resources used by VC is 59810
+Total resources used is 748146
+Max resources used by VC is 59297

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/InductivePredicates.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/InductivePredicates.dfy
@@ -259,19 +259,36 @@ module SomeCoolDisjunctionTests {
     P(x)
   }
 
-  least lemma L[ORDINAL](x: int)
-    requires P(x) || Q(x)
+  least lemma L[ORDINAL](x: int, b: bool)
+    requires (b && P(x)) || (!b && Q(x))
     ensures false  // fine
   {
     // The following proof should not be necessary. This lemma used to verify
     // automatically, but after a change with CanCall, it stopped verifying.
     // The problem may be due to https://github.com/Z3Prover/z3/issues/7444.
     // After it is fixed, we should try removing the following lines again.
+
+    // After some more changes to Dafny, this test is failing again. And again,
+    // the problem seems to be due an issue in Z3. Annoyingly, the part Z3
+    // can't figure out is in the _k.IsLimit case, which Dafny fills in automatically
+    // and gives no way for a user to interact with. By introducing an "if" statement
+    //     if (_module.__default.P_h($LS($LS($LZ)), _k#0, x#1)) {
+    //     } else {
+    //       assert _module.__default.Q_h($LS($LS($LZ)), _k#0, x#1);
+    //     }
+    // in Boogie (inside the _k.IsLimit branch), Z3 completes the proof. So, it
+    // seems the boolean that Boogie introduces for the control flow somehow helps.
+    // For this reason, the parameter "b: bool" was introduced above. Apparently,
+    // it is enough to get Z3 in a better mood to complete the proof. Once this has
+    // been fixed in Z3, this boolean parameter should be removed from this test again.
+
     assert !_k.IsLimit;
-    if P#[_k](x) {
+    if b && P#[_k](x) {
       assert P#[_k](x) == Q#[_k - 1](x);
+      L(x, !b);
     } else {
-      assert Q#[_k](x);
+      assert !b && Q#[_k](x);
+      L(x, !b);
     }
   }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/SubsetTypes.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/SubsetTypes.dfy.expect
@@ -91,5 +91,5 @@ SubsetTypes.dfy(459,6): Error: assertion might not hold
 SubsetTypes.dfy(464,4): Error: assertion might not hold
 
 Dafny program verifier finished with 13 verified, 91 errors
-Total resources used is 739000
+Total resources used is 738700
 Max resources used by VC is 75000

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/SubsetTypes.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/SubsetTypes.dfy.expect
@@ -91,5 +91,5 @@ SubsetTypes.dfy(459,6): Error: assertion might not hold
 SubsetTypes.dfy(464,4): Error: assertion might not hold
 
 Dafny program verifier finished with 13 verified, 91 errors
-Total resources used is 738700
-Max resources used by VC is 75000
+Total resources used is 738600
+Max resources used by VC is 76700

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TailCalls.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TailCalls.dfy
@@ -168,7 +168,7 @@ function U(x: int, ghost y: int): nat
 
 function {:tailrecursion} Q(n: nat): nat {
   if n % 5 == 0 then
-    var s := Q;  // error: this use of Q is not a tail call
+    var s := Q;  // error (x2): this use of Q is not a tail call, and cannot use Q as naked function here
     10
   else if n % 5 == 1 then
     Q(Q(n - 1))  // error: inner Q is not a tail call

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TailCalls.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TailCalls.dfy.expect
@@ -28,4 +28,5 @@ TailCalls.dfy(462,11): Error: a recursive call in this context is not recognized
 TailCalls.dfy(110,14): Error: the recursive call to '_ctor' is not tail recursive, because the assignment of the LHS happens after the call
 TailCalls.dfy(126,19): Error: the recursive call to 'Compute' is not tail recursive because the actual type argument is not the formal type parameter 'G'
 TailCalls.dfy(139,17): Error: the recursive call to 'Run' is not tail recursive because the actual type argument 1 is not the formal type parameter 'G'
-30 resolution/type errors detected in TailCalls.dfy
+TailCalls.dfy(171,13): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+31 resolution/type errors detected in TailCalls.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeParameters.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeParameters.dfy.expect
@@ -16,4 +16,4 @@ TypeParameters.dfy(175,14): Error: this invariant could not be proved to be main
 TypeParameters.dfy(175,37): Related location: this proposition could not be proved
 TypeParameters.dfy(376,20): Error: assertion might not hold
 
-Dafny program verifier finished with 31 verified, 9 errors
+Dafny program verifier finished with 30 verified, 9 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny1/SchorrWaite.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny1/SchorrWaite.dfy.expect
@@ -1,4 +1,4 @@
 
 Dafny program verifier finished with 272 verified, 0 errors
-Total resources used is 27987600
-Max resources used by VC is 1817957
+Total resources used is 27749890
+Max resources used by VC is 2181911

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny1/SchorrWaite.dfy.refresh.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny1/SchorrWaite.dfy.refresh.expect
@@ -1,4 +1,4 @@
 
 Dafny program verifier finished with 276 verified, 0 errors
-Total resources used is 27733327
-Max resources used by VC is 1227140
+Total resources used is 28898941
+Max resources used by VC is 1253781

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/Bug82.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/Bug82.dfy
@@ -1,11 +1,11 @@
 // RUN: %testDafnyForEachResolver "%s"
 
 
-ghost function {:opaque} Reverse(id:int) : int
+ghost opaque function Reverse(id: int): int
 
-ghost function RefineToMap(ReverseKey:int->int) : bool
+ghost function RefineToMap(ReverseKey: int -> int): bool
 
-ghost function RefineToMapOfSeqNums() : bool
+ghost function RefineToMapOfSeqNums(): bool
 {
-    RefineToMap(Reverse)
+  RefineToMap(Reverse)
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/Bug82.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/Bug82.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/MonadicLaws.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/MonadicLaws.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 9 verified, 0 errors
+Dafny program verifier finished with 8 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/git-issue182.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/git-issue182.dfy.expect
@@ -1,2 +1,3 @@
 git-issue182.dfy(5,8): Error: Postcondition must be a boolean (got () -> bool)
-1 resolution/type errors detected in git-issue182.dfy
+git-issue182.dfy(5,8): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+2 resolution/type errors detected in git-issue182.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/induction-principle-code/AST.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/induction-principle-code/AST.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 4 verified, 0 errors
+Dafny program verifier finished with 3 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy
@@ -31,11 +31,11 @@
 /// anonymous functions (“lambdas”) modularly: every time a lambda is created,
 /// as with `(fun () -> parentheses' ())`, Dafny checks that the function can be
 /// called in any context.  To see why, consider the function `Apply` below and
-/// the following two uses of it:
+/// the following two uses of it (see also parser_combinators_error.dfy):
 
 function Apply(f: () -> int): int { f() }
 
-function F0(): int { Apply(F0) }
+// function F0(): int { Apply(F0) } // cannot use F0 naked here (see parser_combinators_error.dfy)
 function F1(): int { Apply(() => F1()) }
 
 /// Dafny rejects `F0` because it does not allow using “naked” recursive

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/examples/parser_combinators.dfy.expect
@@ -1,7 +1,6 @@
-parser_combinators.dfy(38,27): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 parser_combinators.dfy(39,33): Error: cannot prove termination; try supplying a decreases clause
 
-Dafny program verifier finished with 8 verified, 2 errors
+Dafny program verifier finished with 8 verified, 1 error
 
 Dafny program verifier did not attempt verification
 "((()))": 3 nested parentheses

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy
@@ -1,0 +1,42 @@
+// RUN: %exits-with 2 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function F(x: int): int
+  decreases G(x) // error: decreases clause cannot use mutually recursive function
+{
+  G(x) - 1
+}
+
+function G(x: int): int
+  decreases F(x) // error: decreases clause cannot use mutually recursive function
+{
+  F(x)
+}
+
+function K(x: nat): int
+  decreases if x == 0 then 0 else 1 + K(x - 1) // error: decreases clause is not allowed to call enclosing function
+{
+  if x == 0 then 200 else 1 + K(x - 1)
+}
+
+function Id(x: int): int {
+  IdBuddy(x)
+}
+
+function IdBuddy(x: int): int
+  decreases x, 0
+{
+  if x <= 0 then x else
+    var id := Id; // error: cannot use Id naked here
+    id(x - 1)
+}
+
+ghost function H(x: int): int {
+  if H != (H) then 0 else 3 // error (x2): cannot use H naked here
+}
+
+datatype Dt = Dt {
+  ghost function J(x: int): int {
+    if (this).J == J then 0 else 3 // error (x2): cannot use J naked here
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6043.dfy.expect
@@ -1,0 +1,9 @@
+git-issue-6043.dfy(5,12): Error: the decreases clause of function 'F' is not allowed to call 'G', because they are mutually recursive
+git-issue-6043.dfy(11,12): Error: the decreases clause of function 'G' is not allowed to call 'F', because they are mutually recursive
+git-issue-6043.dfy(17,38): Error: a decreases clause is not allowed to call the enclosing function
+git-issue-6043.dfy(30,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(35,5): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(35,11): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(40,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+git-issue-6043.dfy(40,19): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
+8 resolution/type errors detected in git-issue-6043.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-847.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-847.dfy
@@ -2,51 +2,51 @@
 // RUN: %diff "%s.expect" "%t"
 
 trait O extends object {
-  var rep:set<O>
-  ghost function union<T>(s:set<set<T>>):set<T> {
+  var rep: set<O>
+
+  ghost function union<T>(s: set<set<T>>): set<T> {
     set o,o1 | o in s && o1 in o :: o1
   }
 
   least predicate ag()
     reads *
   {
-    rep=={} || (forall o:O | o in rep :: o.ag())
+    rep=={} || (forall o: O | o in rep :: o.ag())
   }
 
-  ghost predicate ldp(n:ORDINAL)
+  ghost predicate ldp(n: ORDINAL)
     reads *
   {
-    ag#[n]() && (forall n1:ORDINAL | n1 < n:: !ag#[n1]())
+    ag#[n]() && (forall n1: ORDINAL | n1 < n :: !ag#[n1]())
   }
 
-  ghost function ld(n:ORDINAL):ORDINAL
+  ghost function ld(n: ORDINAL): ORDINAL
     reads *
     requires ag#[n]()
     ensures ldp(ld(n))
   {
-    if ldp(n) then n else var n1:ORDINAL :| n1 < n && ag#[n1](); ld(n1)
+    if ldp(n) then n else var n1: ORDINAL :| n1 < n && ag#[n1](); ld(n1)
   }
 
-  ghost function level():ORDINAL
+  ghost function level(): ORDINAL
     reads fr()
     requires ag()
     ensures ldp(level())
   {
-    var n:ORDINAL :| ag#[n](); ld(n)
+    var n: ORDINAL :| ag#[n](); ld(n)
   }
 
   least lemma l1()
     requires ag()
-    ensures forall o:O | o in rep :: o.level() < level()
+    ensures forall o: O | o in rep :: o.level() < level()
     decreases level()
   {}
 
-  ghost function fr():set<O>
+  ghost function fr(): set<O>
     requires ag()
     reads *
-    decreases level()
+    decreases level() // error: fr and level are mutually recursive, so fr is not allowed to use level in its decreases clause
   {
-    {this} + union(set o:O | o in rep :: l1(); o.fr())
+    {this} + union(set o: O | o in rep :: l1(); o.fr())
   }
 }
-

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-847.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-847.dfy.expect
@@ -1,4 +1,2 @@
-git-issue-847.dfy(40,39): Error: a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas
-git-issue-847.dfy(40,49): Error: a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas
-git-issue-847.dfy(41,14): Error: a recursive call from a greatest lemma can go only to other greatest lemmas and prefix lemmas
-3 resolution/type errors detected in git-issue-847.dfy
+git-issue-847.dfy(48,14): Error: the decreases clause of function 'O.fr' is not allowed to call 'level', because they are mutually recursive
+1 resolution/type errors detected in git-issue-847.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy
@@ -61,3 +61,37 @@ method AllocationTest(oldcell: Cell)
     case true =>  assert old(k(y, b)) < 50;  // error: argument y is not allocated in old state
   }
 }
+
+module TwoStateFunctions {
+  method Apply(ghost f: int -> int, x: int) returns (ghost y: int)
+    ensures y == f(x)
+  {
+    y := f(x);
+  }
+
+  class Cell {
+    var data: int
+
+    twostate function F(x: int): int {
+      old(data) + x
+    }
+  }
+
+  method Caller(c: Cell)
+    requires c.data == 9
+    modifies c
+  {
+    c.data := c.data + 1;
+    label L:
+    assert c.F(11) == 20;
+
+    var y := Apply(c.F, 11);
+    assert y == 20;
+
+    assert c.F@L(11) == 21;
+    y := Apply(u => c.F@L(u), 11);
+    assert y == 21;
+
+    assert c.F(100) == 0; // error
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Apply.dfy.expect
@@ -1,6 +1,7 @@
+Apply.dfy(95,4): Error: assertion might not hold
 Apply.dfy(46,23): Error: function could not be proved to be allocated in the state in which the function is invoked
 Apply.dfy(57,31): Error: argument could not be proved to be allocated in the state in which the function is invoked
 Apply.dfy(58,31): Error: argument could not be proved to be allocated in the state in which the function is invoked
 Apply.dfy(61,31): Error: argument could not be proved to be allocated in the state in which the function is invoked
 
-Dafny program verifier finished with 4 verified, 4 errors
+Dafny program verifier finished with 7 verified, 5 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Monads.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Monads.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 18 verified, 0 errors
+Dafny program verifier finished with 14 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s" -- --allow-deprecation
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s"
 
 
 module Functions {
@@ -19,86 +19,52 @@ module Functions {
 
 module Requires {
   ghost function t(x: nat): nat
-    requires !t.requires(x);  // error: use of naked function in its own SCC
+    requires !t.requires(x)  // error: use of naked function in its own SCC
   { x }
 
   ghost function g(x: nat): nat
-    requires !(g).requires(x);  // error: use of naked function in its own SCC
+    requires !(g).requires(x)  // error: use of naked function in its own SCC
   { x }
 
   ghost function D(x: int): int  // used so termination errors don't mask other errors
-  ghost function g2(x: int): int decreases D(x) { h(x) }  // error: precondition violation
+  ghost function g2(x: int): int decreases D(x) { h(x) }
   ghost function h(x: int): int
-    requires !g2.requires(x);  // error: use of naked function in its own SCC
+    requires !g2.requires(x)  // error: use of naked function in its own SCC
   { x }
 }
 
 module Reads {
   ghost function t(x: nat): nat
-    reads t.reads(x);
+    reads t.reads(x)
   { x }
 
   ghost function g(x: nat): nat
-    reads (g).reads(x);
+    reads (g).reads(x)
   { x }
 
   ghost function g2(x: int): int
   { h(x) }
 
   ghost function h(x: int): int
-    reads g2.reads(x);
+    reads g2.reads(x)
   { x }
 }
 
 module ReadsGenerics {
   class Cl<A> {
     ghost function t<B>(a: A, b: B): (A, B)
-      reads t.reads(a, b);
+      reads t.reads(a, b)
     { (a, b) }
 
     ghost function g<B>(a: A, b: B): (A, B)
-      reads (g).reads(a, b);
+      reads (g).reads(a, b)
     { (a, b) }
 
     ghost function g2<B>(a: A, b: B): (A, B)
     { h(a, b) }
 
     ghost function h<B>(a: A, b: B): (A, B)
-      reads g2.reads(a, b);
+      reads g2.reads(a, b)
     { (a, b) }
-  }
-}
-
-module TwoStateFunctions {
-  method Apply(ghost f: int -> int, x: int) returns (ghost y: int)
-    ensures y == f(x)
-  {
-    y := f(x);
-  }
-
-  class Cell {
-    var data: int
-
-    twostate function F(x: int): int {
-      old(data) + x
-    }
-  }
-
-  method Caller(c: Cell)
-    requires c.data == 9
-    modifies c
-  {
-    c.data := c.data + 1;
-    label L:
-    assert c.F(11) == 20;
-
-    var y := Apply(c.F, 11);
-    assert y == 20;
-
-    assert c.F@L(11) == 21;
-    y := Apply(u => c.F@L(u), 11);
-    assert y == 21;
-
-    assert c.F(100) == 0; // error
   }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/hofs/Naked.dfy.expect
@@ -3,16 +3,11 @@ Naked.dfy(12,7): Error: cannot use naked function in recursive setting. Possible
 Naked.dfy(17,58): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(22,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(26,15): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-Naked.dfy(30,50): Error: function precondition could not be proved
-Naked.dfy(32,13): Related location: this proposition could not be proved
 Naked.dfy(32,14): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(38,10): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(42,11): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-Naked.dfy(46,4): Error: cannot prove termination; try supplying a decreases clause
 Naked.dfy(49,10): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(56,12): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(60,13): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
 Naked.dfy(67,12): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-Naked.dfy(102,4): Error: assertion might not hold
-
-Dafny program verifier finished with 5 verified, 15 errors
+12 resolution/type errors detected in Naked.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy
@@ -1,4 +1,4 @@
-// RUN: %exits-with 4 %verify --show-hints "%s" > "%t"
+// RUN: %exits-with 2 %verify --show-hints "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 ghost function fact(n: int): int

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/wishlist/naked-function-in-recursive-setting.dfy.expect
@@ -1,5 +1,3 @@
 naked-function-in-recursive-setting.dfy(4,15): Info: auto-accumulator tail recursive
-naked-function-in-recursive-setting.dfy(4,15): Info: decreases n
 naked-function-in-recursive-setting.dfy(10,11): Error: cannot use naked function in recursive setting. Possible solution: eta expansion.
-
-Dafny program verifier finished with 0 verified, 1 error
+1 resolution/type errors detected in naked-function-in-recursive-setting.dfy

--- a/docs/HowToFAQ/Errors-Resolver2.md
+++ b/docs/HowToFAQ/Errors-Resolver2.md
@@ -168,7 +168,7 @@ and optimizing tail-recursion opportunities in mutually recursive functions.
 ```dafny
 function {:tailrecursion} f(n: nat): nat
 {
-  if n == 0 then n else var ff := f; ff(n-1)
+  if n == 0 then n else var r := f(n-1); r
 }
 ```
 


### PR DESCRIPTION
Because `CanCall` is now used everywhere, the Boogie variable `$FunctionContextHeight` is no longer needed.

This PR also removes the variable `$ModuleContextHeight`, which has been unused for some time now.

Depends on https://github.com/dafny-lang/dafny/pull/6045

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
