### PR TITLE
feat: add schema types for match/case, more patterns, print

### DIFF
--- a/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchCase.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchCase.cs
@@ -1,14 +1,13 @@
-using System.Diagnostics.Contracts;
+#nullable enable
 
 namespace Microsoft.Dafny;
 
 public abstract class NestedMatchCase : NodeWithOrigin {
   public ExtendedPattern Pat;
 
+  [SyntaxConstructor]
   protected NestedMatchCase(IOrigin origin, ExtendedPattern pat) : base(origin) {
-    Contract.Requires(origin != null);
-    Contract.Requires(pat != null);
-    this.Pat = pat;
+    Pat = pat;
   }
 
   public void CheckLinearNestedMatchCase(Type type, ResolutionContext resolutionContext, ModuleResolver resolver) {

--- a/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchCaseExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchCaseExpr.cs
@@ -1,6 +1,6 @@
-using System;
+#nullable enable
+
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 
@@ -8,19 +8,20 @@ namespace Microsoft.Dafny;
 
 public class NestedMatchCaseExpr : NestedMatchCase, IAttributeBearingDeclaration {
   public Expression Body;
-  public Attributes Attributes { get; set; }
+  public Attributes? Attributes { get; set; }
 
   string IAttributeBearingDeclaration.WhatKind => "match expression case";
 
-  public NestedMatchCaseExpr(IOrigin origin, ExtendedPattern pat, Expression body, Attributes attrs) : base(origin, pat) {
-    Contract.Requires(body != null);
-    this.Body = body;
-    this.Attributes = attrs;
+  [SyntaxConstructor]
+  public NestedMatchCaseExpr(IOrigin origin, ExtendedPattern pat, Expression body, Attributes? attributes = null)
+    : base(origin, pat) {
+    Body = body;
+    Attributes = attributes;
   }
 
   public override IEnumerable<INode> Children =>
     Attributes.AsEnumerable().
-      Concat<Node>(new Node[] { Body, Pat });
+      Concat(new Node[] { Body, Pat });
 
   public override IEnumerable<INode> PreResolveChildren => Children;
 

--- a/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchCaseStmt.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchCaseStmt.cs
@@ -1,28 +1,25 @@
-using System;
+#nullable enable
+
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Microsoft.Dafny;
 
 public class NestedMatchCaseStmt : NestedMatchCase, IAttributeBearingDeclaration, ICloneable<NestedMatchCaseStmt> {
   public List<Statement> Body;
-  public Attributes Attributes { get; set; }
+  public Attributes? Attributes { get; set; }
   string IAttributeBearingDeclaration.WhatKind => "match statement case";
-  public NestedMatchCaseStmt(IOrigin rangeOrigin, ExtendedPattern pat, List<Statement> body) : base(rangeOrigin, pat) {
-    Contract.Requires(body != null);
-    this.Body = body;
-    this.Attributes = null;
-  }
-  public NestedMatchCaseStmt(IOrigin origin, ExtendedPattern pat, List<Statement> body, Attributes attrs) : base(origin, pat) {
-    Contract.Requires(body != null);
-    this.Body = body;
-    this.Attributes = attrs;
+
+  [SyntaxConstructor]
+  public NestedMatchCaseStmt(IOrigin origin, ExtendedPattern pat, List<Statement> body, Attributes? attributes = null)
+    : base(origin, pat) {
+    Body = body;
+    Attributes = attributes;
   }
 
   private NestedMatchCaseStmt(Cloner cloner, NestedMatchCaseStmt original) : base(original.Origin, original.Pat) {
-    this.Body = original.Body.Select(stmt => cloner.CloneStmt(stmt, false)).ToList();
-    this.Attributes = cloner.CloneAttributes(original.Attributes);
+    Body = original.Body.Select(stmt => cloner.CloneStmt(stmt, false)).ToList();
+    Attributes = cloner.CloneAttributes(original.Attributes);
   }
 
   public NestedMatchCaseStmt Clone(Cloner cloner) {

--- a/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchExpr.cs
@@ -1,6 +1,6 @@
-using System;
+#nullable enable
+
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Microsoft.Dafny;
@@ -19,28 +19,28 @@ public class NestedMatchExpr : Expression, ICloneable<NestedMatchExpr>, ICanForm
   IReadOnlyList<NestedMatchCase> INestedMatch.Cases => Cases;
 
   public bool UsesOptionalBraces;
-  public Attributes Attributes;
+  public Attributes? Attributes;
 
-  [FilledInDuringResolution]
-  public Expression Flattened { get; set; }
+  [FilledInDuringResolution] public Expression Flattened { get; set; } = null!;
 
   public NestedMatchExpr(Cloner cloner, NestedMatchExpr original) : base(cloner, original) {
-    this.Source = cloner.CloneExpr(original.Source);
-    this.Cases = original.Cases.Select(cloner.CloneNestedMatchCaseExpr).ToList();
-    this.UsesOptionalBraces = original.UsesOptionalBraces;
+    Source = cloner.CloneExpr(original.Source);
+    Cases = original.Cases.Select(cloner.CloneNestedMatchCaseExpr).ToList();
+    UsesOptionalBraces = original.UsesOptionalBraces;
 
     if (cloner.CloneResolvedFields) {
       Flattened = cloner.CloneExpr(original.Flattened);
     }
   }
 
-  public NestedMatchExpr(IOrigin origin, Expression source, [Captured] List<NestedMatchCaseExpr> cases, bool usesOptionalBraces, Attributes attrs = null) : base(origin) {
-    Contract.Requires(source != null);
-    Contract.Requires(cce.NonNullElements(cases));
-    this.Source = source;
-    this.Cases = cases;
-    this.UsesOptionalBraces = usesOptionalBraces;
-    this.Attributes = attrs;
+  [SyntaxConstructor]
+  public NestedMatchExpr(IOrigin origin, Expression source, [Captured] List<NestedMatchCaseExpr> cases,
+    bool usesOptionalBraces, Attributes? attributes = null)
+    : base(origin) {
+    Source = source;
+    Cases = cases;
+    UsesOptionalBraces = usesOptionalBraces;
+    Attributes = attributes;
   }
 
   public override IEnumerable<Expression> SubExpressions {

--- a/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchStmt.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/NestedMatchStmt.cs
@@ -1,6 +1,6 @@
-using System;
+#nullable enable
+
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace Microsoft.Dafny;
@@ -14,12 +14,12 @@ public class NestedMatchStmt : Statement, ICloneable<NestedMatchStmt>, ICanForma
 
   public bool UsesOptionalBraces;
 
-  [FilledInDuringResolution] public Statement Flattened { get; set; }
+  [FilledInDuringResolution] public Statement Flattened { get; set; } = null!;
 
   private void InitializeAttributes() {
     // Default case for match is false
     bool splitMatch = Attributes.Contains(Attributes, "split");
-    Attributes.ContainsBool(Attributes, "split", ref splitMatch);
+    _ = Attributes.ContainsBool(Attributes, "split", ref splitMatch);
     foreach (var c in Cases) {
       if (!Attributes.Contains(c.Attributes, "split")) {
         List<Expression> args = [
@@ -73,10 +73,9 @@ public class NestedMatchStmt : Statement, ICloneable<NestedMatchStmt>, ICanForma
     }
   }
 
-  public NestedMatchStmt(IOrigin origin, Expression source, [Captured] List<NestedMatchCaseStmt> cases, bool usesOptionalBraces, Attributes attributes = null)
+  [SyntaxConstructor]
+  public NestedMatchStmt(IOrigin origin, Expression source, [Captured] List<NestedMatchCaseStmt> cases, bool usesOptionalBraces, Attributes? attributes = null)
     : base(origin, attributes) {
-    Contract.Requires(source != null);
-    Contract.Requires(cce.NonNullElements(cases));
     Source = source;
     Cases = cases;
     UsesOptionalBraces = usesOptionalBraces;
@@ -143,7 +142,7 @@ public class NestedMatchStmt : Statement, ICloneable<NestedMatchStmt>, ICanForma
   }
 
   public override void ResolveGhostness(ModuleResolver resolver, ErrorReporter reporter, bool mustBeErasable,
-    ICodeContext codeContext, string proofContext,
+    ICodeContext codeContext, string? proofContext,
     bool allowAssumptionVariables, bool inConstructorInitializationPhase) {
     var hasGhostPattern = Cases.
       SelectMany(caze => caze.Pat.DescendantsAndSelf)

--- a/Source/DafnyCore/AST/Expressions/Conditional/Patterns/DisjunctivePattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/Patterns/DisjunctivePattern.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -6,9 +8,11 @@ namespace Microsoft.Dafny;
 
 public class DisjunctivePattern : ExtendedPattern {
   public List<ExtendedPattern> Alternatives;
+
+  [SyntaxConstructor]
   public DisjunctivePattern(IOrigin origin, List<ExtendedPattern> alternatives, bool isGhost = false) : base(origin, isGhost) {
-    Contract.Requires(alternatives != null && alternatives.Count > 0);
-    this.Alternatives = alternatives;
+    Contract.Requires(alternatives.Count > 0);
+    Alternatives = alternatives;
   }
 
   public override IEnumerable<INode> Children => Alternatives;

--- a/Source/DafnyCore/AST/Expressions/Conditional/Patterns/IdPattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/Patterns/IdPattern.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
@@ -8,15 +10,20 @@ namespace Microsoft.Dafny;
 public class IdPattern : ExtendedPattern, IHasReferences {
   public bool HasParenthesis { get; }
   public String Id;
-  public PreType PreType;
-  public Type Type; // This is the syntactic type, ExtendedPatterns disappear during resolution.
 
-  public IVariable BoundVar { get; set; } // Only set if there are no arguments
+  public Type? SyntacticType { get; }
 
-  public List<ExtendedPattern> Arguments; // null if just an identifier; possibly empty argument list if a constructor call
-  public LiteralExpr ResolvedLit; // null if just an identifier
+  private Type? type;
+  public Type Type => type ??= SyntacticType ?? new InferredTypeProxy();
+
+  public IVariable? BoundVar { get; set; } // Only set if there are no arguments
+
+  public List<ExtendedPattern>? Arguments; // null if just an identifier; possibly empty argument list if a constructor call
+
+  public LiteralExpr? ResolvedLit; // null if just an identifier
+
   [FilledInDuringResolution]
-  public DatatypeCtor Ctor;
+  public DatatypeCtor? Ctor;
 
   public bool IsWildcardPattern =>
     Arguments == null && Id.StartsWith(WildcardString);
@@ -34,35 +41,36 @@ public class IdPattern : ExtendedPattern, IHasReferences {
     Id = original.Id;
     Arguments = original.Arguments?.Select(cloner.CloneExtendedPattern).ToList();
     HasParenthesis = original.HasParenthesis;
-    Type = cloner.CloneType(original.Type);
+    SyntacticType = original.SyntacticType;
     if (cloner.CloneResolvedFields) {
+      type = cloner.CloneType(original.type);
       BoundVar = cloner.CloneIVariable(original.BoundVar, false);
     }
   }
 
-  public IdPattern(IOrigin origin, String id, List<ExtendedPattern> arguments, bool isGhost = false, bool hasParenthesis = false) : base(origin, isGhost) {
-    Contract.Requires(id != null);
-    Contract.Requires(arguments != null); // Arguments can be empty, but shouldn't be null
+  public IdPattern(IOrigin origin, String id, List<ExtendedPattern>? arguments,
+    bool isGhost = false, bool hasParenthesis = false)
+    : this(origin, id, null, arguments, isGhost, hasParenthesis) {
+    Id = id;
+    Arguments = arguments;
     HasParenthesis = hasParenthesis;
-    this.Id = id;
-    this.Type = new InferredTypeProxy();
-    this.Arguments = arguments;
   }
 
-  public IdPattern(IOrigin origin, String id, Type type, List<ExtendedPattern> arguments, bool isGhost = false) : base(origin, isGhost) {
-    Contract.Requires(id != null);
-    Contract.Requires(arguments != null); // Arguments can be empty, but shouldn't be null
-    this.Id = id;
-    this.Type = type ?? new InferredTypeProxy();
-    this.Arguments = arguments;
-    this.IsGhost = isGhost;
+  [SyntaxConstructor]
+  public IdPattern(IOrigin origin, String id, Type? syntacticType, List<ExtendedPattern>? arguments,
+    bool isGhost = false, bool hasParenthesis = false)
+    : base(origin, isGhost) {
+    Id = id;
+    SyntacticType = syntacticType;
+    Arguments = arguments;
+    HasParenthesis = hasParenthesis;
   }
 
   public override string ToString() {
     if (Arguments == null || Arguments.Count == 0) {
       return Id;
     } else {
-      List<string> cps = Arguments.ConvertAll<string>(x => x.ToString());
+      List<string> cps = Arguments.ConvertAll<string>(x => x.ToString()!);
       return string.Format("{0}({1})", Id, String.Join(", ", cps));
     }
   }
@@ -158,7 +166,7 @@ public class IdPattern : ExtendedPattern, IHasReferences {
         // finds in full scope, not just current scope
         if (e.Resolved is MemberSelectExpr mse) {
           if (mse.Member.IsStatic && mse.Member is ConstantField cf) {
-            Expression c = cf.Rhs;
+            Expression? c = cf.Rhs;
             if (c is LiteralExpr lit) {
               this.ResolvedLit = lit;
               if (type.Equals(e.ResolvedExpression.Type)) {

--- a/Source/DafnyCore/AST/Expressions/Conditional/Patterns/LitPattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/Patterns/LitPattern.cs
@@ -1,13 +1,14 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Numerics;
 
 namespace Microsoft.Dafny;
 
 public class LitPattern : ExtendedPattern {
   public Expression OrigLit;  // the expression as parsed; typically a LiteralExpr, but could be a NegationExpression
-  private LiteralExpr optimisticallyDesugaredLit;
+  private LiteralExpr? optimisticallyDesugaredLit;
 
   /// <summary>
   /// The patterns of match constructs are rewritten very early during resolution, before any type information
@@ -41,7 +42,7 @@ public class LitPattern : ExtendedPattern {
           if (lit.Value is BaseTypes.BigDec d) {
             optimisticallyDesugaredLit = new LiteralExpr(neg.Origin, -d);
           } else {
-            var n = (BigInteger)lit.Value;
+            var n = (BigInteger)lit.Value!;
             var tok = new Token(neg.Origin.line, neg.Origin.col) {
               Uri = neg.Origin.Uri,
               val = "-0"
@@ -56,9 +57,10 @@ public class LitPattern : ExtendedPattern {
     }
   }
 
-  public LitPattern(IOrigin origin, Expression lit, bool isGhost = false) : base(origin, isGhost) {
-    Contract.Requires(lit is LiteralExpr || lit is NegationExpression);
-    this.OrigLit = lit;
+  [SyntaxConstructor]
+  public LitPattern(IOrigin origin, Expression origLit, bool isGhost = false) : base(origin, isGhost) {
+    Contract.Requires(origLit is LiteralExpr || origLit is NegationExpression);
+    OrigLit = origLit;
   }
 
   public override string ToString() {

--- a/Source/DafnyCore/AST/Expressions/LiteralExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/LiteralExpr.cs
@@ -1,9 +1,7 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Numerics;
-using Microsoft.BaseTypes;
 
 
 namespace Microsoft.Dafny;
@@ -148,9 +146,17 @@ public class CharLiteralExpr : LiteralExpr, ICloneable<CharLiteralExpr> {
 
 public class StringLiteralExpr : LiteralExpr, ICloneable<StringLiteralExpr> {
   public bool IsVerbatim;
+
+  /// <summary>
+  /// Because the base field type is object, we need an object constructor here as well
+  /// </summary>
+  [SyntaxConstructor]
+  public StringLiteralExpr(IOrigin origin, object value, bool isVerbatim)
+    : this(origin, (string)value, isVerbatim) {
+  }
+
   public StringLiteralExpr(IOrigin origin, string value, bool isVerbatim)
     : base(origin, value) {
-    Contract.Requires(value != null);
     IsVerbatim = isVerbatim;
   }
 

--- a/Source/DafnyCore/AST/Statements/Methods/PrintStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Methods/PrintStmt.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Diagnostics.Contracts;
@@ -20,11 +22,6 @@ public class PrintStmt : Statement, ICloneable<PrintStmt>, ICanFormat {
     OptionRegistry.RegisterGlobalOption(TrackPrintEffectsOption, OptionCompatibility.CheckOptionLocalImpliesLibrary);
   }
 
-  [ContractInvariantMethod]
-  void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Args));
-  }
-
   public PrintStmt Clone(Cloner cloner) {
     return new PrintStmt(cloner, this);
   }
@@ -33,11 +30,9 @@ public class PrintStmt : Statement, ICloneable<PrintStmt>, ICanFormat {
     Args = original.Args.Select(cloner.CloneExpr).ToList();
   }
 
-  public PrintStmt(IOrigin origin, List<Expression> args)
-    : base(origin) {
-    Contract.Requires(origin != null);
-    Contract.Requires(cce.NonNullElements(args));
-
+  [SyntaxConstructor]
+  public PrintStmt(IOrigin origin, List<Expression> args, Attributes? attributes = null)
+    : base(origin, attributes) {
     Args = args;
   }
   public override IEnumerable<Expression> NonSpecificationSubExpressions {
@@ -55,7 +50,7 @@ public class PrintStmt : Statement, ICloneable<PrintStmt>, ICanFormat {
 
   public override void ResolveGhostness(ModuleResolver resolver, ErrorReporter reporter, bool mustBeErasable,
     ICodeContext codeContext,
-    string proofContext, bool allowAssumptionVariables, bool inConstructorInitializationPhase) {
+    string? proofContext, bool allowAssumptionVariables, bool inConstructorInitializationPhase) {
     if (mustBeErasable) {
       reporter.Error(MessageSource.Resolver, ResolutionErrors.ErrorId.r_print_statement_is_not_ghost, this,
         "print statement is not allowed in this context (because this is a ghost method or because the statement is guarded by a specification-only expression)");

--- a/Source/DafnyCore/AST/SyntaxDeserializer/Generated.cs
+++ b/Source/DafnyCore/AST/SyntaxDeserializer/Generated.cs
@@ -234,6 +234,24 @@ namespace Microsoft.Dafny
             return ReadLiteralExpr();
         }
 
+        public StringLiteralExpr ReadStringLiteralExpr()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadAbstract<Object>();
+            var parameter2 = ReadBoolean();
+            return new StringLiteralExpr(parameter0, parameter1, parameter2);
+        }
+
+        public StringLiteralExpr ReadStringLiteralExprOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadStringLiteralExpr();
+        }
+
         public CharLiteralExpr ReadCharLiteralExpr()
         {
             var parameter0 = ReadAbstract<IOrigin>();
@@ -361,6 +379,501 @@ namespace Microsoft.Dafny
         {
             int ordinal = ReadInt32();
             return (TernaryExpr.Opcode)ordinal;
+        }
+
+        public NestedMatchExpr ReadNestedMatchExpr()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadAbstract<Expression>();
+            var parameter2 = ReadList<NestedMatchCaseExpr>(() => ReadNestedMatchCaseExpr());
+            var parameter3 = ReadBoolean();
+            var parameter4 = ReadAttributesOption();
+            return new NestedMatchExpr(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public NestedMatchExpr ReadNestedMatchExprOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadNestedMatchExpr();
+        }
+
+        public LitPattern ReadLitPattern()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter2 = ReadBoolean();
+            var parameter1 = ReadAbstract<Expression>();
+            return new LitPattern(parameter0, parameter1, parameter2);
+        }
+
+        public LitPattern ReadLitPatternOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadLitPattern();
+        }
+
+        public IdPattern ReadIdPattern()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter4 = ReadBoolean();
+            var parameter1 = ReadString();
+            var parameter2 = ReadAbstractOption<Type>();
+            var parameter3 = ReadListOption<ExtendedPattern>(() => ReadAbstract<ExtendedPattern>());
+            var parameter5 = ReadBoolean();
+            return new IdPattern(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5);
+        }
+
+        public IdPattern ReadIdPatternOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadIdPattern();
+        }
+
+        public DisjunctivePattern ReadDisjunctivePattern()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter2 = ReadBoolean();
+            var parameter1 = ReadList<ExtendedPattern>(() => ReadAbstract<ExtendedPattern>());
+            return new DisjunctivePattern(parameter0, parameter1, parameter2);
+        }
+
+        public DisjunctivePattern ReadDisjunctivePatternOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadDisjunctivePattern();
+        }
+
+        public NestedMatchCaseStmt ReadNestedMatchCaseStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadAbstract<ExtendedPattern>();
+            var parameter2 = ReadList<Statement>(() => ReadAbstract<Statement>());
+            var parameter3 = ReadAttributesOption();
+            return new NestedMatchCaseStmt(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public NestedMatchCaseStmt ReadNestedMatchCaseStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadNestedMatchCaseStmt();
+        }
+
+        public ExpectStmt ReadExpectStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter3 = ReadAttributesOption();
+            var parameter1 = ReadAbstract<Expression>();
+            var parameter2 = ReadAbstractOption<Expression>();
+            return new ExpectStmt(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public ExpectStmt ReadExpectStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadExpectStmt();
+        }
+
+        public AssertStmt ReadAssertStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter3 = ReadAttributesOption();
+            var parameter1 = ReadAbstract<Expression>();
+            var parameter2 = ReadAssertLabelOption();
+            return new AssertStmt(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public AssertStmt ReadAssertStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAssertStmt();
+        }
+
+        public Label ReadLabel()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadString();
+            return new Label(parameter0, parameter1);
+        }
+
+        public Label ReadLabelOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadLabel();
+        }
+
+        public AssertLabel ReadAssertLabel()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadString();
+            return new AssertLabel(parameter0, parameter1);
+        }
+
+        public AssertLabel ReadAssertLabelOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAssertLabel();
+        }
+
+        public AllocateClass ReadAllocateClass()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter3 = ReadAttributesOption();
+            var parameter1 = ReadAbstract<Type>();
+            var parameter2 = ReadActualBindingsOption();
+            return new AllocateClass(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public AllocateClass ReadAllocateClassOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAllocateClass();
+        }
+
+        public AllocateArray ReadAllocateArray()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter4 = ReadAttributesOption();
+            var parameter1 = ReadAbstractOption<Type>();
+            var parameter2 = ReadList<Expression>(() => ReadAbstract<Expression>());
+            var parameter3 = ReadAbstractOption<Expression>();
+            return new AllocateArray(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public AllocateArray ReadAllocateArrayOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAllocateArray();
+        }
+
+        public ExprRhs ReadExprRhs()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter2 = ReadAttributesOption();
+            var parameter1 = ReadAbstract<Expression>();
+            return new ExprRhs(parameter0, parameter1, parameter2);
+        }
+
+        public ExprRhs ReadExprRhsOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadExprRhs();
+        }
+
+        public ReturnStmt ReadReturnStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter2 = ReadAttributesOption();
+            var parameter1 = ReadListOption<AssignmentRhs>(() => ReadAbstract<AssignmentRhs>());
+            return new ReturnStmt(parameter0, parameter1, parameter2);
+        }
+
+        public ReturnStmt ReadReturnStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadReturnStmt();
+        }
+
+        public PrintStmt ReadPrintStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter2 = ReadAttributesOption();
+            var parameter1 = ReadList<Expression>(() => ReadAbstract<Expression>());
+            return new PrintStmt(parameter0, parameter1, parameter2);
+        }
+
+        public PrintStmt ReadPrintStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadPrintStmt();
+        }
+
+        public FrameExpression ReadFrameExpression()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadAbstract<Expression>();
+            var parameter2 = ReadStringOption();
+            return new FrameExpression(parameter0, parameter1, parameter2);
+        }
+
+        public FrameExpression ReadFrameExpressionOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadFrameExpression();
+        }
+
+        public AttributedExpression ReadAttributedExpression()
+        {
+            var parameter0 = ReadAbstract<Expression>();
+            var parameter1 = ReadAssertLabelOption();
+            var parameter2 = ReadAttributesOption();
+            return new AttributedExpression(parameter0, parameter1, parameter2);
+        }
+
+        public AttributedExpression ReadAttributedExpressionOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAttributedExpression();
+        }
+
+        public DividedBlockStmt ReadDividedBlockStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter4 = ReadAttributesOption();
+            var parameter1 = ReadList<Statement>(() => ReadAbstract<Statement>());
+            var parameter2 = ReadAbstractOption<IOrigin>();
+            var parameter3 = ReadList<Statement>(() => ReadAbstract<Statement>());
+            return new DividedBlockStmt(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public DividedBlockStmt ReadDividedBlockStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadDividedBlockStmt();
+        }
+
+        public BlockStmt ReadBlockStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter2 = ReadAttributesOption();
+            var parameter1 = ReadList<Statement>(() => ReadAbstract<Statement>());
+            return new BlockStmt(parameter0, parameter1, parameter2);
+        }
+
+        public BlockStmt ReadBlockStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadBlockStmt();
+        }
+
+        public WhileStmt ReadWhileStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter6 = ReadAttributesOption();
+            var parameter2 = ReadList<AttributedExpression>(() => ReadAttributedExpression());
+            var parameter3 = ReadSpecification<Expression>();
+            var parameter4 = ReadSpecification<FrameExpression>();
+            var parameter5 = ReadBlockStmt();
+            var parameter1 = ReadAbstract<Expression>();
+            return new WhileStmt(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5, parameter6);
+        }
+
+        public WhileStmt ReadWhileStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadWhileStmt();
+        }
+
+        public IfStmt ReadIfStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter5 = ReadAttributesOption();
+            var parameter1 = ReadBoolean();
+            var parameter2 = ReadAbstractOption<Expression>();
+            var parameter3 = ReadBlockStmt();
+            var parameter4 = ReadAbstractOption<Statement>();
+            return new IfStmt(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5);
+        }
+
+        public IfStmt ReadIfStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadIfStmt();
+        }
+
+        public BreakOrContinueStmt ReadBreakOrContinueStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter4 = ReadAttributesOption();
+            var parameter1 = ReadNameOption();
+            var parameter2 = ReadInt32();
+            var parameter3 = ReadBoolean();
+            return new BreakOrContinueStmt(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public BreakOrContinueStmt ReadBreakOrContinueStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadBreakOrContinueStmt();
+        }
+
+        public VarDeclStmt ReadVarDeclStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter3 = ReadAttributesOption();
+            var parameter1 = ReadList<LocalVariable>(() => ReadLocalVariable());
+            var parameter2 = ReadAbstractOption<ConcreteAssignStatement>();
+            return new VarDeclStmt(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public VarDeclStmt ReadVarDeclStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadVarDeclStmt();
+        }
+
+        public AssignStatement ReadAssignStatement()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter4 = ReadAttributesOption();
+            var parameter1 = ReadList<Expression>(() => ReadAbstract<Expression>());
+            var parameter2 = ReadList<AssignmentRhs>(() => ReadAbstract<AssignmentRhs>());
+            var parameter3 = ReadBoolean();
+            return new AssignStatement(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public AssignStatement ReadAssignStatementOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadAssignStatement();
+        }
+
+        public LocalVariable ReadLocalVariable()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadString();
+            var parameter2 = ReadAbstractOption<Type>();
+            var parameter3 = ReadBoolean();
+            return new LocalVariable(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public LocalVariable ReadLocalVariableOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadLocalVariable();
+        }
+
+        public NestedMatchStmt ReadNestedMatchStmt()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter4 = ReadAttributesOption();
+            var parameter1 = ReadAbstract<Expression>();
+            var parameter2 = ReadList<NestedMatchCaseStmt>(() => ReadNestedMatchCaseStmt());
+            var parameter3 = ReadBoolean();
+            return new NestedMatchStmt(parameter0, parameter1, parameter2, parameter3, parameter4);
+        }
+
+        public NestedMatchStmt ReadNestedMatchStmtOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadNestedMatchStmt();
+        }
+
+        public NestedMatchCaseExpr ReadNestedMatchCaseExpr()
+        {
+            var parameter0 = ReadAbstract<IOrigin>();
+            var parameter1 = ReadAbstract<ExtendedPattern>();
+            var parameter2 = ReadAbstract<Expression>();
+            var parameter3 = ReadAttributesOption();
+            return new NestedMatchCaseExpr(parameter0, parameter1, parameter2, parameter3);
+        }
+
+        public NestedMatchCaseExpr ReadNestedMatchCaseExprOption()
+        {
+            if (ReadIsNull())
+            {
+                return default;
+            }
+
+            return ReadNestedMatchCaseExpr();
         }
 
         public ITEExpr ReadITEExpr()
@@ -680,24 +1193,6 @@ namespace Microsoft.Dafny
             }
 
             return ReadLambdaExpr();
