### PR TITLE
Convention for extern constructors to match non-externs

### DIFF
--- a/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/SinglePassCodeGenerator/SinglePassCodeGenerator.cs
@@ -4126,14 +4126,10 @@ namespace Microsoft.Dafny.Compilers {
         EmitNew(allocateClass.Type, typeRhs.Origin, constructor != null ? allocateClass.InitCall : null, wRhs, wStmts);
         // Proceed with initialization
         if (allocateClass.InitCall != null) {
-          if (constructor != null && IsExternallyImported(constructor)) {
-            // initialization was done at the time of allocation
-          } else {
-            var wrBefore = wStmts.Fork();
-            var wrCall = wStmts.Fork();
-            var wrAfter = wStmts;
-            TrCallStmt(allocateClass.InitCall, nw, wrCall, wrBefore, wrAfter);
-          }
+          var wrBefore = wStmts.Fork();
+          var wrCall = wStmts.Fork();
+          var wrAfter = wStmts;
+          TrCallStmt(allocateClass.InitCall, nw, wrCall, wrBefore, wrAfter);
         }
         // Assign to the final LHS
         EmitIdentifier(nw, wr);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6333/git-issue-6333.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6333/git-issue-6333.dfy
@@ -1,0 +1,8 @@
+// RUN: %testDafnyForEachCompiler --refresh-exit-code=0 "%s" -- --type-system-refresh=false --allow-external-contracts
+
+include "../../libraries/src/MutableMap/MutableMap.dfy"
+import opened DafnyLibraries
+
+method Main() {
+  var m: MutableMap<nat, nat> := new MutableMap(true);
+}


### PR DESCRIPTION
### What was changed?

Exactly as it says on the tin (to fix #6333). Checking to see what crashes...

### How has this been tested?
Under `Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issue-6333`. Need to update `Source/IntegrationTests/TestFiles/LitTests/LitTest/libraries` by `Source/DafnyStandardLibraries` for tests to work.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>