### PR TITLE
feat: Add scientific notation and dot shorthand support for real literals

### DIFF
--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -75,7 +75,9 @@ TOKENS
         .
   digits = digit {['_'] digit}.
   hexdigits = "0x" hexdigit {['_'] hexdigit}.
-  decimaldigits = digit {['_'] digit} '.' digit {['_'] digit}.
+  realnumber = digit {['_'] digit} '.' {digit {['_'] digit}} [('e'|'E') ['+'|'-'] digit {['_'] digit}]
+             | digit {['_'] digit} ('e'|'E') ['+'|'-'] digit {['_'] digit}
+             | '.' digit {['_'] digit} [('e'|'E') ['+'|'-'] digit {['_'] digit}].
   // NOTE: all alphabetic strings used in the grammar become reserved words automatically
   // The reason to include a definition here is so that a token can be referred to by its 'kind',
   // as in la.kind == _bool
@@ -4734,11 +4736,11 @@ DotSuffix<out Token x, out Token y>
   .)
   ( Ident<out x>
   | digits         (. x = t; .)
-  | decimaldigits  (. x = t;
+  | realnumber  (. x = t;
                       int exponent = x.val.IndexOf('e');
                       if (0 <= exponent) {
                         // this is not a legal field/destructor name
-                        // Also it is not currently reachable, because decimaldigits does not yet support exponents
+                        // Scientific notation is not allowed in field/destructor names
                         SemErr(ErrorId.p_invalid_name_after_dot, x, "invalid name after a '.'");
                       } else {
                         int dot = x.val.IndexOf('.');
@@ -4899,8 +4901,27 @@ Nat<out BigInteger n>
 /*------------------------------------------------------------------------*/
 Dec<out BaseTypes.BigDec d>
 = (. d = BaseTypes.BigDec.ZERO; .)
-  (decimaldigits
+  (realnumber
     (. var S = Util.RemoveUnderscores(t.val);
+       // Convert uppercase E to lowercase e for scientific notation compatibility
+       S = S.Replace('E', 'e');
+       // Handle leading dot case (e.g., ".1" -> "0.1", ".5e2" -> "0.5e2")
+       if (S.StartsWith(".")) {
+         S = "0" + S;
+       }
+       // Handle trailing dot case (e.g., "1." -> "1.0", "5.e2" -> "5.0e2")
+       int dotIndex = S.IndexOf('.');
+       int eIndex = S.IndexOf('e');
+       if (dotIndex >= 0 && (eIndex < 0 || dotIndex + 1 == eIndex)) {
+         // Either "1." or "5.e2" case - need to add zero after dot
+         if (eIndex < 0) {
+           // Simple "1." case
+           S += "0";
+         } else {
+           // "5.e2" case - insert "0" between dot and e
+           S = S.Substring(0, dotIndex + 1) + "0" + S.Substring(eIndex);
+         }
+       }
        try {
          d = BaseTypes.BigDec.FromString(S);
        } catch (System.FormatException) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotation.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotation.dfy
@@ -1,0 +1,252 @@
+// RUN: %exits-with 0 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Test basic scientific notation parsing and semantics
+method BasicScientificNotation() {
+  // Basic positive exponents
+  var a := 1.23e2;     // 123.0
+  var b := 1.23E2;     // 123.0 (uppercase E)
+  var c := 1.23e+2;    // 123.0 (explicit +)
+  
+  // Basic negative exponents  
+  var d := 1.23e-2;    // 0.0123
+  var e := 1.23E-2;    // 0.0123 (uppercase E)
+  
+  // Zero exponent
+  var f := 1.23e0;     // 1.23
+  var g := 1.23e+0;    // 1.23
+  var h := 1.23e-0;    // 1.23
+  
+  // Verify basic equivalences
+  assert a == b == c == 123.0;
+  assert d == e == 0.0123;
+  assert f == g == h == 1.23;
+  
+  // Cross-format equivalences
+  assert a == b == c;
+  assert d == e;
+  assert f == g == h;
+}
+
+method IntegerScientificNotation() {
+  // Integer base with scientific notation
+  var a := 5e2;        // 500.0
+  var b := 5E2;        // 500.0
+  var c := 5e+2;       // 500.0
+  var d := 5e-1;       // 0.5
+  var e := 5e0;        // 5.0
+  
+  assert a == b == c == 500.0;
+  assert d == 0.5;
+  assert e == 5.0;
+  
+  assert a == b == c;
+}
+
+method TrailingDotLiterals() {
+  // Basic trailing dot literals
+  var a := 1.;         // 1.0
+  var b := 123.;       // 123.0
+  var c := 0.;         // 0.0
+  
+  // Trailing dots with scientific notation
+  var d := 5.e2;       // 500.0
+  var e := 42.E-1;     // 4.2
+  var f := 1.e0;       // 1.0
+  
+  // Trailing dots with underscores
+  var g := 1_000.;     // 1000.0
+  var h := 1_2.e3;     // 12000.0
+  
+  // Verify values
+  assert a == 1.0;
+  assert b == 123.0;
+  assert c == 0.0;
+  assert d == 500.0;
+  assert e == 4.2;
+  assert f == 1.0;
+  assert g == 1000.0;
+  assert h == 12000.0;
+  
+  // Equivalences with traditional forms
+  assert a == 1.0;
+  assert b == 123.0;
+  assert d == 5.0e2;
+  assert e == 42.0E-1;
+}
+
+method LeadingDotLiterals() {
+  // Basic leading dot literals
+  var a := .1;         // 0.1
+  var b := .25;        // 0.25
+  var c := .0;         // 0.0
+  
+  // Leading dots with scientific notation
+  var d := .5e3;       // 500.0
+  var e := .75E-2;     // 0.0075
+  var f := .1e0;       // 0.1
+  
+  // Leading dots with underscores
+  var g := .1_2_3;     // 0.123
+  var h := .5_0e2;     // 50.0
+  
+  // Verify values
+  assert a == 0.1;
+  assert b == 0.25;
+  assert c == 0.0;
+  assert d == 500.0;
+  assert e == 0.0075;
+  assert f == 0.1;
+  assert g == 0.123;
+  assert h == 50.0;
+  
+  // Equivalences with traditional forms
+  assert a == 0.1;
+  assert b == 0.25;
+  assert d == 0.5e3;
+  assert e == 0.75E-2;
+}
+
+method DotLiteralArithmetic() {
+  // Arithmetic with trailing dots
+  var a := 5.;         // 5.0
+  var b := 2.;         // 2.0
+  
+  // Arithmetic with leading dots
+  var c := .5;         // 0.5
+  var d := .25;        // 0.25
+  
+  // Mixed arithmetic
+  assert a + b == 7.0;
+  assert a - b == 3.0;
+  assert a * b == 10.0;
+  assert a / b == 2.5;
+  
+  assert c + d == 0.75;
+  assert c - d == 0.25;
+  assert c * d == 0.125;
+  assert c / d == 2.0;
+  
+  // Mixed with traditional forms
+  assert a + 1.0 == 6.0;
+  assert c * 2.0 == 1.0;
+  assert 10. / 2. == 5.0;
+  assert .1 + .9 == 1.0;
+}
+
+method LargeExponents() {
+  // Large positive exponents
+  var a := 1.0e10;     // 10,000,000,000.0
+  var b := 2.5e8;      // 250,000,000.0
+  
+  // Large negative exponents
+  var c := 1.0e-10;    // 0.0000000001
+  var d := 2.5e-8;     // 0.000000025
+  
+  // Verify relationships
+  assert a == 10000000000.0;
+  assert b == 250000000.0;
+  assert c == 0.0000000001;
+  assert d == 0.000000025;
+  
+  // Mathematical relationships
+  assert a / 1.0e10 == 1.0;
+  assert b / 1.0e8 == 2.5;
+  assert c * 1.0e10 == 1.0;
+  assert d * 1.0e8 == 2.5;
+}
+
+method ScientificNotationArithmetic() {
+  var a := 1.5e2;      // 150.0
+  var b := 3.0e1;      // 30.0
+  var c := 2.0e-1;     // 0.2
+  
+  // Basic arithmetic
+  assert a + b == 180.0;
+  assert a - b == 120.0;
+  assert a * c == 30.0;
+  assert a / b == 5.0;
+  
+  // Mixed with regular decimals
+  assert a + 50.0 == 200.0;
+  assert b * 2.0 == 60.0;
+  assert c + 0.8 == 1.0;
+}
+
+method EdgeCases() {
+  // Zero with scientific notation
+  var a := 0.0e5;      // 0.0
+  var b := 0e-3;       // 0.0
+  
+  // Zero with dot literals
+  var c := 0.;         // 0.0
+  var d := .0;         // 0.0
+  
+  // Very small numbers
+  var e := 1e-100;     // Very small positive
+  var f := 1.0e-100;   // Very small positive
+  
+  // Numbers close to 1
+  var g := 9.99e-1;    // 0.999
+  var h := 1.01e0;     // 1.01
+  
+  assert a == b == c == d == 0.0;
+  assert e == f > 0.0;
+  assert g < 1.0;
+  assert h > 1.0;
+}
+
+method UnderscoreSupport() {
+  // Test underscores in scientific notation for improved readability
+  // Dafny already supports underscores in decimal literals (e.g., 1_234.567_890)
+  // so we extend this support to scientific notation for consistency
+  var a := 1_2.3_4e1_0;    // 123.4e10 - underscores in base and exponent
+  var b := 1_0e-0_5;       // 10e-05 = 10e-5 - underscores with negative exponent
+  
+  // Underscores with dot literals
+  var c := 1_000.;         // 1000.0 - trailing dot with underscores
+  var d := .1_2_3;         // 0.123 - leading dot with underscores
+  
+  assert a == 123400000000.0;
+  assert b == 0.0001;
+  assert c == 1000.0;
+  assert d == 0.123;
+}
+
+method ComparisonOperations() {
+  var small := 1.0e-5;     // 0.00001
+  var medium := 1.0e0;     // 1.0
+  var large := 1.0e5;      // 100000.0
+  
+  // Ordering
+  assert small < medium;
+  assert medium < large;
+  assert small < large;
+  
+  // Equality with equivalent forms
+  assert 1.0e2 == 100.0;
+  assert 5.0e-1 == 0.5;
+  assert 1.0e0 == 1.0;
+  
+  // Equality with dot literals
+  assert 1. == 1.0;
+  assert .5 == 0.5;
+  assert 5.e1 == 50.0;
+  assert .1e1 == 1.0;
+}
+
+method TypeConversions() {
+  var r := 1.23e2;     // 123.0
+  
+  // Floor operation
+  assert r.Floor == 123;
+  
+  // Conversion to int (when appropriate)
+  assert (1.0e2).Floor == 100;
+  assert (5.0e0).Floor == 5;
+  
+  // Floor with dot literals
+  assert (5.).Floor == 5;
+  assert (.5e1).Floor == 5;    // 0.5e1 = 5.0
+  assert (1.9).Floor == 1;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotation.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotation.dfy.expect
@@ -1,0 +1,1 @@
+Dafny program verifier finished with 11 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy
@@ -1,0 +1,47 @@
+// RUN: %exits-with 2 %resolve "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Test error cases for scientific notation and dot literals
+
+method MalformedScientificNotation() {
+  // Incomplete scientific notation - missing exponent
+  var a := 1.23e;      // Error: incomplete
+  var b := 5.e;        // Error: incomplete  
+  var c := .5e;        // Error: incomplete
+  
+  // Missing digits after decimal in scientific notation
+  var d := .e2;        // Error: no digits after dot
+}
+
+method InvalidUnderscorePlacement() {
+  // Invalid underscore before dot
+  var a := 1_.;        // Error: underscore before dot
+  var b := 1_2_.;      // Error: underscore before dot
+  
+  // Invalid underscore after dot at start
+  var c := ._5;        // Error: underscore after dot at start
+  var d := ._1_2;      // Error: underscore after dot at start
+  
+  // Invalid underscore in exponent
+  var e := 1.e_2;      // Error: underscore at start of exponent
+  var f := 1.e2_;      // Error: underscore at end of exponent
+}
+
+method EmptyAndInvalidCases() {
+  // Just a decimal point
+  var a := .;          // Error: lone decimal point
+  
+  // Multiple decimal points
+  var b := 1.2.3;      // Error: multiple dots
+  var c := .1.2;       // Error: multiple dots
+}
+
+method InvalidCombinations() {
+  // Multiple e's
+  var a := 1.23e2e3;   // Error: multiple exponents
+  
+  // Invalid characters in scientific notation
+  var b := 1.23f5;     // Error: 'f' instead of 'e'
+  var c := 1.23E+;     // Error: missing exponent after +
+  var d := 1.23E-;     // Error: missing exponent after -
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy.expect
@@ -1,0 +1,86 @@
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(8,21): Error: this symbol not expected in VarDeclStatement
+  |
+8 |   ghost var a := 1.23e;      // Error: incomplete
+  |                      ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(9,19): Error: this symbol not expected in VarDeclStatement
+  |
+9 |   ghost var b := 5.e;        // Error: incomplete  
+  |                    ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(10,19): Error: this symbol not expected in VarDeclStatement
+   |
+10 |   ghost var c := .5e;        // Error: incomplete
+   |                    ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(13,17): Error: invalid Rhs
+   |
+13 |   ghost var d := .e2;        // Error: no digits after dot
+   |                  ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(18,18): Error: this symbol not expected in VarDeclStatement
+   |
+18 |   ghost var a := 1_.;        // Error: underscore before dot
+   |                   ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(19,20): Error: this symbol not expected in VarDeclStatement
+   |
+19 |   ghost var b := 1_2_.;      // Error: underscore before dot
+   |                     ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(22,17): Error: invalid Rhs
+   |
+22 |   ghost var c := ._5;        // Error: underscore after dot at start
+   |                  ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(23,17): Error: invalid Rhs
+   |
+23 |   ghost var d := ._1_2;      // Error: underscore after dot at start
+   |                  ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(26,19): Error: this symbol not expected in VarDeclStatement
+   |
+26 |   ghost var e := 1.e_2;      // Error: underscore at start of exponent
+   |                    ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(27,21): Error: this symbol not expected in VarDeclStatement
+   |
+27 |   ghost var f := 1.e2_;      // Error: underscore at end of exponent
+   |                      ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(32,17): Error: invalid Rhs
+   |
+32 |   ghost var a := .;          // Error: lone decimal point
+   |                  ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(35,20): Error: this symbol not expected in VarDeclStatement
+   |
+35 |   ghost var b := 1.2.3;      // Error: multiple dots
+   |                     ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(36,19): Error: this symbol not expected in VarDeclStatement
+   |
+36 |   ghost var c := .1.2;       // Error: multiple dots
+   |                    ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(41,23): Error: this symbol not expected in VarDeclStatement
+   |
+41 |   ghost var a := 1.23e2e3;   // Error: multiple exponents
+   |                        ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(44,21): Error: this symbol not expected in VarDeclStatement
+   |
+44 |   ghost var b := 1.23f5;     // Error: 'f' instead of 'e'
+   |                      ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(45,21): Error: this symbol not expected in VarDeclStatement
+   |
+45 |   ghost var c := 1.23E+;     // Error: missing exponent after +
+   |                      ^
+
+Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/ScientificNotationErrors.dfy(46,21): Error: this symbol not expected in VarDeclStatement
+   |
+46 |   ghost var d := 1.23E-;     // Error: missing exponent after -
+   |                      ^
+
+17 parse errors detected in ScientificNotationErrors.dfy

--- a/docs/DafnyRef/Grammar.md
+++ b/docs/DafnyRef/Grammar.md
@@ -300,9 +300,12 @@ prefaced by `0x` and
 possibly interspersed with underscores for readability (but not beginning or ending with an underscore).
 Example: `0xffff_ffff`.
 
-A `decimaldigits` token is a decimal fraction constant, possibly interspersed with underscores for readability (but not beginning or ending with an underscore).
-It has digits both before and after a single period (`.`) character. There is no syntax for floating point numbers with exponents.
-Example: `123_456.789_123`.
+A `realnumber` token is a real number literal, possibly interspersed with
+underscores for readability (but not beginning or ending with an underscore).
+It can be a decimal fraction (like `123.456`), scientific notation (like
+`1.23e5` or `123e5`), or convenient shorthand forms with leading or trailing
+dots (like `.5` or `1.`). All forms produce real number values.
+Examples: `123_456.789_123`, `1.23e5`, `123E-2`, `5e+10`, `1.`, `.5`, `5.e2`.
 
 ### 2.6.4. Escaped Character {#sec-escaped-characters}
 
@@ -510,5 +513,5 @@ the `--quantifier-syntax:4` option needs to be provided to enable this feature (
 
 Integer and bitvector literals may be expressed in either decimal or hexadecimal (`digits` or `hexdigits`).
 
-Real number literals are written as decimal fractions (`decimaldigits`).
+Real number literals are written as real number tokens (`realnumber`).
 

--- a/docs/DafnyRef/Types.md
+++ b/docs/DafnyRef/Types.md
@@ -234,20 +234,22 @@ a lower case `x`, but the hexadecimal digits themselves are case
 insensitive).  Leading zeros are allowed.  To form negative literals,
 use the unary minus operator, as in `-12`, but not `-(12)`.
 
-There are also literals for some of the reals.  These are
-written as a decimal point with a nonempty sequence of decimal digits
-on both sides, optionally prefixed by a `-` character.
-For example, `1.0`, `1609.344`, `-12.5`, and `0.5772156649`.
-Real literals using exponents are not supported in Dafny. For now, you'd have to write your own function for that, e.g. 
-<!-- %check-verify -->
-```dafny
-// realExp(2.37, 100) computes 2.37e100
-function realExp(r: real, e: int): real decreases if e > 0 then e else -e {
-  if e == 0 then r
-  else if e < 0 then realExp(r/10.0, e+1)
-  else realExp(r*10.0, e-1)
-}
-```
+There are also **real literals** for some of the reals. Real literals
+can be written in several forms:
+
+**Decimal form**: A decimal point with decimal digits, optionally
+prefixed by a `-` character. The basic form has digits on both sides
+of the decimal point, like `1.0`, `1609.344`, `-12.5`, and `0.5772156649`.
+Convenient shorthand forms are also supported: trailing dots
+(like `1.` for `1.0`) and leading dots (like `.5` for `0.5`).
+
+**Scientific notation**: Uses `e` or `E` to denote the exponent.
+For example, `1.23e5` (which equals `123000.0`), `1.23E-2`
+(which equals `0.0123`), and `5e0` (which equals `5.0`). The exponent
+can be optionally prefixed with `+` or `-`, as in `1.0e+10` or `2.5e-3`.
+Both decimal numbers with optional exponents (like `1.23e5`) and integers
+with mandatory exponents (like `123e5`) are supported. Scientific notation
+can also be combined with dot shorthands, such as `5.e2` or `.5e3`.
 
 For integers (in both decimal and hexadecimal form) and reals,
 any two digits in a literal may be separated by an underscore in order

--- a/docs/dev/news/6286.feat
+++ b/docs/dev/news/6286.feat
@@ -1,0 +1,1 @@
+Real literals now support scientific notation using `e` or `E` to denote the exponent (like `1.23e5` for `123000.0` or `5e-2` for `0.05`). Real literals also support convenient shorthand forms: trailing dots (like `1.` for `1.0`) and leading dots (like `.5` for `0.5`). These shorthand forms can be combined with scientific notation, such as `.125e3` for `125.0`.


### PR DESCRIPTION
- Add scientific notation support (e.g., 1.23e5, 5e-2, 123E+4)
- Add trailing dot shorthand (e.g., 1. for 1.0)
- Add leading dot shorthand (e.g., .5 for 0.5)
- Support combining dot shorthands with scientific notation (.125e3)
- Update grammar to handle all new real literal forms
- Add comprehensive tests for parsing and error cases
- Update documentation with consistent terminology
