### PR TITLE
Migration from OSSRH to Central Portal for Java runtime

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
+++ b/Source/DafnyRuntime/DafnyRuntimeJava/build.gradle
@@ -92,8 +92,8 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
### What was changed?

Exactly as it says on the tin. Should the base be `4.11.0`?

### How has this been tested?
I released the 4.11 Java runtime and it worked.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
