### PR TITLE
chore: Bump Boogie version to 3.5.5

### DIFF
--- a/Source/DafnyCore/AST/AstVisitor.cs
+++ b/Source/DafnyCore/AST/AstVisitor.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Dafny {
 
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // unexpected member type
+        throw new Cce.UnreachableException(); // unexpected member type
       }
     }
 

--- a/Source/DafnyCore/AST/Attributes.cs
+++ b/Source/DafnyCore/AST/Attributes.cs
@@ -50,7 +50,7 @@ public class Attributes : NodeWithOrigin, ICanFormat {
   [ContractInvariantMethod]
   void ObjectInvariant() {
     Contract.Invariant(Name != null);
-    Contract.Invariant(cce.NonNullElements(Args));
+    Contract.Invariant(Cce.NonNullElements(Args));
   }
 
   public static readonly string AxiomAttributeName = "axiom";

--- a/Source/DafnyCore/AST/Cloner.cs
+++ b/Source/DafnyCore/AST/Cloner.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Dafny {
       } else if (d is TupleTypeDecl) {
         // Tuple type declarations only exist in the system module. Therefore, they are never cloned.
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       } else if (d is IndDatatypeDecl) {
         var dd = (IndDatatypeDecl)d;
         var tps = dd.TypeArgs.ConvertAll(CloneTypeParam);
@@ -433,7 +433,7 @@ namespace Microsoft.Dafny {
       }
 
       Contract.Assert(false);
-      throw new cce.UnreachableException(); // unexpected statement TODO, make all statements inherit from ICloneable.
+      throw new Cce.UnreachableException(); // unexpected statement TODO, make all statements inherit from ICloneable.
     }
 
     public MatchCaseStmt CloneMatchCaseStmt(MatchCaseStmt c) {
@@ -473,7 +473,7 @@ namespace Microsoft.Dafny {
         return new CalcStmt.TernaryCalcOp(CloneExpr(((CalcStmt.TernaryCalcOp)op).Index));
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 

--- a/Source/DafnyCore/AST/Expressions/Applications/FunctionCallExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Applications/FunctionCallExpr.cs
@@ -64,7 +64,7 @@ public class FunctionCallExpr : Expression, IHasReferences, ICloneable<FunctionC
   void ObjectInvariant() {
     Contract.Invariant(Name != null);
     Contract.Invariant(Receiver != null);
-    Contract.Invariant(cce.NonNullElements(Args));
+    Contract.Invariant(Cce.NonNullElements(Args));
     Contract.Invariant(
       Function == null || TypeApplication_AtEnclosingClass == null ||
       Function.EnclosingClass.TypeArgs.Count == TypeApplication_AtEnclosingClass.Count);
@@ -86,7 +86,7 @@ public class FunctionCallExpr : Expression, IHasReferences, ICloneable<FunctionC
     Contract.Requires(origin != null);
     Contract.Requires(fn != null);
     Contract.Requires(receiver != null);
-    Contract.Requires(cce.NonNullElements(args));
+    Contract.Requires(Cce.NonNullElements(args));
     Contract.Requires(openParen != null || args.Count == 0);
     Contract.Ensures(type == null);
   }

--- a/Source/DafnyCore/AST/Expressions/Collections/MultiSetFormingExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Collections/MultiSetFormingExpr.cs
@@ -16,7 +16,7 @@ public class MultiSetFormingExpr : Expression, ICloneable<MultiSetFormingExpr> {
   [Captured]
   public MultiSetFormingExpr(IOrigin origin, Expression e)
     : base(origin) {
-    cce.Owner.AssignSame(this, e);
+    Cce.Owner.AssignSame(this, e);
     E = e;
   }
 

--- a/Source/DafnyCore/AST/Expressions/Comprehensions/QuantifierExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Comprehensions/QuantifierExpr.cs
@@ -73,7 +73,7 @@ public abstract class QuantifierExpr : ComprehensionExpr, TypeParameter.ParentTy
   public virtual Expression LogicalBody(bool bypassSplitQuantifier = false) {
     // Don't call this on a quantifier with a Split clause: it's not a real quantifier. The only exception is the Compiler.
     Contract.Requires(bypassSplitQuantifier || SplitQuantifier == null);
-    throw new cce.UnreachableException(); // This body is just here for the "Requires" clause
+    throw new Cce.UnreachableException(); // This body is just here for the "Requires" clause
   }
 
   public override IEnumerable<INode> PreResolveChildren => base.SubExpressions;

--- a/Source/DafnyCore/AST/Expressions/Conditional/Patterns/ExtendedPattern.cs
+++ b/Source/DafnyCore/AST/Expressions/Conditional/Patterns/ExtendedPattern.cs
@@ -78,7 +78,7 @@ public abstract class ExtendedPattern : NodeWithOrigin {
         /* =[2]= */
         return;
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     } else if (type.AsDatatype is TupleTypeDecl tupleTypeDecl) {
       if (!(this is IdPattern)) {
@@ -126,7 +126,7 @@ public abstract class ExtendedPattern : NodeWithOrigin {
       var dtd = type.AsDatatype;
       Dictionary<string, DatatypeCtor> ctors = dtd.ConstructorsByName;
       if (ctors == null) {
-        Contract.Assert(false); throw new cce.UnreachableException();  // Datatype not found
+        Contract.Assert(false); throw new Cce.UnreachableException();  // Datatype not found
       }
       // Check if the head of the pattern is a constructor or a variable
       if (ctors.TryGetValue(idpat.Id, out var ctor)) {

--- a/Source/DafnyCore/AST/Expressions/Expression.cs
+++ b/Source/DafnyCore/AST/Expressions/Expression.cs
@@ -180,7 +180,7 @@ public abstract class Expression : NodeWithOrigin {
   public static IEnumerable<Expression> Conjuncts(Expression expr) {
     Contract.Requires(expr != null);
     Contract.Requires(expr.Type.IsBoolType);
-    Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<Expression>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<Expression>>()));
 
     expr = StripParens(expr);
     if (expr is UnaryOpExpr { Op: UnaryOpExpr.Opcode.Not } unary) {
@@ -207,7 +207,7 @@ public abstract class Expression : NodeWithOrigin {
   public static IEnumerable<Expression> Disjuncts(Expression expr) {
     Contract.Requires(expr != null);
     Contract.Requires(expr.Type.IsBoolType);
-    Contract.Ensures(cce.NonNullElements(Contract.Result<IEnumerable<Expression>>()));
+    Contract.Ensures(Cce.NonNullElements(Contract.Result<IEnumerable<Expression>>()));
 
     expr = StripParens(expr);
     if (expr is UnaryOpExpr { Op: UnaryOpExpr.Opcode.Not } unary) {

--- a/Source/DafnyCore/AST/Expressions/Heap/OldExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Heap/OldExpr.cs
@@ -33,7 +33,7 @@ public class OldExpr : Expression, ICloneable<OldExpr>, ICanFormat {
   public OldExpr(IOrigin origin, Expression expr, string? at = null)
     : base(origin) {
     Contract.Requires(origin != null);
-    cce.Owner.AssignSame(this, expr);
+    Cce.Owner.AssignSame(this, expr);
     Expr = expr;
     At = at;
   }

--- a/Source/DafnyCore/AST/Expressions/Operators/BinaryExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/Operators/BinaryExpr.cs
@@ -296,7 +296,7 @@ public class BinaryExpr : Expression, ICloneable<BinaryExpr>, ICanFormat {
         return "^";
       default:
         Contract.Assert(false);
-        throw new cce.UnreachableException();  // unexpected operator
+        throw new Cce.UnreachableException();  // unexpected operator
     }
   }
   public Expression E0;

--- a/Source/DafnyCore/AST/Expressions/StmtExpr.cs
+++ b/Source/DafnyCore/AST/Expressions/StmtExpr.cs
@@ -71,7 +71,7 @@ public class StmtExpr : Expression, ICanFormat, ICloneable<StmtExpr> {
       case BlockByProofStmt stmt:
         return GetStatementConclusion(stmt.Body);
       default:
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected statement
     }
   }
 

--- a/Source/DafnyCore/AST/Grammar/Printer/Printer.Expression.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer/Printer.Expression.cs
@@ -890,7 +890,7 @@ namespace Microsoft.Dafny {
               break;
             default:
               Contract.Assert(false);
-              throw new cce.UnreachableException(); // unexpected unary opcode
+              throw new Cce.UnreachableException(); // unexpected unary opcode
           }
 
           bool parensNeeded = ParensNeeded(opBindingStrength, contextBindingStrength, fragileContext);
@@ -993,7 +993,7 @@ namespace Microsoft.Dafny {
             opBindingStrength = BindingStrengthEquiv; break;
           default:
             Contract.Assert(false);
-            throw new cce.UnreachableException(); // unexpected binary operator
+            throw new Cce.UnreachableException(); // unexpected binary operator
         }
 
         bool parensNeeded = ParensNeeded(opBindingStrength, contextBindingStrength, fragileContext);
@@ -1535,7 +1535,7 @@ namespace Microsoft.Dafny {
         wr.Write("locals");
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // unexpected expression
+        throw new Cce.UnreachableException(); // unexpected expression
       }
     }
 

--- a/Source/DafnyCore/AST/Grammar/Printer/Printer.Statement.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer/Printer.Statement.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Dafny {
               PrintModifyStmt(indent, (ModifyStmt)s.S, true);
             } else {
               Contract.Assert(false);
-              throw new cce.UnreachableException(); // unexpected skeleton statement
+              throw new Cce.UnreachableException(); // unexpected skeleton statement
             }
 
             break;
@@ -479,7 +479,7 @@ namespace Microsoft.Dafny {
           // content already handled earlier
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected statement
       }
     }
 
@@ -813,7 +813,7 @@ namespace Microsoft.Dafny {
           }
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected RHS
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected RHS
       }
 
       if (rhs.HasAttributes()) {

--- a/Source/DafnyCore/AST/Grammar/Printer/Printer.cs
+++ b/Source/DafnyCore/AST/Grammar/Printer/Printer.cs
@@ -748,7 +748,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
           }
           state = 2;
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected member
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected member
         }
       }
     }
@@ -817,7 +817,7 @@ NoGhost - disable printing of functions, ghost methods, and proof
           return "-";
         default:
           Contract.Assert(false);  // unexpected VarianceSyntax
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 

--- a/Source/DafnyCore/AST/Grammar/ProgramParser.cs
+++ b/Source/DafnyCore/AST/Grammar/ProgramParser.cs
@@ -321,7 +321,7 @@ public class ProgramParser {
     Contract.Requires(uri != null);
     System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(ParseErrors).TypeHandle);
     System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(ResolutionErrors).TypeHandle);
-    byte[] /*!*/ buffer = cce.NonNull(Encoding.Default.GetBytes(s));
+    byte[] /*!*/ buffer = Cce.NonNull(Encoding.Default.GetBytes(s));
     var ms = new MemoryStream(buffer, false);
     var firstToken = new Token {
       Uri = uri

--- a/Source/DafnyCore/AST/Grammar/SourcePreprocessor.cs
+++ b/Source/DafnyCore/AST/Grammar/SourcePreprocessor.cs
@@ -46,7 +46,7 @@ public static class SourcePreprocessor {
   // "arg" is assumed to be trimmed
   private static bool IfdefConditionSaysToInclude(string arg, List<string> /*!*/ defines) {
     Contract.Requires(arg != null);
-    Contract.Requires(cce.NonNullElements(defines));
+    Contract.Requires(Cce.NonNullElements(defines));
     bool sense = true;
     while (arg.StartsWith("!")) {
       sense = !sense;
@@ -58,7 +58,7 @@ public static class SourcePreprocessor {
 
   public static string ProcessDirectives(TextReader reader, List<string> /*!*/ defines) {
     Contract.Requires(reader != null);
-    Contract.Requires(cce.NonNullElements(defines));
+    Contract.Requires(Cce.NonNullElements(defines));
     Contract.Ensures(Contract.Result<string>() != null);
     string newline = null;
     StringBuilder sb = new StringBuilder();

--- a/Source/DafnyCore/AST/Members/ConstantField.cs
+++ b/Source/DafnyCore/AST/Members/ConstantField.cs
@@ -45,7 +45,7 @@ public class ConstantField : Field, ICallable, ICanAutoRevealDependencies, ICanV
   public List<Formal> Ins { get { return []; } }
   public ModuleDefinition EnclosingModule { get { return this.EnclosingClass.EnclosingModuleDefinition; } }
   public bool MustReverify { get { return false; } }
-  public bool AllowsNontermination { get { throw new cce.UnreachableException(); } }
+  public bool AllowsNontermination { get { throw new Cce.UnreachableException(); } }
   CodeGenIdGenerator ICodeContext.CodeGenIdGenerator => CodeGenIdGenerator;
 
   public string NameRelativeToModule {
@@ -57,10 +57,10 @@ public class ConstantField : Field, ICallable, ICanAutoRevealDependencies, ICanV
       }
     }
   }
-  public Specification<Expression> Decreases { get { throw new cce.UnreachableException(); } }
+  public Specification<Expression> Decreases { get { throw new Cce.UnreachableException(); } }
   public bool InferredDecreases {
-    get { throw new cce.UnreachableException(); }
-    set { throw new cce.UnreachableException(); }
+    get { throw new Cce.UnreachableException(); }
+    set { throw new Cce.UnreachableException(); }
   }
   public bool AllowsAllocation => true;
 

--- a/Source/DafnyCore/AST/Members/Constructor.cs
+++ b/Source/DafnyCore/AST/Members/Constructor.cs
@@ -44,11 +44,11 @@ public class Constructor : MethodOrConstructor {
     this.body = body;
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ins));
-    Contract.Requires(cce.NonNullElements(req));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ins));
+    Contract.Requires(Cce.NonNullElements(req));
     Contract.Requires(mod != null);
-    Contract.Requires(cce.NonNullElements(ens));
+    Contract.Requires(Cce.NonNullElements(ens));
     Contract.Requires(decreases != null);
   }
 

--- a/Source/DafnyCore/AST/Members/ExtremeLemma.cs
+++ b/Source/DafnyCore/AST/Members/ExtremeLemma.cs
@@ -36,12 +36,12 @@ public abstract class ExtremeLemma : Method {
       typeArgs, ins, req, ens, reads, decreases, outs, mod, body, signatureEllipsis) {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ins));
-    Contract.Requires(cce.NonNullElements(outs));
-    Contract.Requires(cce.NonNullElements(req));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ins));
+    Contract.Requires(Cce.NonNullElements(outs));
+    Contract.Requires(Cce.NonNullElements(req));
     Contract.Requires(mod != null);
-    Contract.Requires(cce.NonNullElements(ens));
+    Contract.Requires(Cce.NonNullElements(ens));
     Contract.Requires(decreases != null);
     TypeOfK = typeOfK;
   }

--- a/Source/DafnyCore/AST/Members/Function.cs
+++ b/Source/DafnyCore/AST/Members/Function.cs
@@ -219,12 +219,12 @@ public class Function : MethodOrFunction, TypeParameter.ParentType, ICallable, I
 
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(TypeArgs));
-    Contract.Invariant(cce.NonNullElements(Ins));
+    Contract.Invariant(Cce.NonNullElements(TypeArgs));
+    Contract.Invariant(Cce.NonNullElements(Ins));
     Contract.Invariant(ResultType != null);
-    Contract.Invariant(cce.NonNullElements(Req));
+    Contract.Invariant(Cce.NonNullElements(Req));
     Contract.Invariant(Reads != null);
-    Contract.Invariant(cce.NonNullElements(Ens));
+    Contract.Invariant(Cce.NonNullElements(Ens));
     Contract.Invariant(Decreases != null);
   }
 

--- a/Source/DafnyCore/AST/Members/GreatestLemma.cs
+++ b/Source/DafnyCore/AST/Members/GreatestLemma.cs
@@ -22,12 +22,12 @@ public class GreatestLemma : ExtremeLemma {
     : base(origin, nameNode, hasStaticKeyword, typeOfK, typeArgs, ins, outs, req, reads, mod, ens, decreases, body, attributes, signatureEllipsis) {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ins));
-    Contract.Requires(cce.NonNullElements(outs));
-    Contract.Requires(cce.NonNullElements(req));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ins));
+    Contract.Requires(Cce.NonNullElements(outs));
+    Contract.Requires(Cce.NonNullElements(req));
     Contract.Requires(mod != null);
-    Contract.Requires(cce.NonNullElements(ens));
+    Contract.Requires(Cce.NonNullElements(ens));
     Contract.Requires(decreases != null);
   }
 

--- a/Source/DafnyCore/AST/Members/ICodeContext.cs
+++ b/Source/DafnyCore/AST/Members/ICodeContext.cs
@@ -142,9 +142,9 @@ public class NoContext : ICodeContext {
   List<TypeParameter> ICodeContext.TypeArgs { get { return []; } }
   List<Formal> ICodeContext.Ins { get { return []; } }
   ModuleDefinition IASTVisitorContext.EnclosingModule { get { return Module; } }
-  bool ICodeContext.MustReverify { get { Contract.Assume(false, "should not be called on NoContext"); throw new cce.UnreachableException(); } }
-  public string FullSanitizedName { get { Contract.Assume(false, "should not be called on NoContext"); throw new cce.UnreachableException(); } }
-  public bool AllowsNontermination { get { Contract.Assume(false, "should not be called on NoContext"); throw new cce.UnreachableException(); } }
+  bool ICodeContext.MustReverify { get { Contract.Assume(false, "should not be called on NoContext"); throw new Cce.UnreachableException(); } }
+  public string FullSanitizedName { get { Contract.Assume(false, "should not be called on NoContext"); throw new Cce.UnreachableException(); } }
+  public bool AllowsNontermination { get { Contract.Assume(false, "should not be called on NoContext"); throw new Cce.UnreachableException(); } }
   CodeGenIdGenerator ICodeContext.CodeGenIdGenerator { get; } = new();
 
   public bool AllowsAllocation => true;

--- a/Source/DafnyCore/AST/Members/LeastLemma.cs
+++ b/Source/DafnyCore/AST/Members/LeastLemma.cs
@@ -21,12 +21,12 @@ public class LeastLemma : ExtremeLemma {
     : base(origin, nameNode, hasStaticKeyword, typeOfK, typeArgs, ins, outs, req, reads, mod, ens, decreases, body, attributes, signatureEllipsis) {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ins));
-    Contract.Requires(cce.NonNullElements(outs));
-    Contract.Requires(cce.NonNullElements(req));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ins));
+    Contract.Requires(Cce.NonNullElements(outs));
+    Contract.Requires(Cce.NonNullElements(req));
     Contract.Requires(mod != null);
