### PR TITLE
feat: add schema types for let/let-or-fail and some patterns

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Applications/ActualBindings.cs
+++ b/Source/DafnyCore/AST/Expressions/Applications/ActualBindings.cs
@@ -32,7 +32,7 @@ public class ActualBindings : NodeWithoutOrigin {
 
   public bool WasResolved => arguments != null;
 
-  public List<Expression>? Arguments => arguments;
+  public List<Expression> Arguments => arguments!;
 
   public void AcceptArgumentExpressionsAsExactParameterList(List<Expression>? args = null) {
     Contract.Requires(!WasResolved); // this operation should be done at most once

--- a/Source/DafnyCore/AST/Expressions/Conditional/Patterns/ExtendedPattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/Patterns/ExtendedPattern.cs
@@ -81,12 +81,12 @@ public abstract class ExtendedPattern : NodeWithOrigin {
         Contract.Assert(false); throw new cce.UnreachableException();
       }
     } else if (type.AsDatatype is TupleTypeDecl tupleTypeDecl) {
-      var udt = type.NormalizeExpand() as UserDefinedType;
       if (!(this is IdPattern)) {
         resolver.reporter.Error(MessageSource.Resolver, this.Origin, "pattern doesn't correspond to a tuple");
         return;
       }
 
+      var udt = (UserDefinedType)type.NormalizeExpand();
       IdPattern idpat = (IdPattern)this;
       if (idpat.Arguments == null) {
         // simple variable

--- a/Source/DafnyCore/AST/Expressions/Conditional/Patterns/ExtendedPattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/Patterns/ExtendedPattern.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
@@ -14,9 +16,9 @@ ExtendedPattern is either:
 public abstract class ExtendedPattern : NodeWithOrigin {
   public bool IsGhost;
 
+  [SyntaxConstructor]
   public ExtendedPattern(IOrigin origin, bool isGhost = false) : base(origin) {
-    Contract.Requires(origin != null);
-    this.IsGhost = isGhost;
+    IsGhost = isGhost;
   }
 
   public IEnumerable<Node> DescendantsAndSelf =>
@@ -43,7 +45,7 @@ public abstract class ExtendedPattern : NodeWithOrigin {
   *  3 - An IdPattern at datatype type representing a constructor of type
   *  4 - An IdPattern at datatype type with no arguments representing a bound variable
   */
-  public void CheckLinearExtendedPattern(Type type, ResolutionContext resolutionContext, ModuleResolver resolver) {
+  public void CheckLinearExtendedPattern(Type? type, ResolutionContext resolutionContext, ModuleResolver resolver) {
     if (type == null) {
       return;
     }
@@ -126,19 +128,19 @@ public abstract class ExtendedPattern : NodeWithOrigin {
       if (ctors == null) {
         Contract.Assert(false); throw new cce.UnreachableException();  // Datatype not found
       }
-      DatatypeCtor ctor = null;
       // Check if the head of the pattern is a constructor or a variable
-      if (ctors.TryGetValue(idpat.Id, out ctor)) {
+      if (ctors.TryGetValue(idpat.Id, out var ctor)) {
+        Contract.Assert(ctor != null);
         /* =[3]= */
         idpat.Ctor = ctor;
-        if (ctor != null && idpat.Arguments == null && ctor.Formals.Count == 0) {
+        if (idpat.Arguments == null && ctor.Formals.Count == 0) {
           // nullary constructor without () -- so convert it to a constructor
           idpat.MakeAConstructor();
         }
         if (idpat.Arguments == null) {
           // pat is a variable
           return;
-        } else if (ctor.Formals != null && ctor.Formals.Count == idpat.Arguments.Count) {
+        } else if (ctor.Formals.Count == idpat.Arguments.Count) {
           if (ctor.Formals.Count == 0) {
             // if nullary constructor
             return;

--- a/Source/DafnyCore/AST/Expressions/Datatypes/DatatypeValue.cs
+++ b/Source/DafnyCore/AST/Expressions/Datatypes/DatatypeValue.cs
@@ -10,7 +10,7 @@ public class DatatypeValue : Expression, IHasReferences, ICloneable<DatatypeValu
   public string DatatypeName;
   public string MemberName;
   public ActualBindings Bindings;
-  public List<Expression>? Arguments => Bindings.Arguments;
+  public List<Expression> Arguments => Bindings.Arguments;
 
   public override IEnumerable<INode> Children => new Node[] { Bindings };
 

--- a/Source/DafnyCore/AST/Expressions/Datatypes/DatatypeValue.cs
+++ b/Source/DafnyCore/AST/Expressions/Datatypes/DatatypeValue.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -8,21 +10,18 @@ public class DatatypeValue : Expression, IHasReferences, ICloneable<DatatypeValu
   public string DatatypeName;
   public string MemberName;
   public ActualBindings Bindings;
-  public List<Expression> Arguments => Bindings.Arguments;
+  public List<Expression>? Arguments => Bindings.Arguments;
 
   public override IEnumerable<INode> Children => new Node[] { Bindings };
 
-  [FilledInDuringResolution] public DatatypeCtor Ctor;
+  [FilledInDuringResolution] public DatatypeCtor? Ctor;
   [FilledInDuringResolution] public List<Type> InferredTypeArgs = [];
   [FilledInDuringResolution] public List<PreType> InferredPreTypeArgs = [];
   [FilledInDuringResolution] public bool IsCoCall;
+
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(DatatypeName != null);
-    Contract.Invariant(MemberName != null);
-    Contract.Invariant(cce.NonNullElements(Arguments));
-    Contract.Invariant(cce.NonNullElements(InferredTypeArgs));
-    Contract.Invariant(Ctor == null || InferredTypeArgs.Count == Ctor.EnclosingDatatype.TypeArgs.Count);
+    Contract.Invariant(Ctor == null || InferredTypeArgs.Count == Ctor?.EnclosingDatatype?.TypeArgs.Count);
   }
 
   public DatatypeValue Clone(Cloner cloner) {
@@ -42,14 +41,15 @@ public class DatatypeValue : Expression, IHasReferences, ICloneable<DatatypeValu
   }
 
   public DatatypeValue(IOrigin origin, string datatypeName, string memberName, [Captured] List<ActualBinding> arguments)
+    : this(origin, datatypeName, memberName, new ActualBindings(arguments)) {
+  }
+
+  [SyntaxConstructor]
+  public DatatypeValue(IOrigin origin, string datatypeName, string memberName, ActualBindings bindings)
     : base(origin) {
-    Contract.Requires(cce.NonNullElements(arguments));
-    Contract.Requires(origin != null);
-    Contract.Requires(datatypeName != null);
-    Contract.Requires(memberName != null);
-    this.DatatypeName = datatypeName;
-    this.MemberName = memberName;
-    this.Bindings = new ActualBindings(arguments);
+    DatatypeName = datatypeName;
+    MemberName = memberName;
+    Bindings = bindings;
   }
 
   /// <summary>

--- a/Source/DafnyCore/AST/Expressions/Variables/CasePattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Variables/CasePattern.cs
@@ -25,7 +25,7 @@ public class CasePattern<VT> : NodeWithOrigin
   public VT? Var;  // finalized by resolution (null if the pattern is a constructor)  Invariant:  Var != null ==> Arguments == null
   public List<CasePattern<VT>>? Arguments;
 
-  [FilledInDuringResolution] public Expression? Expr;  // an r-value version of the CasePattern;
+  [FilledInDuringResolution] public Expression Expr = null!;  // an r-value version of the CasePattern;
 
   public void MakeAConstructor() {
     Arguments = [];

--- a/Source/DafnyCore/AST/Expressions/Variables/LetOrFailExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Variables/LetOrFailExpr.cs
@@ -1,14 +1,17 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.Dafny;
 
 public class LetOrFailExpr : ConcreteSyntaxExpression, ICloneable<LetOrFailExpr>, ICanFormat {
-  public CasePattern<BoundVar>/*?*/ Lhs; // null means void-error handling: ":- E; F", non-null means "var pat :- E; F"
+  public CasePattern<BoundVar>? Lhs; // null means void-error handling: ":- E; F", non-null means "var pat :- E; F"
   public Expression Rhs;
   public Expression Body;
 
-  public LetOrFailExpr(IOrigin origin, CasePattern<BoundVar>/*?*/ lhs, Expression rhs, Expression body) : base(origin) {
+  [SyntaxConstructor]
+  public LetOrFailExpr(IOrigin origin, CasePattern<BoundVar>? lhs, Expression rhs, Expression body) : base(origin) {
     Lhs = lhs;
     Rhs = rhs;
     Body = body;

--- a/Source/DafnyCore/AST/SyntaxDeserializer/Generated.cs
+++ b/Source/DafnyCore/AST/SyntaxDeserializer/Generated.cs
@@ -75,6 +75,46 @@ namespace Microsoft.Dafny
             return ReadUserDefinedType();
         }
 
+        public LetExpr ReadLetExpr()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadList<CasePattern<BoundVar>>(() => ReadCasePattern<BoundVar>());
+            var parameter2 = ReadList<Expression>(() => ReadAbstract<Expression>());
+            var parameter3 = ReadAbstract<Expression>();
+            var parameter4 = ReadBoolean();
+            var parameter5 = ReadAttributesOption();
+            return new LetExpr(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5);
+        }
+
+        public LetExpr ReadLetExprOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadLetExpr();
+        }
+
+        public Attributes ReadAttributes()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadString();
+            var parameter2 = ReadList<Expression>(() => ReadAbstract<Expression>());
+            var parameter3 = ReadAttributesOption();
+            return new Attributes(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public Attributes ReadAttributesOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAttributes();
+        }
+
         public IdentifierExpr ReadIdentifierExpr()
         {
             var parameter0 = ReadAbstract<IOrigin>();
@@ -211,6 +251,92 @@ namespace Microsoft.Dafny
             return ReadCharLiteralExpr();
         }
 
+        public DatatypeValue ReadDatatypeValue()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadString();
+            var parameter2 = ReadString();
+            var parameter3 = ReadActualBindings();
+            return new DatatypeValue(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public DatatypeValue ReadDatatypeValueOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadDatatypeValue();
+        }
+
+        public ModuleQualifiedId ReadModuleQualifiedId()
+        {
+            var parameter0 = ReadList<Name>(() => ReadName());
+            return new ModuleQualifiedId(parameter0);
+        }
+
+        public ModuleQualifiedId ReadModuleQualifiedIdOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadModuleQualifiedId();
+        }
+
+        public Name ReadName()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadString();
+            return new Name(parameter0, parameter1);
+        }
+
+        public Name ReadNameOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadName();
+        }
+
+        public ActualBinding ReadActualBinding()
+        {
+            var parameter0 = ReadAbstractOption<IOrigin>();
+            var parameter1 = ReadAbstract<Expression>();
+            var parameter2 = ReadBoolean();
+            return new ActualBinding(parameter0, parameter1, parameter2);
+        }
+
+        public ActualBinding ReadActualBindingOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadActualBinding();
+        }
+
+        public ActualBindings ReadActualBindings()
+        {
+            var parameter0 = ReadList<ActualBinding>(() => ReadActualBinding());
+            return new ActualBindings(parameter0);
+        }
+
+        public ActualBindings ReadActualBindingsOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadActualBindings();
+        }
+
         public TernaryExpr ReadTernaryExpr()
         {
             var parameter0 = ReadAbstract<IOrigin>();
@@ -255,6 +381,90 @@ namespace Microsoft.Dafny
             }
 
             return ReadITEExpr();
+        }
+
+        public LetOrFailExpr ReadLetOrFailExpr()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadCasePatternOption<BoundVar>();
+            var parameter2 = ReadAbstract<Expression>();
+            var parameter3 = ReadAbstract<Expression>();
+            return new LetOrFailExpr(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public LetOrFailExpr ReadLetOrFailExprOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadLetOrFailExpr();
+        }
+
+        public Formal ReadFormal()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadName();
+            var parameter2 = ReadAbstractOption<Type>();
+            var parameter4 = ReadBoolean();
+            var parameter3 = ReadBoolean();
+            var parameter5 = ReadAbstractOption<Expression>();
+            var parameter6 = ReadAttributesOption();
+            var parameter7 = ReadBoolean();
+            var parameter8 = ReadBoolean();
+            var parameter9 = ReadBoolean();
+            var parameter10 = ReadStringOption();
+            return new Formal(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5, parameter6, parameter7, parameter8, parameter9, parameter10);
+        }
+
+        public Formal ReadFormalOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadFormal();
+        }
+
+        public BoundVar ReadBoundVar()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadName();
+            var parameter2 = ReadAbstractOption<Type>();
+            var parameter3 = ReadBoolean();
+            return new BoundVar(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public BoundVar ReadBoundVarOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadBoundVar();
+        }
+
+        public QuantifiedVar ReadQuantifiedVar()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadName();
+            var parameter2 = ReadAbstractOption<Type>();
+            var parameter3 = ReadAbstractOption<Expression>();
+            var parameter4 = ReadAbstractOption<Expression>();
+            return new QuantifiedVar(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public QuantifiedVar ReadQuantifiedVarOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadQuantifiedVar();
         }
 
         public ParensExpression ReadParensExpression()
@@ -330,23 +540,6 @@ namespace Microsoft.Dafny
             return ReadExprDotName();
         }
 
-        public Name ReadName()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadString();
-            return new Name(parameter0, parameter1);
-        }
-
-        public Name ReadNameOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadName();
-        }
-
         public ApplySuffix ReadApplySuffix()
         {
             var parameter0 = ReadAbstract<IOrigin>();
@@ -367,75 +560,6 @@ namespace Microsoft.Dafny
             return ReadApplySuffix();
         }
 
-        public ModuleQualifiedId ReadModuleQualifiedId()
-        {
-            var parameter0 = ReadList<Name>(() => ReadName());
-            return new ModuleQualifiedId(parameter0);
-        }
-
-        public ModuleQualifiedId ReadModuleQualifiedIdOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadModuleQualifiedId();
-        }
-
-        public Attributes ReadAttributes()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadString();
-            var parameter2 = ReadList<Expression>(() => ReadAbstract<Expression>());
-            var parameter3 = ReadAttributesOption();
-            return new Attributes(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public Attributes ReadAttributesOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAttributes();
-        }
-
-        public ActualBinding ReadActualBinding()
-        {
-            var parameter0 = ReadAbstractOption<IOrigin>();
-            var parameter1 = ReadAbstract<Expression>();
-            var parameter2 = ReadBoolean();
-            return new ActualBinding(parameter0, parameter1, parameter2);
-        }
-
-        public ActualBinding ReadActualBindingOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadActualBinding();
-        }
-
-        public ActualBindings ReadActualBindings()
-        {
-            var parameter0 = ReadList<ActualBinding>(() => ReadActualBinding());
-            return new ActualBindings(parameter0);
-        }
-
-        public ActualBindings ReadActualBindingsOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadActualBindings();
-        }
-
         public NameSegment ReadNameSegment()
         {
             var parameter0 = ReadAbstract<IOrigin>();
@@ -452,71 +576,6 @@ namespace Microsoft.Dafny
             }
 
             return ReadNameSegment();
