### PR TITLE
fix: Fix antecedent in induction hypothesis

### DIFF
--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrForallStmt.cs
@@ -170,6 +170,7 @@ public partial class BoogieGenerator {
       Contract.Assert(s0.Method.Ins.Count == s0.Args.Count);
       var callEtran = new ExpressionTranslator(this, Predef, etran.HeapExpr, initHeap, etran.scope);
       Bpl.Expr anteCanCalls, ante;
+      Bpl.Expr typeAndAdditionalAntecedents;
       Bpl.Expr post = Bpl.Expr.True;
       Bpl.Trigger tr;
       if (forallExpressions != null) {
@@ -179,28 +180,28 @@ public partial class BoogieGenerator {
           expr = quantifierExpr;
         }
         boundVars = expr.BoundVars;
-        ante = initEtran.TrBoundVariablesRename(boundVars, bvars, out substMap);
+        typeAndAdditionalAntecedents = initEtran.TrBoundVariablesRename(boundVars, bvars, out substMap);
+        if (additionalRange != null) {
+          typeAndAdditionalAntecedents = BplAnd(typeAndAdditionalAntecedents, additionalRange(substMap, initEtran));
+        }
         tr = TrTrigger(callEtran, expr.Attributes, expr.Origin, bvars, substMap, s0.MethodSelect.TypeArgumentSubstitutionsWithParents());
 
         var p = Substitute(expr.Range, null, substMap);
         anteCanCalls = initEtran.CanCallAssumption(p);
-        ante = BplAnd(ante, initEtran.TrExpr(p));
-        if (additionalRange != null) {
-          ante = BplAnd(ante, additionalRange(substMap, initEtran));
-        }
+        ante = initEtran.TrExpr(p);
         p = Substitute(expr.Term, null, substMap);
         post = BplAnd(post, callEtran.CanCallAssumption(p));
         post = BplAnd(post, callEtran.TrExpr(p));
       } else {
-        ante = initEtran.TrBoundVariablesRename(boundVars, bvars, out substMap);
+        typeAndAdditionalAntecedents = initEtran.TrBoundVariablesRename(boundVars, bvars, out substMap);
+        if (additionalRange != null) {
+          // additionalRange produces something of the form canCallAssumptions ==> TrExpr
+          typeAndAdditionalAntecedents = BplAnd(typeAndAdditionalAntecedents, additionalRange(substMap, initEtran));
+        }
 
         var p = Substitute(range, null, substMap);
         anteCanCalls = initEtran.CanCallAssumption(p);
-        ante = BplAnd(ante, initEtran.TrExpr(p));
-        if (additionalRange != null) {
-          // additionalRange produces something of the form canCallAssumptions ==> TrExpr
-          ante = BplAnd(ante, additionalRange(substMap, initEtran));
-        }
+        ante = initEtran.TrExpr(p);
 
         var receiver = new BoogieWrapper(initEtran.TrExpr(Substitute(s0.Receiver, null, substMap, s0.MethodSelect.TypeArgumentSubstitutionsWithParents())), s0.Receiver.Type);
         for (int i = 0; i < s0.Method.Ins.Count; i++) {
@@ -235,6 +236,7 @@ public partial class BoogieGenerator {
       if (includeCanCalls) {
         body = BplAnd(anteCanCalls, body);
       }
+      body = BplImp(typeAndAdditionalAntecedents, body);
       var qq = new Bpl.ForallExpr(tok, bvars, tr, body);
       exporter.Add(TrAssumeCmd(tok, qq));
     }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/GHC-MergeSort.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/dafny4/GHC-MergeSort.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 52 verified, 0 errors
+Dafny program verifier finished with 55 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6366.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6366.dfy
@@ -1,0 +1,56 @@
+// RUN: %exits-with 4 %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Nat = Nat(n: nat)
+
+datatype SeqNat = Seq(seqn: seq<Nat>) {
+  predicate LessThan(n: nat) 
+  decreases seqn
+  {
+    if seqn == [] then true else seqn[0].n < n && Seq(seqn[1..]).LessThan(n)
+  }
+}
+
+predicate LessThan(ss: seq<SeqNat>, n: nat) {
+  if ss == [] then true else
+    ss[0].LessThan(n) && LessThan(ss[1..], n)
+}
+
+lemma Foo(ss: seq<SeqNat>, l: nat)
+  requires l < |ss|
+  requires LessThan(ss, 30)
+  requires LessThan(ss, 239)
+  ensures ss[l].LessThan(1) // error: (but this was once provable, due to a bug)
+{
+  if ss != [] {
+    if l != 0 {
+      Foo(ss[1..], l - 1);
+      assert ss[1..][l - 1] == ss[l];
+      assert ss[1..][l - 1..] == ss[l..];
+    }
+  }
+}
+
+method Main() {
+  var sn: SeqNat := Seq([Nat(28)]);
+  assert sn.LessThan(30);
+  assert sn.LessThan(239);
+
+  var ss := [sn];
+  var l := 0;
+  Foo(ss, l);
+
+  // by the postcondition of Foo:
+  assert ss[l].LessThan(1);
+  assert ss[l] == sn;
+  assert sn.LessThan(1);
+  assert sn.seqn[0].n < 1;
+
+  // yet:
+  assert sn.seqn[0] == Nat(28);
+  assert sn.seqn[0].n == 28;
+  assert 28 < 1;
+  assert false;
+
+  print 10 / 0;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6366.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6366.dfy.expect
@@ -1,0 +1,8 @@
+git-issue-6366.dfy(26,4): Error: a postcondition could not be proved on this return path
+git-issue-6366.dfy(23,24): Related location: this is the postcondition that could not be proved
+git-issue-6366.dfy(10,43): Related location: this proposition could not be proved
+git-issue-6366.dfy(26,4): Error: a postcondition could not be proved on this return path
+git-issue-6366.dfy(23,24): Related location: this is the postcondition that could not be proved
+git-issue-6366.dfy(10,73): Related location: this proposition could not be proved
+
+Dafny program verifier finished with 4 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/lit.site.cfg
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/lit.site.cfg
@@ -164,7 +164,7 @@ def buildCmd(cmd, args):
         argStr = ' /'.join(args)
         return f'{cmd} /{argStr}'
     else:
-        return args
+        return cmd
         
 dafny = addParams(buildCmd(dafnyExecutable, dafnyArgs))
 boogie = buildCmd(boogieExecutable, boogieArgs)


### PR DESCRIPTION
This PR fixes a soundness issue in automatically generated induction hypotheses.

Fixes #6366 

## Description of the problem and fix

The problem reported in #6366 was due to a missing antecedent in automatically generated induction hypotheses. For a lemma

``` dafny
lemma L(x: X)
  requires Pre(x)
  ensures Post(x)
  decreases D(x)
```

the induction hypothesis was previously generated as

``` boogie
forall y ::
  Pre#CanCall(y) &&
  (Is(y, X) &&
   Pre(y) &&
   D(y) < D(x)
   ==>
   Post(y))
```

This is incorrect, because it gives access to `Pre#CanCall(y)` even if `Is(y, X)` does not hold. It also gives access to `Pre#CanCall(y)` for any `y`, not just `y`s that are smaller than `x`; that seems unintentional, but not a soundness issue.

The proper way to formulate the induction hypothesis is

``` boogie
forall y ::
  Is(y, X) &&
  D(y) < D(x)
  ==>
    Pre#CanCall(y) &&
    (Pre(y) 
     ==>
     Post(y))
```

This PR makes this change.

## Effects of the previous bug

This bug was present in every induction hypothesis generated by auto-induction and so could have had an effect on every `lemma`. To exploit the bug, the following conditions would have had to hold:

* the `Is(y, X)` predicate for type `X` distinguishes `y` from other values of the representation type in Boogie, and
* the "can call" predicate generated from the lemma's precondition leads to conflicting conclusions for different types, and
* the underlying solver finds the proof.

In the reported bug, all 3 apply.

* The Dafny type `X` for which the induction hypothesis was intended is `seq<SeqNat>`. It has the same underlying Boogie type as the Dafny type `seq<Nat>`, since both are essentially a "sequence of `Box`" in the Boogie encoding. If such a sequence is nonempty, then its first element has type `SeqNat` or `Nat`, respectively. The various constructors of a `datatype` are represented as functions with disjoint ranges. The axiomatization is actually stricter; it says that the `datatype` constructors of all types have disjoint ranges, and thus a `SeqNat` value is known to be different from a `Nat` value.
* The "can call" predicate for each of the two `LessThan` functions implies the `Is(_, X)` predicate for its first argument. More precisely, it says that the argument is a value produced by the `SeqNat` or `Nat` constructor, respectively. (This is included in the "can call" predicate as a "free fact" for every single-constructor `datatype`.) By the previous bullet, this distinguishes a `SeqNat` from a `Nat`.
* The lemma precondition `LessThan(ss, 30) && LessThan(ss, 239)` is cruicial, because its "can call" predicate looks like

    LessThan#CanCall(ss, 30) &&
    (LessThan(ss, 30) ==> LessThan(ss, 239))

and this is then used in the induction hypothesis. The occurrence of the `LessThan(ss, 30)` is just in a disjunct, so it will not always be in the SMT solver's context. However, _if_ the SMT solver happens to start its case study with the left disjunct, `LessThan(ss, 30)`, then it will continue to instantiate quantifiers based on this term, even if the `ss` is not of the intended type. Lemma learning in SMT solvers today ignores the matching patterns of quantifiers, and therefore the solver will learn the proof of `false` on the left branch and will then apply that learnt lemma on the right branch, too. In contrast, if the SMT solver happens to start with the right disjunct, then it will not be able to complete the proof, so an error will be reported. For this reason (which can be called "lack of confluence"), small changes to the repro can mask the soundness issue (i.e., can cause the SMT solver not to find the proof).



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