-        }
-
-        public FrameExpression ReadFrameExpression()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadAbstract<Expression>();
-            var parameter2 = ReadStringOption();
-            return new FrameExpression(parameter0, parameter1, parameter2);
-        }
-
-        public FrameExpression ReadFrameExpressionOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadFrameExpression();
         }
 
         public SeqUpdateExpr ReadSeqUpdateExpr()
@@ -1170,58 +1665,6 @@ namespace Microsoft.Dafny
             return (SubsetTypeDecl.WKind)ordinal;
         }
 
-        public AttributedExpression ReadAttributedExpression()
-        {
-            var parameter0 = ReadAbstract<Expression>();
-            var parameter1 = ReadAssertLabelOption();
-            var parameter2 = ReadAttributesOption();
-            return new AttributedExpression(parameter0, parameter1, parameter2);
-        }
-
-        public AttributedExpression ReadAttributedExpressionOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAttributedExpression();
-        }
-
-        public Label ReadLabel()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadString();
-            return new Label(parameter0, parameter1);
-        }
-
-        public Label ReadLabelOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadLabel();
-        }
-
-        public AssertLabel ReadAssertLabel()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadString();
-            return new AssertLabel(parameter0, parameter1);
-        }
-
-        public AssertLabel ReadAssertLabelOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAssertLabel();
-        }
-
         public Method ReadMethod()
         {
             var parameter0 = ReadAbstract<IOrigin>();
@@ -1251,278 +1694,6 @@ namespace Microsoft.Dafny
             }
 
             return ReadMethod();
