### PR TITLE
Fix generics insidematch

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/genericsInsideMatch.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/genericsInsideMatch.dfy
@@ -1,0 +1,17 @@
+// RUN: %verify --allow-warnings "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype List<X> = Nil | Cons(head: X, tail: List<X>)
+
+method Split<X>(ws: List<X>) returns (ans: int)
+{
+  match ws
+  case Cons(a, Cons(b, tail)) => {
+    forall rx: List<X>
+    {}
+    return 0;
+  }
+  case _ => {
+    return 0;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/genericsInsideMatch.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/genericsInsideMatch.dfy.expect
@@ -1,3 +1,3 @@
-genericsInsideMatch.dfy(10,4): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section quantifier instantiation rules in the reference manual.
+genericsInsideMatch.dfy(10,4): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/genericsInsideMatch.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/patterns/genericsInsideMatch.dfy.expect
@@ -1,0 +1,3 @@
+genericsInsideMatch.dfy(10,4): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section quantifier instantiation rules in the reference manual.
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/docs/dev/news/6199.fix
+++ b/docs/dev/news/6199.fix
@@ -1,0 +1,1 @@
+Fixed a crash that could occur when using generics inside a match statement


### PR DESCRIPTION
Fixes #6199

### What was changed?
- Fix crash that occurs when matching a generic type inside a match

### How has this been tested?
- Added CLI test

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