-        }
-
-        public Formal ReadFormal()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadName();
-            var parameter2 = ReadAbstractOption<Type>();
-            var parameter4 = ReadBoolean();
-            var parameter3 = ReadBoolean();
-            var parameter5 = ReadAbstractOption<Expression>();
-            var parameter6 = ReadAttributesOption();
-            var parameter7 = ReadBoolean();
-            var parameter8 = ReadBoolean();
-            var parameter9 = ReadBoolean();
-            var parameter10 = ReadStringOption();
-            return new Formal(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5, parameter6, parameter7, parameter8, parameter9, parameter10);
-        }
-
-        public Formal ReadFormalOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadFormal();
-        }
-
-        public BoundVar ReadBoundVar()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadName();
-            var parameter2 = ReadAbstractOption<Type>();
-            var parameter3 = ReadBoolean();
-            return new BoundVar(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public BoundVar ReadBoundVarOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadBoundVar();
-        }
-
-        public QuantifiedVar ReadQuantifiedVar()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadName();
-            var parameter2 = ReadAbstractOption<Type>();
-            var parameter3 = ReadAbstractOption<Expression>();
-            var parameter4 = ReadAbstractOption<Expression>();
-            return new QuantifiedVar(parameter0, parameter1, parameter2, parameter3, parameter4);
-        }
-
-        public QuantifiedVar ReadQuantifiedVarOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadQuantifiedVar();
         }
 
         public SetComprehension ReadSetComprehension()