-        }
-
-        public ExpectStmt ReadExpectStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter3 = ReadAttributesOption();
-            var parameter1 = ReadAbstract<Expression>();
-            var parameter2 = ReadAbstractOption<Expression>();
-            return new ExpectStmt(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public ExpectStmt ReadExpectStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadExpectStmt();
-        }
-
-        public AssertStmt ReadAssertStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter3 = ReadAttributesOption();
-            var parameter1 = ReadAbstract<Expression>();
-            var parameter2 = ReadAssertLabelOption();
-            return new AssertStmt(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public AssertStmt ReadAssertStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAssertStmt();
-        }
-
-        public AllocateClass ReadAllocateClass()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter3 = ReadAttributesOption();
-            var parameter1 = ReadAbstract<Type>();
-            var parameter2 = ReadActualBindingsOption();
-            return new AllocateClass(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public AllocateClass ReadAllocateClassOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAllocateClass();
-        }
-
-        public AllocateArray ReadAllocateArray()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter4 = ReadAttributesOption();
-            var parameter1 = ReadAbstractOption<Type>();
-            var parameter2 = ReadList<Expression>(() => ReadAbstract<Expression>());
-            var parameter3 = ReadAbstractOption<Expression>();
-            return new AllocateArray(parameter0, parameter1, parameter2, parameter3, parameter4);
-        }
-
-        public AllocateArray ReadAllocateArrayOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAllocateArray();
-        }
-
-        public ExprRhs ReadExprRhs()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter2 = ReadAttributesOption();
-            var parameter1 = ReadAbstract<Expression>();
-            return new ExprRhs(parameter0, parameter1, parameter2);
-        }
-
-        public ExprRhs ReadExprRhsOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadExprRhs();
-        }
-
-        public ReturnStmt ReadReturnStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter2 = ReadAttributesOption();
-            var parameter1 = ReadListOption<AssignmentRhs>(() => ReadAbstract<AssignmentRhs>());
-            return new ReturnStmt(parameter0, parameter1, parameter2);
-        }
-
-        public ReturnStmt ReadReturnStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadReturnStmt();
-        }
-
-        public DividedBlockStmt ReadDividedBlockStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter4 = ReadAttributesOption();
-            var parameter1 = ReadList<Statement>(() => ReadAbstract<Statement>());
-            var parameter2 = ReadAbstractOption<IOrigin>();
-            var parameter3 = ReadList<Statement>(() => ReadAbstract<Statement>());
-            return new DividedBlockStmt(parameter0, parameter1, parameter2, parameter3, parameter4);
-        }
-
-        public DividedBlockStmt ReadDividedBlockStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadDividedBlockStmt();
-        }
-
-        public BlockStmt ReadBlockStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter2 = ReadAttributesOption();
-            var parameter1 = ReadList<Statement>(() => ReadAbstract<Statement>());
-            return new BlockStmt(parameter0, parameter1, parameter2);
-        }
-
-        public BlockStmt ReadBlockStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadBlockStmt();
-        }
-
-        public WhileStmt ReadWhileStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter6 = ReadAttributesOption();
-            var parameter2 = ReadList<AttributedExpression>(() => ReadAttributedExpression());
-            var parameter3 = ReadSpecification<Expression>();
-            var parameter4 = ReadSpecification<FrameExpression>();
-            var parameter5 = ReadBlockStmt();
-            var parameter1 = ReadAbstract<Expression>();
-            return new WhileStmt(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5, parameter6);
-        }
-
-        public WhileStmt ReadWhileStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadWhileStmt();
-        }
-
-        public IfStmt ReadIfStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter5 = ReadAttributesOption();
-            var parameter1 = ReadBoolean();
-            var parameter2 = ReadAbstractOption<Expression>();
-            var parameter3 = ReadBlockStmt();
-            var parameter4 = ReadAbstractOption<Statement>();
-            return new IfStmt(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5);
-        }
-
-        public IfStmt ReadIfStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadIfStmt();
-        }
-
-        public BreakOrContinueStmt ReadBreakOrContinueStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter4 = ReadAttributesOption();
-            var parameter1 = ReadNameOption();
-            var parameter2 = ReadInt32();
-            var parameter3 = ReadBoolean();
-            return new BreakOrContinueStmt(parameter0, parameter1, parameter2, parameter3, parameter4);
-        }
-
-        public BreakOrContinueStmt ReadBreakOrContinueStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadBreakOrContinueStmt();
-        }
-
-        public VarDeclStmt ReadVarDeclStmt()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter3 = ReadAttributesOption();
-            var parameter1 = ReadList<LocalVariable>(() => ReadLocalVariable());
-            var parameter2 = ReadAbstractOption<ConcreteAssignStatement>();
-            return new VarDeclStmt(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public VarDeclStmt ReadVarDeclStmtOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadVarDeclStmt();
-        }
-
-        public AssignStatement ReadAssignStatement()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter4 = ReadAttributesOption();
-            var parameter1 = ReadList<Expression>(() => ReadAbstract<Expression>());
-            var parameter2 = ReadList<AssignmentRhs>(() => ReadAbstract<AssignmentRhs>());
-            var parameter3 = ReadBoolean();
-            return new AssignStatement(parameter0, parameter1, parameter2, parameter3, parameter4);
-        }
-
-        public AssignStatement ReadAssignStatementOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadAssignStatement();
-        }
-
-        public LocalVariable ReadLocalVariable()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadString();
-            var parameter2 = ReadAbstractOption<Type>();
-            var parameter3 = ReadBoolean();
-            return new LocalVariable(parameter0, parameter1, parameter2, parameter3);
-        }
-
-        public LocalVariable ReadLocalVariableOption()
-        {
-            if (ReadIsNull())
-            {
-                return default;
-            }
-
-            return ReadLocalVariable();
         }
 
         public Constructor ReadConstructor()
