### PR TITLE
Fix Rust tests via lit on osx

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/avoid_soundness_mut.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/avoid_soundness_mut.dfy
@@ -1,8 +1,8 @@
 // RUN: %baredafny build -t:rs "%s"
-// RUN: "%S/avoid_soundness_mut-rust/cargo" run --release > "%t"
+// RUN: cd "%S/avoid_soundness_mut-rust" ; %cargo run --release > "%t"
 // RUN: %diff "%s.expect" "%t"
 // RUN: %baredafny build -t:rs --raw-pointers "%s"
-// RUN: "%S/avoid_soundness_mut-rust/cargo" run --release > "%t"
+// RUN: cd "%S/avoid_soundness_mut-rust" ; %cargo run --release > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 newtype u8 = x: int | 0 <= x < 256

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/cargoreleasefailure.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/cargoreleasefailure.dfy
@@ -2,7 +2,7 @@
 // RUN: %baredafny build --target=rs "%s"
 // If there is no '#[inline(never)]' in front of ::dafny_runtime::increment_strong_count
 // then the release will think it's safe to remove the strong count increment, resulting ins a segfault
-// RUN: "%S/cargoreleasefailure-rust/cargo" run --release
+// RUN: cd "%S/cargoreleasefailure-rust" ; %cargo run --release
 
 module  TraitModule {
   trait {:termination false} MyTrait {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/cargotest.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/cargotest.dfy
@@ -1,6 +1,6 @@
 // NONUNIFORM: Test of cargo test to support Dafny tests
 // RUN: %baredafny build --target=rs "%s" > "%t"
-// RUN: %exits-with 101 "%S/cargotest-rust/cargo" test >> "%t"
+// RUN: cd "%S/cargotest-rust" ; %exits-with 101 %cargo test >> "%t"
 // RUN: %OutputCheck --file-to-check "%t" "%S/cargotest1.check"
 // RUN: %OutputCheck --file-to-check "%t" "%S/cargotest2.check"
 // RUN: %OutputCheck --file-to-check "%t" "%S/cargotest3.check"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/tests.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/tests.dfy
@@ -1,8 +1,8 @@
 // NONUNIFORM: Test of the Dafny-to-Rust tests
 // RUN: %baredafny test --target=rs "%s" > "%t"
-// RUN: %diff "%s.expect" "%t
+// RUN: %diff "%s.expect" "%t"
 // RUN: %baredafny build --compile-suffix --target=rs "%s" > "%t"
-// RUN: "%S/tests-rust/cargo" run -- Hello > "%t"
+// RUN: cd "%S/tests-rust" ; %cargo run -- Hello > "%t"
 // RUN: %diff "%s.main.expect" "%t"
 
 method {:test} TestIfTestsAreWorking() {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/translate-additional/more_dafny.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/translate-additional/more_dafny.dfy
@@ -3,7 +3,7 @@
 // RUN: %exits-with -any %rm -f "%S/project_depending_on_dafny/src/more_dafny_extern.rs"
 // RUN: %mv "%S/more_dafny-rust/src/more_dafny.rs" "%S/project_depending_on_dafny/src/additional_module.rs"
 // RUN: %mv "%S/more_dafny-rust/src/more_dafny_extern.rs" "%S/project_depending_on_dafny/src/more_dafny_extern.rs"
-// RUN: "%S/project_depending_on_dafny/cargo" run > "%t"
+// RUN: cd "%S/project_depending_on_dafny" ; %cargo run > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module SubModule {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/lit.site.cfg
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/lit.site.cfg
@@ -197,8 +197,11 @@ config.substitutions.append( ('%refmanexamples', os.path.join(repositoryRoot, 'd
 config.substitutions.append( ('%os', os.name) )
 config.substitutions.append( ('%ver', ver ) )
 config.substitutions.append( ('%sed', 'sed -E' ) )
+config.substitutions.append( ('%rm', 'rm' ) )
+config.substitutions.append( ('%mv', 'mv' ) )
 config.substitutions.append( ('%exits-with', "python3 " + os.path.join(repositoryRoot, 'Scripts/test-exit.py') ) )
 config.substitutions.append( ('!', "python3 " + os.path.join(repositoryRoot, 'Scripts/test-exit.py') + " -z" ) )
+config.substitutions.append( ('%cargo', 'cargo' ) )
 
 if os.name == "nt":
     config.available_features = [ 'windows' ]


### PR DESCRIPTION
* Change the hack

      %exits-with 101 "%S/cargotest-rust/cargo" test

  to

      cd "%S/cargotest-rust" ; %exits-with 101 %cargo test

  in five test files related to Rust.

* Fill in definitions for `%rm`, `%mv`, and `%cargo`.

* Fix a missing `"` in a `RUN` command

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
