### PR TITLE
chore: optimize Sequence::to_array()

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeRust/Cargo.toml
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-once_cell = "1.18.0"
-num = "0.4"
-itertools = "0.11.0"
+once_cell = "1.21.1"
+num = "0.4.3"
+itertools = "0.14.0"
 
 [features]
 # Use `dafny translate rs --rust-sync --include-runtime file.dfy`

--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/lib.rs
@@ -886,6 +886,7 @@ where
     pub fn append_recursive(array: &mut Vec<T>, this: &Sequence<T>) {
             let mut this_ptr : * const Sequence<T> = this;
         loop {
+            // SAFETY: The invariant is that this_ptr is always a pointer to a sub-sequence of the original `this`parameter when following the field name 'right', which are allocated in this scope
             match unsafe { &*this_ptr  } {
                 Sequence::ArraySequence { values, .. } =>
                 {

--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/tests/mod.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/tests/mod.rs
@@ -74,14 +74,14 @@ mod tests {
     // This one is still the bad kind of recursive
     #[test]
     fn test_sequence_right() {
-        let a: Sequence<i32> = Sequence::<i32>::from_array_owned(vec![1, 2]);
-        let b = Sequence::<i32>::from_array_owned(vec![3, 4]);
-        let c = Sequence::<i32>::from_array_owned(vec![5, 6]);
-        let d = Sequence::<i32>::from_array_owned(vec![7, 8]);
-        let e = Sequence::<i32>::from_array_owned(vec![9, 10]);
-        let f = Sequence::<i32>::from_array_owned(vec![11, 12]);
-        let g = Sequence::<i32>::from_array_owned(vec![13, 14]);
-        let h = Sequence::<i32>::from_array_owned(vec![15, 16]);
+        let a: Sequence<i32> = seq![1, 2];
+        let b = seq![3, 4];
+        let c = seq![5, 6];
+        let d = seq![7, 8];
+        let e = seq![9, 10];
+        let f = seq![11, 12];
+        let g = seq![13, 14];
+        let h = seq![15, 16];
         let c1 = Sequence::<i32>::new_concat_sequence(&a, &b);
         let c2 = Sequence::<i32>::new_concat_sequence(&c1, &c);
         let c3 = Sequence::<i32>::new_concat_sequence(&c2, &d);
@@ -96,14 +96,14 @@ mod tests {
     // This one is successfully tail recursive
     #[test]
     fn test_sequence_left() {
-        let a: Sequence<i32> = Sequence::<i32>::from_array_owned(vec![1, 2]);
-        let b = Sequence::<i32>::from_array_owned(vec![3, 4]);
-        let c = Sequence::<i32>::from_array_owned(vec![5, 6]);
-        let d = Sequence::<i32>::from_array_owned(vec![7, 8]);
-        let e = Sequence::<i32>::from_array_owned(vec![9, 10]);
-        let f = Sequence::<i32>::from_array_owned(vec![11, 12]);
-        let g = Sequence::<i32>::from_array_owned(vec![13, 14]);
-        let h = Sequence::<i32>::from_array_owned(vec![15, 16]);
+        let a = seq![1, 2];
+        let b = seq![3, 4];
+        let c = seq![5, 6];
+        let d = seq![7, 8];
+        let e = seq![9, 10];
+        let f = seq![11, 12];
+        let g = seq![13, 14];
+        let h = seq![15, 16];
         let c1 = Sequence::<i32>::new_concat_sequence(&g, &h);
         let c2 = Sequence::<i32>::new_concat_sequence(&f, &c1);
         let c3 = Sequence::<i32>::new_concat_sequence(&e, &c2);
@@ -124,8 +124,8 @@ mod tests {
 
         // Create a concat array, wrap it into a lazy one, get the i-th element,
         // and verify that this operation flattened the array
-        let left: Sequence<i32> = Sequence::<i32>::from_array_owned(vec![1, 2, 3]);
-        let right = Sequence::<i32>::from_array_owned(vec![4, 5, 6]);
+        let left = seq![1, 2, 3];
+        let right = seq![4, 5, 6];
         let concat = Sequence::<i32>::new_concat_sequence(&left, &right);
 
         assert_eq!(concat.cardinality_usize(), 6);

--- a/Source/DafnyRuntime/DafnyRuntimeRust/src/tests/mod.rs
+++ b/Source/DafnyRuntime/DafnyRuntimeRust/src/tests/mod.rs
@@ -71,7 +71,51 @@ mod tests {
         }
     }
 
+    // This one is still the bad kind of recursive
     #[test]
+    fn test_sequence_right() {
+        let a: Sequence<i32> = Sequence::<i32>::from_array_owned(vec![1, 2]);
+        let b = Sequence::<i32>::from_array_owned(vec![3, 4]);
+        let c = Sequence::<i32>::from_array_owned(vec![5, 6]);
+        let d = Sequence::<i32>::from_array_owned(vec![7, 8]);
+        let e = Sequence::<i32>::from_array_owned(vec![9, 10]);
+        let f = Sequence::<i32>::from_array_owned(vec![11, 12]);
+        let g = Sequence::<i32>::from_array_owned(vec![13, 14]);
+        let h = Sequence::<i32>::from_array_owned(vec![15, 16]);
+        let c1 = Sequence::<i32>::new_concat_sequence(&a, &b);
+        let c2 = Sequence::<i32>::new_concat_sequence(&c1, &c);
+        let c3 = Sequence::<i32>::new_concat_sequence(&c2, &d);
+        let c4 = Sequence::<i32>::new_concat_sequence(&c3, &e);
+        let c5 = Sequence::<i32>::new_concat_sequence(&c4, &f);
+        let c6 = Sequence::<i32>::new_concat_sequence(&c5, &g);
+        let c7 = Sequence::<i32>::new_concat_sequence(&c6, &h);
+        let arr = c7.to_array();
+        assert_eq!(*arr, vec![1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+    }
+
+    // This one is successfully tail recursive
+    #[test]
+    fn test_sequence_left() {
+        let a: Sequence<i32> = Sequence::<i32>::from_array_owned(vec![1, 2]);
+        let b = Sequence::<i32>::from_array_owned(vec![3, 4]);
+        let c = Sequence::<i32>::from_array_owned(vec![5, 6]);
+        let d = Sequence::<i32>::from_array_owned(vec![7, 8]);
+        let e = Sequence::<i32>::from_array_owned(vec![9, 10]);
+        let f = Sequence::<i32>::from_array_owned(vec![11, 12]);
+        let g = Sequence::<i32>::from_array_owned(vec![13, 14]);
+        let h = Sequence::<i32>::from_array_owned(vec![15, 16]);
+        let c1 = Sequence::<i32>::new_concat_sequence(&g, &h);
+        let c2 = Sequence::<i32>::new_concat_sequence(&f, &c1);
+        let c3 = Sequence::<i32>::new_concat_sequence(&e, &c2);
+        let c4 = Sequence::<i32>::new_concat_sequence(&d, &c3);
+        let c5 = Sequence::<i32>::new_concat_sequence(&c, &c4);
+        let c6 = Sequence::<i32>::new_concat_sequence(&b, &c5);
+        let c7 = Sequence::<i32>::new_concat_sequence(&a, &c6);
+        let arr = c7.to_array();
+        assert_eq!(*arr, vec![1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+    }
+
+   #[test]
     fn test_sequence() {
         let values = vec![1, 2, 3];
         let seq = Sequence::<i32>::from_array_owned(values.clone());
@@ -80,7 +124,7 @@ mod tests {
 
         // Create a concat array, wrap it into a lazy one, get the i-th element,
         // and verify that this operation flattened the array
-        let left = Sequence::<i32>::from_array_owned(vec![1, 2, 3]);
+        let left: Sequence<i32> = Sequence::<i32>::from_array_owned(vec![1, 2, 3]);
         let right = Sequence::<i32>::from_array_owned(vec![4, 5, 6]);
         let concat = Sequence::<i32>::new_concat_sequence(&left, &right);
 
@@ -327,7 +371,6 @@ mod tests {
         assert_eq!(map![].merge(&m_4), m_4);
         let m_5 = m_4.merge(&map![3 => 9, 6 => 12]);
         assert_eq!(m_5.cardinality_usize(), 5);
-        println!("m_4 is {:?}", m_4);
         assert_eq!(m_4.get(&3), 6);
         assert_eq!(m_5.get(&3), 9);
         assert_eq!(m_5.subtract(&set! {}), m_5);
@@ -571,7 +614,6 @@ mod tests {
                 7 as i32 + if test1 { *MaybePlacebo::read(&t) } else { 0 },
             ));
         }
-        println!("{}", MaybePlacebo::read(&t));
         MaybePlacebo::read(&t)
     }
 
@@ -748,11 +790,6 @@ mod tests {
             .iter()
             .cloned()
             .any(Rc::new(|i: u32| i % 2 == 0).as_ref()));
-
-        for i in set! {1, 3, 5, 7}.iter() {
-            println!("{}", i);
-        }
-
         assert!(multiset! {1, 1, 5, 7}
             .iter()
             .all(Rc::new(|i: u32| i % 2 == 1).as_ref()));


### PR DESCRIPTION

### What was changed?
append_recursive is now tail recursive in the most common case

### How has this been tested?
Tests added to ensure correctness.
explicit `println!`s are necessary to prove tail recursion.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