@@ -1735,6 +1794,16 @@ namespace Microsoft.Dafny
                 return ReadUserDefinedType();
             }
 
+            if (actualType == typeof(LetExpr))
+            {
+                return ReadLetExpr();
+            }
+
+            if (actualType == typeof(Attributes))
+            {
+                return ReadAttributes();
+            }
+
             if (actualType == typeof(IdentifierExpr))
             {
                 return ReadIdentifierExpr();
@@ -1770,6 +1839,31 @@ namespace Microsoft.Dafny
                 return ReadCharLiteralExpr();
             }
 
+            if (actualType == typeof(DatatypeValue))
+            {
+                return ReadDatatypeValue();
+            }
+
+            if (actualType == typeof(ModuleQualifiedId))
+            {
+                return ReadModuleQualifiedId();
+            }
+
+            if (actualType == typeof(Name))
+            {
+                return ReadName();
+            }
+
+            if (actualType == typeof(ActualBinding))
+            {
+                return ReadActualBinding();
+            }
+
+            if (actualType == typeof(ActualBindings))
+            {
+                return ReadActualBindings();
+            }
+
             if (actualType == typeof(TernaryExpr))
             {
                 return ReadTernaryExpr();
@@ -1778,6 +1872,26 @@ namespace Microsoft.Dafny
             if (actualType == typeof(ITEExpr))
             {
                 return ReadITEExpr();
+            }
+
+            if (actualType == typeof(LetOrFailExpr))
+            {
+                return ReadLetOrFailExpr();
+            }
+
+            if (actualType == typeof(Formal))
+            {
+                return ReadFormal();
+            }
+
+            if (actualType == typeof(BoundVar))
+            {
+                return ReadBoundVar();
+            }
+
+            if (actualType == typeof(QuantifiedVar))
+            {
+                return ReadQuantifiedVar();
             }
 
             if (actualType == typeof(ParensExpression))
@@ -1800,54 +1914,14 @@ namespace Microsoft.Dafny
                 return ReadExprDotName();
             }
 
