### PR TITLE
Opaque modifies clause

### DIFF
--- a/Source/DafnyCore/AST/Statements/OpaqueBlock.cs
+++ b/Source/DafnyCore/AST/Statements/OpaqueBlock.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Dafny;
 
 public class OpaqueBlock : BlockStmt, ICanResolveNewAndOld, ICloneable<OpaqueBlock> {
   public List<AttributedExpression> Ensures;
+
+  /**
+   * Default is empty. Does not assume the method modifies as a default
+   */
   public Specification<FrameExpression> Modifies;
 
   protected OpaqueBlock(Cloner cloner, OpaqueBlock original) : base(cloner, original) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -175,7 +175,12 @@ namespace Microsoft.Dafny {
         if (label == null) {
           return Old;
         }
-        var heapAt = new Boogie.IdentifierExpr(Token.NoToken, "$Heap_at_" + label.AssignUniqueId(BoogieGenerator.CurrentIdGenerator), Predef.HeapType);
+
+        return WithHeapVariable("$Heap_at_" + label.AssignUniqueId(BoogieGenerator.CurrentIdGenerator));
+      }
+
+      public ExpressionTranslator WithHeapVariable(string heapVariableName) {
+        var heapAt = new Boogie.IdentifierExpr(Token.NoToken, heapVariableName, Predef.HeapType);
         return new ExpressionTranslator(BoogieGenerator, Predef, heapAt, This, applyLimited_CurrentFunction, layerInterCluster, layerIntraCluster, scope, readsFrame, modifiesFrame, stripLits);
       }
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -651,7 +651,7 @@ namespace Microsoft.Dafny {
         var modifies = m.Mod;
         var allowsAllocation = m.AllowsAllocation;
 
-        ApplyModifiesEffect(m, etran, builder, modifies, allowsAllocation, m.IsGhost);
+        ApplyModifiesEffect(m, etran.Old, etran, builder, modifies, allowsAllocation, m.IsGhost);
       }
 
       // also play havoc with the out parameters
@@ -688,13 +688,14 @@ namespace Microsoft.Dafny {
       return stmts;
     }
 
-    public void ApplyModifiesEffect(INode node, ExpressionTranslator etran, BoogieStmtListBuilder builder,
+    public void ApplyModifiesEffect(INode node, ExpressionTranslator beforeBlockExpressionTranslator,
+      ExpressionTranslator etran, BoogieStmtListBuilder builder,
       Specification<FrameExpression> modifies, bool allowsAllocation, bool isGhostContext) {
       // play havoc with the heap according to the modifies clause
       builder.Add(new Boogie.HavocCmd(node.Origin, [etran.HeapCastToIdentifierExpr]));
       // assume the usual two-state boilerplate information
-      foreach (BoilerplateTriple tri in GetTwoStateBoilerplate(node.Origin, modifies.Expressions, isGhostContext, 
-                 allowsAllocation, etran.Old, etran, etran.Old)) {
+      foreach (BoilerplateTriple tri in GetTwoStateBoilerplate(node.Origin, modifies.Expressions, isGhostContext,
+                 allowsAllocation, beforeBlockExpressionTranslator, etran, beforeBlockExpressionTranslator)) {
         if (tri.IsFree) {
           builder.Add(TrAssumeCmd(node.Origin, tri.Expr));
         }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -693,7 +693,8 @@ namespace Microsoft.Dafny {
       // play havoc with the heap according to the modifies clause
       builder.Add(new Boogie.HavocCmd(node.Origin, [etran.HeapCastToIdentifierExpr]));
       // assume the usual two-state boilerplate information
-      foreach (BoilerplateTriple tri in GetTwoStateBoilerplate(node.Origin, modifies.Expressions, isGhostContext, allowsAllocation, etran.Old, etran, etran.Old)) {
+      foreach (BoilerplateTriple tri in GetTwoStateBoilerplate(node.Origin, modifies.Expressions, isGhostContext, 
+                 allowsAllocation, etran.Old, etran, etran.Old)) {
         if (tri.IsFree) {
           builder.Add(TrAssumeCmd(node.Origin, tri.Expr));
         }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
@@ -232,6 +232,7 @@ class GranularModifies
 {
   var x : int
   var y : int
+  var objects: set<GranularModifies>
 
   method foo()
     modifies this
@@ -239,8 +240,9 @@ class GranularModifies
     ensures y == 1
   {
     x := 1;
+    objects := {this};
     opaque
-      modifies this`y
+      modifies objects`y
       ensures y == 1
       // ensures x == 1
     {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
@@ -227,3 +227,24 @@ method FreshEnsures() {
   }
   assert false;
 }
+
+class Test
+{
+  var x : int
+  var y : int
+
+  method foo()
+    modifies this
+    ensures x == 1
+    ensures y == 1
+  {
+    x := 1;
+    opaque
+      modifies this`y
+      ensures y == 1
+      // ensures x == 1
+    {
+      y := 1;
+    }
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy
@@ -228,7 +228,7 @@ method FreshEnsures() {
   assert false;
 }
 
-class Test
+class GranularModifies
 {
   var x : int
   var y : int

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/ast/statement/opaqueBlock.dfy.expect
@@ -14,4 +14,4 @@ opaqueBlock.dfy(206,6): Error: assignment might update an object not in the encl
 opaqueBlock.dfy(218,2): Error: assertion might not hold
 opaqueBlock.dfy(228,2): Error: assertion might not hold
 
-Dafny program verifier finished with 3 verified, 15 errors
+Dafny program verifier finished with 4 verified, 15 errors

--- a/docs/news/6217.fix
+++ b/docs/news/6217.fix
@@ -1,0 +1,1 @@
+modifies clauses in opaque blocks now work as intended


### PR DESCRIPTION
Fixes #6217

### What was changed?
- Let modifies clauses of opaque blocks use the heap before the block as 'old', instead of the one at the start of the method.

### How has this been tested?
- Added a test case to opaqueBlock.dfy

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
