### PR TITLE
Fix: Bitvector shift in `--type-system-refresh`

### DIFF
--- a/Source/DafnyCore/Rewriters/BitvectorOptimization.cs
+++ b/Source/DafnyCore/Rewriters/BitvectorOptimization.cs
@@ -44,7 +44,7 @@ public class BitvectorOptimizationVisitor : BottomUpVisitor {
   }
 
   protected override void VisitOneExpr(Expression expr) {
-    if (expr.Type is BitvectorType bvType) {
+    if (expr.Type.AsBitVectorType is {} bvType) {
 
       if (expr is BinaryExpr binExpr && IsShiftOp(binExpr.Op)) {
         binExpr.E1 = ShrinkBitVectorShiftAmount(binExpr.E1, bvType);

--- a/Source/DafnyCore/Rewriters/BitvectorOptimization.cs
+++ b/Source/DafnyCore/Rewriters/BitvectorOptimization.cs
@@ -44,7 +44,7 @@ public class BitvectorOptimizationVisitor : BottomUpVisitor {
   }
 
   protected override void VisitOneExpr(Expression expr) {
-    if (expr.Type.AsBitVectorType is { } bvType) {
+    if (expr is { Type.AsBitVectorType: { } bvType }) {
 
       if (expr is BinaryExpr binExpr && IsShiftOp(binExpr.Op)) {
         binExpr.E1 = ShrinkBitVectorShiftAmount(binExpr.E1, bvType);

--- a/Source/DafnyCore/Rewriters/BitvectorOptimization.cs
+++ b/Source/DafnyCore/Rewriters/BitvectorOptimization.cs
@@ -44,7 +44,7 @@ public class BitvectorOptimizationVisitor : BottomUpVisitor {
   }
 
   protected override void VisitOneExpr(Expression expr) {
-    if (expr.Type.AsBitVectorType is {} bvType) {
+    if (expr.Type.AsBitVectorType is { } bvType) {
 
       if (expr is BinaryExpr binExpr && IsShiftOp(binExpr.Op)) {
         binExpr.E1 = ShrinkBitVectorShiftAmount(binExpr.E1, bvType);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/conversions.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/conversions.dfy
@@ -1,4 +1,6 @@
 // NONUNIFORM: Rust-specific tests
+// RUN: %baredafny run --target=rs --enforce-determinism --type-system-refresh "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
 // RUN: %baredafny run --target=rs --enforce-determinism "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
@@ -27,10 +29,12 @@ method TestCompile(input: Option<Uint8>) returns (output: Option<Uint8>) {
   return None;
 }
 
+type CustomBv16 = bv16
+
 method Main() {
   var x: Uint8 := 2;
   // Correct rendering of expressions that can interpret the first '<' as a generic argument
-  var y: bv16 := (x as bv16) << 2;
+  var y: bv16 := (x as CustomBv16) << 2;
   expect y == 8;
   expect (x as bv16) < 3;
   expect (x as bv16) <= 3;

--- a/docs/dev/news/6196.fix
+++ b/docs/dev/news/6196.fix
@@ -1,0 +1,1 @@
+No more compilation issue when using bitvector shifts in Rust with the new resolver


### PR DESCRIPTION
Fixes #6196 

I updated the test to ensure it was breaking and that this PR fixes the test.
Basically, a test was testing if the type was a bitvector type, but this type was a synonym type with the new resolver so that needed to be updated.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