-    Contract.Requires(cce.NonNullElements(ens));
+    Contract.Requires(Cce.NonNullElements(ens));
     Contract.Requires(decreases != null);
   }
 

--- a/Source/DafnyCore/AST/Members/MethodOrConstructor.cs
+++ b/Source/DafnyCore/AST/Members/MethodOrConstructor.cs
@@ -108,13 +108,13 @@ public abstract class MethodOrConstructor : MethodOrFunction, TypeParameter.Pare
 
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(TypeArgs));
-    Contract.Invariant(cce.NonNullElements(Ins));
-    Contract.Invariant(cce.NonNullElements(Outs));
-    Contract.Invariant(cce.NonNullElements(Req));
+    Contract.Invariant(Cce.NonNullElements(TypeArgs));
+    Contract.Invariant(Cce.NonNullElements(Ins));
+    Contract.Invariant(Cce.NonNullElements(Outs));
+    Contract.Invariant(Cce.NonNullElements(Req));
     Contract.Invariant(Reads != null);
     Contract.Invariant(Mod != null);
-    Contract.Invariant(cce.NonNullElements(Ens));
+    Contract.Invariant(Cce.NonNullElements(Ens));
     Contract.Invariant(Decreases != null);
   }
 
@@ -137,11 +137,11 @@ public abstract class MethodOrConstructor : MethodOrFunction, TypeParameter.Pare
     : base(origin, nameNode, isGhost, attributes, signatureEllipsis, typeArgs, ins, req, ens, reads, decreases) {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ins));
-    Contract.Requires(cce.NonNullElements(req));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ins));
+    Contract.Requires(Cce.NonNullElements(req));
     Contract.Requires(reads != null);
-    Contract.Requires(cce.NonNullElements(ens));
+    Contract.Requires(Cce.NonNullElements(ens));
     Contract.Requires(decreases != null);
     this.Mod = mod;
     MustReverify = false;

--- a/Source/DafnyCore/AST/Modules/DefaultClassDecl.cs
+++ b/Source/DafnyCore/AST/Modules/DefaultClassDecl.cs
@@ -23,7 +23,7 @@ public class DefaultClassDecl : TopLevelDeclWithMembers, RevealableTypeDecl {
   public DefaultClassDecl(ModuleDefinition enclosingModule, [Captured] List<MemberDecl> members)
     : base(SourceOrigin.NoToken, new Name("_default"), enclosingModule, [], members, null, []) {
     Contract.Requires(enclosingModule != null);
-    Contract.Requires(cce.NonNullElements(members));
+    Contract.Requires(Cce.NonNullElements(members));
     this.NewSelfSynonym();
   }
 }

--- a/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
+++ b/Source/DafnyCore/AST/Modules/ModuleDefinition.cs
@@ -117,7 +117,7 @@ Generate module names in the older A_mB_mC style instead of the current A.B.C sc
 
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(TopLevelDecls));
+    Contract.Invariant(Cce.NonNullElements(TopLevelDecls));
     Contract.Invariant(CallGraph != null);
   }
 

--- a/Source/DafnyCore/AST/Statements/Assignment/AssignStatement.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/AssignStatement.cs
@@ -30,8 +30,8 @@ public class AssignStatement : ConcreteAssignStatement, ICloneable<AssignStateme
 
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Lhss));
-    Contract.Invariant(cce.NonNullElements(Rhss));
+    Contract.Invariant(Cce.NonNullElements(Lhss));
+    Contract.Invariant(Cce.NonNullElements(Rhss));
   }
 
   public AssignStatement Clone(Cloner cloner) {
@@ -48,8 +48,8 @@ public class AssignStatement : ConcreteAssignStatement, ICloneable<AssignStateme
 
   public AssignStatement(IOrigin origin, List<Expression> lhss, List<AssignmentRhs> rhss)
     : base(origin, lhss) {
-    Contract.Requires(cce.NonNullElements(lhss));
-    Contract.Requires(cce.NonNullElements(rhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(rhss));
     Contract.Requires(lhss.Count != 0 || rhss.Count == 1);
     Rhss = rhss;
     CanMutateKnownState = false;
@@ -59,8 +59,8 @@ public class AssignStatement : ConcreteAssignStatement, ICloneable<AssignStateme
   public AssignStatement(IOrigin origin, List<Expression> lhss, List<AssignmentRhs> rhss, bool canMutateKnownState,
     Attributes? attributes = null)
     : base(origin, lhss, attributes) {
-    Contract.Requires(cce.NonNullElements(lhss));
-    Contract.Requires(cce.NonNullElements(rhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(rhss));
     Contract.Requires(lhss.Count != 0 || rhss.Count == 1);
     Rhss = rhss;
     CanMutateKnownState = canMutateKnownState;

--- a/Source/DafnyCore/AST/Statements/Assignment/AssignSuchThatStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/AssignSuchThatStmt.cs
@@ -54,7 +54,7 @@ public class AssignSuchThatStmt : ConcreteAssignStatement, ICloneable<AssignSuch
   public AssignSuchThatStmt(IOrigin origin, List<Expression> lhss, Expression expr, AttributedToken assumeToken, Attributes attributes)
     : base(origin, lhss, attributes) {
     Contract.Requires(origin != null);
-    Contract.Requires(cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
     Contract.Requires(lhss.Count != 0);
     Contract.Requires(expr != null);
     Expr = expr;

--- a/Source/DafnyCore/AST/Statements/Assignment/ConcreteAssignStatement.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/ConcreteAssignStatement.cs
@@ -16,7 +16,7 @@ public abstract class ConcreteAssignStatement : Statement, ICanFormat {
 
   public ConcreteAssignStatement(IOrigin origin, List<Expression> lhss, Attributes attributes = null)
     : base(origin, attributes) {
-    Contract.Requires(cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
     Lhss = lhss;
   }
 

--- a/Source/DafnyCore/AST/Statements/Assignment/SingleAssignStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/SingleAssignStmt.cs
@@ -93,7 +93,7 @@ public class SingleAssignStmt : Statement, ICloneable<SingleAssignStmt> {
       case NonGhostKind.ArrayElement: return "array element";
       default:
         Contract.Assume(false);  // unexpected NonGhostKind
-        throw new cce.UnreachableException();  // please compiler
+        throw new Cce.UnreachableException();  // please compiler
     }
   }
   /// <summary>

--- a/Source/DafnyCore/AST/Statements/Assignment/VarDeclStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Assignment/VarDeclStmt.cs
@@ -10,7 +10,7 @@ public class VarDeclStmt : Statement, ICloneable<VarDeclStmt>, ICanFormat {
   public ConcreteAssignStatement? Assign;
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Locals));
+    Contract.Invariant(Cce.NonNullElements(Locals));
     Contract.Invariant(Locals.Count != 0);
   }
 

--- a/Source/DafnyCore/AST/Statements/CalcStmt.cs
+++ b/Source/DafnyCore/AST/Statements/CalcStmt.cs
@@ -95,7 +95,7 @@ public class CalcStmt : Statement, ICloneable<CalcStmt>, ICanFormat {
         return other.ResultOp(this);
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -140,7 +140,7 @@ public class CalcStmt : Statement, ICloneable<CalcStmt>, ICanFormat {
         return new TernaryCalcOp(minIndex); // ToDo: if we could compare expressions for syntactic equality, we could use this here to optimize
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
@@ -213,12 +213,12 @@ public class CalcStmt : Statement, ICloneable<CalcStmt>, ICanFormat {
   [ContractInvariantMethod]
   void ObjectInvariant() {
     Contract.Invariant(Lines != null);
-    Contract.Invariant(cce.NonNullElements(Lines));
+    Contract.Invariant(Cce.NonNullElements(Lines));
     Contract.Invariant(Hints != null);
-    Contract.Invariant(cce.NonNullElements(Hints));
+    Contract.Invariant(Cce.NonNullElements(Hints));
     Contract.Invariant(StepOps != null);
     Contract.Invariant(Steps != null);
-    Contract.Invariant(cce.NonNullElements(Steps));
+    Contract.Invariant(Cce.NonNullElements(Steps));
     Contract.Invariant(Hints.Count == Math.Max(Lines.Count - 1, 0));
     Contract.Invariant(StepOps.Count == Hints.Count);
   }
@@ -229,8 +229,8 @@ public class CalcStmt : Statement, ICloneable<CalcStmt>, ICanFormat {
     Contract.Requires(lines != null);
     Contract.Requires(hints != null);
     Contract.Requires(stepOps != null);
-    Contract.Requires(cce.NonNullElements(lines));
-    Contract.Requires(cce.NonNullElements(hints));
+    Contract.Requires(Cce.NonNullElements(lines));
+    Contract.Requires(Cce.NonNullElements(hints));
     Contract.Requires(hints.Count == Math.Max(lines.Count - 1, 0));
     Contract.Requires(stepOps.Count == hints.Count);
     UserSuppliedOp = userSuppliedOp;

--- a/Source/DafnyCore/AST/Statements/ControlFlow/ForallStmt.cs
+++ b/Source/DafnyCore/AST/Statements/ControlFlow/ForallStmt.cs
@@ -66,10 +66,10 @@ public class ForallStmt : Statement, ICloneable<ForallStmt>, ICanFormat {
   public ForallStmt(IOrigin origin, List<BoundVar> boundVars, Attributes attributes, Expression range, List<AttributedExpression> ens, Statement body)
     : base(origin, attributes) {
     Contract.Requires(origin != null);
-    Contract.Requires(cce.NonNullElements(boundVars));
+    Contract.Requires(Cce.NonNullElements(boundVars));
     Contract.Requires(range != null);
     Contract.Requires(boundVars.Count != 0 || LiteralExpr.IsTrue(range));
-    Contract.Requires(cce.NonNullElements(ens));
+    Contract.Requires(Cce.NonNullElements(ens));
     BoundVars = boundVars;
     Range = range;
     Ens = ens;

--- a/Source/DafnyCore/AST/Statements/ControlFlow/LoopStmt.cs
+++ b/Source/DafnyCore/AST/Statements/ControlFlow/LoopStmt.cs
@@ -11,7 +11,7 @@ public abstract class LoopStmt : LabeledStatement, IHasNavigationToken {
   public Specification<FrameExpression> Mod;
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Invariants));
+    Contract.Invariant(Cce.NonNullElements(Invariants));
     Contract.Invariant(Decreases != null);
     Contract.Invariant(Mod != null);
   }
@@ -29,7 +29,7 @@ public abstract class LoopStmt : LabeledStatement, IHasNavigationToken {
   protected LoopStmt(IOrigin origin, List<AttributedExpression> invariants, Specification<Expression> decreases, Specification<FrameExpression> mod)
     : base(origin, [], null) {
     Contract.Requires(origin != null);
-    Contract.Requires(cce.NonNullElements(invariants));
+    Contract.Requires(Cce.NonNullElements(invariants));
     Contract.Requires(decreases != null);
     Contract.Requires(mod != null);
 
@@ -43,7 +43,7 @@ public abstract class LoopStmt : LabeledStatement, IHasNavigationToken {
     Specification<FrameExpression> mod, List<Label> labels, Attributes attributes)
     : base(origin, labels, attributes) {
     Contract.Requires(origin != null);
-    Contract.Requires(cce.NonNullElements(invariants));
+    Contract.Requires(Cce.NonNullElements(invariants));
     Contract.Requires(decreases != null);
     Contract.Requires(mod != null);
 

--- a/Source/DafnyCore/AST/Statements/DividedBlockStmt.cs
+++ b/Source/DafnyCore/AST/Statements/DividedBlockStmt.cs
@@ -24,8 +24,8 @@ public class DividedBlockStmt : BlockLikeStmt, ICloneable<DividedBlockStmt> {
     IOrigin? separatorTok, List<Statement> bodyProper, List<Label> labels, Attributes? attributes = null)
     : base(origin, labels, attributes) {
     Contract.Requires(origin != null);
-    Contract.Requires(cce.NonNullElements(bodyInit));
-    Contract.Requires(cce.NonNullElements(bodyProper));
+    Contract.Requires(Cce.NonNullElements(bodyInit));
+    Contract.Requires(Cce.NonNullElements(bodyProper));
     this.BodyInit = bodyInit;
     this.SeparatorTok = separatorTok;
     this.BodyProper = bodyProper;

--- a/Source/DafnyCore/AST/Statements/Methods/CallStmt.cs
+++ b/Source/DafnyCore/AST/Statements/Methods/CallStmt.cs
@@ -12,8 +12,8 @@ public class CallStmt : Statement, ICloneable<CallStmt> {
   [ContractInvariantMethod]
   void ObjectInvariant() {
     Contract.Invariant(MethodSelect.Member is MethodOrConstructor);
-    Contract.Invariant(cce.NonNullElements(Lhs));
-    Contract.Invariant(cce.NonNullElements(Args));
+    Contract.Invariant(Cce.NonNullElements(Lhs));
+    Contract.Invariant(Cce.NonNullElements(Args));
   }
 
   public override IEnumerable<INode> Children => Lhs.Concat(new Node[] { MethodSelect, Bindings });
@@ -34,10 +34,10 @@ public class CallStmt : Statement, ICloneable<CallStmt> {
       TokenRange overrideToken = null)
     : base(overrideToken == null ? rangeOrigin : new OverrideCenter(rangeOrigin, overrideToken)) {
     Contract.Requires(rangeOrigin != null);
-    Contract.Requires(cce.NonNullElements(lhs));
+    Contract.Requires(Cce.NonNullElements(lhs));
     Contract.Requires(memSel != null);
     Contract.Requires(memSel.Member is MethodOrConstructor);
-    Contract.Requires(cce.NonNullElements(args));
+    Contract.Requires(Cce.NonNullElements(args));
 
     this.Lhs = lhs;
     this.MethodSelect = memSel;

--- a/Source/DafnyCore/AST/Substituter.cs
+++ b/Source/DafnyCore/AST/Substituter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Dafny {
             }
           }
 
-          return cce.NonNull(substExprFinal);
+          return Cce.NonNull(substExprFinal);
         }
       } else if (expr is DisplayExpression) {
         DisplayExpression e = (DisplayExpression)expr;
@@ -572,7 +572,7 @@ namespace Microsoft.Dafny {
         return bound;  // nothing to substitute
       } else {
         Contract.Assume(false);  // unexpected BoundedPool
-        throw new cce.UnreachableException();  // to please compiler
+        throw new Cce.UnreachableException();  // to please compiler
       }
     }
 
@@ -683,12 +683,12 @@ namespace Microsoft.Dafny {
     }
 
     protected List<Expression/*!*/>/*!*/ SubstituteExprList(List<Expression/*!*/>/*!*/ elist) {
-      Contract.Requires(cce.NonNullElements(elist));
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Expression>>()));
+      Contract.Requires(Cce.NonNullElements(elist));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Expression>>()));
 
       List<Expression> newElist = null;  // initialized lazily
       for (int i = 0; i < elist.Count; i++) {
-        cce.LoopInvariant(newElist == null || newElist.Count == i);
+        Cce.LoopInvariant(newElist == null || newElist.Count == i);
 
         Expression substE = Substitute(elist[i]);
         if (substE != elist[i] && newElist == null) {
@@ -898,7 +898,7 @@ namespace Microsoft.Dafny {
           labelledStatement.Labels, null);
         r = rr;
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected statement
       }
 
       r.Attributes = SubstAttributes(stmt.Attributes);
@@ -978,7 +978,7 @@ namespace Microsoft.Dafny {
         c = new HavocRhs(rhs.Origin);
       } else {
         // since the Substituter is assumed to operate on statements only if they are part of a StatementExpression, then the TypeRhs case cannot occur
-        Contract.Assume(false); throw new cce.UnreachableException();
+        Contract.Assume(false); throw new Cce.UnreachableException();
       }
       c.Attributes = SubstAttributes(rhs.Attributes);
       return c;
@@ -1005,12 +1005,12 @@ namespace Microsoft.Dafny {
         return new CalcStmt.TernaryCalcOp(Substitute(((CalcStmt.TernaryCalcOp)op).Index));
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
     }
 
     public Attributes SubstAttributes(Attributes attrs) {
-      Contract.Requires(cce.NonNullDictionaryAndValues(substMap));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(substMap));
       if (attrs != null) {
         var newArgs = new List<Expression>();  // allocate it eagerly, what the heck, it doesn't seem worth the extra complexity in the code to do it lazily for the infrequently occurring attributes
         bool anyArgSubst = false;

--- a/Source/DafnyCore/AST/TypeDeclarations/ClassDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/ClassDecl.cs
@@ -12,7 +12,7 @@ public class ClassDecl : ClassLikeDecl {
   [FilledInDuringResolution] public bool HasConstructor;  // filled in (early) during resolution; true iff there exists a member that is a Constructor
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Members));
+    Contract.Invariant(Cce.NonNullElements(Members));
     Contract.Invariant(Traits != null);
   }
 
@@ -24,8 +24,8 @@ public class ClassDecl : ClassLikeDecl {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
     Contract.Requires(enclosingModuleDefinition != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(members));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(members));
     NonNullTypeDecl = new NonNullTypeDecl(this);
     IsRefining = isRefining;
     this.NewSelfSynonym();

--- a/Source/DafnyCore/AST/TypeDeclarations/ClassLikeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/ClassLikeDecl.cs
@@ -33,8 +33,8 @@ public abstract class ClassLikeDecl : TopLevelDeclWithMembers, RevealableTypeDec
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
     Contract.Requires(enclosingModuleDefinition != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(members));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(members));
   }
 
   public virtual bool SetIndent(int indentBefore, TokenNewIndentCollector formatter) {

--- a/Source/DafnyCore/AST/TypeDeclarations/CoDatatypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/CoDatatypeDecl.cs
@@ -14,9 +14,9 @@ public class CoDatatypeDecl : DatatypeDecl {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
     Contract.Requires(enclosingModule != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ctors));
-    Contract.Requires(cce.NonNullElements(members));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ctors));
+    Contract.Requires(Cce.NonNullElements(members));
     Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
   }
 

--- a/Source/DafnyCore/AST/TypeDeclarations/DatatypeCtor.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/DatatypeCtor.cs
@@ -11,7 +11,7 @@ public class DatatypeCtor : Declaration, TypeParameter.ParentType, IHasDocstring
   public List<Formal> Formals;
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Formals));
+    Contract.Invariant(Cce.NonNullElements(Formals));
     Contract.Invariant(
       Destructors.Count == 0 || // this is until resolution
       Destructors.Count == Formals.Count);  // after resolution
@@ -28,7 +28,7 @@ public class DatatypeCtor : Declaration, TypeParameter.ParentType, IHasDocstring
     : base(origin, nameNode, attributes) {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
-    Contract.Requires(cce.NonNullElements(formals));
+    Contract.Requires(Cce.NonNullElements(formals));
     this.Formals = formals;
     this.IsGhost = isGhost;
   }

--- a/Source/DafnyCore/AST/TypeDeclarations/DatatypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/DatatypeDecl.cs
@@ -13,7 +13,7 @@ public abstract class DatatypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl
   [FilledInDuringResolution] public Dictionary<string, DatatypeCtor> ConstructorsByName { get; set; }
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Ctors));
+    Contract.Invariant(Cce.NonNullElements(Ctors));
     Contract.Invariant(1 <= Ctors.Count);
   }
 
@@ -28,9 +28,9 @@ public abstract class DatatypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
     Contract.Requires(enclosingModuleDefinition != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ctors));
