### PR TITLE
Correctly display project files errors when using build command

### DIFF
--- a/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
+++ b/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
@@ -95,6 +95,12 @@ namespace Microsoft.Dafny {
       var otherFiles = new List<string>();
       var outputWriter = options.OutputWriter;
 
+      var consoleErrorReporter = new ConsoleErrorReporter(options);
+      options.DafnyProject.Errors.CopyDiagnostics(consoleErrorReporter);
+      if (options.DafnyProject.Errors.HasErrors) {
+        return (ExitValue.PREPROCESSING_ERROR, [], []);
+      }
+
       if (options.UseStdin) {
         var dafnyFile = DafnyFile.HandleStandardInput(options, Token.NoToken);
         dafnyFiles.Add(dafnyFile);
@@ -129,7 +135,6 @@ namespace Microsoft.Dafny {
         var supportedExtensions = options.Backend.SupportedExtensions;
         bool isDafnyFile = false;
         try {
-          var consoleErrorReporter = new ConsoleErrorReporter(options);
           await foreach (var df in DafnyFile.CreateAndValidate(
                            OnDiskFileSystem.Instance, consoleErrorReporter, options, new Uri(Path.GetFullPath(file)),
                            Token.Cli, options.LibraryFiles.Contains(file))) {

--- a/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
+++ b/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
@@ -96,9 +96,11 @@ namespace Microsoft.Dafny {
       var outputWriter = options.OutputWriter;
 
       var consoleErrorReporter = new ConsoleErrorReporter(options);
-      options.DafnyProject.Errors.CopyDiagnostics(consoleErrorReporter);
-      if (options.DafnyProject.Errors.HasErrors) {
-        return (ExitValue.PREPROCESSING_ERROR, [], []);
+      if (options.DafnyProject != null) {
+        options.DafnyProject.Errors.CopyDiagnostics(consoleErrorReporter);
+        if (options.DafnyProject.Errors.HasErrors) {
+          return (ExitValue.PREPROCESSING_ERROR, [], []);
+        }
       }
 
       if (options.UseStdin) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy
@@ -55,4 +55,8 @@
 // RUN: echo '15' >> %t
 // RUN: ! %baredafny format --use-basename-for-filename --check "%S/dfyconfig.toml" &>> "%t"
 
+// Project files may not contain unknown properties
+// RUN: echo '16' >> %t
+// RUN: ! %build "%S/broken/dfyconfig.toml" &>> %t
+
 // RUN: %diff "%s.expect" "%t"

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/projectFile.dfy.expect
@@ -41,3 +41,5 @@ Compilation failed because warnings were found and --allow-warnings is false
 15
 The file input.dfy needs to be formatted
 Error: 1 file needs formatting.
+16
+dfyconfig.toml(1,0): Error: Dafny project files do not have the property includdddes

--- a/docs/dev/news/6107.fix
+++ b/docs/dev/news/6107.fix
@@ -1,0 +1,1 @@
+Correctly display project files errors when using build command


### PR DESCRIPTION
Fixes #6107

### What was changed?
Correctly display project files errors when using build command

### How has this been tested?
Updated existing CLI test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