@@ -1854,6 +2025,11 @@ namespace Microsoft.Dafny
                 return ReadLiteralExpr();
             }
 
+            if (actualType == typeof(StringLiteralExpr))
+            {
+                return ReadStringLiteralExpr();
+            }
+
             if (actualType == typeof(CharLiteralExpr))
             {
                 return ReadCharLiteralExpr();
@@ -1887,6 +2063,136 @@ namespace Microsoft.Dafny
             if (actualType == typeof(TernaryExpr))
             {
                 return ReadTernaryExpr();
+            }
+
+            if (actualType == typeof(NestedMatchExpr))
+            {
+                return ReadNestedMatchExpr();
+            }
+
+            if (actualType == typeof(LitPattern))
+            {
+                return ReadLitPattern();
+            }
+
+            if (actualType == typeof(IdPattern))
+            {
+                return ReadIdPattern();
+            }
+
+            if (actualType == typeof(DisjunctivePattern))
+            {
+                return ReadDisjunctivePattern();
+            }
+
+            if (actualType == typeof(NestedMatchCaseStmt))
+            {
+                return ReadNestedMatchCaseStmt();
+            }
+
+            if (actualType == typeof(ExpectStmt))
+            {
+                return ReadExpectStmt();
+            }
+
+            if (actualType == typeof(AssertStmt))
+            {
+                return ReadAssertStmt();
+            }
+
+            if (actualType == typeof(Label))
+            {
+                return ReadLabel();
+            }
+
+            if (actualType == typeof(AssertLabel))
+            {
+                return ReadAssertLabel();
+            }
+
+            if (actualType == typeof(AllocateClass))
+            {
+                return ReadAllocateClass();
+            }
+
+            if (actualType == typeof(AllocateArray))
+            {
+                return ReadAllocateArray();
+            }
+
+            if (actualType == typeof(ExprRhs))
+            {
+                return ReadExprRhs();
+            }
+
+            if (actualType == typeof(ReturnStmt))
+            {
+                return ReadReturnStmt();
+            }
+
+            if (actualType == typeof(PrintStmt))
+            {
+                return ReadPrintStmt();
+            }
+
+            if (actualType == typeof(FrameExpression))
+            {
+                return ReadFrameExpression();
+            }
+
+            if (actualType == typeof(AttributedExpression))
+            {
+                return ReadAttributedExpression();
+            }
+
+            if (actualType == typeof(DividedBlockStmt))
+            {
+                return ReadDividedBlockStmt();
+            }
+
+            if (actualType == typeof(BlockStmt))
+            {
+                return ReadBlockStmt();
+            }
+
+            if (actualType == typeof(WhileStmt))
+            {
+                return ReadWhileStmt();
+            }
+
+            if (actualType == typeof(IfStmt))
+            {
+                return ReadIfStmt();
+            }
+
+            if (actualType == typeof(BreakOrContinueStmt))
+            {
+                return ReadBreakOrContinueStmt();
+            }
+
+            if (actualType == typeof(VarDeclStmt))
+            {
+                return ReadVarDeclStmt();
+            }
+
+            if (actualType == typeof(AssignStatement))
+            {
+                return ReadAssignStatement();
+            }
+
+            if (actualType == typeof(LocalVariable))
+            {
+                return ReadLocalVariable();
+            }
+
+            if (actualType == typeof(NestedMatchStmt))
+            {
+                return ReadNestedMatchStmt();
+            }
+
+            if (actualType == typeof(NestedMatchCaseExpr))
+            {
+                return ReadNestedMatchCaseExpr();
             }
 
             if (actualType == typeof(ITEExpr))
@@ -1967,11 +2273,6 @@ namespace Microsoft.Dafny
             if (actualType == typeof(LambdaExpr))
             {
                 return ReadLambdaExpr();
-            }
-
-            if (actualType == typeof(FrameExpression))
-            {
-                return ReadFrameExpression();
             }
 
             if (actualType == typeof(SeqUpdateExpr))
@@ -2099,94 +2400,9 @@ namespace Microsoft.Dafny
                 return ReadSubsetTypeDecl();
             }
 
