### PR TITLE
Fixes resolver crashes related to datatypes and traits

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/Flows.cs
+++ b/Source/DafnyCore/Resolver/PreType/Flows.cs
@@ -223,7 +223,9 @@ abstract class Flow {
     var aDecl = ((UserDefinedType)a).ResolvedClass;
     var bDecl = ((UserDefinedType)b).ResolvedClass;
     var commonSupertypeDecl = PreTypeConstraints.JoinHeads(aDecl, bDecl, context.SystemModuleManager);
-    Contract.Assert(commonSupertypeDecl != null);
+    if (commonSupertypeDecl == null) {
+      return null; // join does not exist (e.g., it is not unique)
+    }
     var aTypeSubstMap = TypeParameter.SubstitutionMap(aDecl.TypeArgs, a.TypeArgs);
     (aDecl as TopLevelDeclWithMembers)?.AddParentTypeParameterSubstitutions(aTypeSubstMap);
     var bTypeSubstMap = TypeParameter.SubstitutionMap(bDecl.TypeArgs, b.TypeArgs);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Types.cs
@@ -1504,7 +1504,7 @@ public partial class BoogieGenerator {
         be = FunctionCall(expr.Origin, "ORD#Offset", Bpl.Type.Int, o);
         be = ConvertExpression(expr.Origin, be, Dafny.Type.Int, toType);
       } else {
-        be = o;
+        be = ConvertExpression(expr.Origin, o, fromType, toTypeFamily);
       }
       CheckResultToBeInType_Aux(tok, new BoogieWrapper(be, toTypeFamily), expr, toType.NormalizeExpandKeepConstraints(), builder, etran, errorMsgPrefix);
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/AsIs-Verify.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/AsIs-Verify.dfy
@@ -13,3 +13,20 @@ method CompareRegression(f: bool ~> nat) {
   var g := f as bool ~> int;
   var h := f as bool ~> pos; // error (case in point: f(true) may be 0)
 }
+
+// regression test:
+
+trait TT {}
+datatype Data extends TT = CreateData
+type JustData = t: TT | t is Data witness *
+
+method Test0(dd: Data) returns (jd: JustData) {
+  // the translation of the following line once generated malformed Boogie (missing Box(...))
+  jd := dd as JustData;
+}
+
+method Test1(tt: TT) returns (jd: JustData)
+  requires tt is Data
+{
+  jd := tt as JustData;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/AsIs-Verify.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny0/AsIs-Verify.dfy.expect
@@ -1,4 +1,4 @@
 AsIs-Verify.dfy(9,24): Error: value of expression (of type 'bool ~> nat') is not known to be an instance of type 'bool ~> pos'
 AsIs-Verify.dfy(14,13): Error: value of expression (of type 'bool ~> nat') is not known to be an instance of type 'bool ~> pos'
 
-Dafny program verifier finished with 1 verified, 2 errors
+Dafny program verifier finished with 3 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317a.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317a.dfy
@@ -1,0 +1,17 @@
+// RUN: %exits-with 2 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// This file contains variations of types (D1 and D2) having several common supertypes. This had
+// once caused various crashes in the resolver.
+
+trait TBase {}
+trait TT {}
+datatype D1 extends TBase, TT = D1
+datatype D2 extends TBase, TT = D2
+type SS = t: TT | t is D1 || t is D2 witness *
+
+method NotUnique(b: bool, d1: D1, d2: D2) {
+  var r0 := if b then d1 else d2; // error: type of RHS is not unique (error message says d1 and d2 have different types)
+  var r1 := (if b then d1 else d2) as TT; // error: type of if-then-else is not unique
+  var r2 := (if b then d1 else d2) as TBase; // error: type of if-then-else is not unique
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317a.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317a.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-6317a.dfy(14,12): Error: the two branches of an if-then-else expression must have the same type (got D1 and D2)
+git-issue-6317a.dfy(15,13): Error: the two branches of an if-then-else expression must have the same type (got D1 and D2)
+git-issue-6317a.dfy(16,13): Error: the two branches of an if-then-else expression must have the same type (got D1 and D2)
+3 resolution/type errors detected in git-issue-6317a.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317b.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317b.dfy
@@ -1,0 +1,39 @@
+// RUN: %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// This file contains variations of types (D1 and D2) having several common supertypes. This had
+// once caused various crashes in the resolver.
+
+trait TBase {}
+trait TT {}
+datatype D1 extends TBase, TT = D1
+datatype D2 extends TBase, TT = D2
+type SS = t: TT | t is D1 || t is D2 witness *
+
+method Fine(b: bool, d1: D1, d2: D2) {
+  var r0: TT := if b then d1 else d2;
+  var r1: TBase := if b then d1 else d2;
+  var r2 := if b then d1 as TBase else d2;
+  var r3 := if b then d1 else d2 as TBase;
+  var r4 := if b then d1 as TT else d2;
+  var r5 := if b then d1 else d2 as TT;
+
+  var s0 := if b then d1 as SS else d2;
+  var s1 := if b then d1 as SS else d2 as SS;
+}
+
+function F0(b: bool, d1: D1, d2: D2): TT {
+  if b then d1 else d2
+}
+
+function F1(b: bool, d1: D1, d2: D2): TBase {
+  if b then d1 else d2
+}
+
+function F2(b: bool, d1: D1, d2: D2): TT {
+  if b then d1 else d2 as SS
+}
+
+function F3(b: bool, d1: D1, d2: D2): TT {
+ if b then d1 else d2 as TT
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317b.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6317b.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors

--- a/docs/dev/news/6321.fix
+++ b/docs/dev/news/6321.fix
@@ -1,0 +1,1 @@
+Fix two resolver crashes involving datatypes and traits


### PR DESCRIPTION
Fixes two problems/crashes in the new resolver.

Fixes #6317 


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
