### PR TITLE
Fix field type parsing by moving _field case to explicit token list

### DIFF
--- a/Source/DafnyCore/AST/Grammar/ParserNonGeneratedPart.cs
+++ b/Source/DafnyCore/AST/Grammar/ParserNonGeneratedPart.cs
@@ -575,6 +575,7 @@ public partial class Parser {
       case _string:
       case _object_q:
       case _object:
+      case _field:
         pt = scanner.Peek();
         return true;
       case _arrayToken:
@@ -614,10 +615,6 @@ public partial class Parser {
         }
         return IsTypeSequence(ref pt, _closeparen);
       default:
-        if (AcceptReferrers() && pt.val == "field") {
-          pt = scanner.Peek();
-          return true;
-        }
         return false;
     }
   }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy
@@ -1,0 +1,10 @@
+// RUN: %exits-with 2 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Parser inconsistency: field type parsing depends on AcceptReferrers() setting
+// Before fix: Parse error "this symbol not expected in VarDeclStatement"
+// After fix: Proper resolution error "Type or type parameter is not declared"
+
+method Test() {
+  var x: seq<field>;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy
@@ -1,10 +1,6 @@
 // RUN: %exits-with 2 %verify "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-// Parser inconsistency: field type parsing depends on AcceptReferrers() setting
-// Before fix: Parse error "this symbol not expected in VarDeclStatement"
-// After fix: Proper resolution error "Type or type parameter is not declared"
-
 method Test() {
   var x: seq<field>;
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy.expect
@@ -1,2 +1,2 @@
-git-issue-6329.dfy(9,13): Error: Type or type parameter is not declared in this scope: field (did you forget to qualify a name or declare a module import 'opened'?) (note that names in outer modules are not visible in contained modules)
+git-issue-6329.dfy(5,13): Error: Type or type parameter is not declared in this scope: field (did you forget to qualify a name or declare a module import 'opened'?) (note that names in outer modules are not visible in contained modules)
 1 resolution/type errors detected in git-issue-6329.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy.expect
@@ -1,0 +1,6 @@
+Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy(9,13): Error: Type or type parameter is not declared in this scope: field (did you forget to qualify a name or declare a module import 'opened'?) (note that names in outer modules are not visible in contained modules)
+  |
+9 |   var x: seq<field>;
+  |              ^^^^^
+
+1 resolution/type errors detected in git-issue-6329.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy.expect
@@ -1,6 +1,2 @@
-Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6329.dfy(9,13): Error: Type or type parameter is not declared in this scope: field (did you forget to qualify a name or declare a module import 'opened'?) (note that names in outer modules are not visible in contained modules)
-  |
-9 |   var x: seq<field>;
-  |              ^^^^^
-
+git-issue-6329.dfy(9,13): Error: Type or type parameter is not declared in this scope: field (did you forget to qualify a name or declare a module import 'opened'?) (note that names in outer modules are not visible in contained modules)
 1 resolution/type errors detected in git-issue-6329.dfy


### PR DESCRIPTION
Fixes #6329, which is a regression since the introduction of `--referrers`

**Changes:**
- Moved `_field` from conditional default case to explicit case in `IsType()` method
- Ensures consistent parsing regardless of `AcceptReferrers()` setting

**Testing:**
- Build successful, all tests pass + the extra one.