### PR TITLE
Fix 6212 dafny to rust compilation issue with conversions

### DIFF
--- a/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
@@ -2317,7 +2317,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (source.Type.NormalizeToAncestorType() is { IsMapType: true } normalized) {
         collKind = DAST.CollKind.create_Map();
         indexType = normalized.AsMapType.Domain;
-      } else if (source.Type.NormalizeToAncestorType() is { AsMultiSetType: {} msType }) {
+      } else if (source.Type.NormalizeToAncestorType() is { AsMultiSetType: { } msType }) {
         collKind = DAST.CollKind.create_Map();
         indexType = msType.Arg;
       } else {

--- a/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
@@ -2334,6 +2334,9 @@ namespace Microsoft.Dafny.Compilers {
       } else if (source.Type.NormalizeToAncestorType() is { IsMapType: true } normalized) {
         collKind = DAST.CollKind.create_Map();
         indexType = normalized.AsMapType.Domain;
+      } else if (source.Type.NormalizeToAncestorType() is { AsMultiSetType: {} msType }) {
+        collKind = DAST.CollKind.create_Map();
+        indexType = msType.Arg;
       } else {
         collKind = DAST.CollKind.create_Seq();
         indexType = Type.Int;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy
@@ -1,0 +1,17 @@
+// RUN: %baredafny verify %args "%s" > "%t"
+// RUN: %baredafny build %args --no-verify -t:cs "%s" >> "%t"
+// RUN: %baredafny build %args --no-verify -t:js "%s" >> "%t"
+// RUN: %baredafny build %args --no-verify -t:cpp "%s" >> "%t"
+// RUN: %baredafny build %args --no-verify -t:java "%s" >> "%t"
+// RUN: %baredafny build %args --no-verify -t:go "%s" >> "%t"
+// RUN: %baredafny build %args --no-verify -t:py "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+module Test {
+  function FindB(): set<string>
+  {
+    var elems := ["a", "a", "b"];
+    var elemsSet := set id <- elems;
+    set x | x in elems && multiset(elems)[x] >= 1
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy
@@ -1,10 +1,5 @@
-// RUN: %baredafny verify %args "%s" > "%t"
-// RUN: %baredafny build %args --no-verify -t:cs "%s" >> "%t"
-// RUN: %baredafny build %args --no-verify -t:js "%s" >> "%t"
-// RUN: %baredafny build %args --no-verify -t:cpp "%s" >> "%t"
-// RUN: %baredafny build %args --no-verify -t:java "%s" >> "%t"
-// RUN: %baredafny build %args --no-verify -t:go "%s" >> "%t"
-// RUN: %baredafny build %args --no-verify -t:py "%s" >> "%t"
+// NONUNIFORM: Testing that we don't need --emit-uncompilable-code.
+// RUN: %baredafny build -t:rs %args  --enforce-determinism "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
 module Test {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with TODO verified, TODO errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6212.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with TODO verified, TODO errors
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Fixes #6212 
Previously, multiset indexing to retrieve the multiplicity wasn't supported in the Dafny-to-Rust compiler, but it worked seamlessly for multisets of integers because the compiler was treating it silently as a `map<int, int>`.
Added proper support for multisets of any types.

### How has this been tested?
Test added

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