-            if (actualType == typeof(AttributedExpression))
-            {
-                return ReadAttributedExpression();
-            }
-
-            if (actualType == typeof(Label))
-            {
-                return ReadLabel();
-            }
-
-            if (actualType == typeof(AssertLabel))
-            {
-                return ReadAssertLabel();
-            }
-
             if (actualType == typeof(Method))
             {
                 return ReadMethod();
-            }
-
-            if (actualType == typeof(ExpectStmt))
-            {
-                return ReadExpectStmt();
-            }
-
-            if (actualType == typeof(AssertStmt))
-            {
-                return ReadAssertStmt();
-            }
-
-            if (actualType == typeof(AllocateClass))
-            {
-                return ReadAllocateClass();
-            }
-
-            if (actualType == typeof(AllocateArray))
-            {
-                return ReadAllocateArray();
-            }
-
-            if (actualType == typeof(ExprRhs))
-            {
-                return ReadExprRhs();
-            }
-
-            if (actualType == typeof(ReturnStmt))
-            {
-                return ReadReturnStmt();
-            }
-
-            if (actualType == typeof(DividedBlockStmt))
-            {
-                return ReadDividedBlockStmt();
-            }
-
-            if (actualType == typeof(BlockStmt))
-            {
-                return ReadBlockStmt();
-            }
-
-            if (actualType == typeof(WhileStmt))
-            {
-                return ReadWhileStmt();
-            }
-
-            if (actualType == typeof(IfStmt))
-            {
-                return ReadIfStmt();
-            }
-
-            if (actualType == typeof(BreakOrContinueStmt))
-            {
-                return ReadBreakOrContinueStmt();
-            }
-
-            if (actualType == typeof(VarDeclStmt))
-            {
-                return ReadVarDeclStmt();
-            }
-
-            if (actualType == typeof(AssignStatement))
-            {
-                return ReadAssignStatement();
-            }
-
-            if (actualType == typeof(LocalVariable))
-            {
-                return ReadLocalVariable();
             }
 
             if (actualType == typeof(Constructor))

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatControlFlow.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatControlFlow.dfy
@@ -52,3 +52,45 @@ method LetOrFailExpressions() returns (out: int) {
   var y := (:- Err(1); 2);
   return y + 3;
 }
