### PR TITLE
Support multiple canVerifies having the same origin

### DIFF
--- a/Source/DafnyCore/AST/SourceOrigin.cs
+++ b/Source/DafnyCore/AST/SourceOrigin.cs
@@ -7,6 +7,16 @@ using VCGeneration;
 
 namespace Microsoft.Dafny;
 
+
+[SyntaxBaseType(typeof(IOrigin))]
+class GeneratedOrigin : OriginWrapper {
+  private string suffix;
+
+  public GeneratedOrigin(IOrigin wrappedOrigin, string suffix) : base(wrappedOrigin) {
+    this.suffix = suffix;
+  }
+}
+
 [method: SyntaxConstructor]
 [SyntaxBaseType(typeof(IOrigin))]
 public class SourceOrigin(TokenRange entireRange, TokenRange? reportingRange = null)

--- a/Source/DafnyCore/Pipeline/Compilation.cs
+++ b/Source/DafnyCore/Pipeline/Compilation.cs
@@ -308,24 +308,25 @@ public class Compilation : IDisposable {
       return false;
     }
 
-    var canVerify = GetCanVerify(verifiableLocation, resolution);
+    var canVerifies = GetCanVerify(verifiableLocation, resolution);
 
-    if (canVerify == null) {
-      return false;
+    var result = false;
+    foreach (var canVerify in canVerifies) {
+      result |= await VerifyCanVerify(canVerify, taskFilter ?? (_ => true), randomSeed, onlyPrepareVerificationForGutterTests);
     }
 
-    return await VerifyCanVerify(canVerify, taskFilter ?? (_ => true), randomSeed, onlyPrepareVerificationForGutterTests);
+    return result;
   }
 
-  private static ICanVerify? GetCanVerify(
+  private static IEnumerable<ICanVerify> GetCanVerify(
     FilePosition verifiableLocation,
     ResolutionResult resolution) {
     if (resolution.CanVerifies?.TryGetValue(verifiableLocation.Uri, out var canVerifyForUri) == true) {
       var canVerifies = canVerifyForUri.Query(verifiableLocation.Position.ToDafnyPosition());
-      return canVerifies.FirstOrDefault();
+      return canVerifies;
     }
 
-    return null;
+    return [];
   }
 
   private async Task<bool> VerifyCanVerify(ICanVerify canVerify, Func<IVerificationTask, bool> taskFilter,
@@ -491,8 +492,8 @@ public class Compilation : IDisposable {
       return;
     }
 
-    var canVerify = GetCanVerify(filePosition, resolution);
-    if (canVerify != null) {
+    var canVerifies = GetCanVerify(filePosition, resolution);
+    foreach (var canVerify in canVerifies) {
       var implementations = tasksPerVerifiable.TryGetValue(canVerify, out var implementationsPerName)
         ? implementationsPerName! : Enumerable.Empty<IVerificationTask>();
       foreach (var view in implementations) {


### PR DESCRIPTION
### What was changed?
- Support multiple canVerifies having the same origin.

### How has this been tested?
- TODO

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
