### PR TITLE
Fix: --compile-suffix avoids the extra renaming of homonymous classes

### DIFF
--- a/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Dafny.Compilers {
     /// </summary>
     private string protectedTypeName(TopLevelDecl dt) {
       var protectedName = IdName(dt);
-      if (dt.EnclosingModuleDefinition is { Name: var moduleName } && moduleName == protectedName) {
+      if (dt.EnclosingModuleDefinition.GetCompileName(Options) == protectedName) {
         return $"_{protectedName}";
       }
       return protectedName;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6014.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6014.dfy
@@ -1,4 +1,4 @@
-// %testDafnyForEachCompiler --refresh-exit-code=0 "%s"
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s"
 // Extra check for the C# compiler with the --compile-suffix option.
 // RUN: %baredafny build -t:cs --compile-suffix "%s"
 // RUN: %OutputCheck --file-to-check "%S/git-issue-6014.cs" "%s"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6014.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6014.dfy
@@ -1,4 +1,13 @@
-// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" 
+// %testDafnyForEachCompiler --refresh-exit-code=0 "%s"
+// Extra check for the C# compiler with the --compile-suffix option.
+// RUN: %baredafny build -t:cs --compile-suffix "%s"
+// RUN: %OutputCheck --file-to-check "%S/git-issue-6014.cs" "%s"
+// Just to make sure that if we use --compile-suffix, we don't do the escape
+// CHECK: .*A_Compile\.A.*
+// With the class named B_Compile, it becomes B__Compile so there should be no conflict
+// Adding this test in case someone changes the underscore escaping rules to account for this possibility
+// CHECK: .*B_Compile\.B__Compile.*
+
 
 module State {
 
@@ -23,6 +32,9 @@ module Enclosing {
     datatype A = Whatever
   }
 
+  module B {
+    datatype B_Compile = Whatever
+  }
 }
 
 module UsingEnclosing {


### PR DESCRIPTION
Fixes #6072 

### What was changed?
I changed it so that the comparison between the module name and the class name is done on the C# string, not the Dafny string vs. C# string.

### How has this been tested?
I added a check to ensure that in the generated C# code, the class named `A` is not escaped when using `--compile-suffix`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