+
+const TWO := 2
+
+method MatchStmt(i: int, b: bool) {
+  match i {
+    case 1 => print "1";
+    case TWO => print "2";
+    case 3 | 4 => print "3 or 4";
+    case other => {
+      match (other, b) {
+        case (-1, b') => print "negative";
+        case (i', true) => print "true";
+        case tuple => print "other tuple";
+      }
+    }
+  }
+  match Pair(i + 1, i * 2) {
+    case Pair(5, y) => print "Pair(5, ?)";
+    case Pair(x, 6) => print "Pair(?, 6)";
+    case pair => print "other pair";
+  }
+}
+
+method MatchExpr(i: int, b: bool) {
+  var s1 := match i {
+    case 1 => "1"
+    case TWO => "2"
+    case 3 | 4 => "3 or 4"
+    case other => 
+      match (other, b) {
+        case (-1, b') => "negative"
+        case (i', true) => "true"
+        case tup => "other"
+      }
+  };
+  var s2 := match Pair(i + 1, i * 2) {
+    case Pair(5, y) => "Pair(5, ?)"
+    case Pair(x, 6) => "Pair(?, 6)"
+    case pair => "other pair"
+  };
+  print s1, s2;
+}

--- a/Source/Scripts/Syntax.cs-schema
+++ b/Source/Scripts/Syntax.cs-schema
@@ -165,6 +165,11 @@ class LiteralExpr : Expression
     Object? value;
 }
 
+class StringLiteralExpr : LiteralExpr
+{
+    Boolean isVerbatim;
+}
+
 class CharLiteralExpr : LiteralExpr
 {
 }
@@ -221,6 +226,217 @@ enum TernaryExprOpcode
 {
     PrefixEqOp,
     PrefixNeqOp
+}
+
+class NestedMatchExpr : Expression
+{
+    Expression source;
+    List<NestedMatchCaseExpr> cases;
+    Boolean usesOptionalBraces;
+    Attributes? attributes;
+}
+
+abstract class NestedMatchCase : NodeWithOrigin
+{
+    ExtendedPattern pat;
+}
+
+abstract class ExtendedPattern : NodeWithOrigin
+{
+    Boolean isGhost;
+}
+
+class LitPattern : ExtendedPattern
+{
+    Expression origLit;
+}
+
+class IdPattern : ExtendedPattern
+{
+    String id;
+    Type? syntacticType;
+    List<ExtendedPattern>? arguments;
+    Boolean hasParenthesis;
+}
+
+class DisjunctivePattern : ExtendedPattern
+{
+    List<ExtendedPattern> alternatives;
+}
+
+class NestedMatchCaseStmt : NestedMatchCase
+{
+    List<Statement> body;
+    Attributes? attributes;
+}
+
+abstract class Statement : NodeWithOrigin
+{
+    Attributes? attributes;
+}
+
+abstract class PredicateStmt : Statement
+{
+    Expression expr;
+}
+
+class ExpectStmt : PredicateStmt
+{
+    Expression? message;
+}
+
+class AssertStmt : PredicateStmt
+{
+    AssertLabel? label;
+}
+
+class Label
+{
+    IOrigin tok;
+    String name;
+}
+
+class AssertLabel : Label
+{
+}
+
+abstract class ProduceStmt : Statement
+{
+    List<AssignmentRhs>? rhss;
+}
+
+abstract class AssignmentRhs : NodeWithOrigin
+{
+    Attributes? attributes;
+}
+
+abstract class TypeRhs : AssignmentRhs
+{
+}
+
+class AllocateClass : TypeRhs
+{
+    Type path;
+    ActualBindings? bindings;
+}
+
+class AllocateArray : TypeRhs
+{
+    Type? explicitType;
+    List<Expression> arrayDimensions;
+    Expression? elementInit;
+}
+
+class ExprRhs : AssignmentRhs
+{
+    Expression expr;
+}
+
+class ReturnStmt : ProduceStmt
+{
+}
+
+class PrintStmt : Statement
+{
+    List<Expression> args;
+}
+
+abstract class LoopStmt : Statement
+{
+    List<AttributedExpression> invariants;
+    Specification<Expression> decreases;
+    Specification<FrameExpression> mod;
+}
+
+class FrameExpression : NodeWithOrigin
+{
+    Expression originalExpression;
+    String? fieldName;
+}
+
+class AttributedExpression
+{
+    Expression e;
+    AssertLabel? label;
+    Attributes? attributes;
+}
+
+abstract class OneBodyLoopStmt : LoopStmt
+{
+    BlockStmt body;
+}
+
+abstract class BlockLikeStmt : Statement
+{
+}
+
+class DividedBlockStmt : BlockLikeStmt
+{
+    List<Statement> bodyInit;
+    IOrigin? separatorTok;
+    List<Statement> bodyProper;
+}
+
+class BlockStmt : BlockLikeStmt
+{
+    List<Statement> body;
+}
+
+class WhileStmt : OneBodyLoopStmt
+{
+    Expression guard;
+}
+
+class IfStmt : Statement
+{
+    Boolean isBindingGuard;
+    Expression? guard;
+    BlockStmt thn;
+    Statement? els;
+}
+
+class BreakOrContinueStmt : Statement
+{
+    Name? targetLabel;
+    Int32 breakAndContinueCount;
+    Boolean isContinue;
+}
+
+class VarDeclStmt : Statement
+{
+    List<LocalVariable> locals;
+    ConcreteAssignStatement? assign;
+}
+
+abstract class ConcreteAssignStatement : Statement
+{
+    List<Expression> lhss;
+}
+
+class AssignStatement : ConcreteAssignStatement
+{
+    List<AssignmentRhs> rhss;
+    Boolean canMutateKnownState;
+}
+
+class LocalVariable : NodeWithOrigin
+{
+    String name;
+    Type? syntacticType;
+    Boolean isGhost;
+}
+
+class NestedMatchStmt : Statement
+{
+    Expression source;
+    List<NestedMatchCaseStmt> cases;
+    Boolean usesOptionalBraces;
+}
+
+class NestedMatchCaseExpr : NestedMatchCase
+{
+    Expression body;
+    Attributes? attributes;
 }
 
 class ITEExpr : Expression
@@ -347,12 +563,6 @@ class MapComprehension : ComprehensionExpr
 class LambdaExpr : ComprehensionExpr
 {
     Specification<FrameExpression> reads;
-}
-
-class FrameExpression : NodeWithOrigin
-{
-    Expression originalExpression;
-    String? fieldName;
 }
 
 class SeqUpdateExpr : Expression
@@ -577,23 +787,6 @@ abstract class MethodOrFunction : MemberDecl
     Specification<Expression> decreases;
 }
 
-class AttributedExpression
-{
-    Expression e;
-    AssertLabel? label;
-    Attributes? attributes;
-}
-
-class Label
-{
-    IOrigin tok;
-    String name;
-}
-
-class AssertLabel : Label
-{
-}
-
 abstract class MethodOrConstructor : MethodOrFunction
 {
     Specification<FrameExpression> mod;
@@ -605,134 +798,6 @@ class Method : MethodOrConstructor
     List<Formal> outs;
     BlockStmt? body;
     Boolean isByMethod;
-}
-
-abstract class Statement : NodeWithOrigin
-{
-    Attributes? attributes;
-}
-
-abstract class PredicateStmt : Statement
-{
-    Expression expr;
-}
-
-class ExpectStmt : PredicateStmt
-{
-    Expression? message;
-}
-
-class AssertStmt : PredicateStmt
-{
-    AssertLabel? label;
-}
-
-abstract class ProduceStmt : Statement
-{
-    List<AssignmentRhs>? rhss;
-}
-
-abstract class AssignmentRhs : NodeWithOrigin
-{
-    Attributes? attributes;
-}
-
-abstract class TypeRhs : AssignmentRhs
-{
-}
-
-class AllocateClass : TypeRhs
-{
-    Type path;
-    ActualBindings? bindings;
-}
-
-class AllocateArray : TypeRhs
-{
-    Type? explicitType;
-    List<Expression> arrayDimensions;
-    Expression? elementInit;
-}
-
-class ExprRhs : AssignmentRhs
-{
-    Expression expr;
-}
-
-class ReturnStmt : ProduceStmt
-{
-}
-
-abstract class LoopStmt : Statement
-{
-    List<AttributedExpression> invariants;
-    Specification<Expression> decreases;
-    Specification<FrameExpression> mod;
-}
-
-abstract class OneBodyLoopStmt : LoopStmt
-{
-    BlockStmt body;
-}
-
-abstract class BlockLikeStmt : Statement
-{
-}
-
-class DividedBlockStmt : BlockLikeStmt
-{
-    List<Statement> bodyInit;
-    IOrigin? separatorTok;
-    List<Statement> bodyProper;
-}
-
-class BlockStmt : BlockLikeStmt
-{
-    List<Statement> body;
-}
-
-class WhileStmt : OneBodyLoopStmt
-{
-    Expression guard;
-}
-
-class IfStmt : Statement
-{
-    Boolean isBindingGuard;
-    Expression? guard;
-    BlockStmt thn;
-    Statement? els;
-}
-
-class BreakOrContinueStmt : Statement
-{
-    Name? targetLabel;
-    Int32 breakAndContinueCount;
-    Boolean isContinue;
-}
-
-class VarDeclStmt : Statement
-{
-    List<LocalVariable> locals;
-    ConcreteAssignStatement? assign;
-}
-
-abstract class ConcreteAssignStatement : Statement
-{
-    List<Expression> lhss;
-}
-
-class AssignStatement : ConcreteAssignStatement
-{
-    List<AssignmentRhs> rhss;
-    Boolean canMutateKnownState;
-}
-
-class LocalVariable : NodeWithOrigin
-{
-    String name;
-    Type? syntacticType;
-    Boolean isGhost;
 }
 
 class Constructor : MethodOrConstructor
@@ -829,9 +894,4 @@ enum ModuleKindEnum
     Concrete,
     Abstract,
     Replaceable
-}
-
-abstract class ExtendedPattern : NodeWithOrigin
-{
-    Boolean isGhost;
 }


### PR DESCRIPTION
### What was changed?

- Add syntax schema types for match/case: `NestedMatchCase`, `NestedMatchCaseExpr`, `NestedMatchCaseStmt`, `NestedMatchExpr`, `NestedMatchStmt`
- Add syntax schema types for patterns: `DisjunctivePattern`, `IdPattern`, `LitPattern`, `StringLiteralExpr`
- Add syntax schema type for `PrintStmt`

### How has this been tested?

- Extended `inputFormatControlFlow.dfy` integration test to exercise new syntax schema types.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
