### PR TITLE
Disable failing rust tests for windows

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/small/07-instantiated-methods.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/small/07-instantiated-methods.dfy
@@ -1,6 +1,7 @@
 // NONUNIFORM: Rust-specific tests
 // RUN: %baredafny run --target=rs --enforce-determinism --type-system-refresh --general-traits=full "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// UNSUPPORTED: windows
 
 trait Super<T> {
   function Compare(a: T, b: T, c: bool): bool

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/small/08-not-all-trait-items-implemented.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/small/08-not-all-trait-items-implemented.dfy
@@ -1,6 +1,7 @@
 // NONUNIFORM: Rust-specific tests
 // RUN: %baredafny run --target=rs --enforce-determinism --type-system-refresh --general-traits=full "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// UNSUPPORTED: windows
 
 trait Reversible {
   function reverse():(r:Reversible)

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/small/10-type-parameter-equality.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/small/10-type-parameter-equality.dfy
@@ -1,6 +1,7 @@
 // NONUNIFORM: Rust-specific tests
 // RUN: %baredafny run --target=rs --enforce-determinism --type-system-refresh --general-traits=full "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
+// UNSUPPORTED: windows
 
 datatype I_<T, U> = I_(t: T, u: U)
 


### PR DESCRIPTION
<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
