### PR TITLE
fix: Generate alloc consequence axiom only for functions that read the heap

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
@@ -83,7 +83,7 @@ public partial class BoogieGenerator {
       etran = readsHeap ? etranHeap : new ExpressionTranslator(this, Predef, (Bpl.Expr)null, f);
     }
 
-    // This method generatew the Consequence Axiom, which has information about the function's
+    // This method generates the Consequence Axiom, which has information about the function's
     // return type and postconditions.
     //
     // axiom  // consequence axiom

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
@@ -223,7 +223,7 @@ public partial class BoogieGenerator {
           // all parameters are included in the CanCall, so that's the only antecedent we need
           Contract.Assert(formals.Contains(bvHeap));
         } else {
-          // CanCall does not include the heap parameter, but, since we will quantify over a heap, we need to
+          // CanCall does not include the heap parameter but, since we will quantify over a heap, we need to
           // make sure the other parameters are connected to that heap
           Contract.Assert(f is not TwoStateFunction);
           ante = BplAnd(ante, parametersIsAlloc);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
@@ -255,17 +255,10 @@ public partial class BoogieGenerator {
       AddOtherDefinition(boogieFunction, new Bpl.Axiom(f.Origin, ax, "consequence axiom for " + f.FullSanitizedName));
     }
 
-    if (f.ResultType.MayInvolveReferences) {
+    if (f.ResultType.MayInvolveReferences && readsHeap) {
+      Contract.Assert(formals.Contains(bvHeap));
       whr = GetWhereClause(f.Origin, funcAppl, f.ResultType, etranHeap, ISALLOC, true);
       if (whr != null) {
-        if (readsHeap) {
-          Contract.Assert(formals.Contains(bvHeap));
-        } else {
-          formals = Util.Cons(bvHeap, formals);
-          var goodHeap = FunctionCall(f.Origin, BuiltinFunction.IsGoodHeap, null, etranHeap.HeapExpr);
-          anteIsAlloc = BplAnd(anteIsAlloc, goodHeap);
-        }
-
         axBody = BplImp(anteIsAlloc, whr);
         if (RemoveLit(axBody) != Bpl.Expr.True) {
           var ax = BplForall(f.Origin, [], formals, null, BplTrigger(whr), axBody);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
@@ -83,8 +83,8 @@ public partial class BoogieGenerator {
       etran = readsHeap ? etranHeap : new ExpressionTranslator(this, Predef, (Bpl.Expr)null, f);
     }
 
-    // This method generate the Consequence Axiom, which has information about the function's
-    // return type and postconditions
+    // This method generatew the Consequence Axiom, which has information about the function's
+    // return type and postconditions.
     //
     // axiom  // consequence axiom
     //   (forall s, $Heap, formals ::                  // let args := $Heap,formals
@@ -127,16 +127,10 @@ public partial class BoogieGenerator {
       reveal = null;
     }
 
-    Bpl.Expr ante = Bpl.Expr.True;
-    Bpl.Expr anteIsAlloc = Bpl.Expr.True;
     if (f is TwoStateFunction) {
       Contract.Assert(bvPrevHeap != null);
       formals.Add(bvPrevHeap);
       args.Add(etran.Old.HeapExpr);
-      // ante:  $IsGoodHeap($prevHeap) &&
-      var goodHeap = FunctionCall(f.Origin, BuiltinFunction.IsGoodHeap, null, etran.Old.HeapExpr);
-      ante = BplAnd(ante, goodHeap);
-      anteIsAlloc = BplAnd(anteIsAlloc, goodHeap);
     }
     var bvHeap = new Bpl.BoundVariable(f.Origin, new Bpl.TypedIdent(f.Origin, Predef.HeapVarName, Predef.HeapType));
     if (f.ReadsHeap) {
@@ -144,22 +138,10 @@ public partial class BoogieGenerator {
     }
     // ante:  $IsGoodHeap($Heap) && $HeapSucc($prevHeap, $Heap) && this != null && formals-have-the-expected-types &&
     if (readsHeap) {
-      Bpl.Expr goodHeap = FunctionCall(f.Origin, BuiltinFunction.IsGoodHeap, null, etranHeap.HeapExpr);
       formals.Add(bvHeap);
-      ante = BplAnd(ante, goodHeap);
-      anteIsAlloc = BplAnd(anteIsAlloc, f.ReadsHeap ? goodHeap : Bpl.Expr.True);
-      if (f is TwoStateFunction) {
-        var heapSucc = HeapSucc(etran.Old.HeapExpr, etran.HeapExpr);
-        ante = BplAnd(ante, heapSucc);
-        anteIsAlloc = BplAnd(anteIsAlloc, f.ReadsHeap ? heapSucc : Bpl.Expr.True);
-      }
-    }
-    // ante:  conditions on bounded type parameters
-    foreach (var typeBoundAxiom in TypeBoundAxioms(f.Origin, Concat(f.EnclosingClass.TypeArgs, f.TypeArgs))) {
-      ante = BplAnd(ante, typeBoundAxiom);
-      anteIsAlloc = BplAnd(anteIsAlloc, typeBoundAxiom);
     }
 
+    Bpl.Expr parametersIsAlloc = Bpl.Expr.True;
     if (!f.IsStatic) {
       var bvThis = new Bpl.BoundVariable(f.Origin, new Bpl.TypedIdent(f.Origin, etran.This, TrReceiverType(f)));
       formals.Add(bvThis);
@@ -168,14 +150,9 @@ public partial class BoogieGenerator {
       args.Add(bvThisIdExpr);
       // add well-typedness conjunct to antecedent
       Type thisType = ModuleResolver.GetReceiverType(f.Origin, f);
-      Bpl.Expr wh = BplAnd(
-        ReceiverNotNull(bvThisIdExpr),
-        (f is TwoStateFunction ? etran.Old : etran).GoodRef(f.Origin, bvThisIdExpr, thisType));
-      ante = BplAnd(ante, wh);
-      anteIsAlloc = BplAnd(anteIsAlloc, ReceiverNotNull(bvThisIdExpr));
-      wh = GetWhereClause(f.Origin, bvThisIdExpr, thisType, f is TwoStateFunction ? etranHeap.Old : etranHeap, ISALLOC, true);
+      Bpl.Expr wh = GetWhereClause(f.Origin, bvThisIdExpr, thisType, f is TwoStateFunction ? etranHeap.Old : etranHeap, ISALLOC, true);
       if (wh != null) {
-        anteIsAlloc = BplAnd(anteIsAlloc, wh);
+        parametersIsAlloc = BplAnd(parametersIsAlloc, wh);
       }
     }
     foreach (Formal p in f.Ins) {
@@ -184,11 +161,10 @@ public partial class BoogieGenerator {
       formals.Add(bv);
       olderInParams.Add(bv);
       args.Add(formal);
-      // add well-typedness conjunct to antecedent
-      Bpl.Expr wh = GetWhereClause(p.Origin, formal, p.Type, p.IsOld ? etran.Old : etran, ISALLOC);
-      if (wh != null) { ante = BplAnd(ante, wh); }
-      wh = GetWhereClause(p.Origin, formal, p.Type, p.IsOld ? etranHeap.Old : etranHeap, ISALLOC);
-      if (wh != null) { anteIsAlloc = BplAnd(anteIsAlloc, wh); }
+      var wh = GetWhereClause(p.Origin, formal, p.Type, p.IsOld ? etranHeap.Old : etranHeap, ISALLOC);
+      if (wh != null) {
+        parametersIsAlloc = BplAnd(parametersIsAlloc, wh);
+      }
     }
 
     Bpl.Expr funcAppl;
@@ -196,14 +172,6 @@ public partial class BoogieGenerator {
       var funcID = new Bpl.IdentifierExpr(f.Origin, f.FullSanitizedName, TrType(f.ResultType));
       var funcArgs = new List<Bpl.Expr>();
       funcArgs.AddRange(tyargs);
-      /*
-      if (f.IsFueled) {
-          funcArgs.Add(etran.layerInterCluster.GetFunctionFuel(f));
-      } else if (layer != null) {
-         var ly = new Bpl.IdentifierExpr(f.Tok, layer);
-         funcArgs.Add(FunctionCall(f.Tok, BuiltinFunction.LayerSucc, null, ly));
-      }
-       */
       if (layer != null) {
         funcArgs.Add(new Bpl.IdentifierExpr(f.Origin, layer));
       }
@@ -216,19 +184,9 @@ public partial class BoogieGenerator {
       funcAppl = new Bpl.NAryExpr(f.Origin, new Bpl.FunctionCall(funcID), funcArgs);
     }
 
-    Bpl.Expr pre = Bpl.Expr.True;
-    foreach (AttributedExpression req in ConjunctsOf(f.Req)) {
-      pre = BplAnd(pre, etran.TrExpr(req.E));
-    }
-    // useViaCanCall: f#canCall(args)
     var canCallFuncID = new Bpl.IdentifierExpr(f.Origin, f.FullSanitizedName + "#canCall", Bpl.Type.Bool);
-    var useViaCanCall = new Bpl.NAryExpr(f.Origin, new Bpl.FunctionCall(canCallFuncID), Concat(tyargs, args));
+    var canCall = new Bpl.NAryExpr(f.Origin, new Bpl.FunctionCall(canCallFuncID), Concat(tyargs, args));
 
-    // ante := useViaCanCall
-    ante = useViaCanCall;
-    anteIsAlloc = useViaCanCall;
-
-    var tr = BplTriggerHeap(this, f.Origin, funcAppl, (f.ReadsHeap || !readsHeap) ? null : etran.HeapExpr);
     Bpl.Expr post = Bpl.Expr.True;
     // substitute function return value with the function call.
     var substMap = new Dictionary<IVariable, Expression>();
@@ -249,22 +207,35 @@ public partial class BoogieGenerator {
     Bpl.Expr whr = GetWhereClause(f.Origin, funcAppl, f.ResultType, etran, NOALLOC);
     if (whr != null) { post = BplAnd(post, whr); }
 
-    Bpl.Expr axBody = BplImp(ante, post);
-    if (RemoveLit(axBody) != Bpl.Expr.True) {
+    if (RemoveLit(post) != Bpl.Expr.True) {
+      var axBody = BplImp(canCall, post);
+      var tr = BplTriggerHeap(this, f.Origin, funcAppl, readsHeap && !f.ReadsHeap ? etran.HeapExpr : null);
       var ax = BplForall(f.Origin, [], formals, null, tr, axBody);
       AddOtherDefinition(boogieFunction, new Bpl.Axiom(f.Origin, ax, "consequence axiom for " + f.FullSanitizedName));
     }
 
-    if (f.ResultType.MayInvolveReferences && readsHeap) {
-      Contract.Assert(formals.Contains(bvHeap));
+    if (f.ResultType.MayInvolveReferences) {
       whr = GetWhereClause(f.Origin, funcAppl, f.ResultType, etranHeap, ISALLOC, true);
+      Contract.Assert(whr != null); // since f.ResultType involves references, there should be an ISALLOC where clause
       if (whr != null) {
-        axBody = BplImp(anteIsAlloc, whr);
-        if (RemoveLit(axBody) != Bpl.Expr.True) {
-          var ax = BplForall(f.Origin, [], formals, null, BplTrigger(whr), axBody);
-          var allocConsequenceAxiom = new Bpl.Axiom(f.Origin, ax, "alloc consequence axiom for " + f.FullSanitizedName);
-          AddOtherDefinition(boogieFunction, allocConsequenceAxiom);
+        Bpl.Expr ante = canCall;
+        if (readsHeap) {
+          // all parameters are included in the CanCall, so that's the only antecedent we need
+          Contract.Assert(formals.Contains(bvHeap));
+        } else {
+          // CanCall does not include the heap parameter, but, since we will quantify over a heap, we need to
+          // make sure the other parameters are connected to that heap
+          Contract.Assert(f is not TwoStateFunction);
+          ante = BplAnd(ante, parametersIsAlloc);
+          formals = Util.Cons(bvHeap, formals);
+          var goodHeap = FunctionCall(f.Origin, BuiltinFunction.IsGoodHeap, null, etranHeap.HeapExpr);
+          ante = BplAnd(ante, goodHeap);
         }
+
+        var axBody = BplImp(ante, whr);
+        var ax = BplForall(f.Origin, [], formals, null, BplTrigger(whr), axBody);
+        var allocConsequenceAxiom = new Bpl.Axiom(f.Origin, ax, "alloc consequence axiom for " + f.FullSanitizedName);
+        AddOtherDefinition(boogieFunction, allocConsequenceAxiom);
       }
     }
   }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.cs
@@ -250,8 +250,8 @@ public partial class BoogieGenerator {
     if (whr != null) { post = BplAnd(post, whr); }
 
     Bpl.Expr axBody = BplImp(ante, post);
-    Bpl.Expr ax = BplForall(f.Origin, [], formals, null, tr, axBody);
     if (RemoveLit(axBody) != Bpl.Expr.True) {
+      var ax = BplForall(f.Origin, [], formals, null, tr, axBody);
       AddOtherDefinition(boogieFunction, new Bpl.Axiom(f.Origin, ax, "consequence axiom for " + f.FullSanitizedName));
     }
 
@@ -267,9 +267,8 @@ public partial class BoogieGenerator {
         }
 
         axBody = BplImp(anteIsAlloc, whr);
-        ax = BplForall(f.Origin, [], formals, null, BplTrigger(whr), axBody);
-
         if (RemoveLit(axBody) != Bpl.Expr.True) {
+          var ax = BplForall(f.Origin, [], formals, null, BplTrigger(whr), axBody);
           var allocConsequenceAxiom = new Bpl.Axiom(f.Origin, ax, "alloc consequence axiom for " + f.FullSanitizedName);
           AddOtherDefinition(boogieFunction, allocConsequenceAxiom);
         }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/blogposts/TestGenerationWithInliningQuantifiedDefinitions.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/blogposts/TestGenerationWithInliningQuantifiedDefinitions.dfy
@@ -8,7 +8,7 @@
 // the verifier chooses to do first. Thus, if something changes in the verifier, then the CHECK lines below
 // may need to be permuted.
 // RUN: %OutputCheck --file-to-check "%t" "%s"
-// CHECK: .*Dafny program verifier finished with 4 verified, 0 errors*
+// CHECK: .*Dafny program verifier finished with 5 verified, 0 errors*
 // CHECK: .*Evaluating the position: checked=yes, checkmate=yes, pawn is attacking*
 // CHECK: .*Evaluating the position: checked=yes, checkmate=no, pawn is attacking*
 // CHECK: .*Evaluating the position: checked=no, checkmate=no*

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy
@@ -54,8 +54,7 @@ module Example1 {
 
     ghost var owned: set<Node>
 
-    constructor()
-    {
+    constructor() {
       head := null;
       owned := {};
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy
@@ -1,0 +1,73 @@
+// RUN: %exits-with 4 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Example0 {
+  datatype Wrapper = Wrapper(obj: Node)
+
+  class Node {
+    var next: Node?
+    ghost var wrappers: set<Wrapper>
+
+    function Wrap(): Wrapper {
+      Wrapper(this)
+    }
+
+    constructor() ensures this.wrappers == {} {
+      this.next := null;
+      this.wrappers := {};
+    }
+
+    constructor Next(next: Node)
+      requires next.wrappers == {}
+      modifies next`wrappers
+      ensures false
+    {
+      this.wrappers := {};
+      next.wrappers := next.wrappers + {Wrapper(next)};
+      new;
+      assert forall r: Node <- {next} + {} :: this.Wrap() !in r.wrappers;
+      assert false; // error
+    }
+  }
+
+  method Main() {
+    var n := new Node();
+    var n2 := new Node.Next(n);
+    print 1/0;
+  }
+}
+
+module Example1 {
+  datatype Referrer = Referrer(obj: Node, field: int)
+  function On(n: Node, f: int): Referrer {
+    Referrer(n, f)
+  }
+
+  class Node {
+    ghost var referrers: set<Referrer>
+
+    var value: int
+  }
+
+  class List1 {
+    var head: Node?
+
+    ghost var owned: set<Node>
+
+    constructor()
+    {
+      head := null;
+      owned := {};
+    }
+
+    method Add(i: int)
+      modifies this
+      ensures false
+    {
+      this.head := new Node;
+      this.owned := {head};
+      this.head.referrers := this.head.referrers + {On(this.head, 1)};
+      assert false; // error
+    }
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy.expect
@@ -1,4 +1,4 @@
 git-issue-6164.dfy(29,6): Error: assertion might not hold
-git-issue-6164.dfy(70,6): Error: assertion might not hold
+git-issue-6164.dfy(69,6): Error: assertion might not hold
 
 Dafny program verifier finished with 4 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6164.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-6164.dfy(29,6): Error: assertion might not hold
+git-issue-6164.dfy(70,6): Error: assertion might not hold
+
+Dafny program verifier finished with 4 verified, 2 errors

--- a/docs/dev/news/6164.fix
+++ b/docs/dev/news/6164.fix
@@ -1,1 +1,1 @@
-fix: Generate alloc consequence axiom only for functions that read the heap (fixes unsoundness)
+Generate alloc consequence axiom only for functions that read the heap (fixes unsoundness)

--- a/docs/dev/news/6164.fix
+++ b/docs/dev/news/6164.fix
@@ -1,0 +1,1 @@
+fix: Generate alloc consequence axiom only for functions that read the heap (fixes unsoundness)


### PR DESCRIPTION
Previously, Dafny generated axioms of the form

``` dafny
// alloc consequence axiom for _module.__default.On
axiom (forall $Heap: Heap, n#0: ref, f#0: int :: 
  { $IsAlloc(_module.__default.On(n#0, f#0), Tclass._module.Referrer(), $Heap) } 
  _module.__default.On#canCall(n#0, f#0) && $IsGoodHeap($Heap)
     ==> $IsAlloc(_module.__default.On(n#0, f#0), Tclass._module.Referrer(), $Heap));
```

for any function whose result type may involve references. This is not sound, since it fails to connect the parameters with the `$Heap`.

The axiom would be sound if the `$Heap` parameter is part of the function and/or its CanCall predicate. In the situation discovered in #6164, the function (named `On`) does not have such a `$Heap` parameter. This PR makes sure that, in those cases, the axiom's antecedent will instead include explicit `isAlloc` predicates that connect the parameter with the heap parameter.

Fixes #6164

### Note for reviewers

Previously, the local variables `ante` and `anteIsAlloc` in method `AddFunctionConsequenceAxiom` were updated in various loops. But then those built-up values were replaced with `useViaCanCall`. This PR cleans that up. The PR also removed the unused local variable `pre` in that method.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
