### PR TITLE
Fix instability in defaultTimeLimit test

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/defaultTimeLimit.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/defaultTimeLimit.dfy
@@ -1,4 +1,5 @@
-// RUN: ! %baredafny verify --use-basename-for-filename "%s" > "%t"
+// RUN: ! %baredafny verify --use-basename-for-filename "%s" > "%t.raw"
+// RUN: %sed 's#\d+ seconds#<redacted> seconds#g' "%t.raw" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 method Foo() {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/defaultTimeLimit.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/defaultTimeLimit.dfy.expect
@@ -1,6 +1,6 @@
-defaultTimeLimit.dfy(4,7): Error: Verification of 'Foo' timed out after 30 seconds. (the limit can be increased using --verification-time-limit)
+defaultTimeLimit.dfy(5,7): Error: Verification of 'Foo' timed out after <redacted> seconds. (the limit can be increased using --verification-time-limit)
   |
-4 | method Foo() {
+5 | method Foo() {
   |        ^^^
 
 


### PR DESCRIPTION
### What was changed?
Fix instability in defaultTimeLimit test. Example failed run: https://github.com/dafny-lang/dafny/actions/runs/13332533239/job/37239919604?pr=5948

### How has this been tested?
N/A

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
