### PR TITLE
Chore: revert nightly-build.yml

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,14 +28,6 @@ jobs:
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
-    secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
-
-  nightly-build-for-4-11-0:
-    if: github.repository_owner == 'dafny-lang'
-    uses: ./.github/workflows/nightly-build-reusable.yml
-    with:
-      ref: 4.11.0
       publish-prerelease: true
     secrets:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
A previous workflow item for releasing Dafny is now crashing nightly builds. I'll revert it for now

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