-            if (actualType == typeof(Name))
-            {
-                return ReadName();
-            }
-
             if (actualType == typeof(ApplySuffix))
             {
                 return ReadApplySuffix();
             }
 
-            if (actualType == typeof(ModuleQualifiedId))
-            {
-                return ReadModuleQualifiedId();
-            }
-
-            if (actualType == typeof(Attributes))
-            {
-                return ReadAttributes();
-            }
-
-            if (actualType == typeof(ActualBinding))
-            {
-                return ReadActualBinding();
-            }
-
-            if (actualType == typeof(ActualBindings))
-            {
-                return ReadActualBindings();
-            }
-
             if (actualType == typeof(NameSegment))
             {
                 return ReadNameSegment();
-            }
-
-            if (actualType == typeof(Formal))
-            {
-                return ReadFormal();
-            }
-
-            if (actualType == typeof(BoundVar))
-            {
-                return ReadBoundVar();
-            }
-
-            if (actualType == typeof(QuantifiedVar))
-            {
-                return ReadQuantifiedVar();
             }
 
             if (actualType == typeof(SetComprehension))

--- a/Source/DafnyCore/AST/SyntaxDeserializer/HandWritten.cs
+++ b/Source/DafnyCore/AST/SyntaxDeserializer/HandWritten.cs
@@ -38,6 +38,28 @@ public partial class SyntaxDeserializer(IDecoder decoder) {
     }
   }
 
