### PR TITLE
Use diagnostics instead of IOrigin in the reporting code, to force ma…

### DIFF
--- a/Source/DafnyCore/AST/Tokens.cs
+++ b/Source/DafnyCore/AST/Tokens.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics.Contracts;
 using System.IO;
 using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Dafny;
 
@@ -153,6 +154,22 @@ public static class TokenExtensions {
   }
 
   public static bool IsSet(this IOrigin token) => token.Uri != null;
+
+
+
+  public static string TokenToString(this Location location, DafnyOptions options) {
+    var currentDirectory = Directory.GetCurrentDirectory();
+    var path = location.Uri.Path;
+    string filename = location.Uri.Scheme switch {
+      "stdin" => "<stdin>",
+      "transcript" => Path.GetFileName(path),
+      _ => options.UseBaseNameForFileName
+        ? Path.GetFileName(path)
+        : (path.StartsWith(currentDirectory) ? Path.GetRelativePath(currentDirectory, path) : path)
+    };
+
+    return $"{filename}({location.Range.Start.Line},{location.Range.Start.Character})";
+  }
 
   public static string TokenToString(this IOrigin tok, DafnyOptions options) {
     if (ReferenceEquals(tok, Token.Cli)) {

--- a/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Diagnostics.Contracts;
 using DAST.Format;
 using Microsoft.Boogie;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Std.Wrappers;
 
 namespace Microsoft.Dafny.Compilers {

--- a/Source/DafnyCore/DafnyConsolePrinter.cs
+++ b/Source/DafnyCore/DafnyConsolePrinter.cs
@@ -79,37 +79,37 @@ public class DafnyConsolePrinter : ConsolePrinter {
     Options = options;
   }
 
-  public override void ReportBplError(Boogie.IToken tok, string message, bool error, TextWriter tw, string category = null) {
-
-    if (Options.Verbosity == CoreOptions.VerbosityLevel.Silent) {
-      return;
-    }
-
-    if (category != null) {
-      message = $"{category}: {message}";
-    }
-
-    var dafnyToken = BoogieGenerator.ToDafnyToken(options.Get(Snippets.ShowSnippets), tok);
-    message = $"{dafnyToken.TokenToString(Options)}: {message}";
-
-    if (error) {
-      ErrorWriteLine(tw, message);
-    } else {
-      tw.WriteLine(message);
-    }
-
-    if (Options.Get(Snippets.ShowSnippets)) {
-      if (tok is IOrigin dafnyTok) {
-        Snippets.WriteSourceCodeSnippet(Options, dafnyTok, tw);
-      } else {
-        ErrorWriteLine(tw, "No Dafny location information, so snippet can't be generated.");
-      }
-    }
-
-    if (tok is NestedOrigin nestedToken) {
-      ReportBplError(nestedToken.Inner, "Related location", false, tw);
-    }
-  }
+  // public override void ReportBplError(Boogie.IToken tok, string message, bool error, TextWriter tw, string category = null) {
+  //
+  //   if (Options.Verbosity == CoreOptions.VerbosityLevel.Silent) {
+  //     return;
+  //   }
+  //
+  //   if (category != null) {
+  //     message = $"{category}: {message}";
+  //   }
+  //
+  //   var dafnyToken = BoogieGenerator.ToDafnyToken(options.Get(Snippets.ShowSnippets), tok);
+  //   message = $"{dafnyToken.TokenToString(Options)}: {message}";
+  //
+  //   if (error) {
+  //     ErrorWriteLine(tw, message);
+  //   } else {
+  //     tw.WriteLine(message);
+  //   }
+  //
+  //   if (Options.Get(Snippets.ShowSnippets)) {
+  //     if (tok is IOrigin dafnyTok) {
+  //       Snippets.WriteSourceCodeSnippet(Options, dafnyTok, tw);
+  //     } else {
+  //       ErrorWriteLine(tw, "No Dafny location information, so snippet can't be generated.");
+  //     }
+  //   }
+  //
+  //   if (tok is NestedOrigin nestedToken) {
+  //     ReportBplError(nestedToken.Inner, "Related location", false, tw);
+  //   }
+  // }
 
   public override void ReportEndVerifyImplementation(Implementation implementation, ImplementationRunResult result) {
     var impl = new ImplementationLogEntry(implementation.VerboseName, implementation.tok);

--- a/Source/DafnyCore/Generic/BatchErrorReporter.cs
+++ b/Source/DafnyCore/Generic/BatchErrorReporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,7 +10,7 @@ public class BatchErrorReporter : ErrorReporter {
 
   public void CopyDiagnostics(ErrorReporter intoReporter) {
     foreach (var diagnostic in AllMessages) {
-      intoReporter.Message(diagnostic.Source, diagnostic.Level, diagnostic.ErrorId, diagnostic.Token, diagnostic.Message);
+      intoReporter.MessageCore(diagnostic);
     }
   }
 
@@ -22,15 +23,14 @@ public class BatchErrorReporter : ErrorReporter {
     };
   }
 
-  protected override bool MessageCore(MessageSource source, ErrorLevel level, string errorId, IOrigin tok, string msg) {
-    if (ErrorsOnly && level != ErrorLevel.Error) {
+  public override bool MessageCore(DafnyDiagnostic dafnyDiagnostic) {
+    if (ErrorsOnly && dafnyDiagnostic.Level != ErrorLevel.Error) {
       // discard the message
       return false;
     }
 
-    var dafnyDiagnostic = new DafnyDiagnostic(source, errorId, tok, msg, level, new List<DafnyRelatedInformation>());
     AllMessages.Add(dafnyDiagnostic);
-    AllMessagesByLevel[level].Add(dafnyDiagnostic);
+    AllMessagesByLevel[dafnyDiagnostic.Level].Add(dafnyDiagnostic);
     return true;
   }
 

--- a/Source/DafnyCore/Generic/DafnyDiagnostic.cs
+++ b/Source/DafnyCore/Generic/DafnyDiagnostic.cs
@@ -1,23 +1,31 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Dafny;
 
-public record DafnyDiagnostic(MessageSource Source, string ErrorId, IOrigin Token, string Message, ErrorLevel Level,
+public class LocationComparer : IComparer<Location> {
+  public static readonly LocationComparer Instance = new();
+  public int Compare(Location x, Location y) {
+    throw new NotImplementedException();
+  }
+}
+
+public record DafnyDiagnostic(MessageSource Source, string ErrorId, Location Token, string Message, ErrorLevel Level,
   IReadOnlyList<DafnyRelatedInformation> RelatedInformation) : IComparable<DafnyDiagnostic> {
   public int CompareTo(DafnyDiagnostic? other) {
     if (other == null) {
       return 1;
     }
-    var r0 = OriginCenterComparer.Instance.Compare(Token, other.Token);
+    var r0 = LocationComparer.Instance.Compare(Token, other.Token);
     if (r0 != 0) {
       return r0;
     }
 
     for (var index = 0; index < RelatedInformation.Count; index++) {
       if (other.RelatedInformation.Count > index) {
-        var r1 = RelatedInformation[index].Token.Center.CompareTo(other.RelatedInformation[index].Token.Center);
+        var r1 = LocationComparer.Instance.Compare(RelatedInformation[index].Token, other.RelatedInformation[index].Token);
         if (r1 != 0) {
           return r1;
         }

--- a/Source/DafnyCore/Generic/ErrorReporter.cs
+++ b/Source/DafnyCore/Generic/ErrorReporter.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using DafnyCore;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Dafny;
 
@@ -38,11 +41,30 @@ public abstract class ErrorReporter {
     return MessageCore(source, level, errorId, tok, msg);
   }
 
-  protected abstract bool MessageCore(MessageSource source, ErrorLevel level, string errorId, IOrigin tok, string msg);
+  protected bool MessageCore(MessageSource source, ErrorLevel level, string errorId, IOrigin rootTok, string msg) {
+    if (ErrorsOnly && level != ErrorLevel.Error) {
+      return false;
+    }
+    var relatedInformation = new List<DafnyRelatedInformation>();
+
+    var usingSnippets = Options.Get(Snippets.ShowSnippets);
+    if (rootTok is NestedOrigin nestedToken) {
+      relatedInformation.AddRange(
+        ErrorReporterExtensions.CreateDiagnosticRelatedInformationFor(
+          nestedToken.Inner, nestedToken.Message, usingSnippets)
+      );
+    }
+
+    var dafnyDiagnostic = new DafnyDiagnostic(source, errorId!, rootTok.Center.ToLspLocation(), msg, level, relatedInformation);
+    return MessageCore(dafnyDiagnostic);
+  }
+
+  public abstract bool MessageCore(DafnyDiagnostic dafnyDiagnostic);
 
   public void Error(MessageSource source, IOrigin tok, string msg) {
     Error(source, ParseErrors.ErrorId.none, tok, msg);
   }
+
   public virtual void Error(MessageSource source, string errorId, IOrigin tok, string msg) {
     Contract.Requires(tok != null);
     Contract.Requires(msg != null);
@@ -197,6 +219,9 @@ public abstract class ErrorReporter {
   }
 
   public string ErrorToString(ErrorLevel header, IOrigin tok, string msg) {
+    return $"{tok.TokenToString(Options)}: {header.ToString()}: {msg}";
+  }
+  public string ErrorToString(ErrorLevel header, Location tok, string msg) {
     return $"{tok.TokenToString(Options)}: {header.ToString()}: {msg}";
   }
 }

--- a/Source/DafnyCore/Generic/ErrorReporterWrapper.cs
+++ b/Source/DafnyCore/Generic/ErrorReporterWrapper.cs
@@ -1,0 +1,17 @@
+#nullable enable
+namespace Microsoft.Dafny;
+
+public class ErrorReporterWrapper(ErrorReporter reporter, string msgPrefix) : BatchErrorReporter(reporter.Options) {
+  public readonly ErrorReporter WrappedReporter = reporter;
+
+  public override bool MessageCore(DafnyDiagnostic dafnyDiagnostic) {
+    if (dafnyDiagnostic.Level == ErrorLevel.Warning) {
+      return false;
+    }
+
+    base.MessageCore(dafnyDiagnostic);
+    return WrappedReporter.MessageCore(dafnyDiagnostic with {
+      Message = msgPrefix + dafnyDiagnostic.Message
+    });
+  }
+}

--- a/Source/DafnyCore/Generic/ReporterExtensions.cs
+++ b/Source/DafnyCore/Generic/ReporterExtensions.cs
@@ -35,12 +35,9 @@ public static class ErrorReporterExtensions {
 
     var dafnyToken = BoogieGenerator.ToDafnyToken(useRange, error.Tok);
 
-    var tokens = new[] { dafnyToken }.Concat(relatedInformation.Select(i => i.Token)).ToList();
-    IOrigin previous = tokens.Last();
-    foreach (var (inner, outer) in relatedInformation.Zip(tokens).Reverse()) {
-      previous = new NestedOrigin(outer, previous, inner.Message);
-    }
-    reporter.Message(MessageSource.Verifier, ErrorLevel.Error, null, previous, error.Msg);
+    var diagnostic = new DafnyDiagnostic(MessageSource.Verifier, null, dafnyToken.ToLspLocation(), error.Msg,
+      ErrorLevel.Error, relatedInformation);
+    reporter.MessageCore(diagnostic);
   }
 
   private const string RelatedLocationCategory = "Related location";
@@ -70,7 +67,7 @@ public static class ErrorReporterExtensions {
 
     message ??= "this proposition could not be proved";
 
-    yield return new DafnyRelatedInformation(token, message);
+    yield return new DafnyRelatedInformation(token.ToLspLocation(), message);
     if (inner != null) {
       foreach (var nestedInformation in CreateDiagnosticRelatedInformationFor(inner, newMessage, usingSnippets)) {
         yield return nestedInformation;

--- a/Source/DafnyCore/Generic/Reporting.cs
+++ b/Source/DafnyCore/Generic/Reporting.cs
@@ -1,8 +1,11 @@
 // Copyright by the contributors to the Dafny Project
 // SPDX-License-Identifier: MIT
 #nullable enable
+using System;
 using System.CommandLine;
 using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Microsoft.Dafny {
 
@@ -14,12 +17,12 @@ namespace Microsoft.Dafny {
     Project, Parser, Cloner, RefinementTransformer, Rewriter, Resolver, Translator, Verifier, Compiler, Documentation, TestGeneration
   }
 
-  public record DafnyRelatedInformation(IOrigin Token, string Message);
+  public record DafnyRelatedInformation(Location Token, string Message);
 
   public class ErrorReporterSink : ErrorReporter {
     public ErrorReporterSink(DafnyOptions options) : base(options) { }
 
-    protected override bool MessageCore(MessageSource source, ErrorLevel level, string errorId, IOrigin tok, string msg) {
+    public override bool MessageCore(DafnyDiagnostic dafnyDiagnostic) {
       return false;
     }
 
@@ -33,26 +36,6 @@ namespace Microsoft.Dafny {
 
     public override int CountExceptVerifierAndCompiler(ErrorLevel level) {
       return 0;
-    }
-  }
-
-  public class ErrorReporterWrapper : BatchErrorReporter {
-
-    private string msgPrefix;
-    public readonly ErrorReporter WrappedReporter;
-
-    public ErrorReporterWrapper(ErrorReporter reporter, string msgPrefix) : base(reporter.Options) {
-      this.msgPrefix = msgPrefix;
-      this.WrappedReporter = reporter;
-    }
-
-    protected override bool MessageCore(MessageSource source, ErrorLevel level, string errorId, IOrigin tok, string msg) {
-      if (level == ErrorLevel.Warning) {
-        return false;
-      }
-
-      base.MessageCore(source, level, errorId, tok, msg);
-      return WrappedReporter.Message(source, level, errorId, tok, msgPrefix + msg);
     }
   }
 }

--- a/Source/DafnyCore/Pipeline/BoogieExtensions.cs
+++ b/Source/DafnyCore/Pipeline/BoogieExtensions.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Dafny {
     public static Range ToLspRange(this IOrigin range) {
       return range.ToDafnyRange().ToLspRange();
     }
+    public static Location ToLspLocation(this IOrigin range) {
+      return new Location() {
+        Uri = DocumentUri.From(range.Center.Uri),
+        Range = range.ToLspRange()
+      };
+    }
 
     /// <summary>
     /// Gets the LSP range of the specified token.

--- a/Source/DafnyCore/Pipeline/Compilation.cs
+++ b/Source/DafnyCore/Pipeline/Compilation.cs
@@ -543,7 +543,7 @@ public class Compilation : IDisposable {
     ReportDiagnosticsInResult(options, canVerify.NavigationToken.val, BoogieGenerator.ToDafnyToken(true, task.Token),
       task.Split.Implementation.GetTimeLimit(options), result, errorReporter);
 
-    return diagnostics.OrderBy(d => d.Token.GetLspPosition()).ToList();
+    return diagnostics.OrderBy(d => d.Token.Range.Start).ToList();
   }
 
   public static void ReportDiagnosticsInResult(DafnyOptions options, string name, IOrigin token,

--- a/Source/DafnyCore/Pipeline/DiagnosticUtil.cs
+++ b/Source/DafnyCore/Pipeline/DiagnosticUtil.cs
@@ -11,11 +11,11 @@ public static class DiagnosticUtil {
       Code = dafnyDiagnostic.ErrorId,
       Severity = ToSeverity(dafnyDiagnostic.Level),
       Message = dafnyDiagnostic.Message,
-      Range = dafnyDiagnostic.Token.GetLspRange(),
+      Range = dafnyDiagnostic.Token.Range,
       Source = dafnyDiagnostic.Source.ToString(),
       RelatedInformation = dafnyDiagnostic.RelatedInformation.Select(r =>
         new DiagnosticRelatedInformation {
-          Location = CreateLocation(r.Token),
+          Location = r.Token,
           Message = r.Message
         }).ToList(),
       CodeDescription = dafnyDiagnostic.ErrorId == null

--- a/Source/DafnyCore/Pipeline/ObservableErrorReporter.cs
+++ b/Source/DafnyCore/Pipeline/ObservableErrorReporter.cs
@@ -27,22 +27,8 @@ namespace Microsoft.Dafny {
       this.entryUri = entryUri;
     }
 
-    protected override bool MessageCore(MessageSource source, ErrorLevel level, string? errorId, IOrigin rootTok, string msg) {
-      if (ErrorsOnly && level != ErrorLevel.Error) {
-        return false;
-      }
-      var relatedInformation = new List<DafnyRelatedInformation>();
-
-      var usingSnippets = Options.Get(Snippets.ShowSnippets);
-      if (rootTok is NestedOrigin nestedToken) {
-        relatedInformation.AddRange(
-          ErrorReporterExtensions.CreateDiagnosticRelatedInformationFor(
-            nestedToken.Inner, nestedToken.Message, usingSnippets)
-        );
-      }
-
-      var dafnyDiagnostic = new DafnyDiagnostic(source, errorId!, rootTok, msg, level, relatedInformation);
-      AddDiagnosticForFile(dafnyDiagnostic, GetUriOrDefault(rootTok));
+    public override bool MessageCore(DafnyDiagnostic dafnyDiagnostic) {
+      AddDiagnosticForFile(dafnyDiagnostic, dafnyDiagnostic.Token.Uri.ToUri());
       return true;
     }
 

--- a/Source/DafnyCore/Resolver/ProgramResolver.cs
+++ b/Source/DafnyCore/Resolver/ProgramResolver.cs
@@ -104,8 +104,7 @@ public class ProgramResolver {
     }
 
     foreach (var diagnostic in moduleResolutionResult.ErrorReporter.AllMessages) {
-      Reporter.Message(diagnostic.Source, diagnostic.Level, diagnostic.ErrorId, diagnostic.Token,
-        diagnostic.Message);
+      Reporter.MessageCore(diagnostic);
     }
   }
 

--- a/Source/DafnyCore/Snippets.cs
+++ b/Source/DafnyCore/Snippets.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using DafnyCore.Options;
 using Microsoft.Dafny;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace DafnyCore;
 
@@ -16,6 +17,30 @@ public class Snippets {
 
   static Snippets() {
     OptionRegistry.RegisterOption(ShowSnippets, OptionScope.Cli);
+  }
+
+  public static void WriteSourceCodeSnippet(DafnyOptions options, Location location, TextWriter tw) {
+    var start = location.Range.Start;
+    var end = location.Range.End;
+    string line = GetFileLine(options, location.Uri.ToUri(), location.Range.Start.Line);
+    if (line == null) {
+      return;
+    }
+
+    if (location.Range.End.Line != location.Range.Start.Line) {
+      return;
+    }
+
+    string lineNumber = (location.Range.Start.Line + 1).ToString();
+    string lineNumberSpaces = new string(' ', lineNumber.Length);
+    string columnSpaces = new string(' ', location.Range.Start.Character);
+
+    var underlineLength = Math.Max(1, location.Range.End.Character - location.Range.Start.Character);
+    string underline = new string('^', underlineLength);
+    tw.WriteLine($"{lineNumberSpaces} |");
+    tw.WriteLine($"{lineNumber} | {line}");
+    tw.WriteLine($"{lineNumberSpaces} | {columnSpaces}{underline}");
+    tw.WriteLine("");
   }
 
   public static void WriteSourceCodeSnippet(DafnyOptions options, IOrigin tok, TextWriter tw) {

--- a/Source/DafnyDriver/CliCompilation.cs
+++ b/Source/DafnyDriver/CliCompilation.cs
@@ -123,8 +123,7 @@ public class CliCompilation {
           Interlocked.Increment(ref warningCount);
         }
         var dafnyDiagnostic = newDiagnostic.Diagnostic;
-        consoleReporter.Message(dafnyDiagnostic.Source, dafnyDiagnostic.Level,
-          dafnyDiagnostic.ErrorId, dafnyDiagnostic.Token, dafnyDiagnostic.Message);
+        consoleReporter.MessageCore(dafnyDiagnostic);
       } else if (ev is FinishedParsing finishedParsing) {
         if (errorCount > 0) {
           var programName = finishedParsing.ParseResult.Program.Name;

--- a/Source/DafnyDriver/Commands/VerifyCommand.cs
+++ b/Source/DafnyDriver/Commands/VerifyCommand.cs
@@ -6,11 +6,8 @@ using System.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
-using DafnyCore;
-using DafnyCore.Options;
 using DafnyDriver.Commands;
 using Microsoft.Boogie;
-using Microsoft.Dafny.Compilers;
 
 namespace Microsoft.Dafny;
 
@@ -194,8 +191,7 @@ public static class VerifyCommand {
       }
 
       foreach (var diagnostic in batchReporter.AllMessages.Order()) {
-        compilation.Compilation.Reporter.Message(diagnostic.Source, diagnostic.Level, diagnostic.ErrorId, diagnostic.Token,
-          diagnostic.Message);
+        compilation.Compilation.Reporter.MessageCore(diagnostic);
       }
     });
 

--- a/Source/DafnyPipeline.Test/DocstringTest.cs
+++ b/Source/DafnyPipeline.Test/DocstringTest.cs
@@ -778,7 +778,7 @@ iterator Iter2(x: int) yields (y: int)
         var dafnyProgram = await Utils.Parse(reporter, programString, false);
         if (reporter.HasErrors) {
           var error = reporter.AllMessagesByLevel[ErrorLevel.Error][0];
-          Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");
+          Assert.False(true, $"{error.Message}: line {error.Token.Range.Start.Line} col {error.Token.Range.Start.Character}");
         }
 
         foreach (var (nodeTokenValue, expectedDocstring) in tests) {

--- a/Source/DafnyPipeline.Test/FormatterBaseTest.cs
+++ b/Source/DafnyPipeline.Test/FormatterBaseTest.cs
@@ -67,7 +67,7 @@ namespace DafnyPipeline.Test {
 
         if (reporter.HasErrors) {
           var error = reporter.AllMessagesByLevel[ErrorLevel.Error][0];
-          Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");
+          Assert.False(true, $"{error.Message}: line {error.Token.Range.Start.Line} col {error.Token.Range.Start.Character}");
         }
 
         var firstToken = dafnyProgram.GetFirstTokenForUri(uri);

--- a/Source/DafnyPipeline.Test/ImplicitAssertionTest.cs
+++ b/Source/DafnyPipeline.Test/ImplicitAssertionTest.cs
@@ -152,12 +152,12 @@ method Test(m: map<int, int>, x: int) {
     var dafnyProgram = parseResult.Program;
     if (reporter.HasErrors) {
       var error = reporter.AllMessagesByLevel[ErrorLevel.Error][0];
-      Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");
+      Assert.False(true, $"{error.Message}: line {error.Token.Range.Start.Line} col {error.Token.Range.Start.Character}");
     }
     DafnyMain.Resolve(dafnyProgram);
     if (reporter.HasErrors) {
       var error = reporter.AllMessagesByLevel[ErrorLevel.Error][0];
-      Assert.False(true, $"{error.Message}: line {error.Token.line} col {error.Token.col}");
+      Assert.False(true, $"{error.Message}: line {error.Token.Range.Start.Line} col {error.Token.Range.Start.Character}");
     }
 
     var boogiePrograms = SynchronousCliCompilation.Translate(options, dafnyProgram).ToList();

--- a/Source/DafnyTestGeneration/FirstPass.cs
+++ b/Source/DafnyTestGeneration/FirstPass.cs
@@ -73,14 +73,15 @@ public class FirstPass {
         $"Test generation returned {Errors.Count()} errors. Fix them to proceed:");
       foreach (var error in Errors) {
         var errorId = error.ErrorId == "none" ? "Error" : error.ErrorId;
-        errorReporter.Error(MessageSource.TestGeneration, errorId, error.Token, error.Message);
+
+        errorReporter.MessageCore(error with { Source = MessageSource.TestGeneration, ErrorId = errorId, Level = ErrorLevel.Error });
       }
     }
     if (Warnings.Count() != 0 && !options.TestGenOptions.IgnoreWarnings) {
       errorReporter.Warning(MessageSource.TestGeneration, "", program.StartToken,
         $"Test generation returned {Warnings.Count()} warnings:");
       foreach (var warning in Warnings) {
-        errorReporter.Warning(MessageSource.TestGeneration, warning.ErrorId, warning.Token, warning.Message);
+        errorReporter.MessageCore(warning with { Source = MessageSource.TestGeneration, ErrorId = warning.ErrorId, Level = ErrorLevel.Warning });
       }
     }
   }
@@ -101,7 +102,7 @@ public class FirstPass {
       }
     }
     if (callableWithMaxTimeLimit != null) {
-      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, SmallTimeLimitWarning, callableWithMaxTimeLimit.Origin,
+      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, SmallTimeLimitWarning, callableWithMaxTimeLimit.Origin.ToLspLocation(),
         $"Method/function {callableWithMaxTimeLimit} is annotated with {{:timeLimit {maxTimeLimit}}} but test " +
         $"generation is called with --{BoogieOptionBag.VerificationTimeLimit.Name}:{options.TimeLimit}." +
         $"\nConsider increasing the time limit for test generation",
@@ -122,7 +123,7 @@ public class FirstPass {
           (attribute.Args.Count == 1 && uint.TryParse(attribute.Args.First().ToString(), out uint result) && result > 0)) {
         continue;
       }
-      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, MalformedAttributeError, toInline.Origin,
+      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, MalformedAttributeError, toInline.Origin.ToLspLocation(),
         $"{{:{TestGenerationOptions.TestInlineAttribute}}} attribute on the {toInline.FullDafnyName} method/function " +
         $"can only take one argument, which must be a positive integer specifying the recursion unrolling limit " +
         $"(absence of such an argument or 1 means no unrolling)",
@@ -170,7 +171,7 @@ public class FirstPass {
       } else {
         message = $"Found a {{:{TestGenerationOptions.TestInlineAttribute}}}-annotated declaration that is neither a method nor a function";
       }
-      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, InlinedMethodNotReachableWarning, toInline.Origin, message,
+      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, InlinedMethodNotReachableWarning, toInline.Origin.ToLspLocation(), message,
         ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
       result = false;
     }
@@ -183,7 +184,7 @@ public class FirstPass {
   /// </summary>
   private bool CheckIsWrappedInAModule(Program program) {
     if (program.DefaultModuleDef.Children.OfType<ClassLikeDecl>().Any() || program.DefaultModuleDef.Children.OfType<DefaultClassDecl>().Any(decl => decl.Children.Any())) {
-      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoExternalModuleError, program.Origin,
+      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoExternalModuleError, program.Origin.ToLspLocation(),
         "Program is not wrapped in a module. Put your code inside \"module M {}\" or equivalent",
         ErrorLevel.Error, new List<DafnyRelatedInformation>()));
       return false;
@@ -199,14 +200,14 @@ public class FirstPass {
     var result = true;
     foreach (MemberDecl declaration in Utils.AllMemberDeclarationsWithAttribute(program.DefaultModule, TestGenerationOptions.TestEntryAttribute)) {
       if (declaration.EnclosingClass is TraitDecl or ArrayClassDecl or IteratorDecl) {
-        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, UnsupportedInputTypeError, declaration.Origin,
+        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, UnsupportedInputTypeError, declaration.Origin.ToLspLocation(),
           $"Test Generation does not support trait, array, or iterator types as receivers of " +
           $"{{:{TestGenerationOptions.TestEntryAttribute}}}-annotated methods.\n" +
           $"Consider writing a wrapper method that creates a receiver and passes on the arguments to it",
           ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
         result = false;
       } else if (declaration.EnclosingClass is ClassDecl) {
-        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, declaration.Origin,
+        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, declaration.Origin.ToLspLocation(),
           $"Test Generation does not fully support class types as receivers of " +
           $"{{:{TestGenerationOptions.TestEntryAttribute}}}-annotated methods.\n" +
           $"Consider writing a wrapper method that creates a receiver and passes on the arguments to it",
@@ -249,7 +250,7 @@ public class FirstPass {
         $"Consider modelling values of type {userDefinedType} with a datatype and passing them as input to " +
         $"{{:{TestGenerationOptions.TestEntryAttribute}}} annotated method/function {testEntry}";
       if (userDefinedType.IsAbstractType || userDefinedType.IsArrayType || userDefinedType.IsTraitType) {
-        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, UnsupportedInputTypeError, type.Origin,
+        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, UnsupportedInputTypeError, type.Origin.ToLspLocation(),
           $"Test Generation does not support abstract types, array types, and trait types as inputs.\n{genericMessage}",
           ErrorLevel.Error, new List<DafnyRelatedInformation>()));
       } else if (userDefinedType.IsRefType) {
@@ -258,23 +259,23 @@ public class FirstPass {
             TypeIsSupported(field.Type, testEntry);
           }
         }
-        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, type.Origin,
+        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, type.Origin.ToLspLocation(),
           $"Test Generation does not fully support class types as inputs.\n{genericMessage}",
           ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
       } else if (userDefinedType.IsArrowType) {
-        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, type.Origin,
+        diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, type.Origin.ToLspLocation(),
           $"Test Generation does not fully support function types as inputs.\n{genericMessage}",
           ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
       } else if (userDefinedType.AsNewtype != null) {
         if (userDefinedType.AsNewtype.Witness == null) {
-          diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoWitnessWarning, type.Origin,
+          diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoWitnessWarning, type.Origin.ToLspLocation(),
             $"Cannot find witness for type {userDefinedType}. Please consider adding a witness to the declaration",
             ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
         }
         isSupported = TypeIsSupported(userDefinedType.AsNewtype.BaseType, testEntry);
       } else if (userDefinedType.AsSubsetType != null) {
         if (userDefinedType.AsSubsetType.Witness == null) {
-          diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoWitnessWarning, type.Origin,
+          diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoWitnessWarning, type.Origin.ToLspLocation(),
             $"Cannot find witness for type {userDefinedType}. Please consider adding a witness to the declaration",
             ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
         }
@@ -283,7 +284,7 @@ public class FirstPass {
         isSupported = TypeIsSupported(userDefinedType.AsTypeSynonym.Rhs, testEntry);
       } else if (userDefinedType.IsDatatype) {
         if (userDefinedType.IsCoDatatype) {
-          diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, type.Origin,
+          diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NotFullySupportedInputTypeWarning, type.Origin.ToLspLocation(),
             $"Test Generation has not been properly tested with co-inductive datatypes.\n{genericMessage}",
             ErrorLevel.Warning, new List<DafnyRelatedInformation>()));
         } else {
@@ -314,7 +315,7 @@ public class FirstPass {
   /// </summary>
   private bool CheckHasTestEntry(Program program) {
     if (!Utils.ProgramHasAttribute(program, TestGenerationOptions.TestEntryAttribute)) {
-      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoTestEntryError, program.Origin,
+      diagnostics.Add(new DafnyDiagnostic(MessageSource.TestGeneration, NoTestEntryError, program.Origin.ToLspLocation(),
         $"Cannot find a method or function annotated with {{:{TestGenerationOptions.TestEntryAttribute}}}",
         ErrorLevel.Error, new List<DafnyRelatedInformation>()));
       return false;


### PR DESCRIPTION
### What was changed?
- Use diagnostics instead of IOrigin in the reporting code, to force making it explicit what range is used in reporting

### How has this been tested?
<!-- Tests can be added to `Source/IntegrationTests/TestFiles/LitTests/LitTest/` or to `Source/*.Test/…` and run with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
