### PR TITLE
C# code generation performs checked cast of index type to int for sequence comprehension lambda (6220)

### DIFF
--- a/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
@@ -2870,11 +2870,8 @@ namespace Microsoft.Dafny.Compilers {
       wrDims[0].Write(lengthVar);
       wrLamBody.WriteLine(";");
 
-      var intIxVar = idGenerator.FreshId("i");
-      var wrLoopBody = wrLamBody.NewBlock(string.Format("for (int {0} = 0; {0} < {1}; {0}++)", intIxVar, lengthVar));
-      var ixVar = IdName(boundVar);
-      wrLoopBody.WriteLine("var {0} = ({1}) {2};",
-        ixVar, TypeName(indexType, wrLoopBody, body.Origin), intIxVar);
+      var ixVar = idGenerator.FreshId("i");
+      var wrLoopBody = wrLamBody.NewBlock(string.Format("for (int {0} = 0; {0} < {2}.ToIntChecked({1}, \"upper bound on index is too large\"); {0}++)", ixVar, lengthVar, DafnyHelpersClass));
       var wrArrName = EmitArrayUpdate([wr => wr.Write(ixVar)], body, wrLoopBody);
       wrArrName.Write(arrVar);
       EndStmt(wrLoopBody);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6220.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6220.dfy
@@ -1,0 +1,17 @@
+// Bug originated from the C# backend, but might as well try every backend
+// RUN: %testDafnyForEachCompiler "%s"
+
+newtype uint64 = x: int | 0 <= x < 0x1_00000000_00000000
+
+function Fill<T>(value: T, n: uint64): seq<T>
+  ensures |Fill(value, n)| == n as nat
+  ensures forall i :: 0 <= i < n ==> Fill(value, n)[i] == value
+{
+  seq(n, _ => value)
+}
+
+method Main()
+{
+  var ss := Fill('a', 42);
+  print ss, "\n";
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6220.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6220.dfy.expect
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
### What was changed?
Exactly as it says on the tin. As a result, the index variable in the generated loop with a cast to the index type was also removed.

### How has this been tested?
Test added.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
