### PR TITLE
chore(ci): Replace ubuntu-20.04 with ubuntu-22.04 in all workflows

### DIFF
--- a/.github/workflows/check-deep-tests-reusable.yml
+++ b/.github/workflows/check-deep-tests-reusable.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-deep-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Dafny
       uses: actions/checkout@v4

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -31,15 +31,15 @@ jobs:
       - name: Populate OS list (all platforms)
         id: populate-os-list-all
         if: inputs.all_platforms
-        run: echo "os-list=[\"ubuntu-20.04\", \"macos-13\", \"windows-2019\"]" >> $GITHUB_OUTPUT
+        run: echo "os-list=[\"ubuntu-22.04\", \"macos-13\", \"windows-2019\"]" >> $GITHUB_OUTPUT
       - name: Populate OS list (one platform)
         id: populate-os-list-one
         if: "!inputs.all_platforms"
-        run: echo "os-list=[\"ubuntu-20.04\"]" >> $GITHUB_OUTPUT
+        run: echo "os-list=[\"ubuntu-22.04\"]" >> $GITHUB_OUTPUT
       - name: Populate OS mapping for package.py
         id: populate-os-mapping
         run: |
-          echo "os-mapping={\"ubuntu-20.04\": \"ubuntu\", \"macos-13\": \"macos\", \"windows-2019\": \"windows\"}" >> $GITHUB_OUTPUT
+          echo "os-mapping={\"ubuntu-22.04\": \"ubuntu\", \"macos-13\": \"macos\", \"windows-2019\": \"windows\"}" >> $GITHUB_OUTPUT
       - name: Populate target runtime version list (all platforms)
         id: populate-target-runtime-version-all
         if: inputs.all_platforms
@@ -78,11 +78,11 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: C++ for ubuntu 20.04
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         sudo apt-get install -y build-essential
     - name: Choose the right C++ for ubuntu 20.04
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 60
     - name: Set up oldest supported JDK

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,7 +20,7 @@ jobs:
   singletons:
     needs: check-deep-tests
     if: always() && (( github.event_name == 'pull_request' && (needs.check-deep-tests.result == 'success' || contains(github.event.pull_request.labels.*.name, 'run-deep-tests'))) || ( github.event_name == 'push' && ( github.ref_name == 'master' || vars.TEST_ON_FORK == 'true' )))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
@@ -82,7 +82,7 @@ jobs:
       compilers: ${{ (contains(github.event.pull_request.labels.*.name, 'run-deep-tests') || contains(github.event.push.labels.*.name, 'run-deep-tests')) && 'cs,java,go,js,cpp,dfy,py' || '' }}
 
   test-coverage-analysis:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Don't include in run-deep-tests, because those tests run on
     # release builds instead of source packages.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-deep-tests') && !contains(github.event.push.labels.*.name, 'run-deep-tests')}}))
@@ -115,13 +115,13 @@ jobs:
       - name: Download integration test artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: integration-test-results-ubuntu-20.04-*
+          pattern: integration-test-results-ubuntu-22.04-*
           merge-multiple: true
 
       - name: Download unit test artifacts
         uses: actions/download-artifact@v4
         with:
-          name: unit-test-results-ubuntu-20.04
+          name: unit-test-results-ubuntu-22.04
 
       - name: Merge reports
         run: |

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -35,7 +35,7 @@ env:
 jobs:
 
   publish-release:
-    runs-on: macos-13   # Put back 'ubuntu-20.04' if macos-latest fails in any way
+    runs-on: macos-13   # Put back 'ubuntu-22.04' if macos-latest fails in any way
     steps:
     - name: Print version
       run: echo ${{ inputs.name }}
@@ -55,11 +55,11 @@ jobs:
       with:
         dotnet-version: ${{env.dotnet-version}}
     - name: C++ for ubuntu 20.04
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         sudo apt-get install -y build-essential
     - name: Choose the right C++ for ubuntu 20.04
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 60
     - name: Set up JDK 18

--- a/.github/workflows/release-downloads-nuget.yml
+++ b/.github/workflows/release-downloads-nuget.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
-        os: [ ubuntu-22.04, ubuntu-20.04, macos-13, windows-2019 ]
+        os: [ ubuntu-22.04, macos-13, windows-2019 ]
 
     steps:
     - name: OS
@@ -111,7 +111,7 @@ jobs:
         # but note we need to skip Dafny since nuget install doesn't work for dotnet tools.
         library-name: [ DafnyPipeline, DafnyServer, DafnyLanguageServer, DafnyRuntime, DafnyCore, DafnyDriver ]
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
-        os: [ ubuntu-latest, ubuntu-20.04, macos-13, windows-2019 ]
+        os: [ ubuntu-latest, ubuntu-22.04, macos-13, windows-2019 ]
 
     steps:
     # Verify that the dependencies of the libraries we publish (e.g. DafnyLanguageServer)

--- a/.github/workflows/release-downloads.yml
+++ b/.github/workflows/release-downloads.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         # This workflow breaks on windows-2022: https://github.com/dafny-lang/dafny/issues/1906
-        os: [ ubuntu-latest, ubuntu-20.04, macos-13, windows-2019 ]
+        os: [ ubuntu-latest, ubuntu-22.04, macos-13, windows-2019 ]
         include:
         - os:  'ubuntu-latest'
-          osn: 'ubuntu-20.04'
-        - os:  'ubuntu-20.04'
-          osn: 'ubuntu-20.04'
+          osn: 'ubuntu-22.04'
+        - os:  'ubuntu-22.04'
+          osn: 'ubuntu-22.04'
         - os:  'macos-13'
           osn: 'x64-macos-13'
         - os:  'windows-2019'

--- a/.github/workflows/xunit-tests-reusable.yml
+++ b/.github/workflows/xunit-tests-reusable.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-13]
+        os: [ubuntu-22.04, windows-2019, macos-13]
         iteration: ${{ fromJson(needs.populate-matrix-dimensions.outputs.iterations) }}
         include:
           - os: macos-13
@@ -58,8 +58,8 @@ jobs:
           - os: windows-2019
             suffix: win
             chmod: false
-          - os: ubuntu-20.04
-            suffix: ubuntu-20.04
+          - os: ubuntu-22.04
+            suffix: ubuntu-22.04
             chmod: true
     env:
       solutionPath: Source/Dafny.sln


### PR DESCRIPTION
ubuntu-20.04 will be [fully unsupported](https://github.com/actions/runner-images/issues/11101) soon.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