-    Contract.Requires(cce.NonNullElements(members));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ctors));
+    Contract.Requires(Cce.NonNullElements(members));
     Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
     Ctors = ctors;
     this.NewSelfSynonym();
@@ -72,12 +72,12 @@ public abstract class DatatypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl
     get {
       // The resolver checks that a NewtypeDecl sits in its own SSC in the call graph.  Therefore,
       // the question of what its Decreases clause is should never arise.
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
   }
   bool ICallable.InferredDecreases {
-    get { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
-    set { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
+    get { throw new Cce.UnreachableException(); }  // see comment above about ICallable.Decreases
+    set { throw new Cce.UnreachableException(); }  // see comment above about ICallable.Decreases
   }
 
   /// <summary>

--- a/Source/DafnyCore/AST/TypeDeclarations/IndDatatypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/IndDatatypeDecl.cs
@@ -40,9 +40,9 @@ public class IndDatatypeDecl : DatatypeDecl {
     Contract.Requires(origin != null);
     Contract.Requires(nameNode != null);
     Contract.Requires(enclosingModuleDefinition != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
-    Contract.Requires(cce.NonNullElements(ctors));
-    Contract.Requires(cce.NonNullElements(members));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(ctors));
+    Contract.Requires(Cce.NonNullElements(members));
     Contract.Requires((isRefining && ctors.Count == 0) || (!isRefining && 1 <= ctors.Count));
   }
 

--- a/Source/DafnyCore/AST/TypeDeclarations/NewtypeDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/NewtypeDecl.cs
@@ -146,12 +146,12 @@ public class NewtypeDecl : TopLevelDeclWithMembers, RevealableTypeDecl, Redirect
     get {
       // The resolver checks that a NewtypeDecl sits in its own SSC in the call graph.  Therefore,
       // the question of what its Decreases clause is should never arise.
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
   }
   bool ICallable.InferredDecreases {
-    get { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
-    set { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
+    get { throw new Cce.UnreachableException(); }  // see comment above about ICallable.Decreases
+    set { throw new Cce.UnreachableException(); }  // see comment above about ICallable.Decreases
   }
 
   public override bool AcceptThis => true;

--- a/Source/DafnyCore/AST/TypeDeclarations/TopLevelDecl.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/TopLevelDecl.cs
@@ -15,7 +15,7 @@ public abstract class TopLevelDecl : Declaration, TypeParameter.ParentType {
   public List<TypeParameter> TypeArgs;
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(TypeArgs));
+    Contract.Invariant(Cce.NonNullElements(TypeArgs));
   }
 
   protected TopLevelDecl(Cloner cloner, TopLevelDecl original, ModuleDefinition enclosingModule) : base(cloner, original) {

--- a/Source/DafnyCore/AST/TypeDeclarations/TypeSynonymDeclBase.cs
+++ b/Source/DafnyCore/AST/TypeDeclarations/TypeSynonymDeclBase.cs
@@ -89,12 +89,12 @@ public abstract class TypeSynonymDeclBase : TopLevelDecl, RedirectingTypeDecl, I
     get {
       // The resolver checks that a NewtypeDecl sits in its own SSC in the call graph.  Therefore,
       // the question of what its Decreases clause is should never arise.
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
   }
   bool ICallable.InferredDecreases {
-    get { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
-    set { throw new cce.UnreachableException(); }  // see comment above about ICallable.Decreases
+    get { throw new Cce.UnreachableException(); }  // see comment above about ICallable.Decreases
+    set { throw new Cce.UnreachableException(); }  // see comment above about ICallable.Decreases
   }
   public override bool CanBeRevealed() {
     return true;

--- a/Source/DafnyCore/AST/Types/TypeParameter.cs
+++ b/Source/DafnyCore/AST/Types/TypeParameter.cs
@@ -79,7 +79,7 @@ public class TypeParameter : TopLevelDecl {
           return TPVariance.Contra;
         default:
           Contract.Assert(false);  // unexpected VarianceSyntax
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
   }
@@ -95,7 +95,7 @@ public class TypeParameter : TopLevelDecl {
           return false;
         default:
           Contract.Assert(false);  // unexpected VarianceSyntax
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
   }

--- a/Source/DafnyCore/AST/Types/Types.cs
+++ b/Source/DafnyCore/AST/Types/Types.cs
@@ -446,7 +446,7 @@ public abstract class Type : NodeWithOrigin {
         case SubsetTypeDecl.WKind.Special:
         default:
           Contract.Assert(false); // unexpected case
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     } else if (cl is SubsetTypeDecl) {
       var td = (SubsetTypeDecl)cl;
@@ -476,7 +476,7 @@ public abstract class Type : NodeWithOrigin {
           }
         default:
           Contract.Assert(false); // unexpected case
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     } else if (cl is TraitDecl traitDecl) {
       return traitDecl.IsReferenceTypeDecl ? AutoInitInfo.CompilableValue : AutoInitInfo.MaybeEmpty;
@@ -518,7 +518,7 @@ public abstract class Type : NodeWithOrigin {
       return r;
     } else {
       Contract.Assert(false); // unexpected type
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
   }
 
@@ -1998,7 +1998,7 @@ public class SelfType : NonProxyType {
       // SelfType's are used only in certain restricted situations. In those situations, we need to be able
       // to substitute for the the SelfType's TypeArg. That's the only case in which we expect to see a
       // SelfType being part of a substitution operation at all.
-      Contract.Assert(false); throw new cce.UnreachableException();
+      Contract.Assert(false); throw new Cce.UnreachableException();
     }
   }
 

--- a/Source/DafnyCore/AST/Types/UserDefinedType.cs
+++ b/Source/DafnyCore/AST/Types/UserDefinedType.cs
@@ -11,7 +11,7 @@ public class UserDefinedType : NonProxyType, IHasReferences {
   void ObjectInvariant() {
     Contract.Invariant(Origin != null);
     Contract.Invariant(Name != null);
-    Contract.Invariant(cce.NonNullElements(TypeArgs));
+    Contract.Invariant(Cce.NonNullElements(TypeArgs));
     Contract.Invariant(NamePath is NameSegment or ExprDotName);
     Contract.Invariant(!ArrowType.IsArrowTypeName(Name) || this is ArrowType);
   }
@@ -152,7 +152,7 @@ public class UserDefinedType : NonProxyType, IHasReferences {
     Contract.Requires(origin != null);
     Contract.Requires(name != null);
     Contract.Requires(resolvedClass != null);
-    Contract.Requires(cce.NonNullElements(typeArgs));
+    Contract.Requires(Cce.NonNullElements(typeArgs));
     Contract.Requires(resolvedClass.TypeArgs.Count == typeArgs.Count);
     Contract.Requires(namePath == null || namePath is NameSegment || namePath is ExprDotName);
     // The following is almost a precondition. In a few places, the source program names a class, not a type,

--- a/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/CSharp/CsharpCodeGenerator.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Dafny.Compilers {
     const string DafnyTypeDescriptor = "Dafny.TypeDescriptor";
 
     internal string TypeParameters(List<TypeParameter>/*?*/ targs, bool addVariance = false, bool uniqueNames = false) {
-      Contract.Requires(targs == null || cce.NonNullElements(targs));
+      Contract.Requires(targs == null || Cce.NonNullElements(targs));
       Contract.Ensures(Contract.Result<string>() != null);
 
       if (targs == null || targs.Count == 0) {
@@ -1386,7 +1386,7 @@ namespace Microsoft.Dafny.Compilers {
           break;
         default:
           Contract.Assert(false); // unexpected native type
-          throw new cce.UnreachableException(); // to please the compiler
+          throw new Cce.UnreachableException(); // to please the compiler
       }
     }
 
@@ -1444,7 +1444,7 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       public void InitializeField(Field field, Type instantiatedFieldType, TopLevelDeclWithMembers enclosingClass) {
-        throw new cce.UnreachableException(); // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
+        throw new Cce.UnreachableException(); // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
       }
 
       public ConcreteSyntaxTree /*?*/ ErrorWriter() => InstanceMemberWriter;
@@ -1633,7 +1633,7 @@ namespace Microsoft.Dafny.Compilers {
         Type ranType = ((MapType)xType).Range;
         return DafnyIMap + "<" + TypeName(domType, wr, tok) + "," + TypeName(ranType, wr, tok) + ">";
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -1774,7 +1774,7 @@ namespace Microsoft.Dafny.Compilers {
         }
         return string.Format($"{s}.Default({wDefaultTypeArguments}{sep}{arguments})");
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -1869,7 +1869,7 @@ namespace Microsoft.Dafny.Compilers {
 
         return AddTypeDescriptorArgs(FullTypeName(udt, ignoreInterface: true), udt, relevantTypeArgs, wr, tok);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 
@@ -1894,7 +1894,7 @@ namespace Microsoft.Dafny.Compilers {
           return $"Dafny.Helpers.UINT64";
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 
@@ -2278,7 +2278,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write("\"))");
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal
       }
     }
 
@@ -2893,7 +2893,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (eeType is SetType) {
         TrParenExpr(".FromSet", expr.E, wr, inLetExprBody, wStmts);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 
@@ -3066,7 +3066,7 @@ namespace Microsoft.Dafny.Compilers {
           }
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
       }
     }
 
@@ -3470,7 +3470,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write($"{DafnyMapClass}<{domtypeName},{rantypeName}>.FromCollection({collName})");
       } else {
         Contract.Assume(false);  // unexpected collection type
-        throw new cce.UnreachableException();  // please compiler
+        throw new Cce.UnreachableException();  // please compiler
       }
     }
 

--- a/Source/DafnyCore/Backends/Cplusplus/CppCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Cplusplus/CppCodeGenerator.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     private string TypeParameters(List<TypeParameter> targs) {
-      Contract.Requires(cce.NonNullElements(targs));
+      Contract.Requires(Cce.NonNullElements(targs));
       Contract.Ensures(Contract.Result<string>() != null);
       if (targs != null) {
         return Util.Comma(targs, tp => "typename " + IdName(tp));
@@ -712,7 +712,7 @@ namespace Microsoft.Dafny.Compilers {
           break;
         default:
           Contract.Assert(false);  // unexpected native type
-          throw new cce.UnreachableException();  // to please the compiler
+          throw new Cce.UnreachableException();  // to please the compiler
       }
     }
 
@@ -761,7 +761,7 @@ namespace Microsoft.Dafny.Compilers {
         CodeGenerator.DeclareField(ClassName, enclosingDecl.TypeArgs, name, isStatic, isConst, type, tok, rhs, FieldWriter, Finisher);
       }
       public void InitializeField(Field field, Type instantiatedFieldType, TopLevelDeclWithMembers enclosingClass) {
-        throw new cce.UnreachableException();  // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
+        throw new Cce.UnreachableException();  // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
       }
       public ConcreteSyntaxTree/*?*/ ErrorWriter() => MethodWriter;
       public void Finish() { }
@@ -996,7 +996,7 @@ namespace Microsoft.Dafny.Compilers {
         }
         return DafnyMapClass + "<" + TypeName(domType, wr, tok) + "," + TypeName(ranType, wr, tok) + ">";
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -1110,7 +1110,7 @@ namespace Microsoft.Dafny.Compilers {
         w.Write("{0}{1}()", s, InstantiateTemplate(udt.TypeArgs));
         return w.ToString();
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
 
     }
@@ -1476,7 +1476,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (e.Value is BaseTypes.BigDec) {
         throw new UnsupportedFeatureException(e.Origin, Feature.RealNumbers);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal
       }
     }
     void EmitIntegerLiteral(BigInteger i, ConcreteSyntaxTree wr) {
@@ -2046,7 +2046,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write(".size()");
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
       }
     }
 
@@ -2287,7 +2287,7 @@ namespace Microsoft.Dafny.Compilers {
           preOpString = "!"; callString = "contains"; reverseArguments = true; break;
 
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected binary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected binary expression
       }
     }
 
@@ -2457,7 +2457,7 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Assume(ct is SetType || ct is MultiSetType);  // follows from precondition
       if (ct is MultiSetType) {
         // This should never occur since there is no syntax for multiset comprehensions yet
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
       var wStmts = wr.Fork();
       wr.Write("{0}.set.emplace(", collName);

--- a/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Dafny/DafnyCodeGenerator.cs
@@ -764,7 +764,7 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       public void InitializeField(Field field, Type instantiatedFieldType, TopLevelDeclWithMembers enclosingClass) {
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       public ConcreteSyntaxTree ErrorWriter() => null;
@@ -1683,7 +1683,7 @@ namespace Microsoft.Dafny.Compilers {
                 break;
               default:
                 // TODO: This may not be exhaustive
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
             }
             break;
         }

--- a/Source/DafnyCore/Backends/DatatypeWrapperEraser.cs
+++ b/Source/DafnyCore/Backends/DatatypeWrapperEraser.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Dafny.Compilers {
           case SimplifyTypeExpandMode.ExpandSynonymsAndSubsetTypesAndNewtypesExceptNativeTypes: return typ.GetRuntimeType();
           default:
             Contract.Assert(false); // unexpected case
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
         }
       }
 

--- a/Source/DafnyCore/Backends/GoLang/GoCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/GoLang/GoCodeGenerator.cs
@@ -1225,7 +1225,7 @@ namespace Microsoft.Dafny.Compilers {
           break;
         default:
           Contract.Assert(false);  // unexpected native type
-          throw new cce.UnreachableException();  // to please the compiler
+          throw new Cce.UnreachableException();  // to please the compiler
       }
     }
     protected class ClassWriter : IClassWriter {
@@ -1551,7 +1551,7 @@ namespace Microsoft.Dafny.Compilers {
         return w.ToString();
 
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -1675,7 +1675,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (xType is MapType) {
         return "_dafny.Map";
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -1784,7 +1784,7 @@ namespace Microsoft.Dafny.Compilers {
         var arguments = relevantTypeArgs.Comma(ta => DefaultValue(ta.Actual, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors));
         return $"{n}({wTypeDescriptorArguments}{sep}{arguments})";
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -2316,7 +2316,7 @@ namespace Microsoft.Dafny.Compilers {
         }
         wr.Write("_dafny.RealOfString(\"{0}\")", str);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal
       }
     }
     void EmitIntegerLiteral(BigInteger i, ConcreteSyntaxTree wr) {
@@ -3242,7 +3242,7 @@ namespace Microsoft.Dafny.Compilers {
             wr.Write($"IntOfInt64(");
             break;
           default:
-            throw new cce.UnreachableException();  // unexpected nativeType.Selection value
+            throw new Cce.UnreachableException();  // unexpected nativeType.Selection value
         }
       }
 
@@ -3280,7 +3280,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (eeType is SetType) {
         TrParenExpr("_dafny.MultiSetFromSet", expr.E, wr, inLetExprBody, wStmts);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 
@@ -3394,7 +3394,7 @@ namespace Microsoft.Dafny.Compilers {
 
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
       }
     }
 

--- a/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Java/JavaCodeGenerator.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Dafny.Compilers {
           return JavaNativeType.Long;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 
@@ -444,7 +444,7 @@ namespace Microsoft.Dafny.Compilers {
         CodeGenerator.DeclareField(name, isStatic, isConst, type, tok, rhs, this);
       }
       public void InitializeField(Field field, Type instantiatedFieldType, TopLevelDeclWithMembers enclosingClass) {
-        throw new cce.UnreachableException();  // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
+        throw new Cce.UnreachableException();  // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
       }
       public ConcreteSyntaxTree/*?*/ ErrorWriter() => InstanceMemberWriter;
 
@@ -624,7 +624,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     string TypeParameters(List<TypeParameter>/*?*/ targs, string suffix = "") {
-      Contract.Requires(targs == null || cce.NonNullElements(targs));
+      Contract.Requires(targs == null || Cce.NonNullElements(targs));
       Contract.Ensures(Contract.Result<string>() != null);
 
       if (targs == null || targs.Count == 0) {
@@ -751,7 +751,7 @@ namespace Microsoft.Dafny.Compilers {
         }
         return $"{DafnyMapClass}<{ActualTypeArgument(domType, TypeParameter.TPVariance.Co, wr, tok)}, {ActualTypeArgument(ranType, TypeParameter.TPVariance.Co, wr, tok)}>";
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -781,7 +781,7 @@ namespace Microsoft.Dafny.Compilers {
         return DafnyMapClass;
       } else {
         Contract.Assert(false);  // unexpected collection type
-        throw new cce.UnreachableException();  // to please the compiler
+        throw new Cce.UnreachableException();  // to please the compiler
       }
     }
 
@@ -1051,7 +1051,7 @@ namespace Microsoft.Dafny.Compilers {
             break;
           default:
             Contract.Assert(false); // unexpected case
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
         }
       }
 
@@ -1149,7 +1149,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write("\"))");
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal
       }
     }
 
@@ -1203,7 +1203,7 @@ namespace Microsoft.Dafny.Compilers {
         case JavaNativeType.Long: return "0L";
         default:
           Contract.Assert(false);  // unexpected native type
-          throw new cce.UnreachableException();  // to please the compiler
+          throw new Cce.UnreachableException();  // to please the compiler
       }
     }
 
@@ -1218,7 +1218,7 @@ namespace Microsoft.Dafny.Compilers {
         case JavaNativeType.Long: name = "long"; literalSuffix = "L"; break;
         default:
           Contract.Assert(false);  // unexpected native type
-          throw new cce.UnreachableException();  // to please the compiler
+          throw new Cce.UnreachableException();  // to please the compiler
       }
     }
 
@@ -1234,7 +1234,7 @@ namespace Microsoft.Dafny.Compilers {
         case JavaNativeType.Long: return "java.lang.Long";
         default:
           Contract.Assert(false);  // unexpected native type
-          throw new cce.UnreachableException();  // to please the compiler
+          throw new Cce.UnreachableException();  // to please the compiler
       }
     }
 
@@ -2350,7 +2350,7 @@ namespace Microsoft.Dafny.Compilers {
           default:
             // Should be an unsigned type by assumption
             Contract.Assert(false);
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
         }
       } else {
         bool isGeneric = type.NormalizeToAncestorType().AsSeqType is { Arg: { IsTypeParameter: true } };
@@ -2571,7 +2571,7 @@ namespace Microsoft.Dafny.Compilers {
             case JavaNativeType.Long: return $"{DafnyTypeDescriptor}.LONG_ARRAY";
             default:
               Contract.Assert(false);
-              throw new cce.UnreachableException();
+              throw new Cce.UnreachableException();
           }
         } else {
           return $"(({DafnyTypeDescriptor}<{BoxedTypeName(type, wr, tok)}>)({TypeDescriptor(elType, wr, tok)}).arrayType())";
@@ -2624,7 +2624,7 @@ namespace Microsoft.Dafny.Compilers {
 
         return AddTypeDescriptorArgs(s, udt.TypeArgs, relevantTypeArgs, wr, udt.Origin);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 
@@ -2634,7 +2634,7 @@ namespace Microsoft.Dafny.Compilers {
         case JavaNativeType.Short: return $"{DafnyTypeDescriptor}.SHORT";
         case JavaNativeType.Int: return $"{DafnyTypeDescriptor}.INT";
         case JavaNativeType.Long: return $"{DafnyTypeDescriptor}.LONG";
-        default: Contract.Assert(false); throw new cce.UnreachableException();
+        default: Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 
@@ -2776,7 +2776,7 @@ namespace Microsoft.Dafny.Compilers {
             break;
           }
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
       }
     }
 
@@ -2896,7 +2896,7 @@ namespace Microsoft.Dafny.Compilers {
                 break;
               default:
                 Contract.Assert(false);
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
             }
           } else {
             switch (op) {
@@ -2914,7 +2914,7 @@ namespace Microsoft.Dafny.Compilers {
                 break;
               default:
                 Contract.Assert(false);
-                throw new cce.UnreachableException();
+                throw new Cce.UnreachableException();
             }
           }
           break;
@@ -3294,7 +3294,7 @@ namespace Microsoft.Dafny.Compilers {
         return $"{s}.{typeargs}Default({wDefaultTypeArguments}{sep}{arguments})";
       } else {
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // unexpected type
+        throw new Cce.UnreachableException(); // unexpected type
       }
     }
 
@@ -3569,7 +3569,7 @@ namespace Microsoft.Dafny.Compilers {
         wr.Write($"new {DafnyMapClass}<{domtypeName},{rantypeName}>({collName})");
       } else {
         Contract.Assume(false);  // unexpected collection type
-        throw new cce.UnreachableException();  // please compiler
+        throw new Cce.UnreachableException();  // please compiler
       }
     }
 
@@ -4107,7 +4107,7 @@ namespace Microsoft.Dafny.Compilers {
         case JavaNativeType.Short: return 16;
         case JavaNativeType.Int: return 32;
         case JavaNativeType.Long: return 64;
-        default: Contract.Assert(false); throw new cce.UnreachableException();
+        default: Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 

--- a/Source/DafnyCore/Backends/JavaScript/JavaScriptCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/JavaScript/JavaScriptCodeGenerator.cs
@@ -667,7 +667,7 @@ namespace Microsoft.Dafny.Compilers {
           break;
         default:
           Contract.Assert(false);  // unexpected native type
-          throw new cce.UnreachableException();  // to please the compiler
+          throw new Cce.UnreachableException();  // to please the compiler
       }
     }
 
@@ -706,7 +706,7 @@ namespace Microsoft.Dafny.Compilers {
         CodeGenerator.DeclareField(name, isStatic, isConst, type, tok, rhs, FieldWriter);
       }
       public void InitializeField(Field field, Type instantiatedFieldType, TopLevelDeclWithMembers enclosingClass) {
-        throw new cce.UnreachableException();  // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
+        throw new Cce.UnreachableException();  // InitializeField should be called only for those compilers that set ClassesRedeclareInheritedFields to false.
       }
       public ConcreteSyntaxTree/*?*/ ErrorWriter() => MethodWriter;
       public void Finish() { }
@@ -855,7 +855,7 @@ namespace Microsoft.Dafny.Compilers {
           return TypeName_UDT(FullTypeName(udt), udt, wr, udt.Origin);
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -949,7 +949,7 @@ namespace Microsoft.Dafny.Compilers {
       } else if (xType is MapType) {
         return DafnyMapClass;
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -1053,7 +1053,7 @@ namespace Microsoft.Dafny.Compilers {
         var arguments = relevantTypeArgs.Comma(arg => DefaultValue(arg, wr, tok, constructTypeParameterDefaultsFromTypeDescriptors));
         return string.Format($"{s}.Default({typeDescriptors}{sep}{arguments})");
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
 
     }
@@ -1438,7 +1438,7 @@ namespace Microsoft.Dafny.Compilers {
           wr.Write("\"))");
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal
       }
     }
     string IntegerLiteral(BigInteger i) {
@@ -2048,7 +2048,7 @@ namespace Microsoft.Dafny.Compilers {
           }
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
       }
     }
 
@@ -2166,7 +2166,7 @@ namespace Microsoft.Dafny.Compilers {
           } else if (IsRepresentedAsBigNumber(e0Type) || e0Type.IsNumericBased(Type.NumericPersuasion.Real)) {
             callString = "isLessThan";
           } else {
-            Contract.Assert(false); throw new cce.UnreachableException();
+            Contract.Assert(false); throw new Cce.UnreachableException();
           }
           break;
         case BinaryExpr.ResolvedOpcode.Le:
@@ -2177,7 +2177,7 @@ namespace Microsoft.Dafny.Compilers {
           } else if (e0Type.IsNumericBased(Type.NumericPersuasion.Real)) {
             callString = "isAtMost";
           } else {
-            Contract.Assert(false); throw new cce.UnreachableException();
+            Contract.Assert(false); throw new Cce.UnreachableException();
           }
           break;
         case BinaryExpr.ResolvedOpcode.Ge:
@@ -2190,7 +2190,7 @@ namespace Microsoft.Dafny.Compilers {
             callString = "isAtMost";
             reverseArguments = true;
           } else {
-            Contract.Assert(false); throw new cce.UnreachableException();
+            Contract.Assert(false); throw new Cce.UnreachableException();
           }
           break;
         case BinaryExpr.ResolvedOpcode.Gt:
@@ -2200,7 +2200,7 @@ namespace Microsoft.Dafny.Compilers {
             callString = "isLessThan";
             reverseArguments = true;
           } else {
-            Contract.Assert(false); throw new cce.UnreachableException();
+            Contract.Assert(false); throw new Cce.UnreachableException();
           }
           break;
         case BinaryExpr.ResolvedOpcode.LtChar when UnicodeCharEnabled:

--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -528,7 +528,7 @@ namespace Microsoft.Dafny.Compilers {
           name = "int"; break;
         default:
           Contract.Assert(false); // unexpected native type
-          throw new cce.UnreachableException(); // to please the compiler
+          throw new Cce.UnreachableException(); // to please the compiler
       }
     }
 
