### PR TITLE
Function deserialization

### DIFF
--- a/Source/DafnyCore/AST/SyntaxDeserializer/Generated.cs
+++ b/Source/DafnyCore/AST/SyntaxDeserializer/Generated.cs
@@ -1783,29 +1783,6 @@ namespace Microsoft.Dafny
             return ReadConstructor();
         }
 
-        public Function ReadFunction()
-        {
-            var parameter0 = ReadAbstract<IOrigin>();
-            var parameter1 = ReadName();
-            var parameter16 = ReadAttributesOption();
-            var parameter3 = ReadBoolean();
-            var parameter17 = ReadAbstractOption<IOrigin>();
-            var parameter5 = ReadList<TypeParameter>(() => ReadTypeParameter());
-            var parameter6 = ReadList<Formal>(() => ReadFormal());
-            var parameter9 = ReadList<AttributedExpression>(() => ReadAttributedExpression());
-            var parameter11 = ReadList<AttributedExpression>(() => ReadAttributedExpression());
-            var parameter10 = ReadSpecification<FrameExpression>();
-            var parameter12 = ReadSpecification<Expression>();
-            var parameter2 = ReadBoolean();
-            var parameter4 = ReadBoolean();
-            var parameter7 = ReadFormalOption();
-            var parameter8 = ReadAbstract<Type>();
-            var parameter13 = ReadAbstractOption<Expression>();
-            var parameter14 = ReadAbstractOption<IOrigin>();
-            var parameter15 = ReadBlockStmtOption();
-            return new Function(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5, parameter6, parameter7, parameter8, parameter9, parameter10, parameter11, parameter12, parameter13, parameter14, parameter15, parameter16, parameter17);
-        }
-
         public Function ReadFunctionOption()
         {
             if (ReadIsNull())

--- a/Source/DafnyCore/AST/SyntaxDeserializer/HandWritten.cs
+++ b/Source/DafnyCore/AST/SyntaxDeserializer/HandWritten.cs
@@ -218,6 +218,10 @@ public partial class SyntaxDeserializer(IDecoder decoder) {
       return (T)(object)ReadAllocateArray();
     }
 
+    if (actualType == typeof(Function)) {
+      return (T)(object)ReadFunction();
+    }
+
     return (T)ReadObject(actualType);
   }
 
@@ -242,6 +246,30 @@ public partial class SyntaxDeserializer(IDecoder decoder) {
     var parameter3 = ReadAbstractOption<Expression>();
     SystemModuleModifiers.Add(b => b.ArrayType(parameter2.Count, new IntType(), true));
     return new AllocateArray(parameter0, parameter1, parameter2, parameter3, parameter4);
+  }
+  
+  public Function ReadFunction()
+  {
+    var parameter0 = ReadAbstract<IOrigin>();
+    var parameter1 = ReadName();
+    var parameter16 = ReadAttributesOption();
+    var parameter3 = ReadBoolean();
+    var parameter17 = ReadAbstractOption<IOrigin>();
+    var parameter5 = ReadList<TypeParameter>(() => ReadTypeParameter());
+    var parameter6 = ReadList<Formal>(() => ReadFormal());
+    var parameter9 = ReadList<AttributedExpression>(() => ReadAttributedExpression());
+    var parameter11 = ReadList<AttributedExpression>(() => ReadAttributedExpression());
+    var parameter10 = ReadSpecification<FrameExpression>();
+    var parameter12 = ReadSpecification<Expression>();
+    var parameter2 = ReadBoolean();
+    var parameter4 = ReadBoolean();
+    var parameter7 = ReadFormalOption();
+    var parameter8 = ReadAbstract<Type>();
+    var parameter13 = ReadAbstractOption<Expression>();
+    var parameter14 = ReadAbstractOption<IOrigin>();
+    var parameter15 = ReadBlockStmtOption();
+    SystemModuleModifiers.Add(b => b.CreateArrowTypeDecl(parameter6.Count));
+    return new Function(parameter0, parameter1, parameter2, parameter3, parameter4, parameter5, parameter6, parameter7, parameter8, parameter9, parameter10, parameter11, parameter12, parameter13, parameter14, parameter15, parameter16, parameter17);
   }
 }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
@@ -6,6 +6,10 @@
 class Anything {
   const x := 3123.012314
 
+  function bar(x:int, y:int) {
+    return x+y;
+  }
+
   method foo() {
     while(true) {
       continue;
@@ -19,6 +23,8 @@ class Anything {
     var tab := new int[3,4];
     tab[0,0] := 0;
     assert(tab[0,0] == 0);
+    
+    var tmp := bar(0,1);
   }
 }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
@@ -6,8 +6,8 @@
 class Anything {
   const x := 3123.012314
 
-  function bar(x:int, y:int) {
-    return x+y;
+  function bar(x:int, y:int):int {
+    x+y
   }
 
   method foo() {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
@@ -6,10 +6,6 @@
 class Anything {
   const x := 3123.012314
 
-  function bar(x:int, y:int):int {
-    x+y
-  }
-
   method foo() {
     while(true) {
       continue;
@@ -24,8 +20,16 @@ class Anything {
     tab[0,0] := 0;
     assert(tab[0,0] == 0);
     
-    var tmp := bar(0,1);
   }
+  
+  
+    function bar(x:int, y:int):int {
+      x+y
+    }
+    
+    method barCall() {
+      var tmp := bar(0,1);
+    }
 }
 
 trait ATrait {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/inputFormatAnything.dfy
@@ -22,14 +22,14 @@ class Anything {
     
   }
   
-  
-    function bar(x:int, y:int):int {
-      x+y
-    }
     
-    method barCall() {
-      var tmp := bar(0,1);
-    }
+  function P2(x:int, y:int) : bool {
+    x>y
+  }
+    
+  function P(x:int) : bool {
+    P2(x,10)
+  }
 }
 
 trait ATrait {

--- a/Source/Scripts/SyntaxDeserializerGenerator.cs
+++ b/Source/Scripts/SyntaxDeserializerGenerator.cs
@@ -19,7 +19,8 @@ public class SyntaxDeserializerGenerator : SyntaxAstVisitor {
     typeof(Specification<>),
     typeof(CasePattern<>),
     typeof(MultiSelectExpr),
-    typeof(AllocateArray)
+    typeof(AllocateArray),
+    typeof(Function)
   ];
 
   private ClassDeclarationSyntax deserializeClass = (ClassDeclarationSyntax)SyntaxFactory.ParseMemberDeclaration(@"


### PR DESCRIPTION
### What was changed?
Mimic the logic of adding `ArrowType` in the `SystemModuleModifiers` when deserializing a function. This is similar to what is done during parsing, see line 2015 of `Dafny.atg`

### How has this been tested?
Tried to extend the file `inputFormatAnything.dfy` but the change I could not make it fail without my changes. 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
