### PR TITLE
Chore: Set up nightly and prerelease for 4.9.2

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,6 +28,14 @@ jobs:
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
+    secrets:
+      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+
+  nightly-build-for-4-9-2:
+    if: github.repository_owner == 'dafny-lang'
+    uses: ./.github/workflows/nightly-build-reusable.yml
+    with:
+      ref: 4.9.2
       publish-prerelease: true
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
This PR sets the nightly releases to be taken from the release branch 4.9.2.
It keeps nightly builds on master though. After publishing 4.9.2 and merging it back
to master, we will revert this PR.