+  private CasePattern<VT> ReadCasePattern<VT>() where VT : IVariable {
+    if (typeof(VT) == typeof(BoundVar)) {
+      var parameter0 = ReadAbstract<IOrigin>();
+      var parameter1 = ReadString();
+      var parameter2 = (VT)(object)ReadBoundVarOption();
+      var parameter3 = ReadListOption(() => ReadCasePattern<VT>());
+      return new CasePattern<VT>(parameter0, parameter1, parameter2, parameter3);
+    } else if (typeof(VT) == typeof(LocalVariable)) {
+      var parameter0 = ReadAbstract<IOrigin>();
+      var parameter1 = ReadString();
+      var parameter2 = (VT)(object)ReadLocalVariableOption();
+      var parameter3 = ReadListOption(() => ReadCasePattern<VT>());
+      return new CasePattern<VT>(parameter0, parameter1, parameter2, parameter3);
+    } else {
+      throw new Exception($"Unhandled CasePattern type: {typeof(VT)}");
+    }
+  }
+
+  private CasePattern<VT>? ReadCasePatternOption<VT>() where VT : IVariable {
+    return ReadIsNull() ? null : ReadCasePattern<VT>();
+  }
+
   private List<T>? ReadListOption<T>(Func<T> readElement) {
     var isNull = decoder.ReadIsNull();
     if (isNull) {

--- a/Source/DafnyCore/Rewriters/InductionHeuristic.cs
+++ b/Source/DafnyCore/Rewriters/InductionHeuristic.cs
@@ -112,10 +112,9 @@ public static class InductionHeuristic {
         default:
           Contract.Assert(false); throw new cce.UnreachableException();  // unexpected ternary expression
       }
-    } else if (expr is DatatypeValue) {
-      var e = (DatatypeValue)expr;
+    } else if (expr is DatatypeValue value) {
       var q = n != null && n.Type.IsDatatype ? exprIsProminent : subExprIsProminent;  // prominent status continues, if we're looking for a variable whose type is a datatype
-      return e.Arguments.Exists(exp => VarOccursInArgumentToRecursiveFunction(options, exp, n, q));
+      return value.Arguments.Exists(exp => VarOccursInArgumentToRecursiveFunction(options, exp, n, q));
     } else if (expr is UnaryExpr) {
       var e = (UnaryExpr)expr;
       // both Not and SeqLength preserve prominence

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatControlFlow.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatControlFlow.dfy
@@ -1,0 +1,54 @@
+// RUN: %tobinary %s > %t.assertFalse.dbin
+// RUN: %verify --input-format Binary --stdin < %t.assertFalse.dbin > %t
+// RUN: %diff "%s.expect" "%t"
+
+datatype Pair = Pair(a: int, b: int)
+
+datatype Flag = Ok | Err(err: int) {
+  function IsFailure(): bool {
+    this.Err?
+  }
+
+  function PropagateFailure(): int requires IsFailure() {
+    this.err
+  }
+}
+
+datatype Extractable = Good(good: int) | Bad(bad: int) {
+  function IsFailure(): bool {
+    this.Bad?
+  }
+
+  function PropagateFailure(): int requires IsFailure() {
+    this.bad
+  }
+
+  function Extract(): int
+    requires !IsFailure()
+  {
+    this.good
+  }
+}
+
+method LetExpressions() {
+  var l0 := {
+    var x := 1; x * 2
+  };
+  var l1 := {
+    var (x, y) := (2, 3); x + y
+  };
+  var l2 := {
+    var x, y := 4, 5; x + y
+  };
+  var l3 := {
+    var Pair(x, y) := Pair(6, 7); x + y
+  };
+}
+
+method LetOrFailExpressions() returns (out: int) {
+  var f0 := {
+    var x :- Bad(0); x
+  };
+  var y := (:- Err(1); 2);
+  return y + 3;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatControlFlow.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatControlFlow.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 4 verified, 0 errors

--- a/Source/Scripts/Syntax.cs-schema
+++ b/Source/Scripts/Syntax.cs-schema
@@ -264,6 +264,7 @@ class BoundVar : NonglobalVariable
 {
 }
 
+// [RedundantField("isGhost")]
 class QuantifiedVar : BoundVar
 {
     Expression? domain;

--- a/Source/Scripts/Syntax.cs-schema
+++ b/Source/Scripts/Syntax.cs-schema
@@ -63,6 +63,29 @@ abstract class Expression : NodeWithOrigin
 {
 }
 
+class LetExpr : Expression
+{
+    List<CasePattern<BoundVar>> lhss;
+    List<Expression> rhss;
+    Expression body;
+    Boolean exact;
+    Attributes? attributes;
+}
+
+class Attributes : NodeWithOrigin
+{
+    String name;
+    List<Expression> args;
+    Attributes? prev;
+}
+
+class CasePattern<VT> : NodeWithOrigin
+{
+    String id;
+    VT? var;
+    List<CasePattern<VT>>? arguments;
+}
+
 class IdentifierExpr : Expression
 {
     String name;
@@ -146,6 +169,46 @@ class CharLiteralExpr : LiteralExpr
 {
 }
 
+class DatatypeValue : Expression
+{
+    String datatypeName;
+    String memberName;
+    ActualBindings bindings;
+}
+
+abstract class NodeWithoutOrigin : Node
+{
+}
+
+class ModuleQualifiedId : NodeWithoutOrigin
+{
+    List<Name> path;
+}
+
+class Name : Node
+{
+    IOrigin origin;
+    String value;
+}
+
+class Specification<T> : NodeWithoutOrigin where T : Node
+{
+    List<T>? expressions;
+    Attributes? attributes;
+}
+
+class ActualBinding : NodeWithoutOrigin
+{
+    IOrigin? formalParameterName;
+    Expression actual;
+    Boolean isGhost;
+}
+
+class ActualBindings : NodeWithoutOrigin
+{
+    List<ActualBinding> argumentBindings;
+}
+
 class TernaryExpr : Expression
 {
     TernaryExprOpcode op;
@@ -170,6 +233,41 @@ class ITEExpr : Expression
 
 abstract class ConcreteSyntaxExpression : Expression
 {
+}
+
+class LetOrFailExpr : ConcreteSyntaxExpression
+{
+    CasePattern<BoundVar>? lhs;
+    Expression rhs;
+    Expression body;
+}
+
+abstract class NonglobalVariable : NodeWithOrigin
+{
+    Name nameNode;
+    Type? syntacticType;
+    Boolean isGhost;
+}
+
+class Formal : NonglobalVariable
+{
+    Boolean inParam;
+    Expression? defaultValue;
+    Attributes? attributes;
+    Boolean isOld;
+    Boolean isNameOnly;
+    Boolean isOlder;
+    String? nameForCompilation;
+}
+
+class BoundVar : NonglobalVariable
+{
+}
+
+class QuantifiedVar : BoundVar
+{
+    Expression? domain;
+    Expression? range;
 }
 
 class ParensExpression : ConcreteSyntaxExpression
@@ -201,51 +299,11 @@ class ExprDotName : SuffixExpr
     List<Type>? optTypeArguments;
 }
 
-class Name : Node
-{
-    IOrigin origin;
-    String value;
-}
-
 class ApplySuffix : SuffixExpr
 {
     IOrigin? atTok;
     ActualBindings bindings;
     Token? closeParen;
-}
-
-abstract class NodeWithoutOrigin : Node
-{
-}
-
-class ModuleQualifiedId : NodeWithoutOrigin
-{
-    List<Name> path;
-}
-
-class Specification<T> : NodeWithoutOrigin where T : Node
-{
-    List<T>? expressions;
-    Attributes? attributes;
-}
-
-class Attributes : NodeWithOrigin
-{
-    String name;
-    List<Expression> args;
-    Attributes? prev;
-}
-
-class ActualBinding : NodeWithoutOrigin
-{
-    IOrigin? formalParameterName;
-    Expression actual;
-    Boolean isGhost;
-}
-
-class ActualBindings : NodeWithoutOrigin
-{
-    List<ActualBinding> argumentBindings;
 }
 
 class NameSegment : ConcreteSyntaxExpression
@@ -260,34 +318,6 @@ abstract class ComprehensionExpr : Expression
     Expression? range;
     Expression term;
     Attributes? attributes;
-}
-
-abstract class NonglobalVariable : NodeWithOrigin
-{
-    Name nameNode;
-    Type? syntacticType;
-    Boolean isGhost;
-}
-
-class Formal : NonglobalVariable
-{
-    Boolean inParam;
-    Expression? defaultValue;
-    Attributes? attributes;
-    Boolean isOld;
-    Boolean isNameOnly;
-    Boolean isOlder;
-    String? nameForCompilation;
-}
-
-class BoundVar : NonglobalVariable
-{
-}
-
-class QuantifiedVar : BoundVar
-{
-    Expression? domain;
-    Expression? range;
 }
 
 class SetComprehension : ComprehensionExpr
@@ -791,4 +821,9 @@ enum ModuleKindEnum
     Concrete,
     Abstract,
     Replaceable
+}
+
+abstract class ExtendedPattern : NodeWithOrigin
+{
+    Boolean isGhost;
 }

--- a/Source/Scripts/SyntaxAstVisitor.cs
+++ b/Source/Scripts/SyntaxAstVisitor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Reflection;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Dafny;
 using Type = System.Type;
 
@@ -92,7 +93,7 @@ public abstract class SyntaxAstVisitor {
       var missingParameters = baseParseConstructor == null ? [] :
         baseParseConstructor.GetParameters().Select(p => p.Name)
           .Except(myParseConstructor.GetParameters().Select(p => p.Name))
-          .ExceptBy(GetNonSerializedNames(type).Select(name => name.ToLower()), str => str?.ToLower())
+          .ExceptBy(GetRedundantFieldNames(type).Select(name => name.ToLower()), str => str?.ToLower())
           .ToList();
       if (missingParameters.Any()) {
         throw new Exception($"in type {type}, missing parameters: {string.Join(",", missingParameters)}");
@@ -174,10 +175,9 @@ public abstract class SyntaxAstVisitor {
   /// Return all field/property names appearing in <see cref="RedundantField"/>
   /// attributes of the specified type (or its base types).
   /// </summary>
-  protected static IEnumerable<string> GetNonSerializedNames(Type type) {
+  protected static IEnumerable<string> GetRedundantFieldNames(Type type) {
     return type.GetCustomAttributes<RedundantField>()
-      .Select(attr => attr.Name)
-      .ToFrozenSet();
+      .Select(attr => attr.Name);
   }
 
   private static (string typeName, string typeArgs) MakeGenericTypeStringParts(

--- a/Source/Scripts/SyntaxDeserializerGenerator.cs
+++ b/Source/Scripts/SyntaxDeserializerGenerator.cs
@@ -102,7 +102,7 @@ using BinaryExprOpcode = Microsoft.Dafny.BinaryExpr.Opcode;
     if (baseType != null && baseType != typeof(ValueType) && baseType != typeof(object)) {
       foreach (var (baseParamName, baseSchemaIndex) in ParameterToSchemaPositions[baseType]) {
         var thisHasParam = schemaToConstructorPosition.ContainsKey(baseSchemaIndex);
-        var fieldIgnored = GetNonSerializedNames(type).Contains(baseParamName);
+        var fieldIgnored = GetRedundantFieldNames(type).Contains(baseParamName);
         if (thisHasParam && fieldIgnored) {
           throw new Exception($"Constructor for type {type.Name} has an unneeded parameter for field/property {baseParamName} which is a {nameof(RedundantField)}");
         }

--- a/Source/Scripts/SyntaxSchemaGenerator.cs
+++ b/Source/Scripts/SyntaxSchemaGenerator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.CommandLine;
+using System.Diagnostics;
 using System.Numerics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -137,6 +138,25 @@ public class SyntaxSchemaGenerator : SyntaxAstVisitor {
       classDeclaration = classDeclaration.WithBaseList(BaseList(SeparatedList(baseList)));
     }
 
+    // note: It would be nice to use proper attributes instead of comments,
+    // but then in order to test-compile the generated schema file,
+    // we'd have to either include or reference the attribute definition, and that gets messy
+    var redundantFieldComments = GetRedundantFieldNames(type).Select(originalMemberName => {
+      // Each schema class field is named according to the corresponding syntax constructor parameter,
+      // but a RedundantField stores the name of the field/property, and these typically differ in case.
+      // Instead of copying each RedundantField attribute verbatim from the original class to the schema class,
+      // we replace each argument with the field name it will have in the generated schema type,
+      // so that schema consumers don't need to consider case mismatches.
+      var originalMember = type.GetMember(originalMemberName).Single(member => member is FieldInfo or PropertyInfo);
+      var declaringTypeCtor = GetParseConstructor(originalMember.DeclaringType!);
+      Debug.Assert(declaringTypeCtor != null);
+      var schemaFieldName = declaringTypeCtor.GetParameters()
+        .Select(param => param.Name)
+        .Single(paramName => originalMemberName.Equals(paramName, StringComparison.InvariantCultureIgnoreCase))!;
+      return Comment($"""// [RedundantField("{schemaFieldName}")]""");
+    });
+    classDeclaration = classDeclaration.WithLeadingTrivia(redundantFieldComments);
+
     classDeclaration = classDeclaration.AddMembers(newFields.ToArray());
     compilationUnit = compilationUnit.AddMembers(classDeclaration);
     generatedTypes.Add(type);
@@ -217,9 +237,10 @@ public class SyntaxSchemaGenerator : SyntaxAstVisitor {
     namespaceDeclaration = namespaceDeclaration.WithMembers(compilationUnit.Members);
     compilationUnit = CompilationUnit().AddMembers(namespaceDeclaration);
     compilationUnit = compilationUnit.AddUsings(
-      UsingDirective(ParseName("System"))).AddUsings(
-      UsingDirective(ParseName("System.Collections.Generic"))).AddUsings(
-      UsingDirective(ParseName("System.Numerics")));
+      UsingDirective(ParseName("System")),
+      UsingDirective(ParseName("System.Collections.Generic")),
+      UsingDirective(ParseName("System.Numerics"))
+    );
 
     // Create a list of basic references that most code will need
     var references = new List<string>
@@ -229,7 +250,6 @@ public class SyntaxSchemaGenerator : SyntaxAstVisitor {
       typeof(System.Runtime.AssemblyTargetedPatchBandAttribute).Assembly.Location,
       typeof(List<>).Assembly.Location,
       typeof(BigInteger).Assembly.Location,
-      typeof(ValueType).Assembly.Location
     }.Distinct().ToList();
     var syntaxTree = CSharpSyntaxTree.Create(compilationUnit);
     var compilation = CSharpCompilation.Create(


### PR DESCRIPTION
### What was changed?

- Add syntax schema types for `LetExpr`, `LetOrFailExpr`, `CasePattern`, `ExtendedPattern`, and `DatatypeValue`
- Denote `RedundantField`s in the generated syntax schema, so that consumers can avoid the need to provide bogus data
    - Note: The representation of redundant fields is likely to change

### How has this been tested?

- Added an integration test for the new syntax schema types
- Manually verified that the new types and `RedundantField` appear as expected in the re-generated syntax schema

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