@@ -578,7 +578,7 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       public void InitializeField(Field field, Type instantiatedFieldType, TopLevelDeclWithMembers enclosingClass) {
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
 
       public ConcreteSyntaxTree ErrorWriter() => MethodWriter;
@@ -699,9 +699,9 @@ namespace Microsoft.Dafny.Compilers {
           ClassLikeDecl or NonNullTypeDecl => $"{DafnyDefaults}.pointer",
           DatatypeDecl => DatatypeDescriptor(udt, udt.TypeArgs, udt.Origin),
           NewtypeDecl or SubsetTypeDecl => CustomDescriptor(udt),
-          _ => throw new cce.UnreachableException()
+          _ => throw new Cce.UnreachableException()
         },
-        _ => throw new cce.UnreachableException()
+        _ => throw new Cce.UnreachableException()
       };
 
       string TypeParameterDescriptor(TypeParameter typeParameter) {
@@ -790,7 +790,7 @@ namespace Microsoft.Dafny.Compilers {
 
       // TODO: I'm not 100% sure this is exhaustive yet
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
 
     private string FullName(TopLevelDecl decl) {
@@ -891,7 +891,7 @@ namespace Microsoft.Dafny.Compilers {
       }
 
       Contract.Assert(false);
-      throw new cce.UnreachableException();  // unexpected type
+      throw new Cce.UnreachableException();  // unexpected type
     }
 
     protected override string TypeName_UDT(string fullCompileName, List<TypeParameter.TPVariance> variance,
@@ -1165,7 +1165,7 @@ namespace Microsoft.Dafny.Compilers {
               break;
             default:
               // TODO: This may not be exhaustive
-              throw new cce.UnreachableException();
+              throw new Cce.UnreachableException();
           }
           break;
       }
@@ -1637,7 +1637,7 @@ namespace Microsoft.Dafny.Compilers {
           TrParenExpr("not", expr, wr, inLetExprBody, wStmts);
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
       }
     }
 
@@ -1792,7 +1792,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected override void TrStmtList(IReadOnlyList<Statement> stmts, ConcreteSyntaxTree writer) {
-      Contract.Requires(cce.NonNullElements(stmts));
+      Contract.Requires(Cce.NonNullElements(stmts));
       Contract.Requires(writer != null);
       var listWriter = new ConcreteSyntaxTree();
       base.TrStmtList(stmts, listWriter);

--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Expression.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Expression.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Dafny.Compilers {
           }
         case OldExpr:
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // 'old' is always a ghost
+          throw new Cce.UnreachableException(); // 'old' is always a ghost
         case UnaryOpExpr opExpr: {
             var e = opExpr;
             if (e.ResolvedOp == UnaryOpExpr.ResolvedOpcode.BVNot) {
@@ -594,7 +594,7 @@ namespace Microsoft.Dafny.Compilers {
           }
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // unexpected expression
+          throw new Cce.UnreachableException(); // unexpected expression
       }
 
       ConcreteSyntaxTree EmitGuardFragment(List<(Expression conj, ISet<IVariable> frees)> unusedConjuncts,

--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Statement.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.Statement.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Dafny.Compilers {
           // content already handled
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected statement
       }
     }
 
@@ -590,7 +590,7 @@ namespace Microsoft.Dafny.Compilers {
         int i = 0;
         var sourceType = (UserDefinedType)s.Source.Type.NormalizeExpand();
         foreach (MatchCaseStmt mc in s.Cases) {
-          var w = MatchCasePrelude(source, sourceType, cce.NonNull(mc.Ctor), mc.Arguments, i, s.Cases.Count, wr);
+          var w = MatchCasePrelude(source, sourceType, Cce.NonNull(mc.Ctor), mc.Arguments, i, s.Cases.Count, wr);
           TrStmtList(mc.Body, w);
           i++;
         }

--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.cs
@@ -828,7 +828,7 @@ namespace Microsoft.Dafny.Compilers {
     protected virtual ConcreteSyntaxTree EmitSign(Type type, ConcreteSyntaxTree wr) {
       // Currently, this should only be called when CompareZeroUsingSign is true
       Contract.Assert(false);
-      throw new cce.UnreachableException();
+      throw new Cce.UnreachableException();
     }
     protected abstract void EmitEmptyTupleList(string tupleTypeArgs, ConcreteSyntaxTree wr);
     protected abstract ConcreteSyntaxTree EmitAddTupleToList(string ingredients, string tupleTypeArgs, ConcreteSyntaxTree wr);
@@ -1412,7 +1412,7 @@ namespace Microsoft.Dafny.Compilers {
 
         default:
           // The operator is one that needs to be handled in the specific compilers.
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected binary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected binary expression
       }
 
       if (dualOp != BinaryExpr.ResolvedOpcode.Add) {  // remember from above that Add stands for "there is no dual"
@@ -2408,7 +2408,7 @@ namespace Microsoft.Dafny.Compilers {
           }
           v.Visit(m);
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected member
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected member
         }
 
         thisContext = null;
@@ -2805,7 +2805,7 @@ namespace Microsoft.Dafny.Compilers {
               unit.Type = f.ResultType;
             } else {
               Contract.Assert(false);  // unexpected type
-              throw new cce.UnreachableException();
+              throw new Cce.UnreachableException();
             }
             DeclareLocalVar(IdName(accVar), accVar.Type, f.Origin, unit, false, w);
           }
@@ -3161,7 +3161,7 @@ namespace Microsoft.Dafny.Compilers {
               break;
             default:
               Contract.Assert(false); // unexpected TailStatus
-              throw new cce.UnreachableException();
+              throw new Cce.UnreachableException();
           }
         } else {
           Contract.Assert(accumulatorVar == null);
@@ -3234,7 +3234,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected string/*!*/ TypeNames(List<Type/*!*/>/*!*/ types, ConcreteSyntaxTree wr, IOrigin tok) {
-      Contract.Requires(cce.NonNullElements(types));
+      Contract.Requires(Cce.NonNullElements(types));
       Contract.Ensures(Contract.Result<string>() != null);
       return Util.Comma(types, ty => TypeName(ty, wr, tok));
     }
@@ -3532,7 +3532,7 @@ namespace Microsoft.Dafny.Compilers {
           ResolvedClass = b.Decl
         };
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected BoundedPool type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected BoundedPool type
       }
     }
 
@@ -4694,7 +4694,7 @@ namespace Microsoft.Dafny.Compilers {
     }
 
     protected virtual void TrStmtList(IReadOnlyList<Statement> stmts, ConcreteSyntaxTree writer) {
-      Contract.Requires(cce.NonNullElements(stmts));
+      Contract.Requires(Cce.NonNullElements(stmts));
       Contract.Requires(writer != null);
       foreach (Statement ss in stmts) {
         // label:        // if any
@@ -4735,7 +4735,7 @@ namespace Microsoft.Dafny.Compilers {
       Contract.Requires(source != null);
       Contract.Requires(sourceType != null);
       Contract.Requires(ctor != null);
-      Contract.Requires(cce.NonNullElements(arguments));
+      Contract.Requires(Cce.NonNullElements(arguments));
       Contract.Requires(0 <= caseIndex && caseIndex < caseCount);
       // if (source.is_Ctor0) {
       //   FormalType f0 = ((Dt_Ctor0)source._D).a0;
@@ -4799,7 +4799,7 @@ namespace Microsoft.Dafny.Compilers {
     /// </summary>
     protected void TrExprList(List<Expression> exprs, ConcreteSyntaxTree wr, bool inLetExprBody, ConcreteSyntaxTree wStmts,
         Func<int, Type> typeAt = null, bool parens = true) {
-      Contract.Requires(cce.NonNullElements(exprs));
+      Contract.Requires(Cce.NonNullElements(exprs));
       if (parens) { wr = wr.ForkInParens(); }
 
       wr.Comma(exprs, (e, index) => {

--- a/Source/DafnyCore/CompileNestedMatch/MatchAst.cs
+++ b/Source/DafnyCore/CompileNestedMatch/MatchAst.cs
@@ -15,15 +15,15 @@ public class MatchExpr : Expression, IMatch, ICloneable<MatchExpr> {  // a Match
   [ContractInvariantMethod]
   void ObjectInvariant() {
     Contract.Invariant(Source != null);
-    Contract.Invariant(cce.NonNullElements(Cases));
-    Contract.Invariant(cce.NonNullElements(MissingCases));
+    Contract.Invariant(Cce.NonNullElements(Cases));
+    Contract.Invariant(Cce.NonNullElements(MissingCases));
   }
 
   public MatchExpr(IOrigin origin, Expression source, [Captured] List<MatchCaseExpr> cases, bool usesOptionalBraces, MatchingContext context = null)
     : base(origin) {
     Contract.Requires(origin != null);
     Contract.Requires(source != null);
-    Contract.Requires(cce.NonNullElements(cases));
+    Contract.Requires(Cce.NonNullElements(cases));
     this.source = source;
     this.cases = cases;
     UsesOptionalBraces = usesOptionalBraces;
@@ -89,13 +89,13 @@ public abstract class MatchCase : NodeWithOrigin, IHasReferences {
   void ObjectInvariant() {
     Contract.Invariant(Origin != null);
     Contract.Invariant(Ctor != null);
-    Contract.Invariant(cce.NonNullElements(Arguments));
+    Contract.Invariant(Cce.NonNullElements(Arguments));
   }
 
   public MatchCase(IOrigin origin, DatatypeCtor ctor, [Captured] List<BoundVar> arguments) : base(origin) {
     Contract.Requires(origin != null);
     Contract.Requires(ctor != null);
-    Contract.Requires(cce.NonNullElements(arguments));
+    Contract.Requires(Cce.NonNullElements(arguments));
     Ctor = ctor;
     Arguments = arguments;
   }
@@ -115,8 +115,8 @@ public class MatchStmt : Statement, IMatch, ICloneable<MatchStmt> {
   [ContractInvariantMethod]
   void ObjectInvariant() {
     Contract.Invariant(Source != null);
-    Contract.Invariant(cce.NonNullElements(Cases));
-    Contract.Invariant(cce.NonNullElements(MissingCases));
+    Contract.Invariant(Cce.NonNullElements(Cases));
+    Contract.Invariant(Cce.NonNullElements(MissingCases));
   }
 
   private Expression source;
@@ -145,7 +145,7 @@ public class MatchStmt : Statement, IMatch, ICloneable<MatchStmt> {
     : base(origin) {
     Contract.Requires(origin != null);
     Contract.Requires(source != null);
-    Contract.Requires(cce.NonNullElements(cases));
+    Contract.Requires(Cce.NonNullElements(cases));
     this.source = source;
     this.cases = cases;
     UsesOptionalBraces = usesOptionalBraces;
@@ -157,7 +157,7 @@ public class MatchStmt : Statement, IMatch, ICloneable<MatchStmt> {
     : base(origin, attributes) {
     Contract.Requires(origin != null);
     Contract.Requires(source != null);
-    Contract.Requires(cce.NonNullElements(cases));
+    Contract.Requires(Cce.NonNullElements(cases));
     this.source = source;
     this.cases = cases;
     UsesOptionalBraces = usesOptionalBraces;
@@ -242,7 +242,7 @@ public class MatchCaseStmt : MatchCase {
 
   [ContractInvariantMethod]
   void ObjectInvariant() {
-    Contract.Invariant(cce.NonNullElements(Body));
+    Contract.Invariant(Cce.NonNullElements(Body));
   }
 
   public override IEnumerable<INode> Children => body;
@@ -251,8 +251,8 @@ public class MatchCaseStmt : MatchCase {
   public MatchCaseStmt(IOrigin rangeOrigin, DatatypeCtor ctor, bool fromBoundVar, [Captured] List<BoundVar> arguments, [Captured] List<Statement> body, Attributes attrs = null)
     : base(rangeOrigin, ctor, arguments) {
     Contract.Requires(ctor != null);
-    Contract.Requires(cce.NonNullElements(arguments));
-    Contract.Requires(cce.NonNullElements(body));
+    Contract.Requires(Cce.NonNullElements(arguments));
+    Contract.Requires(Cce.NonNullElements(body));
     this.body = body;
     Attributes = attrs;
     FromBoundVar = fromBoundVar;
@@ -284,7 +284,7 @@ public class MatchCaseExpr : MatchCase {
     : base(origin, ctor, arguments) {
     Contract.Requires(origin != null);
     Contract.Requires(ctor != null);
-    Contract.Requires(cce.NonNullElements(arguments));
+    Contract.Requires(Cce.NonNullElements(arguments));
     Contract.Requires(body != null);
     this.body = body;
     Attributes = attrs;

--- a/Source/DafnyCore/CompileNestedMatch/MatchFlattener.cs
+++ b/Source/DafnyCore/CompileNestedMatch/MatchFlattener.cs
@@ -108,7 +108,7 @@ public class MatchFlattener : IRewriter {
       }
       return expression;
     }
-    Contract.Assert(false); throw new cce.UnreachableException(); // Returned container should be a CExpr
+    Contract.Assert(false); throw new Cce.UnreachableException(); // Returned container should be a CExpr
   }
 
   private Statement CompileNestedMatchStmt(NestedMatchStmt nestedMatchStmt) {
@@ -143,7 +143,7 @@ public class MatchFlattener : IRewriter {
         null, false, false);
       return result;
     }
-    Contract.Assert(false); throw new cce.UnreachableException(); // Returned container should be a StmtContainer
+    Contract.Assert(false); throw new Cce.UnreachableException(); // Returned container should be a StmtContainer
   }
 
   private IEnumerable<NestedMatchCaseStmt> FlattenNestedMatchCaseStmt(NestedMatchCaseStmt c) {
@@ -270,7 +270,7 @@ public class MatchFlattener : IRewriter {
         var (head, tail) = SplitPath(path);
         if (!(head is IdPattern)) {
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // in Variable case with a constant pattern
+          throw new Cce.UnreachableException(); // in Variable case with a constant pattern
         }
 
         var currPattern = (IdPattern)head;
@@ -278,7 +278,7 @@ public class MatchFlattener : IRewriter {
         if (currPattern.Arguments != null) {
           if (dtd == null) {
             Contract.Assert(false);
-            throw new cce.UnreachableException(); // non-nullary constructors of a non-datatype;
+            throw new Cce.UnreachableException(); // non-nullary constructors of a non-datatype;
           } else {
             Reporter.Error(MessageSource.Resolver, currPattern.Origin,
               "Type mismatch: expected constructor of type {0}.  Got {1}.", dtd.Name, currPattern.Id);
@@ -366,7 +366,7 @@ public class MatchFlattener : IRewriter {
             ctorToFromBoundVar.Add(ctor.Name);
           }
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();
+          Contract.Assert(false); throw new Cce.UnreachableException();
         }
       }
       // Add variables corresponding to the arguments of the current constructor (ctor) to the matchees
@@ -481,7 +481,7 @@ public class MatchFlattener : IRewriter {
           mti.UpdateCaseCopyCount(tail.CaseId, 1);
           pathsForLiteral.Add(newPath);
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();
+          Contract.Assert(false); throw new Cce.UnreachableException();
         }
       }
       var blockContext = context.FillHole(new LitCtx(ifBlockLiteral));
@@ -577,7 +577,7 @@ public class MatchFlattener : IRewriter {
       }
     }
 
-    throw new cce.UnreachableException();
+    throw new Cce.UnreachableException();
   }
 
   record CaseBody(IOrigin Tok, Node Node, Attributes Attributes = null);
@@ -591,7 +591,7 @@ public class MatchFlattener : IRewriter {
       return new CaseBody(tok, ((ExprPatternPath)path).Body, ((ExprPatternPath)path).Attributes);
     }
 
-    Contract.Assert(false); throw new cce.UnreachableException();
+    Contract.Assert(false); throw new Cce.UnreachableException();
   }
 
   private List<Statement> UnboxStmt(Statement statement) {

--- a/Source/DafnyCore/Dafny.atg
+++ b/Source/DafnyCore/Dafny.atg
@@ -603,7 +603,7 @@ TraitDecl<DeclModifierData dmodIn, ModuleDefinition/*!*/ module, out TraitDecl/*
 
 /*------------------------------------------------------------------------*/
 ClassMemberDecl<. DeclModifierData dmod, List<MemberDecl> mm, bool allowConstructors, bool moduleLevelDecl.>
-= (. Contract.Requires(cce.NonNullElements(mm));
+= (. Contract.Requires(Cce.NonNullElements(mm));
      MethodOrConstructor/*!*/ m;
      Function/*!*/ f;
   .)
@@ -677,7 +677,7 @@ DatatypeDecl<DeclModifierData dmod, ModuleDefinition/*!*/ module, out DatatypeDe
 DatatypeMemberName<out Token id> = NoUSIdentOrDigits<out id> .
 
 DatatypeMemberDecl<.List<DatatypeCtor/*!*/>/*!*/ ctors.>
-= (. Contract.Requires(cce.NonNullElements(ctors));
+= (. Contract.Requires(Cce.NonNullElements(ctors));
      Attributes attrs = null;
      Token/*!*/ id;
      List<Formal/*!*/> formals = new List<Formal/*!*/>();
@@ -710,7 +710,7 @@ TypeMembers<. ModuleDefinition/*!*/ module, List<MemberDecl> members .>
 
 /*------------------------------------------------------------------------*/
 FieldDecl<.DeclModifierData dmod, List<MemberDecl> mm.>
-= (. Contract.Requires(cce.NonNullElements(mm));
+= (. Contract.Requires(Cce.NonNullElements(mm));
      Attributes attrs = null;
      Type/*!*/ ty;
      Name name;
@@ -733,7 +733,7 @@ FieldDecl<.DeclModifierData dmod, List<MemberDecl> mm.>
 
 /*------------------------------------------------------------------------*/
 ConstantFieldDecl<.DeclModifierData dmod, List<MemberDecl/*!*/>/*!*/ mm, bool moduleLevelDecl.>
-= (. Contract.Requires(cce.NonNullElements(mm));
+= (. Contract.Requires(Cce.NonNullElements(mm));
      Type/*!*/ ty;
      Expression e = null;
      if (moduleLevelDecl && dmod.StaticToken != null) {
@@ -1071,7 +1071,7 @@ IteratorDecl<DeclModifierData dmod, ModuleDefinition module, out IteratorDecl/*!
 TypeVariableName<out Name name> = Name<out name> .
 
 GenericParameters<.List<TypeParameter> typeParameters, bool allowVariance.>
-= (. Contract.Requires(cce.NonNullElements(typeParameters)); .)
+= (. Contract.Requires(Cce.NonNullElements(typeParameters)); .)
   // If a "<" combined with a Variance symbol could be a new token, then the parser here will need to be more complex,
   // since, for example, a < followed immediately by a Variance symbol would scan as the wrong token.
   // Fortunately that is not currently the case.
@@ -1367,11 +1367,11 @@ InvariantClause<. List<AttributedExpression> invariants.> =
 /*------------------------------------------------------------------------*/
 MethodSpec<.bool isGhost, List<AttributedExpression> req, List<FrameExpression> reads, List<FrameExpression> mod, List<AttributedExpression> ens,
             List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, ref Attributes readsAttrs, string caption, bool performThisDeprecatedCheck.>
-= (. Contract.Requires(cce.NonNullElements(req));
-     Contract.Requires(cce.NonNullElements(reads));
-     Contract.Requires(cce.NonNullElements(mod));
-     Contract.Requires(cce.NonNullElements(ens));
-     Contract.Requires(cce.NonNullElements(decreases));
+= (. Contract.Requires(Cce.NonNullElements(req));
+     Contract.Requires(Cce.NonNullElements(reads));
+     Contract.Requires(Cce.NonNullElements(mod));
+     Contract.Requires(Cce.NonNullElements(ens));
+     Contract.Requires(Cce.NonNullElements(decreases));
   .)
   SYNC
   { ReadsClause<reads, ref readsAttrs, false, false, true>
@@ -1403,7 +1403,7 @@ IteratorSpec<.List<FrameExpression/*!*/>/*!*/ reads, List<FrameExpression/*!*/>/
 
 /*------------------------------------------------------------------------*/
 Formals<.bool incoming, bool allowGhostKeyword, bool allowNewKeyword, bool allowOlderKeyword, List<Formal> formals.>
-= (. Contract.Requires(cce.NonNullElements(formals));
+= (. Contract.Requires(Cce.NonNullElements(formals));
      Type ty;
      bool isGhost;
      bool isOld;
@@ -1452,7 +1452,7 @@ ParameterDefaultValue<bool incoming, out Expression defaultValue>
 
 /*------------------------------------------------------------------------*/
 FormalsOptionalIds<.List<Formal/*!*/>/*!*/ formals.>
-= (. Contract.Requires(cce.NonNullElements(formals));
+= (. Contract.Requires(Cce.NonNullElements(formals));
      SourceOrigin/*!*/ range;  Type/*!*/ ty;  Name/*!*/ name;  bool isGhost;  Expression/*?*/ defaultValue;
      bool isNameOnly;
      Attributes attributes;
@@ -1670,7 +1670,7 @@ OptGenericInstantiation<.out List<Type> gt, bool inExpressionContext.>  /* NOTE:
 
 /*------------------------------------------------------------------------*/
 GenericInstantiation<.List<Type> gt.>
-= (. Contract.Requires(cce.NonNullElements(gt)); Type/*!*/ ty; .)
+= (. Contract.Requires(Cce.NonNullElements(gt)); Type/*!*/ ty; .)
   "<"
   (
     ">" (. SemErr(ErrorId.p_no_empty_type_parameter_list, t, "empty type parameter lists are not permitted"); .)
@@ -2026,9 +2026,9 @@ FunctionDecl<DeclModifierData dmod, out Function/*!*/ f>
 
 /*------------------------------------------------------------------------*/
 FunctionSpec<.List<AttributedExpression> reqs, List<FrameExpression> reads, List<AttributedExpression> ens, List<Expression> decreases, ref Attributes decAttrs, ref Attributes readsAttrs.>
-= (. Contract.Requires(cce.NonNullElements(reqs));
-     Contract.Requires(cce.NonNullElements(reads));
-     Contract.Requires(decreases == null || cce.NonNullElements(decreases));
+= (. Contract.Requires(Cce.NonNullElements(reqs));
+     Contract.Requires(Cce.NonNullElements(reads));
+     Contract.Requires(decreases == null || Cce.NonNullElements(decreases));
   .)
   SYNC
   { RequiresClause<reqs, true>
@@ -2130,7 +2130,7 @@ FrameExpression<out FrameExpression fe, bool allowLemma, bool allowLambda>
       FrameField<out id> 
       (. 
         if(AcceptReferrers()) {
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
         fieldName = id.val;
         feTok = id;
@@ -2765,7 +2765,7 @@ WhileStmt<out Statement stmt>
                                       alternatives, usesOptionalBraces, [], attrs);
        .)
   |
-    ( Guard<out guard>           (. Contract.Assume(guard == null || cce.Owner.None(guard)); .)
+    ( Guard<out guard>           (. Contract.Assume(guard == null || Cce.Owner.None(guard)); .)
     | ellipsis                   (. guardEllipsis = t; 
                                     errors.Deprecated(ErrorId.p_deprecated_statement_refinement, t, "the ... refinement feature in statements is deprecated");
                                  .)

--- a/Source/DafnyCore/DafnyCore.csproj
+++ b/Source/DafnyCore/DafnyCore.csproj
@@ -38,7 +38,7 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
       <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
-      <PackageReference Include="Boogie.ExecutionEngine" Version="3.4.3" />
+      <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.5" />
       <PackageReference Include="Tomlyn" Version="0.17.0" />
   </ItemGroup>
 

--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -113,8 +113,8 @@ namespace Microsoft.Dafny {
       if (options.PrintFile != null) {
         bplFilename = options.PrintFile;
       } else {
-        string baseName = cce.NonNull(Path.GetFileName(baseFile));
-        baseName = cce.NonNull(Path.ChangeExtension(baseName, "bpl"));
+        string baseName = Cce.NonNull(Path.GetFileName(baseFile));
+        baseName = Cce.NonNull(Path.ChangeExtension(baseName, "bpl"));
         bplFilename = Path.Combine(Path.GetTempPath(), baseName);
       }
 
@@ -179,7 +179,7 @@ namespace Microsoft.Dafny {
 
         case PipelineOutcome.ResolvedAndTypeChecked:
           engine.EliminateDeadVariables(program);
-          engine.CollectModSets(program);
+          engine.CollectModifies(program);
           engine.CoalesceBlocks(program);
           engine.Inline(program);
           var inferAndVerifyOutcome = await engine.InferAndVerify(output, program, stats, programId);
@@ -187,7 +187,7 @@ namespace Microsoft.Dafny {
 
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // unexpected outcome
+          throw new Cce.UnreachableException(); // unexpected outcome
       }
     }
   }

--- a/Source/DafnyCore/DafnyOptions.cs
+++ b/Source/DafnyCore/DafnyOptions.cs
@@ -295,10 +295,10 @@ namespace Microsoft.Dafny {
     /// </summary>
     public bool BaseParse(string[] args, bool allowFile) {
       Environment = Environment + "Command Line Options: " + string.Join(" ", args);
-      args = cce.NonNull<string[]>((string[])args.Clone());
+      args = Cce.NonNull<string[]>((string[])args.Clone());
       Bpl.CommandLineParseState state;
       for (state = InitializeCommandLineParseState(args); state.i < args.Length; state.i = state.nextIndex) {
-        cce.LoopInvariant(state.args == args);
+        Cce.LoopInvariant(state.args == args);
         string file = args[state.i];
         state.s = file.Trim();
         bool flag = state.s.StartsWith("-") || state.s.StartsWith("/");

--- a/Source/DafnyCore/Generic/SccGraph.cs
+++ b/Source/DafnyCore/Generic/SccGraph.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Dafny {
       public List<Vertex/*!*/> SccMembers;  // non-null only for the representative of the SCC
       [ContractInvariantMethod]
       void ObjectInvariant() {
-        Contract.Invariant(cce.NonNullElements(Successors));
-        Contract.Invariant(SccMembers == null || cce.NonNullElements(SccMembers));
+        Contract.Invariant(Cce.NonNullElements(Successors));
+        Contract.Invariant(SccMembers == null || Cce.NonNullElements(SccMembers));
       }
 
       public Vertex SccRepresentative;  // null if not computed
@@ -60,8 +60,8 @@ namespace Microsoft.Dafny {
     [ContractInvariantMethod]
     void ObjectInvariant() {
       Contract.Invariant(vertices != null);
-      Contract.Invariant(cce.NonNullElements(vertices.Values));
-      Contract.Invariant(topologicallySortedRepresentatives == null || cce.NonNullElements(topologicallySortedRepresentatives));
+      Contract.Invariant(Cce.NonNullElements(vertices.Values));
+      Contract.Invariant(topologicallySortedRepresentatives == null || Cce.NonNullElements(topologicallySortedRepresentatives));
       Contract.Invariant(!sccComputed || topologicallySortedRepresentatives != null);
     }
 
@@ -176,7 +176,7 @@ namespace Microsoft.Dafny {
     /// Returns a list of the topologically sorted SCCs, each represented in the list by its representative node.
     /// </summary>
     public List<Node> TopologicallySortedComponents() {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Node>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Node>>()));
       ComputeSCCs();
       Contract.Assert(topologicallySortedRepresentatives != null);  // follows from object invariant
       return topologicallySortedRepresentatives.ConvertAll(v => v.N);
@@ -187,7 +187,7 @@ namespace Microsoft.Dafny {
     /// that contains 'n'.
     /// </summary>
     public List<Node> GetSCC(Node n) {
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<Node>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<Node>>()));
       Vertex v = GetVertex(n);
       ComputeSCCs();
       Vertex repr = v.SccRepresentative;
@@ -250,7 +250,7 @@ namespace Microsoft.Dafny {
     /// </summary>
     void SearchC(Vertex/*!*/ v, Stack<Vertex/*!*/>/*!*/ stack, ref int cnt) {
       Contract.Requires(v != null);
-      Contract.Requires(cce.NonNullElements(stack));
+      Contract.Requires(Cce.NonNullElements(stack));
       Contract.Requires(v.Visited == VisitedStatus.Unvisited);
       Contract.Requires(topologicallySortedRepresentatives != null);
       Contract.Ensures(v.Visited != VisitedStatus.Unvisited);

--- a/Source/DafnyCore/HumanReadableOutputWriter.cs
+++ b/Source/DafnyCore/HumanReadableOutputWriter.cs
@@ -95,7 +95,7 @@ public class HumanReadableOutputWriter(DafnyOptions options) : IDafnyOutputWrite
       case ErrorLevel.Info:
         return ConsoleColor.Green;
       default:
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
     }
   }
 }

--- a/Source/DafnyCore/Resolver/BoundsDiscovery/BoundsDiscovery.cs
+++ b/Source/DafnyCore/Resolver/BoundsDiscovery/BoundsDiscovery.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Dafny {
           case BinaryExpr.ResolvedOpcode.Gt:
           case BinaryExpr.ResolvedOpcode.Ge:
             Contract.Assert(false);
-            throw new cce.UnreachableException(); // promised by postconditions of NormalizedConjunct
+            throw new Cce.UnreachableException(); // promised by postconditions of NormalizedConjunct
           case BinaryExpr.ResolvedOpcode.Lt:
             if (e0.Type.IsNumericBased(Type.NumericPersuasion.Int)) {
               conjunctsQualifyingAsRangeConstraints++;

--- a/Source/DafnyCore/Resolver/CheckTypeCharacteristicsVisitor.cs
+++ b/Source/DafnyCore/Resolver/CheckTypeCharacteristicsVisitor.cs
@@ -320,7 +320,7 @@ class CheckTypeCharacteristicsVisitor : ResolverTopDownVisitor<bool> {
     } else if (type is TypeProxy) {
       // the type was underconstrained; this is checked elsewhere, but it is not in violation of the equality-type test
     } else {
-      Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+      Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
     }
   }
 

--- a/Source/DafnyCore/Resolver/ExpressionTester.cs
+++ b/Source/DafnyCore/Resolver/ExpressionTester.cs
@@ -484,7 +484,7 @@ public class ExpressionTester {
       return false;
     } else if (expr is IdentifierExpr) {
       IdentifierExpr e = (IdentifierExpr)expr;
-      return cce.NonNull(e.Var).IsGhost;
+      return Cce.NonNull(e.Var).IsGhost;
     } else if (expr is DatatypeValue) {
       var e = (DatatypeValue)expr;
       if (e.Ctor.IsGhost) {
@@ -653,7 +653,7 @@ public class ExpressionTester {
     } else if (expr is LocalsObjectExpression) {
       return true;
     } else {
-      Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+      Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
     }
   }
   static void MakeGhostAsNeeded(List<CasePattern<BoundVar>> lhss) {

--- a/Source/DafnyCore/Resolver/GhostInterestVisitor.cs
+++ b/Source/DafnyCore/Resolver/GhostInterestVisitor.cs
@@ -531,7 +531,7 @@ class GhostInterestVisitor {
         Visit(blockByProofStmt.Proof, true, "a by block");
         break;
       default:
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
     }
   }
 

--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -1129,8 +1129,8 @@ namespace Microsoft.Dafny {
       string moduleDescription, bool isAnExport) {
 
       Contract.Requires(declarations != null);
-      Contract.Requires(cce.NonNullElements(datatypeDependencies.GetVertices()));
-      Contract.Requires(cce.NonNullElements(codatatypeDependencies.GetVertices()));
+      Contract.Requires(Cce.NonNullElements(datatypeDependencies.GetVertices()));
+      Contract.Requires(Cce.NonNullElements(codatatypeDependencies.GetVertices()));
       Contract.Requires(AllTypeConstraints.Count == 0);
 
       Contract.Ensures(AllTypeConstraints.Count == 0);
@@ -2415,7 +2415,7 @@ namespace Microsoft.Dafny {
           }
 
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected member type
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected member type
         }
       }
 
@@ -2733,7 +2733,7 @@ namespace Microsoft.Dafny {
     /// </summary>
     void SccStratosphereCheck(IndDatatypeDecl startingPoint, Graph<IndDatatypeDecl/*!*/>/*!*/ dependencies) {
       Contract.Requires(startingPoint != null);
-      Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(cce.NonNullElements(dependencies));
+      Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(Cce.NonNullElements(dependencies));
 
       var scc = dependencies.GetSCC(startingPoint);
       int totalCleared = 0;
@@ -2881,7 +2881,7 @@ namespace Microsoft.Dafny {
 
     void DetermineEqualitySupport(IndDatatypeDecl startingPoint, Graph<IndDatatypeDecl/*!*/>/*!*/ dependencies) {
       Contract.Requires(startingPoint != null);
-      Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(cce.NonNullElements(dependencies));
+      Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(Cce.NonNullElements(dependencies));
 
       var scc = dependencies.GetSCC(startingPoint);
 
@@ -3977,7 +3977,7 @@ namespace Microsoft.Dafny {
         case BinaryExpr.Opcode.BitwiseOr: return BinaryExpr.ResolvedOpcode.BitwiseOr;
         case BinaryExpr.Opcode.BitwiseXor: return BinaryExpr.ResolvedOpcode.BitwiseXor;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected operator
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected operator
       }
     }
 

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Dafny {
             e.Type = Type.String();
             ResolveType(e.Origin, e.Type, resolutionContext, ResolveTypeOptionEnum.DontInfer, null);
           } else {
-            Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal type
+            Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal type
           }
         }
       } else if (expr is ThisExpr) {
@@ -773,7 +773,7 @@ namespace Microsoft.Dafny {
             expr.Type = Type.Bool;
             break;
           default:
-            Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary operator
+            Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary operator
         }
 
         // We do not have enough information to compute `e.ResolvedOp` yet.
@@ -975,7 +975,7 @@ namespace Microsoft.Dafny {
             break;
 
           default:
-            Contract.Assert(false); throw new cce.UnreachableException();  // unexpected operator
+            Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected operator
         }
         // We should also fill in e.ResolvedOp, but we may not have enough information for that yet.  So, instead, delay
         // setting e.ResolvedOp until inside CheckTypeInference.
@@ -1191,7 +1191,7 @@ namespace Microsoft.Dafny {
         expr.Type = new InferredTypeProxy();
         return;
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
       }
 
       if (expr.Type == null) {
@@ -2836,7 +2836,7 @@ namespace Microsoft.Dafny {
           }
 
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected member type
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected member type
         }
         Contract.Assert(AllTypeConstraints.Count == 0);
       }
@@ -2891,7 +2891,7 @@ namespace Microsoft.Dafny {
     void AddDatatypeDependencyEdge(IndDatatypeDecl dt, Type tp, Graph<IndDatatypeDecl> dependencies) {
       Contract.Requires(dt != null);
       Contract.Requires(tp != null);
-      Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(cce.NonNullElements(dependencies));
+      Contract.Requires(dependencies != null);  // more expensive check: Contract.Requires(Cce.NonNullElements(dependencies));
 
       tp = tp.NormalizeExpand();
       var dependee = tp.AsIndDatatype;
@@ -3730,7 +3730,7 @@ namespace Microsoft.Dafny {
         } else if (s.Rhs is HavocRhs havocRhs) {
           havocRhs.Resolve(this, resolutionContext);
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected RHS
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected RHS
         }
 
       } else if (stmt is CallStmt) {
@@ -3991,7 +3991,7 @@ namespace Microsoft.Dafny {
       } else if (stmt is LabeledStatement) {
         // content already handled
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 
@@ -4268,7 +4268,7 @@ namespace Microsoft.Dafny {
       } else if (type is SelfType) {
         // do nothing.
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
       return null;
     }
@@ -5038,7 +5038,7 @@ namespace Microsoft.Dafny {
           }
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -6036,9 +6036,9 @@ namespace Microsoft.Dafny {
       if (member == null) {
         // error has already been reported by ResolveMember
       } else if (member is MethodOrConstructor) {
-        reporter.Error(MessageSource.Resolver, e, "member {0} in type {1} refers to a method, but only functions can be used in this context", e.Name, cce.NonNull(ctype).Name);
+        reporter.Error(MessageSource.Resolver, e, "member {0} in type {1} refers to a method, but only functions can be used in this context", e.Name, Cce.NonNull(ctype).Name);
       } else if (!(member is Function)) {
-        reporter.Error(MessageSource.Resolver, e, "member {0} in type {1} does not refer to a function", e.Name, cce.NonNull(ctype).Name);
+        reporter.Error(MessageSource.Resolver, e, "member {0} in type {1} does not refer to a function", e.Name, Cce.NonNull(ctype).Name);
       } else {
         Function function = (Function)member;
         e.Function = function;

--- a/Source/DafnyCore/Resolver/PreType/PreTypeAdvice.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeAdvice.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Dafny {
         Target.Real => preTypeResolver.Type2PreType(Type.Real),
         Target.String => preTypeResolver.Type2PreType(StringDecl()),
         Target.Object => preTypeResolver.Type2PreType(preTypeResolver.resolver.SystemModuleManager.ObjectQ()),
-        _ => throw new cce.UnreachableException() // unexpected case
+        _ => throw new Cce.UnreachableException() // unexpected case
       };
       return target;
     }

--- a/Source/DafnyCore/Resolver/PreType/PreTypeConstraints.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeConstraints.cs
@@ -806,7 +806,7 @@ namespace Microsoft.Dafny {
           return true;
         default:
           Contract.Assert(false); // unexpected case
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
       }
     }
 

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Dafny {
                 AddConfirmation(PreTypeConstraints.CommonConfirmationBag.InCharFamily, charPreType, e.Origin, "character literal used as if it had type {0}");
                 ResolveCollectionProducingExpr(PreType.TypeNameSeq, $"string literal \"{e.EscapedValue}\"", e, charPreType, PreTypeConstraints.CommonConfirmationBag.InSeqFamily, true);
               } else {
-                Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal type
+                Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal type
               }
             }
 
@@ -460,7 +460,7 @@ namespace Microsoft.Dafny {
                 expr.PreType = ConstrainResultToBoolFamily(expr.Origin, "assigned", "boolean literal used as if it had type {0}");
                 break;
               default:
-                Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary operator
+                Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary operator
             }
 
             break;
@@ -971,7 +971,7 @@ namespace Microsoft.Dafny {
           locals.Type = localsType;
           break;
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
       }
 
       if (expr.PreType == null) {
@@ -1296,7 +1296,7 @@ namespace Microsoft.Dafny {
 
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException(); // unexpected operator
+          throw new Cce.UnreachableException(); // unexpected operator
       }
       // We should also fill in e.ResolvedOp, but we may not have enough information for that yet.  So, instead, delay
       // setting e.ResolvedOp until inside CheckTypeInference.

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Statements.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Statements.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Dafny {
         } else if (s.Rhs is HavocRhs havocRhs) {
           havocRhs.Resolve(this, resolutionContext);
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected RHS
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected RHS
         }
 
       } else if (stmt is CallStmt callStmt) {
@@ -411,7 +411,7 @@ namespace Microsoft.Dafny {
       } else if (stmt is LabeledStatement) {
         // content already handled 
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
     }
 

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Dafny {
       } else if (type is UserDefinedType udt) {
         decl = udt.ResolvedClass;
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
       return decl;
     }
@@ -1214,7 +1214,7 @@ namespace Microsoft.Dafny {
         }
 
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected member type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected member type
       }
     }
 

--- a/Source/DafnyCore/Resolver/PreType/PreTypeToType.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeToType.cs
@@ -268,7 +268,7 @@ class PreTypeToTypeVisitor : ASTVisitor<IASTVisitorContext> {
         var rhsMaybeNullType = new UserDefinedType(stmt.Origin, arrayTypeDecl.Name, arrayTypeDecl, [allocateArray.ElementType]);
         rhsType = UserDefinedType.CreateNonNullType(rhsMaybeNullType);
       } else {
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
       }
       tRhs.Type = rhsType;
 

--- a/Source/DafnyCore/Resolver/PreType/UnderspecificationDetector.cs
+++ b/Source/DafnyCore/Resolver/PreType/UnderspecificationDetector.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Dafny {
           return BinaryExpr.ResolvedOpcode.BitwiseXor;
         default:
           Contract.Assert(false);
-          throw new cce.UnreachableException();  // unexpected operator
+          throw new Cce.UnreachableException();  // unexpected operator
       }
     }
 

--- a/Source/DafnyCore/Resolver/TailRecursion.cs
+++ b/Source/DafnyCore/Resolver/TailRecursion.cs
@@ -584,7 +584,7 @@ class TailRecursion {
             }
           default:
             Contract.Assert(false); // unexpected case
-            throw new cce.UnreachableException();
+            throw new Cce.UnreachableException();
         }
       }
       // not an operator that allows accumulation, so drop down below

--- a/Source/DafnyCore/Resolver/TypeCharacteristicChecker.cs
+++ b/Source/DafnyCore/Resolver/TypeCharacteristicChecker.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Dafny {
           }
         }
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
       return false;
     }

--- a/Source/DafnyCore/Rewriters/AutoReqFunctionRewriter.cs
+++ b/Source/DafnyCore/Rewriters/AutoReqFunctionRewriter.cs
@@ -380,7 +380,7 @@ public class AutoReqFunctionRewriter : IRewriter {
       var e = (ConcreteSyntaxExpression)expr;
       reqs.AddRange(GenerateAutoReqs(e.ResolvedExpression));
     } else {
-      //Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+      //Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
     }
 
     return reqs;

--- a/Source/DafnyCore/Rewriters/InductionHeuristic.cs
+++ b/Source/DafnyCore/Rewriters/InductionHeuristic.cs
@@ -110,7 +110,7 @@ public static class InductionHeuristic {
             VarOccursInArgumentToRecursiveFunction(options, e.E1, n, subExprIsProminent) ||
             VarOccursInArgumentToRecursiveFunction(options, e.E2, n, subExprIsProminent);
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected ternary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected ternary expression
       }
     } else if (expr is DatatypeValue value) {
       var q = n != null && n.Type.IsDatatype ? exprIsProminent : subExprIsProminent;  // prominent status continues, if we're looking for a variable whose type is a datatype

--- a/Source/DafnyCore/Rewriters/RefinementTransformer.cs
+++ b/Source/DafnyCore/Rewriters/RefinementTransformer.cs
@@ -1249,7 +1249,7 @@ namespace Microsoft.Dafny {
             }
             if (doMerge) {
               // Go ahead with the merge:
-              Contract.Assert(cce.NonNullElements(stmtGenerated));
+              Contract.Assert(Cce.NonNullElements(stmtGenerated));
               body.AddRange(stmtGenerated);
               i++; j++;
             } else {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.BoogieFactory.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.BoogieFactory.cs
@@ -610,7 +610,7 @@ namespace Microsoft.Dafny {
           return FunctionCall(tok, "local_field", Predef.FieldName(tok), args);
 
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected built-in function
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected built-in function
       }
     }
 
@@ -663,7 +663,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(tok != null);
       Contract.Requires(function != null);
       Contract.Requires(returnType != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       Contract.Ensures(Contract.Result<Bpl.NAryExpr>() != null);
 
       List<Bpl.Expr> aa = [];

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Decreases.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Decreases.cs
@@ -39,9 +39,9 @@ public partial class BoogieGenerator {
                             Dictionary<TypeParameter, Type> typeMap,
                             ExpressionTranslator etranCurrent, bool oldCaller, BoogieStmtListBuilder builder, bool inferredDecreases, string hint) {
     Contract.Requires(tok != null);
-    Contract.Requires(cce.NonNullElements(contextDecreases));
-    Contract.Requires(cce.NonNullElements(calleeDecreases));
-    Contract.Requires(cce.NonNullDictionaryAndValues(substMap));
+    Contract.Requires(Cce.NonNullElements(contextDecreases));
+    Contract.Requires(Cce.NonNullElements(calleeDecreases));
+    Contract.Requires(Cce.NonNullDictionaryAndValues(substMap));
     Contract.Requires(etranCurrent != null);
     Contract.Requires(builder != null);
 
@@ -109,11 +109,11 @@ public partial class BoogieGenerator {
   Bpl.Expr DecreasesCheck(List<IOrigin> toks, List<VarDeclStmt> prevGhostLocals,
                           List<Expression> dafny0, List<Expression> dafny1, List<Bpl.Expr> ee0, List<Bpl.Expr> ee1,
                           BoogieStmtListBuilder builder, string suffixMsg, bool allowNoChange, bool includeLowerBound) {
-    Contract.Requires(cce.NonNullElements(toks));
-    Contract.Requires(cce.NonNullElements(dafny0));
-    Contract.Requires(cce.NonNullElements(dafny1));
-    Contract.Requires(cce.NonNullElements(ee0));
-    Contract.Requires(cce.NonNullElements(ee1));
+    Contract.Requires(Cce.NonNullElements(toks));
+    Contract.Requires(Cce.NonNullElements(dafny0));
+    Contract.Requires(Cce.NonNullElements(dafny1));
+    Contract.Requires(Cce.NonNullElements(ee0));
+    Contract.Requires(Cce.NonNullElements(ee1));
     Contract.Requires(Predef != null);
     Contract.Requires(dafny0.Count == dafny1.Count && dafny0.Count == ee0.Count && ee0.Count == ee1.Count);
     Contract.Requires(builder == null || suffixMsg != null);
@@ -287,7 +287,7 @@ public partial class BoogieGenerator {
         b0 = FunctionCall(tok, BuiltinFunction.DtRank, null, e0);
         b1 = FunctionCall(tok, BuiltinFunction.DtRank, null, e1);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();
+        Contract.Assert(false); throw new Cce.UnreachableException();
       }
       eq = Bpl.Expr.Eq(b0, b1);
       less = Bpl.Expr.Lt(b0, b1);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Dafny {
           case LocalsObjectExpression:
             return Predef.Locals;
           default:
-            Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+            Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
         }
       }
 
@@ -653,7 +653,7 @@ namespace Microsoft.Dafny {
               return Boogie.Expr.Unary(GetToken(ternaryExpr), UnaryOperator.Opcode.Not, r);
             }
           default:
-            Contract.Assert(false); throw new cce.UnreachableException();  // unexpected ternary expression
+            Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected ternary expression
         }
       }
 
@@ -750,7 +750,7 @@ namespace Microsoft.Dafny {
             BoogieGenerator.DefiniteAssignmentTrackers.TryGetValue(name, out var defass);
             return defass;
           default:
-            Contract.Assert(false); throw new cce.UnreachableException();  // unexpected unary expression
+            Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression
         }
       }
 
@@ -762,7 +762,7 @@ namespace Microsoft.Dafny {
         } else if (eType is SeqType seqType) {
           return BoogieGenerator.FunctionCall(GetToken(formingExpr), BuiltinFunction.MultiSetFromSeq, BoogieGenerator.TrType(seqType.Arg), TrExpr(e.E));
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();
+          Contract.Assert(false); throw new Cce.UnreachableException();
         }
       }
 
@@ -788,7 +788,7 @@ namespace Microsoft.Dafny {
           Type t = dtv.Ctor.Formals[i].Type;
           var bArg = TrExpr(arg);
           argsAreLit = argsAreLit && BoogieGenerator.IsLit(bArg);
-          args.Add(BoogieGenerator.AdaptBoxing(GetToken(value), bArg, cce.NonNull(arg.Type), t));
+          args.Add(BoogieGenerator.AdaptBoxing(GetToken(value), bArg, Cce.NonNull(arg.Type), t));
         }
         Boogie.IdentifierExpr id = new Boogie.IdentifierExpr(GetToken(dtv), dtv.Ctor.FullName, Predef.DatatypeType);
         Boogie.Expr ret = new Boogie.NAryExpr(GetToken(dtv), new Boogie.FunctionCall(id), args);
@@ -887,7 +887,7 @@ namespace Microsoft.Dafny {
         } else if (e.Value is BaseTypes.BigDec) {
           return MaybeLit(Boogie.Expr.Literal((BaseTypes.BigDec)e.Value));
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected literal
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected literal
         }
       }
 
@@ -997,13 +997,13 @@ namespace Microsoft.Dafny {
           Boogie.Expr val = BoxIfNecessary(GetToken(updateExpr), TrExpr(e.Value), mt.Range);
           return FunctionCall(GetToken(updateExpr), mt.Finite ? "Map#Build" : "IMap#Build", maptype, seq, index, val);
         } else if (seqType is MultiSetType) {
-          Type elmtType = cce.NonNull((MultiSetType)seqType).Arg;
+          Type elmtType = Cce.NonNull((MultiSetType)seqType).Arg;
           Boogie.Expr index = BoxIfNecessary(GetToken(updateExpr), TrExpr(e.Index), elmtType);
           Boogie.Expr val = TrExpr(e.Value);
           return BoogieGenerator.UpdateMultisetMultiplicity(GetToken(updateExpr), seq, index, val);
         } else {
           Contract.Assert(false);
-          throw new cce.UnreachableException();
+          throw new Cce.UnreachableException();
         }
       }
 
@@ -1118,8 +1118,8 @@ namespace Microsoft.Dafny {
           var rawA = TrExpr(p.A);
           var rawB = TrExpr(p.B);
           isLit = isLit && BoogieGenerator.IsLit(rawA) && BoogieGenerator.IsLit(rawB);
-          Boogie.Expr elt = BoxIfNecessary(GetToken(displayExpr), rawA, cce.NonNull(p.A.Type));
-          Boogie.Expr elt2 = BoxIfNecessary(GetToken(displayExpr), rawB, cce.NonNull(p.B.Type));
+          Boogie.Expr elt = BoxIfNecessary(GetToken(displayExpr), rawA, Cce.NonNull(p.A.Type));
+          Boogie.Expr elt2 = BoxIfNecessary(GetToken(displayExpr), rawB, Cce.NonNull(p.B.Type));
           s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, elt, elt2);
         }
         if (isLit) {
@@ -1157,7 +1157,7 @@ namespace Microsoft.Dafny {
         foreach (Expression ee in displayExpr.Elements) {
           var rawElement = TrExpr(ee);
           isLit = isLit && BoogieGenerator.IsLit(rawElement);
-          Boogie.Expr ss = BoxIfNecessary(GetToken(displayExpr), rawElement, cce.NonNull(ee.Type));
+          Boogie.Expr ss = BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type));
           s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetUnionOne : BuiltinFunction.ISetUnionOne, Predef.BoxType, s, ss);
         }
         if (isLit) {
@@ -1407,7 +1407,7 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
           Type t = e.Function.Ins[i].Type;
           Expr tr_ee = TrExpr(ee);
           argsAreLit = argsAreLit && BoogieGenerator.IsLit(tr_ee);
-          args.Add(BoogieGenerator.AdaptBoxing(GetToken(e), tr_ee, cce.NonNull(ee.Type), t));
+          args.Add(BoogieGenerator.AdaptBoxing(GetToken(e), tr_ee, Cce.NonNull(ee.Type), t));
         }
         return args;
       }
@@ -1881,7 +1881,7 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
         } else if (expr is LocalsObjectExpression) {
           return Expr.True;
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
         }
       }
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
@@ -702,7 +702,7 @@ namespace Microsoft.Dafny {
                     CheckSubrange(result.Origin, etran.TrExpr(result), ee.Type, et, ee, returnBuilder);
                   });
                 }
-                Bpl.Cmd cmd = Bpl.Cmd.SimpleAssign(p.Origin, lhs, AdaptBoxing(p.Origin, etran.TrExpr(ee), cce.NonNull(ee.Type), et));
+                Bpl.Cmd cmd = Bpl.Cmd.SimpleAssign(p.Origin, lhs, AdaptBoxing(p.Origin, etran.TrExpr(ee), Cce.NonNull(ee.Type), et));
                 builder.Add(cmd);
                 if (!etran.UsesOldHeap) {
                   // the argument can't be assumed to be allocated for the old heap
@@ -1384,7 +1384,7 @@ namespace Microsoft.Dafny {
             break;
           }
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected expression
       }
 
       addResultCommands?.Invoke(builder, expr);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Fields.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Fields.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Dafny {
         // OR:
         //       !$IsGhostField(f);    // if the field is not a ghost field
         Bpl.Expr fdim = Bpl.Expr.Eq(FunctionCall(f.Origin, BuiltinFunction.FDim, ty, Bpl.Expr.Ident(fc)), Bpl.Expr.Literal(0));
-        Bpl.Expr declType = Bpl.Expr.Eq(FunctionCall(f.Origin, BuiltinFunction.FieldOfDecl, ty, new Bpl.IdentifierExpr(f.Origin, GetClass(cce.NonNull(f.EnclosingClass))), new Bpl.IdentifierExpr(f.Origin, GetFieldNameFamily(f.Name))), Bpl.Expr.Ident(fc));
+        Bpl.Expr declType = Bpl.Expr.Eq(FunctionCall(f.Origin, BuiltinFunction.FieldOfDecl, ty, new Bpl.IdentifierExpr(f.Origin, GetClass(Cce.NonNull(f.EnclosingClass))), new Bpl.IdentifierExpr(f.Origin, GetFieldNameFamily(f.Name))), Bpl.Expr.Ident(fc));
         Bpl.Expr cond = BplAnd(fdim, declType);
         var ig = FunctionCall(f.Origin, BuiltinFunction.IsGhostField, ty, Bpl.Expr.Ident(fc));
         cond = BplAnd(cond, f.IsGhost ? ig : Bpl.Expr.Not(ig));

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Dafny {
         } else if (member is MethodOrConstructor method) {
           AddMethod_Top(method, false, includeAllMethods);
         } else {
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected member
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected member
         }
         ResetAssertionOnlyFilter();
       }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.SplitExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.SplitExpr.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Dafny {
                 Expression ee = e.Args[i];
                 Type t = e.Function.Ins[i].Type;
                 Expr tr_ee = etran.TrExpr(ee);
-                Bpl.Expr wh = GetWhereClause(e.Origin, tr_ee, cce.NonNull(ee.Type), etran, NOALLOC);
+                Bpl.Expr wh = GetWhereClause(e.Origin, tr_ee, Cce.NonNull(ee.Type), etran, NOALLOC);
                 if (wh != null) {
                   fargs = BplAnd(fargs, wh);
                 }
@@ -629,7 +629,7 @@ namespace Microsoft.Dafny {
         Formal p = f.Ins[i];
         var formalType = p.Type.Subst(fexp.GetTypeArgumentSubstitutions());
         Expression arg = fexp.Args[i];
-        arg = new BoxingCastExpr(arg, cce.NonNull(arg.Type), formalType);
+        arg = new BoxingCastExpr(arg, Cce.NonNull(arg.Type), formalType);
         arg.Type = formalType;  // resolve here
         substMap.Add(p, arg);
       }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.cs
@@ -167,9 +167,9 @@ namespace Microsoft.Dafny {
 
     [ContractInvariantMethod]
     void ObjectInvariant() {
-      Contract.Invariant(cce.NonNullDictionaryAndValues(classes));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(fields));
-      Contract.Invariant(cce.NonNullDictionaryAndValues(fieldFunctions));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(classes));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(fields));
+      Contract.Invariant(Cce.NonNullDictionaryAndValues(fieldFunctions));
       Contract.Invariant(codeContext == null || codeContext.EnclosingModule == currentModule);
     }
 
@@ -697,8 +697,8 @@ namespace Microsoft.Dafny {
     Bpl.Program ReadPrelude() {
       string preludePath = options.DafnyPrelude;
       if (preludePath == null) {
-        //using (System.IO.Stream stream = cce.NonNull( System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("DafnyPrelude.bpl")) // Use this once Spec#/VSIP supports designating a non-.resx project item as an embedded resource
-        string codebase = cce.NonNull(System.IO.Path.GetDirectoryName(cce.NonNull(System.Reflection.Assembly.GetExecutingAssembly().Location)));
+        //using (System.IO.Stream stream = Cce.NonNull( System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("DafnyPrelude.bpl")) // Use this once Spec#/VSIP supports designating a non-.resx project item as an embedded resource
+        string codebase = Cce.NonNull(System.IO.Path.GetDirectoryName(Cce.NonNull(System.Reflection.Assembly.GetExecutingAssembly().Location)));
         preludePath = System.IO.Path.Combine(codebase, "DafnyPrelude.bpl");
       }
 
@@ -1333,7 +1333,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(formals != null);
       Contract.Ensures(Contract.ValueAtReturn(out bvs).Count == Contract.ValueAtReturn(out args).Count);
       Contract.Ensures(Contract.ValueAtReturn(out bvs) != null);
-      Contract.Ensures(cce.NonNullElements(Contract.ValueAtReturn(out args)));
+      Contract.Ensures(Cce.NonNullElements(Contract.ValueAtReturn(out args)));
 
       var varNameGen = CurrentIdGenerator.NestedFreshIdGenerator("a#");
       bvs = [];
@@ -1503,10 +1503,10 @@ namespace Microsoft.Dafny {
       readonly BoogieGenerator boogieGenerator;
       [ContractInvariantMethod]
       void ObjectInvariant() {
-        Contract.Invariant(cce.NonNullElements(Formals));
-        Contract.Invariant(cce.NonNullElements(ReplacementExprs));
+        Contract.Invariant(Cce.NonNullElements(Formals));
+        Contract.Invariant(Cce.NonNullElements(ReplacementExprs));
         Contract.Invariant(Formals.Count == ReplacementExprs.Count);
-        Contract.Invariant(cce.NonNullElements(ReplacementFormals));
+        Contract.Invariant(Cce.NonNullElements(ReplacementFormals));
         Contract.Invariant(SubstMap != null);
       }
 
@@ -2096,7 +2096,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(tok != null);
       Contract.Requires(frameIdentifier != null);
       Contract.Requires(frameIdentifier.Type != null);
-      Contract.Requires(cce.NonNullElements(frameClause));
+      Contract.Requires(Cce.NonNullElements(frameClause));
       Contract.Requires(builder != null);
       Contract.Requires(Predef != null);
 
@@ -2248,8 +2248,8 @@ namespace Microsoft.Dafny {
       Contract.Requires(o != null);
       // Contract.Requires(f != null); // f == null means approximate
       Contract.Requires(etran != null);
-      Contract.Requires(cce.NonNullElements(rw));
-      Contract.Requires(substMap == null || cce.NonNullDictionaryAndValues(substMap));
+      Contract.Requires(Cce.NonNullElements(rw));
+      Contract.Requires(substMap == null || Cce.NonNullDictionaryAndValues(substMap));
       Contract.Requires(Predef != null);
       Contract.Requires(receiverReplacement == null || substMap != null);
       Contract.Ensures(Contract.Result<Bpl.Expr>() != null);
@@ -2262,8 +2262,8 @@ namespace Microsoft.Dafny {
       Contract.Requires(o != null);
       // Contract.Requires(f != null); // f == null means approximate
       Contract.Requires(etran != null);
-      Contract.Requires(cce.NonNullElements(rw));
-      Contract.Requires(substMap == null || cce.NonNullDictionaryAndValues(substMap));
+      Contract.Requires(Cce.NonNullElements(rw));
+      Contract.Requires(substMap == null || Cce.NonNullDictionaryAndValues(substMap));
       Contract.Requires(Predef != null);
       Contract.Requires(receiverReplacement == null || substMap != null);
       Contract.Ensures(Contract.Result<Bpl.Expr>() != null);
@@ -2327,8 +2327,8 @@ namespace Microsoft.Dafny {
       Contract.Requires(boxO != null);
       // Contract.Requires(f != null); // f == null means approximate
       Contract.Requires(etran != null);
-      Contract.Requires(cce.NonNullElements(rw));
-      Contract.Requires(substMap == null || cce.NonNullDictionaryAndValues(substMap));
+      Contract.Requires(Cce.NonNullElements(rw));
+      Contract.Requires(substMap == null || Cce.NonNullDictionaryAndValues(substMap));
       Contract.Requires(Predef != null);
       Contract.Requires((substMap == null && receiverReplacement == null) || substMap != null);
       Contract.Ensures(Contract.Result<Bpl.Expr>() != null);
@@ -2530,13 +2530,13 @@ namespace Microsoft.Dafny {
     // Use trType to translate types in the args list
     Bpl.Expr ClassTyCon(UserDefinedType cl, List<Bpl.Expr> args) {
       Contract.Requires(cl != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       return ClassTyCon(cl.ResolvedClass, args);
     }
 
     Bpl.Expr ClassTyCon(TopLevelDecl cl, List<Bpl.Expr> args) {
       Contract.Requires(cl != null);
-      Contract.Requires(cce.NonNullElements(args));
+      Contract.Requires(Cce.NonNullElements(args));
       return FunctionCall(cl.Origin, GetClassTyCon(cl), Predef.Ty, args);
     }
 
@@ -3017,7 +3017,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(modifiesClause != null);
       Contract.Requires(etranPre != null);
       Contract.Requires(etran != null);
-      Contract.Ensures(cce.NonNullElements(Contract.Result<List<BoilerplateTriple>>()));
+      Contract.Ensures(Cce.NonNullElements(Contract.Result<List<BoilerplateTriple>>()));
 
       var boilerplate = new List<BoilerplateTriple>();
       if (!canAllocate && modifiesClause.Count == 0) {
@@ -3057,7 +3057,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(tok != null);
       Contract.Requires(etran != null);
       Contract.Requires(etranPre != null);
-      Contract.Requires(cce.NonNullElements(frame));
+      Contract.Requires(Cce.NonNullElements(frame));
       Contract.Requires(Predef != null);
       Contract.Ensures(Contract.Result<Bpl.Expr>() != null);
 
@@ -3226,7 +3226,7 @@ namespace Microsoft.Dafny {
       } else if (type is SeqType) {
         return Predef.SeqType;
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -3680,7 +3680,7 @@ namespace Microsoft.Dafny {
       var idGen = new VerificationIdGenerator();
       foreach (Expression e in decreases) {
         Contract.Assert(e != null);
-        Bpl.LocalVariable bfVar = new Bpl.LocalVariable(e.Origin, new Bpl.TypedIdent(e.Origin, idGen.FreshId(varPrefix), TrType(cce.NonNull(e.Type))));
+        Bpl.LocalVariable bfVar = new Bpl.LocalVariable(e.Origin, new Bpl.TypedIdent(e.Origin, idGen.FreshId(varPrefix), TrType(Cce.NonNull(e.Type))));
         locals.GetOrAdd(bfVar);
         Bpl.IdentifierExpr bf = new Bpl.IdentifierExpr(e.Origin, bfVar);
         oldBfs.Add(bf);
@@ -3771,7 +3771,7 @@ namespace Microsoft.Dafny {
       } else if (type is FieldType) {
         return new Bpl.IdentifierExpr(Token.NoToken, "TField", Predef.Ty);
       } else {
-        Contract.Assert(false); throw new cce.UnreachableException();  // unexpected type
+        Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected type
       }
     }
 
@@ -4781,7 +4781,7 @@ namespace Microsoft.Dafny {
     public static Expression Substitute(Expression expr, Expression receiverReplacement, Dictionary<IVariable, Expression/*!*/>/*!*/ substMap,
       Dictionary<TypeParameter, Type> typeMap = null, Label oldLabel = null) {
       Contract.Requires(expr != null);
-      Contract.Requires(cce.NonNullDictionaryAndValues(substMap));
+      Contract.Requires(Cce.NonNullDictionaryAndValues(substMap));
       Contract.Ensures(Contract.Result<Expression>() != null);
       var s = new Substituter(receiverReplacement, substMap, typeMap ?? new Dictionary<TypeParameter, Type>(), oldLabel);
       return s.Substitute(expr);

--- a/Source/DafnyCore/Verifier/Expressions/TranslateBinaryExpr.cs
+++ b/Source/DafnyCore/Verifier/Expressions/TranslateBinaryExpr.cs
@@ -265,7 +265,7 @@ public partial class BoogieGenerator {
               case BinaryExpr.ResolvedOpcode.GtChar: bOp = BinaryOperator.Opcode.Gt; break;
               default:
                 Contract.Assert(false);  // unexpected case
-                throw new cce.UnreachableException();  // to please compiler
+                throw new Cce.UnreachableException();  // to please compiler
             }
             return Expr.Binary(GetToken(binaryExpr), bOp, operand0, operand1);
           }
@@ -302,9 +302,9 @@ public partial class BoogieGenerator {
             return BoogieGenerator.FunctionCall(GetToken(binaryExpr), f, null, e0, e1);
           }
         case BinaryExpr.ResolvedOpcode.InSet:
-          Contract.Assert(false); throw new cce.UnreachableException();  // this case handled above
+          Contract.Assert(false); throw new Cce.UnreachableException();  // this case handled above
         case BinaryExpr.ResolvedOpcode.NotInSet:
-          Contract.Assert(false); throw new cce.UnreachableException();  // this case handled above
+          Contract.Assert(false); throw new Cce.UnreachableException();  // this case handled above
         case BinaryExpr.ResolvedOpcode.Union: {
             var setType = binaryExpr.Type.NormalizeToAncestorType().AsSetType;
             bool finite = setType.Finite;
@@ -334,9 +334,9 @@ public partial class BoogieGenerator {
         case BinaryExpr.ResolvedOpcode.MultiSetDisjoint:
           return BoogieGenerator.FunctionCall(GetToken(binaryExpr), BuiltinFunction.MultiSetDisjoint, null, e0, e1);
         case BinaryExpr.ResolvedOpcode.InMultiSet:
-          Contract.Assert(false); throw new cce.UnreachableException();  // this case handled above
+          Contract.Assert(false); throw new Cce.UnreachableException();  // this case handled above
         case BinaryExpr.ResolvedOpcode.NotInMultiSet:
-          Contract.Assert(false); throw new cce.UnreachableException();  // this case handled above
+          Contract.Assert(false); throw new Cce.UnreachableException();  // this case handled above
         case BinaryExpr.ResolvedOpcode.MultiSetUnion:
           return BoogieGenerator.FunctionCall(GetToken(binaryExpr), BuiltinFunction.MultiSetUnion,
             BoogieGenerator.TrType(binaryExpr.Type.NormalizeToAncestorType().AsMultiSetType.Arg), e0, e1);
@@ -404,7 +404,7 @@ public partial class BoogieGenerator {
             BoogieGenerator.FunctionCall(GetToken(binaryExpr), binaryExpr.E1.Type.IsDatatype ? BuiltinFunction.DtRank : BuiltinFunction.BoxRank, null, e1));
 
         default:
-          Contract.Assert(false); throw new cce.UnreachableException();  // unexpected binary expression
+          Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected binary expression
       }
       liftLit = liftLit && !keepLits;
       var ae0 = keepLits ? oe0 : e0;

--- a/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
+++ b/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
@@ -20,7 +20,7 @@ public partial class BoogieGenerator {
       foreach (Expression ee in displayExpr.Elements) {
         var rawElement = TrExpr(ee);
         isLit = isLit && BoogieGenerator.IsLit(rawElement);
-        var ss = BoxIfNecessary(GetToken(displayExpr), rawElement, cce.NonNull(ee.Type));
+        var ss = BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type));
         result = BoogieGenerator.FunctionCall(GetToken(displayExpr), BuiltinFunction.MultiSetUnionOne, Predef.BoxType, result,
           ss);
       }

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrAssignment.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrAssignment.cs
@@ -40,8 +40,8 @@ public partial class BoogieGenerator {
     BoogieStmtListBuilder builder, Variables locals, ExpressionTranslator etran, Statement stmt) {
     Contract.Requires(lhsBuilder != null);
     Contract.Requires(bLhss != null);
-    Contract.Requires(cce.NonNullElements(lhss));
-    Contract.Requires(cce.NonNullElements(rhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(rhss));
     Contract.Requires(builder != null);
     Contract.Requires(etran != null);
     Contract.Requires(Predef != null);
@@ -91,8 +91,8 @@ public partial class BoogieGenerator {
   List<Bpl.Expr> ProcessUpdateAssignRhss(List<Expression> lhss, List<AssignmentRhs> rhss,
     BoogieStmtListBuilder builder, Variables locals, ExpressionTranslator etran,
     Statement stmt) {
-    Contract.Requires(cce.NonNullElements(lhss));
-    Contract.Requires(cce.NonNullElements(rhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(rhss));
     Contract.Requires(builder != null);
     Contract.Requires(etran != null);
     Contract.Requires(Predef != null);
@@ -194,7 +194,7 @@ public partial class BoogieGenerator {
     out List<AssignToLhs> lhsBuilders, out List<Bpl.IdentifierExpr/*may be null*/> bLhss,
     out Bpl.Expr[] prevObj, out Bpl.Expr[] prevIndex, out string[] prevNames, Expression originalInitialLhs = null) {
 
-    Contract.Requires(cce.NonNullElements(lhss));
+    Contract.Requires(Cce.NonNullElements(lhss));
     Contract.Requires(builder != null);
     Contract.Requires(etran != null);
     Contract.Requires(Predef != null);

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
@@ -323,7 +323,7 @@ public partial class BoogieGenerator {
       MemberSelectExpr e => (e.Obj, e.Member as Field),
       SeqSelectExpr e => (e.Seq, null),
       MultiSelectExpr e => (e.Array, null),
-      _ => throw new cce.UnreachableException()
+      _ => throw new Cce.UnreachableException()
     };
     var desc = new Modifiable(description, GetContextModifiesFrames(), lhsObj, lhsField);
     definedness.Add(Assert(lhs.Origin, Bpl.Expr.SelectTok(lhs.Origin, etran.ModifiesFrame(lhs.Origin), obj, F),

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrStatement.cs
@@ -456,7 +456,7 @@ public partial class BoogieGenerator {
         break;
       default:
         Contract.Assert(false);
-        throw new cce.UnreachableException(); // unexpected statement
+        throw new Cce.UnreachableException(); // unexpected statement
     }
   }
 

--- a/Source/DafnyCore/Verifier/Statements/MatchVerifier.cs
+++ b/Source/DafnyCore/Verifier/Statements/MatchVerifier.cs
@@ -160,7 +160,7 @@ public class MatchStmtVerifier {
       }
       generator.CheckSubrange(p.Origin, new IdentifierExpr(p.Origin, local), pFormalType, p.Type,
         new Microsoft.Dafny.IdentifierExpr(p.Origin, p), localTypeAssumptions);
-      args.Add(generator.CondApplyBox(mc.Origin, new IdentifierExpr(p.Origin, local), cce.NonNull(p.Type), mc.Ctor.Formals[i].Type));
+      args.Add(generator.CondApplyBox(mc.Origin, new IdentifierExpr(p.Origin, local), Cce.NonNull(p.Type), mc.Ctor.Formals[i].Type));
     }
     IdentifierExpr id = new IdentifierExpr(mc.Origin, mc.Ctor.FullName, generator.Predef.DatatypeType);
     return new NAryExpr(mc.Origin, new FunctionCall(id), args);

--- a/Source/DafnyDriver/JsonVerificationLogger.cs
+++ b/Source/DafnyDriver/JsonVerificationLogger.cs
@@ -133,7 +133,7 @@ public class JsonVerificationLogger : IVerificationResultFormatLogger {
         return currentVcOutcome;
       default:
         Contract.Assert(false);
-        throw new cce.UnreachableException();
+        throw new Cce.UnreachableException();
     }
   }
 

--- a/Source/DafnyDriver/Legacy/DafnyBackwardsCompatibleCli.cs
+++ b/Source/DafnyDriver/Legacy/DafnyBackwardsCompatibleCli.cs
@@ -42,7 +42,7 @@ public static class DafnyBackwardsCompatibleCli {
   }
 
   private static async Task<int> ThreadMain(TextWriter outputWriter, TextWriter errorWriter, TextReader inputReader, string[] args) {
-    Contract.Requires(cce.NonNullElements(args));
+    Contract.Requires(Cce.NonNullElements(args));
 
     var legacyResult = await TryLegacyArgumentParser(inputReader, outputWriter, errorWriter, args);
     if (legacyResult == null) {

--- a/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
+++ b/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Dafny {
       ReadOnlyCollection<string> otherFileNames,
       DafnyOptions options, ProofDependencyManager depManager,
       bool lookForSnapshots = true, string programId = null) {
-      Contract.Requires(cce.NonNullElements(dafnyFiles));
+      Contract.Requires(Cce.NonNullElements(dafnyFiles));
       var dafnyFileNames = DafnyFile.FileNames(dafnyFiles);
 
       ExitValue exitValue = ExitValue.SUCCESS;
@@ -307,7 +307,7 @@ namespace Microsoft.Dafny {
           var boogiePrograms =
             await DafnyMain.LargeStackFactory.StartNew(() => Translate(engine.Options, dafnyProgram).ToList());
 
-          string baseName = cce.NonNull(Path.GetFileName(dafnyFileNames[^1]));
+          string baseName = Cce.NonNull(Path.GetFileName(dafnyFileNames[^1]));
           (verified, outcome, moduleStats) =
             await BoogieAsync(dafnyProgram.Reporter, options, baseName, boogiePrograms, programId);
 

--- a/Source/DafnyServer/DafnyHelper.cs
+++ b/Source/DafnyServer/DafnyHelper.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Dafny {
     private bool BoogieOnce(string moduleName, Bpl.Program boogieProgram) {
       if (boogieProgram.Resolve(options) == 0 && boogieProgram.Typecheck(options) == 0) { //FIXME ResolveAndTypecheck?
         engine.EliminateDeadVariables(boogieProgram);
-        engine.CollectModSets(boogieProgram);
+        engine.CollectModifies(boogieProgram);
         engine.CoalesceBlocks(boogieProgram);
         engine.Inline(boogieProgram);
 

--- a/Source/DafnyTestGeneration/ProgramModifier.cs
+++ b/Source/DafnyTestGeneration/ProgramModifier.cs
@@ -54,7 +54,7 @@ namespace DafnyTestGeneration {
       program.Typecheck(options);
       using (var engine = ExecutionEngine.CreateWithoutSharedCache(options)) {
         engine.EliminateDeadVariables(program);
-        engine.CollectModSets(program);
+        engine.CollectModifies(program);
         engine.Inline(program);
       }
       program.RemoveTopLevelDeclarations(declaration => declaration is Implementation or Procedure && Utils.DeclarationHasAttribute(declaration, "inline"));

--- a/customBoogie.patch
+++ b/customBoogie.patch
@@ -61,7 +61,7 @@ index 4a8b2f89b..a308be9bf 100644
        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
        <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
--      <PackageReference Include="Boogie.ExecutionEngine" Version="3.4.3" />
+-      <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.5" />
 +      <ProjectReference Include="..\..\boogie\Source\ExecutionEngine\ExecutionEngine.csproj" />
 +      <ProjectReference Include="..\..\boogie\Source\BaseTypes\BaseTypes.csproj" />
 +      <ProjectReference Include="..\..\boogie\Source\Core\Core.csproj" />

--- a/docs/DafnyRef/Options.txt
+++ b/docs/DafnyRef/Options.txt
@@ -412,49 +412,53 @@ Usage: dafny [ option ... ] [ filename ... ]
   Multiple .bpl files supplied on the command line are concatenated into one
   Boogie program.
 
-  /lib:<name>    : Include definitions in library <name>. The file <name>.bpl
-                   must be an included resource in Core.dll. Currently, the
-                   following libraries are supported---base, node.
-  /proc:<p>      : Only check procedures matched by pattern <p>. This option
-                   may be specified multiple times to match multiple patterns.
-                   The pattern <p> matches the whole procedure name and may
-                   contain * wildcards which match any character zero or more
-                   times.
-  /noProc:<p>    : Do not check procedures matched by pattern <p>. Exclusions
-                   with /noProc are applied after inclusions with /proc.
-  /noResolve     : parse only
-  /noTypecheck   : parse and resolve only
-
-  /print:<file>  : print Boogie program after parsing it
-                   (use - as <file> to print to console)
-  /pretty:<n>
-                0 - print each Boogie statement on one line (faster).
+  /lib:<name>   Include definitions in library <name>. The file <name>.bpl
+                must be an included resource in Core.dll. Currently, the
+                following libraries are supported---base, node.
+  /proc:<p>     Only check procedures matched by pattern <p>. This option
+                may be specified multiple times to match multiple patterns.
+                The pattern <p> matches the whole procedure name and may
+                contain * wildcards which match any character zero or more
+                times.
+  /noProc:<p>   Do not check procedures matched by pattern <p>. Exclusions
+                with /noProc are applied after inclusions with /proc.
+  /noResolve    parse only
+  /noTypecheck  parse and resolve only
+  /print:<file>
+                print Boogie program after parsing it
+                (use - as <file> to print to console)
+  /pretty:<n>   0 - print each Boogie statement on one line (faster).
                 1 (default) - pretty-print with some line breaks.
-  /printWithUniqueIds : print augmented information that uniquely
-                   identifies variables
-  /printUnstructured : with /print option, desugars all structured statements
-  /printPassive :  with /print option, prints passive version of program
-  /printDesugared : with /print option, desugars calls
-  /printLambdaLifting : with /print option, desugars lambda lifting
-
-  /freeVarLambdaLifting : Boogie's lambda lifting transforms the bodies of lambda
-                         expressions into templates with holes. By default, holes
-                         are maximally large subexpressions that do not contain
-                         bound variables. This option performs a form of lambda
-                         lifting in which holes are the lambda's free variables.
-
-  /overlookTypeErrors : skip any implementation with resolution or type
-                        checking errors
-
+  /printWithUniqueIds
+                print augmented information that uniquely identifies variables
+  /printUnstructured
+                with /print option, desugars all structured statements
+  /printPassive
+                with /print option, prints passive version of program
+  /printDesugared
+                with /print option, desugars calls
+  /printLambdaLifting
+                with /print option, desugars lambda lifting
+  /freeVarLambdaLifting
+                Boogie's lambda lifting transforms the bodies of lambda
+                expressions into templates with holes. By default, holes
+                are maximally large subexpressions that do not contain
+                bound variables. This option performs a form of lambda
+                lifting in which holes are the lambda's free variables.
+  /overlookTypeErrors
+                skip any implementation with resolution or type checking errors
   /loopUnroll:<n>
                 unroll loops, following up to n back edges (and then some)
                 default is -1, which means loops are not unrolled
   /extractLoops
-                extract reducible loops into recursive procedures and
-                inline irreducible loops using the bound supplied by /loopUnroll:<n>
+                convert all irreducible loops to reducible forms by node splitting
+                and extract all loops into recursive procedures
   /soundLoopUnrolling
                 sound loop unrolling
-  /doModSetAnalysis
+  /kInductionDepth:<k>
+                uses combined-case k-induction to soundly eliminate loops,
+                by unwinding proportional to the supplied parameter
+  /inferModifies
                 automatically infer modifies clauses
   /printModel:<n>
                 0 (default) - do not print Z3's error model
@@ -466,24 +470,19 @@ Usage: dafny [ option ... ] [ filename ... ]
   /enhancedErrorMessages:<n>
                 0 (default) - no enhanced error messages
                 1 - Z3 error model enhanced error messages
-
   /printCFG:<prefix> : print control flow graph of each implementation in
                        Graphviz format to files named:
                          <prefix>.<procedure name>.dot
-
   /useBaseNameForFileName : When parsing use basename of file for tokens instead
                             of the path supplied on the command line
-
   /emitDebugInformation:<n>
                 0 - do not emit debug information
                 1 (default) - emit the debug information :qid, :skolemid and set-info :boogie-vc-id
-
   /normalizeNames:<n>
                 0 (default) - Keep Boogie program names when generating SMT commands
                 1 - Normalize Boogie program names when generating SMT commands. 
                   This keeps SMT solver input, and thus output, 
                   constant when renaming declarations in the input program.
-
   /normalizeDeclarationOrder:<n>
                 0 - Keep order of top-level declarations when generating SMT commands.
                 1 (default) - Normalize order of top-level declarations when generating SMT commands.
@@ -522,6 +521,8 @@ Usage: dafny [ option ... ] [ filename ... ]
   /traceTimes   output timing information at certain points in the pipeline
   /tracePOs     output information about the number of proof obligations
                 (also included in the /trace output)
+  /forceBplErrors
+                show boogie errors even if {:msg ...} attribute is present
   /break        launch and break into debugger
 
   ---- Civl options ----------------------------------------------------------
@@ -650,7 +651,11 @@ Usage: dafny [ option ... ] [ filename ... ]
                 assignments, and calls can be labeled for inclusion in this
                 report. This generalizes and replaces the previous
                 (undocumented) `/printNecessaryAssertions` option.
-
+  /warnVacuousProofs
+                Automatically add missing `{:id ...}` attributes to assumptions,
+                assertions, requires clauses, ensures clauses, and calls; enable the
+                `/trackVerificationCoverage` option; and warn when proof goals are
+                not covered by a proof.
   /keepQuantifier
                 If pool-based quantifier instantiation creates instances of a quantifier
                 then keep the quantifier along with the instances. By default, the quantifier

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "boogie": {
-      "version": "3.2.5",
+      "version": "3.5.5",
       "commands": [
         "boogie"
       ]


### PR DESCRIPTION
## Summary
- Bumped Boogie from 3.2.5/3.4.3 to 3.5.5 across all packages
- Updated namespace references from `cce` to `Cce` for compatibility with newer Boogie
- Updated API calls from `CollectModSets` to `CollectModifies`

## Test plan
- [x] Solution builds successfully with `dotnet build`
- [x] Run CI