### PR TITLE
Fix binary forall split

### DIFF
--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
@@ -172,7 +172,7 @@ public partial class BoogieGenerator {
       Bpl.Expr anteCanCalls, ante;
       Bpl.Expr post = Bpl.Expr.True;
       Bpl.Trigger tr;
-      if (forallExpressions != null) {
+      if (((QuantifierExpr)forallExpressions?[0])?.SplitQuantifierExpression is QuantifierExpr) {
         // translate based on the forallExpressions since the triggers are computed based on it already.
         QuantifierExpr expr = (QuantifierExpr)forallExpressions[0];
         while (expr.SplitQuantifier != null) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/forallStatement.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/forallStatement.dfy
@@ -1,0 +1,15 @@
+// RUN: ! %verify %s &> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+predicate P(x: int)
+predicate G(x: int)
+
+lemma SplitIntoConjunctOfForalls(x: int) 
+  ensures P(x)
+  ensures G(x)
+{
+  forall y: int {:trigger P(y), G(y)} 
+  {
+    SplitIntoConjunctOfForalls(y + 1);
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/forallStatement.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/forallStatement.dfy.expect
@@ -1,0 +1,9 @@
+forallStatement.dfy(10,0): Error: a postcondition could not be proved on this return path
+forallStatement.dfy(8,11): Related location: this is the postcondition that could not be proved
+forallStatement.dfy(10,0): Error: a postcondition could not be proved on this return path
+forallStatement.dfy(9,11): Related location: this is the postcondition that could not be proved
+forallStatement.dfy(13,30): Error: cannot prove termination; try supplying a decreases clause
+forallStatement.dfy(13,30): Error: decreases expression must be bounded below by 0
+forallStatement.dfy(7,33): Related location: this proposition could not be proved
+
+Dafny program verifier finished with 0 verified, 4 errors

--- a/docs/dev/news/6129.fix
+++ b/docs/dev/news/6129.fix
@@ -1,0 +1,1 @@
+Fix a case where a forall statement would cause Dafny to crash


### PR DESCRIPTION
Fixed #6129

### What was changed?
Prevent a crash that would occur when a forall statement was split into a conjunct of two foralls.

### How has this been tested?
Added a CLI test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
