### PR TITLE
Relax restrictions for constants in value traits

### DIFF
--- a/Source/DafnyCore/AST/Statements/Assignment/SingleAssignStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/SingleAssignStmt.cs
@@ -120,7 +120,7 @@ public class SingleAssignStmt : Statement, ICloneable<SingleAssignStmt> {
       }
     } else {
       // LHS denotes an array element, which is always non-ghost
-      return NonGhostKind.ArrayElement;
+      return NonGhostKind.IsGhost;
     }
     return NonGhostKind.IsGhost;
   }

--- a/Source/DafnyCore/AST/Statements/Assignment/SingleAssignStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/SingleAssignStmt.cs
@@ -120,7 +120,7 @@ public class SingleAssignStmt : Statement, ICloneable<SingleAssignStmt> {
       }
     } else {
       // LHS denotes an array element, which is always non-ghost
-      return NonGhostKind.IsGhost;
+      return NonGhostKind.ArrayElement;
     }
     return NonGhostKind.IsGhost;
   }

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1872,8 +1872,8 @@ namespace Microsoft.Dafny {
       var statik = f.IsStatic ? "static " : "";
 
       if (f.IsGhost && !f.Type.IsNonempty) {
-        reporter.Error(MessageSource.Resolver, f.Origin,
-          $"{statik}ghost const field '{f.Name}' of type '{f.Type}' (which may be empty) must give a defining value{hint}");
+        // reporter.Error(MessageSource.Resolver, f.Origin,
+        //   $"{statik}ghost const field '{f.Name}' of type '{f.Type}' (which may be empty) must give a defining value{hint}");
       } else if (!f.IsGhost && !f.Type.HasCompilableValue) {
         reporter.Error(MessageSource.Resolver, f.Origin,
           $"{statik}non-ghost const field '{f.Name}' of type '{f.Type}' (which does not have a default compiled value) must give a defining value{hint}");

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1148.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1148.dfy
@@ -1,4 +1,4 @@
-// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s"
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s" -- --general-traits=datatype
 
 
 module AutoInitRegressions {
@@ -42,6 +42,13 @@ module AutoInitRegressions {
     static const Static: Y  // error: Y is not auto-init
     const Instance: Y  // error: Y is not auto-init
   }
+
+  trait PossiblyDatatypeTrait {
+    static const StaticField: Y  // error: Y is not nonempty
+    const InstanceField: Y
+  }    
+
+  datatype PossiblyDatatypeTraitImpl extends PossiblyDatatypeTrait = PossiblyDatatypeTraitImpl { } // error
 }
 
 module NonemptyRegressions {
@@ -79,4 +86,11 @@ module NonemptyRegressions {
     ghost static const Static: Y  // error: Y is not nonempty
     ghost const Instance: Y  // error: Y is not nonempty
   }
+
+  trait PossiblyDatatypeTrait {
+    ghost static const StaticField: Y  // error: Y is not nonempty
+    ghost const InstanceField: Y
+  }    
+
+  datatype PossiblyDatatypeTraitImpl extends PossiblyDatatypeTrait = PossiblyDatatypeTraitImpl { } // error
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1148.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1148.dfy.expect
@@ -10,7 +10,7 @@ git-issue-1148.dfy(37,10): Error: non-ghost const field 'Instance' of type 'Y' (
 git-issue-1148.dfy(42,17): Error: static non-ghost const field 'Static' of type 'Y' (which does not have a default compiled value) must give a defining value
 git-issue-1148.dfy(43,10): Error: non-ghost const field 'Instance' of type 'Y' (which does not have a default compiled value) must give a defining value
 git-issue-1148.dfy(47,17): Error: static non-ghost const field 'StaticField' of type 'Y' (which does not have a default compiled value) must give a defining value
-git-issue-1148.dfy(51,11): Error: datatype 'PossiblyDatatypeTraitImpl' may not inherit a non-ghost const field 'InstanceField' of type 'Y' (which does not have a default compiled value) without a defining value
+git-issue-1148.dfy(51,11): Error: datatype 'PossiblyDatatypeTraitImpl' must not inherit a non-ghost const field 'InstanceField' of type 'Y' (which does not have a default compiled value) without a defining value
 git-issue-1148.dfy(63,14): Error: static ghost const field 'Global' of type 'Y' (which may be empty) must give a defining value
 git-issue-1148.dfy(59,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
 git-issue-1148.dfy(60,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1148.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-1148.dfy.expect
@@ -9,15 +9,19 @@ git-issue-1148.dfy(36,17): Error: static non-ghost const field 'Static' of type 
 git-issue-1148.dfy(37,10): Error: non-ghost const field 'Instance' of type 'Y' (which does not have a default compiled value) must give a defining value
 git-issue-1148.dfy(42,17): Error: static non-ghost const field 'Static' of type 'Y' (which does not have a default compiled value) must give a defining value
 git-issue-1148.dfy(43,10): Error: non-ghost const field 'Instance' of type 'Y' (which does not have a default compiled value) must give a defining value
-git-issue-1148.dfy(56,14): Error: static ghost const field 'Global' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(52,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(53,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(59,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(58,8): Error: class 'Class' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
-git-issue-1148.dfy(64,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(68,8): Error: class 'TraitImpl' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
-git-issue-1148.dfy(73,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(74,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(79,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
-git-issue-1148.dfy(80,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
-22 resolution/type errors detected in git-issue-1148.dfy
+git-issue-1148.dfy(47,17): Error: static non-ghost const field 'StaticField' of type 'Y' (which does not have a default compiled value) must give a defining value
+git-issue-1148.dfy(51,11): Error: datatype 'PossiblyDatatypeTraitImpl' may not inherit a non-ghost const field 'InstanceField' of type 'Y' (which does not have a default compiled value) without a defining value
+git-issue-1148.dfy(63,14): Error: static ghost const field 'Global' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(59,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(60,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(66,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(65,8): Error: class 'Class' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
+git-issue-1148.dfy(71,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(75,8): Error: class 'TraitImpl' with fields without known initializers, like 'InstanceField' of type 'Y', must declare a constructor
+git-issue-1148.dfy(80,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(81,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(86,23): Error: static ghost const field 'Static' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(87,16): Error: ghost const field 'Instance' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(91,23): Error: static ghost const field 'StaticField' of type 'Y' (which may be empty) must give a defining value
+git-issue-1148.dfy(95,11): Error: datatype 'PossiblyDatatypeTraitImpl' must not inherit a ghost const field 'InstanceField' of type 'Y' (which may be empty) without a defining value
+26 resolution/type errors detected in git-issue-1148.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraits.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraits.dfy
@@ -216,14 +216,14 @@ module UninitializedConsts {
     ghost const A: AutoInit
     ghost const B: AutoInit := 15
 
-    const g: Nonempty // error: requires initialization
+    const g: Nonempty
     const h: Nonempty := 15
     ghost const G: Nonempty
     ghost const H: Nonempty := 15
 
-    const s: PossiblyEmpty // error: requires initialization
+    const s: PossiblyEmpty
     const t: PossiblyEmpty := 15
-    ghost const S: PossiblyEmpty // error: requires initialization
+    ghost const S: PossiblyEmpty
     ghost const T: PossiblyEmpty := 15
   }
 

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraits.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraits.dfy.expect
@@ -77,9 +77,6 @@ NonReferenceTraits.dfy(192,16): Error: ghost const field 'S' of type 'PossiblyEm
 NonReferenceTraits.dfy(202,10): Error: non-ghost const field 'g' of type 'Nonempty' (which does not have a default compiled value) must give a defining value
 NonReferenceTraits.dfy(207,10): Error: non-ghost const field 's' of type 'PossiblyEmpty' (which does not have a default compiled value) must give a defining value
 NonReferenceTraits.dfy(209,16): Error: ghost const field 'S' of type 'PossiblyEmpty' (which may be empty) must give a defining value
-NonReferenceTraits.dfy(219,10): Error: non-ghost const field 'g' of type 'Nonempty' (which does not have a default compiled value) must give a defining value (consider changing the field to be a function, or restricting the enclosing trait to be a reference type by adding 'extends object')
-NonReferenceTraits.dfy(224,10): Error: non-ghost const field 's' of type 'PossiblyEmpty' (which does not have a default compiled value) must give a defining value (consider changing the field to be a function, or restricting the enclosing trait to be a reference type by adding 'extends object')
-NonReferenceTraits.dfy(226,16): Error: ghost const field 'S' of type 'PossiblyEmpty' (which may be empty) must give a defining value (consider changing the field to be a function, or restricting the enclosing trait to be a reference type by adding 'extends object')
 NonReferenceTraits.dfy(279,8): Error: class 'ClassWithParentWithoutConstructor' with fields without known initializers, like 'g' of type 'Nonempty', must declare a constructor
 NonReferenceTraits.dfy(295,17): Error: static non-ghost const field 'g' of type 'Nonempty' (which does not have a default compiled value) must give a defining value
 NonReferenceTraits.dfy(300,17): Error: static non-ghost const field 's' of type 'PossiblyEmpty' (which does not have a default compiled value) must give a defining value
@@ -112,4 +109,4 @@ NonReferenceTraits.dfy(460,9): Error: == can only be applied to expressions of t
 NonReferenceTraits.dfy(470,9): Error: == can only be applied to expressions of types that support equality (got TraitA)
 NonReferenceTraits.dfy(471,9): Error: == can only be applied to expressions of types that support equality (got TraitB)
 NonReferenceTraits.dfy(472,14): Error: set argument type must support equality (got TraitA)
-62 resolution/type errors detected in NonReferenceTraits.dfy
+59 resolution/type errors detected in NonReferenceTraits.dfy

--- a/docs/dev/news/6314.feat
+++ b/docs/dev/news/6314.feat
@@ -1,0 +1,1 @@
+Allow value traits (those that do not extend from object), to declare const fields without initializers. 


### PR DESCRIPTION
Asking for 2 reviewers since this change potentially introduces a soundness bug

### What was changed?
- Allow initialized const fields that are non-init or possible-empty, in value traits. To ensure soundness, extra checks are added to members that inherit from such traits and that do not require constructors, such as datatypes and newtypes.

### How has this been tested?
- Updated test `git-issue-1148.dfy` with new cases

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
