### PR TITLE
fix: Fix crash in resolution of structural-inclusion greater-than operator

### DIFF
--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -3850,7 +3850,7 @@ namespace Microsoft.Dafny {
             return BinaryExpr.ResolvedOpcode.Disjoint;
           }
         case BinaryExpr.Opcode.Lt:
-          if (operandType.IsIndDatatype) {
+          if (operandType.IsIndDatatype || leftOperandType.IsIndDatatype) {
             return BinaryExpr.ResolvedOpcode.RankLt;
           } else if (operandType is SetType) {
             return BinaryExpr.ResolvedOpcode.ProperSubset;
@@ -3910,7 +3910,7 @@ namespace Microsoft.Dafny {
             return BinaryExpr.ResolvedOpcode.Mul;
           }
         case BinaryExpr.Opcode.Gt:
-          if (operandType.IsDatatype) {
+          if (operandType.IsIndDatatype || leftOperandType.IsIndDatatype) {
             return BinaryExpr.ResolvedOpcode.RankGt;
           } else if (operandType is SetType) {
             return BinaryExpr.ResolvedOpcode.ProperSuperset;

--- a/Source/DafnyCore/Resolver/PreType/UnderspecificationDetector.cs
+++ b/Source/DafnyCore/Resolver/PreType/UnderspecificationDetector.cs
@@ -426,7 +426,7 @@ namespace Microsoft.Dafny {
         case BinaryExpr.Opcode.Disjoint:
           return operandFamilyName == PreType.TypeNameMultiset ? BinaryExpr.ResolvedOpcode.MultiSetDisjoint : BinaryExpr.ResolvedOpcode.Disjoint;
         case BinaryExpr.Opcode.Lt: {
-            if (operandPreType is DPreType dp && PreTypeResolver.AncestorPreType(dp)?.Decl is IndDatatypeDecl) {
+            if (OperatesOnIndDatatype(leftOperandPreType, operandPreType)) {
               return BinaryExpr.ResolvedOpcode.RankLt;
             }
             return operandFamilyName switch {
@@ -475,7 +475,7 @@ namespace Microsoft.Dafny {
             _ => BinaryExpr.ResolvedOpcode.Mul
           };
         case BinaryExpr.Opcode.Gt: {
-            if (operandPreType is DPreType dp && PreTypeResolver.AncestorPreType(dp)?.Decl is IndDatatypeDecl) {
+            if (OperatesOnIndDatatype(leftOperandPreType, operandPreType)) {
               return BinaryExpr.ResolvedOpcode.RankGt;
             }
             return operandFamilyName switch {
@@ -520,6 +520,11 @@ namespace Microsoft.Dafny {
           Contract.Assert(false);
           throw new cce.UnreachableException();  // unexpected operator
       }
+    }
+
+    static bool OperatesOnIndDatatype(PreType left, PreType right) {
+      return (left is DPreType dpLeft && PreTypeResolver.AncestorPreType(dpLeft)?.Decl is IndDatatypeDecl) ||
+             (right is DPreType dpRight && PreTypeResolver.AncestorPreType(dpRight)?.Decl is IndDatatypeDecl);
     }
 
     void CheckVariable(IVariable v, string whatIsBeingChecked) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154a.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154a.dfy
@@ -1,0 +1,8 @@
+// RUN: %testDafnyForEachResolver "%s"
+
+datatype List<X> = Nil | Cons(head: X, tail: List<X>)
+
+lemma Test<X, Y>(xs: List<X>, y: Y) {
+  // the > in the following line once used to crash the resolver
+  assert y < xs <==> xs > y;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154a.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154a.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154b.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154b.dfy
@@ -1,0 +1,8 @@
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s"
+
+codatatype IList<X> = Nil | ICons(head: X, tail: IList<X>)
+
+lemma ITest<X, Y>(xs: IList<X>, y: Y) {
+  var b0 := y < xs; // error: < expects one operand to be an inductive datatype, not a codatatype
+  var b1 := xs > y; // error: > expects one operand to be an inductive datatype, not a codatatype
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154b.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6154b.dfy.expect
@@ -1,0 +1,3 @@
+git-issue-6154b.dfy(6,14): Error: arguments to rank comparison must be datatypes (got Y and IList<X>)
+git-issue-6154b.dfy(7,15): Error: arguments to rank comparison must be datatypes (got IList<X> and Y)
+2 resolution/type errors detected in git-issue-6154b.dfy

--- a/docs/dev/news/6155.fix
+++ b/docs/dev/news/6155.fix
@@ -1,0 +1,1 @@
+Fix crash in resolution of structural-inclusion greater-than operator


### PR DESCRIPTION
Fix resolution crash of `>` for datatypes.

Fixes #6154

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
