### PR TITLE
fix: Escape string literals in error messages

### DIFF
--- a/Source/DafnyCore/AST/Expressions/LiteralExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/LiteralExpr.cs
@@ -29,6 +29,8 @@ public class LiteralExpr : Expression, ICloneable<LiteralExpr> {
   /// </summary>
   public object? Value;
 
+  public string EscapedValue => $"{Value}".Replace("{", "{{").Replace("}", "}}");
+
   [System.Diagnostics.Contracts.Pure]
   public static bool IsTrue(Expression e) {
     Contract.Requires(e != null);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -77,15 +77,15 @@ namespace Microsoft.Dafny {
                 e.PreType = CreatePreTypeProxy($"boolean literal '{boolValue.ToString().ToLower()}'");
                 Constraints.AddDefaultAdvice(e.PreType, CommonAdvice.Target.Bool);
                 AddConfirmation(PreTypeConstraints.CommonConfirmationBag.InBoolFamily, e.PreType, e.Origin, "boolean literal used as if it had type {0}");
-              } else if (e is CharLiteralExpr) {
-                e.PreType = CreatePreTypeProxy($"character literal '{e.Value}'");
+              } else if (e is CharLiteralExpr charLiteralExpr) {
+                e.PreType = CreatePreTypeProxy($"character literal '{e.EscapedValue}'");
                 Constraints.AddDefaultAdvice(e.PreType, CommonAdvice.Target.Char);
                 AddConfirmation(PreTypeConstraints.CommonConfirmationBag.InCharFamily, e.PreType, e.Origin, "character literal used as if it had type {0}");
-              } else if (e is StringLiteralExpr) {
+              } else if (e is StringLiteralExpr stringLiteralExpr) {
                 var charPreType = CreatePreTypeProxy($"character in string literal");
                 Constraints.AddDefaultAdvice(charPreType, CommonAdvice.Target.Char);
                 AddConfirmation(PreTypeConstraints.CommonConfirmationBag.InCharFamily, charPreType, e.Origin, "character literal used as if it had type {0}");
-                ResolveCollectionProducingExpr(PreType.TypeNameSeq, $"string literal \"{e.Value}\"", e, charPreType, PreTypeConstraints.CommonConfirmationBag.InSeqFamily, true);
+                ResolveCollectionProducingExpr(PreType.TypeNameSeq, $"string literal \"{e.EscapedValue}\"", e, charPreType, PreTypeConstraints.CommonConfirmationBag.InSeqFamily, true);
               } else {
                 Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal type
               }

--- a/Source/DafnyStandardLibraries/src/Std/Parsers/Core/ParsersBuilders.dfy
+++ b/Source/DafnyStandardLibraries/src/Std/Parsers/Core/ParsersBuilders.dfy
@@ -255,7 +255,7 @@ abstract module Std.Parsers.Builders {
     /** `a.M3(unfolder, f)` evaluates `a` on the input, and then extracts its result to a triplet
         thanks to unfolder, on which it can apply the mapping function.
         Verbose equivalent: `a.Map3(unfolder, f)`.
-        If the parser returns a triplet already, use `Mid()` as built-in unfolder. */
+        If the parser returns a triplet already, use `MId()` as built-in unfolder. */
     function M3<R1, R2, R3, U>(unfolder: R -> (R1, R2, R3), mappingFunc: (R1, R2, R3) -> U): (p: B<U>) {
       B(P.Map(apply, (x: R) => var x := unfolder(x); mappingFunc(x.0, x.1, x.2)))
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeInferenceRefreshErrors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeInferenceRefreshErrors.dfy
@@ -279,3 +279,18 @@ module ArrayInitializer {
     var a: array<bool> := new [n] [23]; // error: array<int> and array<bool> are incompatible
   }
 }
+
+module EscapedStringLiterals {
+  // Make sure that string literals given in the input are properly escaped before they are
+  // displayed in error messages
+  method Test() returns (u: int) {
+    u := "x"; // error
+    u := "{"; // error
+    u := "{{"; // error
+    u := "}"; // error
+    u := "{0}"; // error
+
+    u := 'x'; // error
+    u := '{'; // error
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeInferenceRefreshErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/TypeInferenceRefreshErrors.dfy.expect
@@ -44,4 +44,11 @@ TypeInferenceRefreshErrors.dfy(269,15): Error: arguments to >= must be of a nume
 TypeInferenceRefreshErrors.dfy(268,15): Error: arguments to > must be of a numeric type, bitvector type, ORDINAL, char, or a set-like type (instead got bool)
 TypeInferenceRefreshErrors.dfy(275,34): Error: array-allocation initialization expression expected to have type 'nat ~> bool' (instead got 'nat -> nat') (covariant type parameter 'R' would require bool :> nat)
 TypeInferenceRefreshErrors.dfy(279,35): Error: integer literal used as if it had type bool
-43 resolution/type errors detected in TypeInferenceRefreshErrors.dfy
+TypeInferenceRefreshErrors.dfy(287,9): Error: string literal "x" used as if it had type int
+TypeInferenceRefreshErrors.dfy(288,9): Error: string literal "{" used as if it had type int
+TypeInferenceRefreshErrors.dfy(289,9): Error: string literal "{{" used as if it had type int
+TypeInferenceRefreshErrors.dfy(290,9): Error: string literal "}" used as if it had type int
+TypeInferenceRefreshErrors.dfy(291,9): Error: string literal "{0}" used as if it had type int
+TypeInferenceRefreshErrors.dfy(293,9): Error: character literal used as if it had type int
+TypeInferenceRefreshErrors.dfy(294,9): Error: character literal used as if it had type int
+50 resolution/type errors detected in TypeInferenceRefreshErrors.dfy

--- a/docs/dev/news/6273.fix
+++ b/docs/dev/news/6273.fix
@@ -1,0 +1,1 @@
+Escape user string literals in error messages


### PR DESCRIPTION
This PR fixes a crash where a string literal in the input was being passed to a string format method that interpreted the string as a format string. Characters like unmatched `{`'s in that string had then caused a crash when error messages were printed.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
