### PR TITLE
(Partially?) Fix nightly build

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeCpp/DafnyRuntime.h
+++ b/Source/DafnyRuntime/DafnyRuntimeCpp/DafnyRuntime.h
@@ -274,7 +274,7 @@ struct get_default<DafnyArray<U>> {
  *********************************************************/
 
 template <typename T>
-T* global_empty_ptr = new T[0];
+T* global_empty_ptr = new T[1];
 
 template <class T>
 struct DafnySequence {


### PR DESCRIPTION
<!-- Please remove these Markdown comments before publishing this PR, since the PR message is often used as the commit description. 
We only allow squash merging and GH suggests the PR details as a default commit message. -->

### What was changed?
Newer windows-2022 runner image started raising a C++ warning: https://github.com/dafny-lang/dafny/actions/runs/18616938938/job/53082743544#step:26:519

There's a second issue as well (`The process cannot access the file 'D:\a\dafny\dafny\dafny\Source\IntegrationTests\bin\Debug\net8.0\Dafny.dll' because it is being used by another process.`) but that doesn't seem to show up in `run-deep-tests` for some reason.

### How has this been tested?
`run-deep-tests`.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
