### PR TITLE
chore(ci): Lock down Rust 1.85.1 for now to fix nightly build on Windows

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -135,10 +135,10 @@ jobs:
 #        rm dafny/Test/libraries/lit.site.cfg # we remove the lit configuration file in the library repo (a git submodule) to prevent override
     - name: Use the default Rust linker (Non-Windows)
       if: runner.os != 'Windows'
-      run: rustup default stable
+      run: rustup default 1.85.1
     - name: Use specific Toolchain (Windows)
       if: runner.os == 'Windows'
-      run: rustup default stable-x86_64-pc-windows-gnu
+      run: rustup default 1.85.1-x86_64-pc-windows-gnu
     - name: Rust-related System information
       run: |
         echo "What is the Rust version?"


### PR DESCRIPTION
<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
[The last nightly build failed on windows](https://github.com/dafny-lang/dafny/actions/runs/14245722393/job/39937179775), and the main differences are a bump in the windows-2019 image version and the Rust platform version bumping from 1.85.1 to 1.86.0. Locking down to 1.85.1 to unblock development for now.

### How has this been tested?
`run-deep-tests`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
