### PR TITLE
Fix: Operators rendering more robust in Rust

### DIFF
--- a/Source/DafnyCore/GeneratedFromDafny/RAST.cs
+++ b/Source/DafnyCore/GeneratedFromDafny/RAST.cs
@@ -6455,6 +6455,7 @@ namespace RAST {
     RAST._IExpr Replace(Func<RAST._IExpr, RAST._IExpr> f, Func<RAST._IType, RAST._IType> ft);
     __T Fold<__T>(__T acc, Func<__T, RAST._IExpr, __T> f, Func<__T, RAST._IType, __T> ft);
     bool NoExtraSemicolonAfter();
+    bool EndsWithTypeThatCanAcceptGenericsWhenPrinting();
     RAST._IPrintingInfo printingInfo { get; }
     bool LeftRequiresParentheses(RAST._IExpr left);
     _System._ITuple2<Dafny.ISequence<Dafny.Rune>, Dafny.ISequence<Dafny.Rune>> LeftParentheses(RAST._IExpr left);
@@ -7351,6 +7352,33 @@ namespace RAST {
     public bool NoExtraSemicolonAfter() {
       return (((((((this).is_DeclareVar) || ((this).is_Assign)) || ((this).is_Break)) || ((this).is_Continue)) || ((this).is_Return)) || ((this).is_For)) || ((((this).is_RawExpr) && ((new BigInteger(((this).dtor_content).Count)).Sign == 1)) && ((((this).dtor_content).Select((new BigInteger(((this).dtor_content).Count)) - (BigInteger.One))) == (new Dafny.Rune(';'))));
     }
+    public bool EndsWithTypeThatCanAcceptGenericsWhenPrinting() {
+      _IExpr _this = this;
+    TAIL_CALL_START: ;
+      RAST._IExpr _source0 = _this;
+      {
+        if (_source0.is_TypeAscription) {
+          RAST._IExpr _0_e = _source0.dtor_left;
+          RAST._IType _1_tpe = _source0.dtor_tpe;
+          return (_1_tpe).EndsWithNameThatCanAcceptGenerics();
+        }
+      }
+      {
+        if (_source0.is_BinaryOp) {
+          Dafny.ISequence<Dafny.Rune> _2_op2 = _source0.dtor_op2;
+          RAST._IExpr _3_left = _source0.dtor_left;
+          RAST._IExpr _4_right = _source0.dtor_right;
+          DAST.Format._IBinaryOpFormat _5_format = _source0.dtor_format2;
+          RAST._IExpr _in0 = _4_right;
+          _this = _in0;
+          ;
+          goto TAIL_CALL_START;
+        }
+      }
+      {
+        return false;
+      }
+    }
     public bool LeftRequiresParentheses(RAST._IExpr left) {
       return ((this).printingInfo).NeedParenthesesForLeft((left).printingInfo);
     }
@@ -8075,7 +8103,7 @@ namespace RAST {
               disjunctiveMatch3 = true;
             }
             if (disjunctiveMatch3) {
-              if ((((_14_op2).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<<"))) && ((_15_left).is_TypeAscription)) && (((_15_left).dtor_tpe).EndsWithNameThatCanAcceptGenerics())) {
+              if (((_14_op2).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<<"))) && ((_15_left).EndsWithTypeThatCanAcceptGenericsWhenPrinting())) {
                 return RAST.PrintingInfo.create_PrecedenceAssociativity(new BigInteger(9), RAST.Associativity.create_LeftToRight());
               } else {
                 return RAST.PrintingInfo.create_PrecedenceAssociativity(new BigInteger(40), RAST.Associativity.create_LeftToRight());
@@ -8118,7 +8146,7 @@ namespace RAST {
               disjunctiveMatch4 = true;
             }
             if (disjunctiveMatch4) {
-              if (((((_14_op2).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"))) || ((_14_op2).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<=")))) && ((_15_left).is_TypeAscription)) && (((_15_left).dtor_tpe).EndsWithNameThatCanAcceptGenerics())) {
+              if ((((_14_op2).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<"))) || ((_14_op2).Equals(Dafny.Sequence<Dafny.Rune>.UnicodeFromString("<=")))) && ((_15_left).EndsWithTypeThatCanAcceptGenericsWhenPrinting())) {
                 return RAST.PrintingInfo.create_PrecedenceAssociativity(new BigInteger(9), RAST.Associativity.create_LeftToRight());
               } else {
                 return RAST.PrintingInfo.create_PrecedenceAssociativity(new BigInteger(80), RAST.Associativity.create_RequiresParentheses());

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/operators.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/operators.dfy
@@ -18,6 +18,12 @@ newtype int32 = x: int  | -0x8000_0000 <= x < 0x8000_0000
 newtype int64 = x: int  | -0x8000_0000_0000_0000 <= x < 0x8000_0000_0000_0000
 newtype int128 = x: int  | -0x8000_0000_0000_0000_0000_0000_0000_0000 <= x < 0x8000_0000_0000_0000_0000_0000_0000_0000
 
+method TestLessEq() {
+  var x64: uint64 := 8 as uint64;
+  expect 8 as uint8 > 1 as uint8 + x64 as uint8;
+  expect 9 as uint8 > 1 as uint8 * x64 as uint8;
+}
+
 method TestU8() {
   var o8: uint8 := 1 as uint8;
   var s8: uint8 := 2 as uint8;

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/operators.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/rust/operators.dfy.expect
@@ -1,5 +1,5 @@
 
-Dafny program verifier finished with 21 verified, 0 errors
+Dafny program verifier finished with 22 verified, 0 errors
 && || ==> <==> <= < >= > != ==
 + * - / %
 operators(u8) operators(u16) operators(u32) operators(u64) operators(u128)


### PR DESCRIPTION
Fixes #6221 

### What was changed?
This is not yet a user visible change since the Dafny-to-Rust compiler is still marked as internal.

### How has this been tested?
Existing tests have been modified. They correctly reproduced the issue and this PR fixes them.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
