### PR TITLE
Add fix for exception that could occur when using includes and top level members

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -168,7 +168,9 @@ namespace Microsoft.Dafny {
     }
 
     void AddMethod_Top(MethodOrConstructor m, bool isByMethod, bool includeAllMethods) {
-      if (!includeAllMethods && !InVerificationScope(m) && !referencedMembers.Contains(m)) {
+      if (!includeAllMethods && 
+          !InVerificationScope(m.EnclosingClass.EnclosingModuleDefinition.EnclosingLiteralModuleDecl) && 
+          !referencedMembers.Contains(m)) {
         // do nothing
         return;
       }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -130,7 +130,12 @@ namespace Microsoft.Dafny {
 
     private ProofDependencyManager proofDependencies;
 
-    // optimizing translation
+    /**
+     * The behavior around this field assumes that usages are visited before declarations
+     * which is only the case when the usage is in a different module than the declaration.
+     * However, we alleviate this problem by saying that any declaration must be kept
+     * if any code in that module is verified.
+     */
     readonly ISet<MemberDecl> referencedMembers = new HashSet<MemberDecl>();
 
     public void AddReferencedMember(MemberDecl m) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/files/defaultModuleAndIncludes/Inputs/producer.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/files/defaultModuleAndIncludes/Inputs/producer.dfy
@@ -1,0 +1,2 @@
+
+method Foo() {}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/files/defaultModuleAndIncludes/root.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/files/defaultModuleAndIncludes/root.dfy
@@ -1,0 +1,7 @@
+include "Inputs/producer.dfy"
+
+class X {
+  method Bar() {
+    Foo();
+  }
+}

--- a/docs/news/6192.fix
+++ b/docs/news/6192.fix
@@ -1,0 +1,1 @@
+Add fix for exception that could occur when using includes and top level members


### PR DESCRIPTION
Fixes #6192

### What was changed?
Add fix for exception that could occur when using includes and top level members

### How has this been tested?
Added test `ast/files/defaultModuleAndInclude/root.dfy`

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
