### PR TITLE
Chore: Fix compliancy of language server with LSP

### DIFF
--- a/Source/DafnyLanguageServer/DafnyLanguageServer.cs
+++ b/Source/DafnyLanguageServer/DafnyLanguageServer.cs
@@ -105,8 +105,8 @@ namespace Microsoft.Dafny.LanguageServer {
 
     private static Task StartedAsync(ILanguageServer server, CancellationToken cancellationToken) {
       // TODO this currently only sent to get rid of the "Server answer pending" of the VSCode plugin.
-      server.SendNotification("serverStarted", DafnyVersion);
-      server.SendNotification("dafnyLanguageServerVersionReceived", DafnyVersion);
+      server.SendNotification("serverStarted", new[] { DafnyVersion });
+      server.SendNotification("dafnyLanguageServerVersionReceived", new[] { DafnyVersion });
       return Task.CompletedTask;
     }
   }

--- a/docs/dev/news/6172.fix
+++ b/docs/dev/news/6172.fix
@@ -1,0 +1,1 @@
+Made the language server compliant with the LSP protocol so that it can be used with other editors, such as Helix


### PR DESCRIPTION
Fixes https://github.com/dafny-lang/dafny/issues/6172. I ensured that two notification messages' parameters that are disregarded anyway in the VSCode extension use the proper LSP semantics of being wrapped with an array or being an object, so that the LSP is compatible with Helix for example. I tested locally that this change does not break the VSCode extension, not sure how to test it furthermore.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
