### PR TITLE
Add test for anonymous class constructor with type params

### DIFF
--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/Class.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/Class.dfy
@@ -127,7 +127,7 @@ method Main() {
   NewtypeWithMethods.Test();
   TestGhostables(70);
   TestInitializationMethods();
-  TestConstructorsWithTypeParameters();
+  ConstructorsWithTypeParameters.Test();
 }
 
 module Module1 {
@@ -241,28 +241,32 @@ method TestInitializationMethods() {
 
 // ---------------------------------------------------
 
-class Cell<X> {
-  var data: X
-  constructor (d: X) {
-    data := d;
+module ConstructorsWithTypeParameters {
+  class Cell<X> {
+    var data: X
+    constructor (d: X) {
+      data := d;
+    }
   }
-}
 
-class ConstructorsWithTypeParameters {
-  var b: bool
-  constructor Init<X>(c: Cell<X>, d: Cell<X>) {
-    b := c == d;
+  class MyClass {
+    var b: bool
+    constructor Init<X>(c: Cell<X>, d: Cell<X>) {
+      b := c == d;
+    }
+    constructor <X>(c: Cell<X>, d: Cell<X>) {
+      b := c == d;
+    }
   }
-  constructor <X>(c: Cell<X>, d: Cell<X>) {
-    b := c == d;
-  }
-}
 
-method TestConstructorsWithTypeParameters() {
-  var cell0 := new Cell(100);
-  var cell1 := new Cell(200);
-  
-  var c0 := new ConstructorsWithTypeParameters.Init(cell0, cell1);
-  var c1 := new ConstructorsWithTypeParameters(cell0, cell0);
-  print c0.b, " ", c1.b, "\n"; // false true
+  method Test() {
+    var cell0 := new Cell(100);
+    var cell1 := new Cell<int>(200); // here, the type argument is for the class
+
+    var c0 := new MyClass.Init(cell0, cell1);
+    var c1 := new MyClass.Init<int>(cell1, cell1); // here, the type argument is for the constructor
+    var c2 := new MyClass(cell0, cell0);
+    // but syntax does not allow explicit type parameter with anonymous constructor:  new MyClass<int>(cell0, cell0)
+    print c0.b, " ", c1.b, " ", c2.b, "\n"; // false true true
+  }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/Class.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/Class.dfy.expect
@@ -13,4 +13,4 @@ TestGhostables
 15
 Init called with x=15
 16
-false true
+false true true


### PR DESCRIPTION
Dafny allows a class to have an anonymous class constructor that takes type parameters (just like it allows named class constructors to have type parameters). Such type parameters can be declared as follows:

``` dafny
class MyClass<X> {
  constructor <Y>(...)
}
```

Unlike named constructors, there's no syntax for explicitly giving the type arguments at the call site, since that would cause a syntactic ambiguity.

Previously, the test suite didn't have any test for declaring an anonymous constructor with type arguments. This PR adds such tests.


<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
