### PR TITLE
fix: thread cco (self-call allowance) through all CanCallAssumption sites (soundness)

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1727,25 +1727,20 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
       }
 
       /// <summary>
-      /// Builds the self-call allowance "e.Receiver == this && e.Args == formals" for a self-call "e" to
-      /// the enclosing function. This is OR'd with the call's #canCall so that the trivial self-call does
-      /// not force #canCall (which would trigger the function's consequence axiom -- a soundness
-      /// circularity when checking the function's own specification).
+      /// Builds the self-call allowance "e.Receiver == this && e.Args == formals", OR'd with #canCall by
+      /// the caller so the trivial self-call does not force #canCall (and thereby the function's
+      /// consequence axiom -- circular when checking the function's own spec).
       ///
-      /// When "cco.AllowanceSubstMap" is set, the allowance is being built in a scope (the standalone
-      /// $let#canCall axiom of a let-such-that expression) where the enclosing function's formals and
-      /// "this" are not the ordinary procedure parameters but are represented by that substitution. In
-      /// that case the allowance must be rewritten into that scope. A formal that is absent from the
-      /// substitution cannot occur in the trivial self-call at all, so the call is necessarily non-trivial
-      /// and no allowance applies; this method returns null to signal that the bare #canCall should be used.
+      /// With cco.AllowanceSubstMap set, the allowance is rewritten into the $let#canCall axiom's scope
+      /// (see CanCallOptions). A formal/receiver absent from that scope cannot occur in the trivial
+      /// self-call, so the call is non-trivial; returns null to signal "use the bare #canCall".
       /// </summary>
       public Expression MakeAllowance(FunctionCallExpr e, CanCallOptions cco = null) {
         var substMap = cco?.AllowanceSubstMap;
         Expression allowance = Expression.CreateBoolLiteral(e.Origin, true);
         if (!e.Function.IsStatic) {
           if (substMap != null && cco.AllowanceReceiver == null) {
-            // The allowance needs "this" but the scope has no representation for it; no allowance applies.
-            return null;
+            return null;  // "this" not in scope: no trivial self-call possible here
           }
           var formalThis = new ThisExpr(cco == null ? e.Function : cco.EnclosingFunction);
           allowance = Expression.CreateAnd(allowance, Expression.CreateEq(e.Receiver, formalThis, e.Receiver.Type));
@@ -1755,14 +1750,11 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
           Expression ee = e.Args[i];
           Formal ff = formals[i];
           if (substMap != null && !substMap.ContainsKey(ff)) {
-            // This formal has no representation in the current scope, so the trivial self-call f(formals)
-            // cannot occur here; the call is non-trivial and gets no allowance.
-            return null;
+            return null;  // this formal not in scope: no trivial self-call possible here
           }
           allowance = Expression.CreateAnd(allowance, Expression.CreateEq(ee, Expression.CreateIdentExpr(ff), ff.Type));
         }
         if (substMap != null) {
-          // Rewrite the formals and "this" into the axiom's scope (see CanCallOptions.AllowanceSubstMap).
           allowance = Substitute(allowance, cco.AllowanceReceiver, substMap, null);
         }
         return allowance;
@@ -1798,9 +1790,8 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
               r = BplAnd(r, correctConstructor);
             }
           } else if (e.Member is ConstantField { Rhs: { } rhs } && BoogieGenerator.RevealedInScope(e.Member)) {
-            // Inlining the const's definition (with "this" := e.Obj) must keep the receiver's own canCall
-            // and propagate the self-call allowance (cco): if e.Obj is a self-call and the RHS mentions it,
-            // dropping cco would emit a bare f#canCall and trigger f's consequence axiom.
+            // Keep the receiver's canCall and propagate cco: if e.Obj is a self-call whose const RHS
+            // mentions "this", dropping cco would emit a bare f#canCall (see MakeAllowance).
             r = BplAnd(r, CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null), cco));
           }
           return r;
@@ -1889,10 +1880,8 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
             Token.NoToken) {
             Type = e.Initializer.Type.AsArrowType.Result
           };
-          // Propagate the self-call allowance (cco) into the per-index "init(i)" application, consistent
-          // with the standalone "init" and "n" calls below. Dropping it would emit a bare f#canCall for a
-          // self-call inside the initializer, which can trigger the function's consequence axiom -- the
-          // same soundness circularity the cco threading avoids elsewhere.
+          // Propagate cco into the per-index "init(i)" application, like the "init"/"n" calls below
+          // (a self-call in the initializer would otherwise emit a bare f#canCall; see MakeAllowance).
           var canCall = CanCallAssumption(dafnyInitApplication, cco);
 
           dafnyInitApplication = new ApplyExpr(e.Origin, new BoogieWrapper(initF, e.Initializer.Type),
@@ -2082,14 +2071,10 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
       public readonly Function EnclosingFunction; // self-call allowance is applied to the enclosing function
       public readonly bool SelfCallAllowanceAlsoForOverride;
 
-      // When the self-call allowance is built in a scope where the enclosing function's formals and "this"
-      // are not the ordinary procedure parameters -- as in the standalone $let#canCall axiom for a
-      // let-such-that expression, whose constraint is translated under a substitution of the function's
-      // free variables to the axiom's bound variables -- the allowance's "argument == formal" comparison
-      // must be expressed in that same scope. When AllowanceSubstMap is set, MakeAllowance rewrites the
-      // formals (via the map) and "this" (via AllowanceReceiver) into that scope; a formal absent from the
-      // map cannot occur in the trivial self-call, so MakeAllowance declines to produce an allowance. Both
-      // are null in the ordinary (procedure-scope) case, where all formals are already in scope.
+      // Set only when building the allowance inside the standalone $let#canCall axiom of a let-such-that
+      // expression, where the enclosing function's formals and "this" are represented not by the procedure
+      // parameters but by this substitution (formals via the map, "this" via AllowanceReceiver). They are
+      // null in the ordinary procedure-scope case. See MakeAllowance.
       public readonly Dictionary<IVariable, Expression> AllowanceSubstMap;
       public readonly Expression AllowanceReceiver;
 

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1726,9 +1726,27 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
         return BoogieGenerator.GetWhereClause(tok, e, type, this, ISALLOC);
       }
 
+      /// <summary>
+      /// Builds the self-call allowance "e.Receiver == this && e.Args == formals" for a self-call "e" to
+      /// the enclosing function. This is OR'd with the call's #canCall so that the trivial self-call does
+      /// not force #canCall (which would trigger the function's consequence axiom -- a soundness
+      /// circularity when checking the function's own specification).
+      ///
+      /// When "cco.AllowanceSubstMap" is set, the allowance is being built in a scope (the standalone
+      /// $let#canCall axiom of a let-such-that expression) where the enclosing function's formals and
+      /// "this" are not the ordinary procedure parameters but are represented by that substitution. In
+      /// that case the allowance must be rewritten into that scope. A formal that is absent from the
+      /// substitution cannot occur in the trivial self-call at all, so the call is necessarily non-trivial
+      /// and no allowance applies; this method returns null to signal that the bare #canCall should be used.
+      /// </summary>
       public Expression MakeAllowance(FunctionCallExpr e, CanCallOptions cco = null) {
+        var substMap = cco?.AllowanceSubstMap;
         Expression allowance = Expression.CreateBoolLiteral(e.Origin, true);
         if (!e.Function.IsStatic) {
+          if (substMap != null && cco.AllowanceReceiver == null) {
+            // The allowance needs "this" but the scope has no representation for it; no allowance applies.
+            return null;
+          }
           var formalThis = new ThisExpr(cco == null ? e.Function : cco.EnclosingFunction);
           allowance = Expression.CreateAnd(allowance, Expression.CreateEq(e.Receiver, formalThis, e.Receiver.Type));
         }
@@ -1736,7 +1754,16 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
         for (int i = 0; i < e.Args.Count; i++) {
           Expression ee = e.Args[i];
           Formal ff = formals[i];
+          if (substMap != null && !substMap.ContainsKey(ff)) {
+            // This formal has no representation in the current scope, so the trivial self-call f(formals)
+            // cannot occur here; the call is non-trivial and gets no allowance.
+            return null;
+          }
           allowance = Expression.CreateAnd(allowance, Expression.CreateEq(ee, Expression.CreateIdentExpr(ff), ff.Type));
+        }
+        if (substMap != null) {
+          // Rewrite the formals and "this" into the axiom's scope (see CanCallOptions.AllowanceSubstMap).
+          allowance = Substitute(allowance, cco.AllowanceReceiver, substMap, null);
         }
         return allowance;
       }
@@ -1830,7 +1857,8 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
             Boogie.IdentifierExpr canCallFuncID = new Boogie.IdentifierExpr(expr.Origin, e.Function.FullSanitizedName + "#canCall", Boogie.Type.Bool);
             List<Boogie.Expr> args = FunctionInvocationArguments(e, null, null);
             Boogie.Expr canCallFuncAppl = new Boogie.NAryExpr(BoogieGenerator.GetToken(expr), new Boogie.FunctionCall(canCallFuncID), args);
-            var add = cco != null && cco.MakeAllowance(e.Function) ? Boogie.Expr.Or(TrExpr(MakeAllowance(e, cco)), canCallFuncAppl) : canCallFuncAppl;
+            var allowance = cco != null && cco.MakeAllowance(e.Function) ? MakeAllowance(e, cco) : null;
+            var add = allowance != null ? Boogie.Expr.Or(TrExpr(allowance), canCallFuncAppl) : canCallFuncAppl;
             r = BplAnd(r, add);
           }
           return r;
@@ -2054,17 +2082,31 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
       public readonly Function EnclosingFunction; // self-call allowance is applied to the enclosing function
       public readonly bool SelfCallAllowanceAlsoForOverride;
 
+      // When the self-call allowance is built in a scope where the enclosing function's formals and "this"
+      // are not the ordinary procedure parameters -- as in the standalone $let#canCall axiom for a
+      // let-such-that expression, whose constraint is translated under a substitution of the function's
+      // free variables to the axiom's bound variables -- the allowance's "argument == formal" comparison
+      // must be expressed in that same scope. When AllowanceSubstMap is set, MakeAllowance rewrites the
+      // formals (via the map) and "this" (via AllowanceReceiver) into that scope; a formal absent from the
+      // map cannot occur in the trivial self-call, so MakeAllowance declines to produce an allowance. Both
+      // are null in the ordinary (procedure-scope) case, where all formals are already in scope.
+      public readonly Dictionary<IVariable, Expression> AllowanceSubstMap;
+      public readonly Expression AllowanceReceiver;
+
       public bool MakeAllowance(Function f) {
         return f == EnclosingFunction || (SelfCallAllowanceAlsoForOverride && f == EnclosingFunction.OverriddenFunction);
       }
 
-      public CanCallOptions(bool skipIsA, Function enclosingFunction, bool selfCallAllowanceAlsoForOverride = false) {
+      public CanCallOptions(bool skipIsA, Function enclosingFunction, bool selfCallAllowanceAlsoForOverride = false,
+        Dictionary<IVariable, Expression> allowanceSubstMap = null, Expression allowanceReceiver = null) {
         Contract.Assert(!selfCallAllowanceAlsoForOverride ||
                         (enclosingFunction.OverriddenFunction != null &&
                          enclosingFunction.Ins.Count == enclosingFunction.OverriddenFunction.Ins.Count));
         this.SkipIsA = skipIsA;
         this.EnclosingFunction = enclosingFunction;
         this.SelfCallAllowanceAlsoForOverride = selfCallAllowanceAlsoForOverride;
+        this.AllowanceSubstMap = allowanceSubstMap;
+        this.AllowanceReceiver = allowanceReceiver;
       }
     }
   }

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1771,7 +1771,10 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
               r = BplAnd(r, correctConstructor);
             }
           } else if (e.Member is ConstantField { Rhs: { } rhs } && BoogieGenerator.RevealedInScope(e.Member)) {
-            r = CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null));
+            // Inlining the const's definition (with "this" := e.Obj) must keep the receiver's own canCall
+            // and propagate the self-call allowance (cco): if e.Obj is a self-call and the RHS mentions it,
+            // dropping cco would emit a bare f#canCall and trigger f's consequence axiom.
+            r = BplAnd(r, CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null), cco));
           }
           return r;
         } else if (expr is SeqSelectExpr) {
@@ -1858,7 +1861,11 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
             Token.NoToken) {
             Type = e.Initializer.Type.AsArrowType.Result
           };
-          var canCall = CanCallAssumption(dafnyInitApplication);
+          // Propagate the self-call allowance (cco) into the per-index "init(i)" application, consistent
+          // with the standalone "init" and "n" calls below. Dropping it would emit a bare f#canCall for a
+          // self-call inside the initializer, which can trigger the function's consequence axiom -- the
+          // same soundness circularity the cco threading avoids elsewhere.
+          var canCall = CanCallAssumption(dafnyInitApplication, cco);
 
           dafnyInitApplication = new ApplyExpr(e.Origin, new BoogieWrapper(initF, e.Initializer.Type),
             [new BoogieWrapper(index, Type.Int)],

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1793,8 +1793,7 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
             }
           } else if (e.Member is ConstantField { Rhs: { } rhs } && BoogieGenerator.RevealedInScope(e.Member)) {
             // Keep the receiver's canCall and propagate cco: if e.Obj is a self-call whose const RHS
-            // mentions "this", dropping cco would emit a bare f#canCall (see MakeAllowance). Only the
-            // allowance is wanted here; this RHS previously got no cco, so it must keep its $IsA# facts.
+            // mentions "this", dropping cco would emit a bare f#canCall (see MakeAllowance).
             r = BplAnd(r, CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null), cco?.AllowanceOnly()));
           }
           return r;
@@ -1886,7 +1885,6 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
           };
           // Propagate cco into the per-index "init(i)" application, like the "init"/"n" calls below
           // (a self-call in the initializer would otherwise emit a bare f#canCall; see MakeAllowance).
-          // Only the allowance is wanted: this application previously got no cco, so it keeps its $IsA# facts.
           var canCall = CanCallAssumption(dafnyInitApplication, cco?.AllowanceOnly());
 
           dafnyInitApplication = new ApplyExpr(e.Origin, new BoogieWrapper(initF, e.Initializer.Type),
@@ -2098,9 +2096,11 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
         return f == EnclosingFunction || (SelfCallAllowanceAlsoForOverride && f == EnclosingFunction.OverriddenFunction);
       }
 
-      /// Returns these options with the $IsA# suppression turned off, keeping only the self-call allowance. Use
-      /// when propagating a cco into a subexpression that previously received none, so that the allowance reaches
-      /// self-calls there without also dropping the $IsA# facts that subexpression used to get.
+      /// Returns these options with the $IsA# suppression turned off, keeping only the self-call allowance. Use at
+      /// every site that forwards a cco into a subexpression which used to receive none: the allowance must reach
+      /// the self-calls there, but a null cco emits $IsA#, so forwarding the suppression as well would silently
+      /// take away facts that subexpression had before. Callers of such a site may have opted into the
+      /// suppression for the whole expression (see SkipIsA), so this cannot be assumed to be a no-op.
       public CanCallOptions AllowanceOnly() {
         return SkipIsA
           ? new CanCallOptions(EnclosingFunction, SelfCallAllowanceAlsoForOverride, AllowanceSubstMap, AllowanceReceiver)

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1732,16 +1732,18 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
       /// consequence axiom -- circular when checking the function's own spec).
       ///
       /// With cco.AllowanceSubstMap set, the allowance is rewritten into the $let#canCall axiom's scope
-      /// (see CanCallOptions). A formal/receiver absent from that scope cannot occur in the trivial
-      /// self-call, so the call is non-trivial; returns null to signal "use the bare #canCall".
+      /// (see CanCallOptions). A formal or receiver with no representation in that scope simply contributes no
+      /// conjunct: the allowance is then weaker, which is the safe direction, since it is only ever OR'd with
+      /// #canCall. It must not instead be reported as "no allowance", which would have the caller emit a bare
+      /// #canCall -- exactly the leak the allowance exists to prevent. In particular, an absent formal does NOT
+      /// mean the self-call is non-trivial: the argument may reach the formal through a let-bound alias, so that
+      /// the alias, not the formal, is the constraint's free variable. Whether an allowance applies at all is
+      /// decided by the caller, via CanCallOptions.MakeAllowance.
       /// </summary>
       public Expression MakeAllowance(FunctionCallExpr e, CanCallOptions cco = null) {
         var substMap = cco?.AllowanceSubstMap;
         Expression allowance = Expression.CreateBoolLiteral(e.Origin, true);
-        if (!e.Function.IsStatic) {
-          if (substMap != null && cco.AllowanceReceiver == null) {
-            return null;  // "this" not in scope: no trivial self-call possible here
-          }
+        if (!e.Function.IsStatic && !(substMap != null && cco.AllowanceReceiver == null)) {
           var formalThis = new ThisExpr(cco == null ? e.Function : cco.EnclosingFunction);
           allowance = Expression.CreateAnd(allowance, Expression.CreateEq(e.Receiver, formalThis, e.Receiver.Type));
         }
@@ -1750,7 +1752,7 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
           Expression ee = e.Args[i];
           Formal ff = formals[i];
           if (substMap != null && !substMap.ContainsKey(ff)) {
-            return null;  // this formal not in scope: no trivial self-call possible here
+            continue;
           }
           allowance = Expression.CreateAnd(allowance, Expression.CreateEq(ee, Expression.CreateIdentExpr(ff), ff.Type));
         }
@@ -1791,8 +1793,9 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
             }
           } else if (e.Member is ConstantField { Rhs: { } rhs } && BoogieGenerator.RevealedInScope(e.Member)) {
             // Keep the receiver's canCall and propagate cco: if e.Obj is a self-call whose const RHS
-            // mentions "this", dropping cco would emit a bare f#canCall (see MakeAllowance).
-            r = BplAnd(r, CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null), cco));
+            // mentions "this", dropping cco would emit a bare f#canCall (see MakeAllowance). Only the
+            // allowance is wanted here; this RHS previously got no cco, so it must keep its $IsA# facts.
+            r = BplAnd(r, CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null), cco?.AllowanceOnly()));
           }
           return r;
         } else if (expr is SeqSelectExpr) {
@@ -1848,8 +1851,9 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
             Boogie.IdentifierExpr canCallFuncID = new Boogie.IdentifierExpr(expr.Origin, e.Function.FullSanitizedName + "#canCall", Boogie.Type.Bool);
             List<Boogie.Expr> args = FunctionInvocationArguments(e, null, null);
             Boogie.Expr canCallFuncAppl = new Boogie.NAryExpr(BoogieGenerator.GetToken(expr), new Boogie.FunctionCall(canCallFuncID), args);
-            var allowance = cco != null && cco.MakeAllowance(e.Function) ? MakeAllowance(e, cco) : null;
-            var add = allowance != null ? Boogie.Expr.Or(TrExpr(allowance), canCallFuncAppl) : canCallFuncAppl;
+            var add = cco != null && cco.MakeAllowance(e.Function)
+              ? Boogie.Expr.Or(TrExpr(MakeAllowance(e, cco)), canCallFuncAppl)
+              : canCallFuncAppl;
             r = BplAnd(r, add);
           }
           return r;
@@ -1882,7 +1886,8 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
           };
           // Propagate cco into the per-index "init(i)" application, like the "init"/"n" calls below
           // (a self-call in the initializer would otherwise emit a bare f#canCall; see MakeAllowance).
-          var canCall = CanCallAssumption(dafnyInitApplication, cco);
+          // Only the allowance is wanted: this application previously got no cco, so it keeps its $IsA# facts.
+          var canCall = CanCallAssumption(dafnyInitApplication, cco?.AllowanceOnly());
 
           dafnyInitApplication = new ApplyExpr(e.Origin, new BoogieWrapper(initF, e.Initializer.Type),
             [new BoogieWrapper(index, Type.Int)],
@@ -2066,7 +2071,11 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
     }
 
     public class CanCallOptions {
-      public bool SkipIsA;
+      // Suppresses the $IsA# conjuncts that a datatype (in)equality would otherwise contribute. This is an
+      // optimization, independent of the self-call allowance below: a site that needs the allowance must not
+      // silently inherit the suppression, or it loses facts it would get with no cco at all (a "null" cco emits
+      // $IsA#). Derive such a cco with AllowanceOnly.
+      public readonly bool SkipIsA;
 
       public readonly Function EnclosingFunction; // self-call allowance is applied to the enclosing function
       public readonly bool SelfCallAllowanceAlsoForOverride;
@@ -2080,6 +2089,15 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
 
       public bool MakeAllowance(Function f) {
         return f == EnclosingFunction || (SelfCallAllowanceAlsoForOverride && f == EnclosingFunction.OverriddenFunction);
+      }
+
+      /// Returns these options with the $IsA# suppression turned off, keeping only the self-call allowance. Use
+      /// when propagating a cco into a subexpression that previously received none, so that the allowance reaches
+      /// self-calls there without also dropping the $IsA# facts that subexpression used to get.
+      public CanCallOptions AllowanceOnly() {
+        return SkipIsA
+          ? new CanCallOptions(false, EnclosingFunction, SelfCallAllowanceAlsoForOverride, AllowanceSubstMap, AllowanceReceiver)
+          : this;
       }
 
       public CanCallOptions(bool skipIsA, Function enclosingFunction, bool selfCallAllowanceAlsoForOverride = false,

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -2072,9 +2072,10 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
 
     public class CanCallOptions {
       // Suppresses the $IsA# conjuncts that a datatype (in)equality would otherwise contribute. This is an
-      // optimization, independent of the self-call allowance below: a site that needs the allowance must not
-      // silently inherit the suppression, or it loses facts it would get with no cco at all (a "null" cco emits
-      // $IsA#). Derive such a cco with AllowanceOnly.
+      // optimization, independent of the self-call allowance below, and it defaults to off: a cco exists to carry
+      // the allowance, so a site that propagates one into a subexpression must not silently also suppress facts
+      // that subexpression would get from no cco at all (a null cco emits $IsA#). Opt in with "skipIsA: true"
+      // only where the whole expression is a top-level specification being assumed, or derive with AllowanceOnly.
       public readonly bool SkipIsA;
 
       public readonly Function EnclosingFunction; // self-call allowance is applied to the enclosing function
@@ -2096,12 +2097,13 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
       /// self-calls there without also dropping the $IsA# facts that subexpression used to get.
       public CanCallOptions AllowanceOnly() {
         return SkipIsA
-          ? new CanCallOptions(false, EnclosingFunction, SelfCallAllowanceAlsoForOverride, AllowanceSubstMap, AllowanceReceiver)
+          ? new CanCallOptions(EnclosingFunction, SelfCallAllowanceAlsoForOverride, AllowanceSubstMap, AllowanceReceiver)
           : this;
       }
 
-      public CanCallOptions(bool skipIsA, Function enclosingFunction, bool selfCallAllowanceAlsoForOverride = false,
-        Dictionary<IVariable, Expression> allowanceSubstMap = null, Expression allowanceReceiver = null) {
+      public CanCallOptions(Function enclosingFunction, bool selfCallAllowanceAlsoForOverride = false,
+        Dictionary<IVariable, Expression> allowanceSubstMap = null, Expression allowanceReceiver = null,
+        bool skipIsA = false) {
         Contract.Assert(!selfCallAllowanceAlsoForOverride ||
                         (enclosingFunction.OverriddenFunction != null &&
                          enclosingFunction.Ins.Count == enclosingFunction.OverriddenFunction.Ins.Count));

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -2102,9 +2102,17 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
       /// take away facts that subexpression had before. Callers of such a site may have opted into the
       /// suppression for the whole expression (see SkipIsA), so this cannot be assumed to be a no-op.
       public CanCallOptions AllowanceOnly() {
-        return SkipIsA
-          ? new CanCallOptions(EnclosingFunction, SelfCallAllowanceAlsoForOverride, AllowanceSubstMap, AllowanceReceiver)
-          : this;
+        return SkipIsA ? new CanCallOptions(this, skipIsA: false) : this;
+      }
+
+      /// Copies "source", overriding SkipIsA. Written as a copy rather than as a fresh construction so
+      /// that a field added to this class later is carried over rather than silently dropped.
+      private CanCallOptions(CanCallOptions source, bool skipIsA) {
+        this.SkipIsA = skipIsA;
+        this.EnclosingFunction = source.EnclosingFunction;
+        this.SelfCallAllowanceAlsoForOverride = source.SelfCallAllowanceAlsoForOverride;
+        this.AllowanceSubstMap = source.AllowanceSubstMap;
+        this.AllowanceReceiver = source.AllowanceReceiver;
       }
 
       public CanCallOptions(Function enclosingFunction, bool selfCallAllowanceAlsoForOverride = false,

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -2071,11 +2071,17 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
     }
 
     public class CanCallOptions {
-      // Suppresses the $IsA# conjuncts that a datatype (in)equality would otherwise contribute. This is an
-      // optimization, independent of the self-call allowance below, and it defaults to off: a cco exists to carry
-      // the allowance, so a site that propagates one into a subexpression must not silently also suppress facts
-      // that subexpression would get from no cco at all (a null cco emits $IsA#). Opt in with "skipIsA: true"
-      // only where the whole expression is a top-level specification being assumed, or derive with AllowanceOnly.
+      // Suppresses the $IsA# conjuncts that a datatype (in)equality would otherwise contribute. $IsA#Dt(d) is a
+      // depth-one case split over Dt's constructors, deliberately rationed: it is emitted only where the
+      // translation inserts it, because "making the RHS disjunction be available too often makes performance go
+      // down" (see AddDepthOneCaseSplitFunction). So this is a performance lever, not a correctness one, and it is
+      // independent of the self-call allowance below.
+      //
+      // It defaults to off because a cco exists to carry the allowance: a site that propagates one into a
+      // subexpression must not silently also suppress facts that subexpression would get from no cco at all (a
+      // null cco emits $IsA#). Opting in narrows what is emitted relative to no cco, so do it only where the
+      // ration is already being spent on the whole expression -- the specification-assumption sites in Methods.cs
+      // and Functions.Wellformedness.cs -- or derive with AllowanceOnly when forwarding.
       public readonly bool SkipIsA;
 
       public readonly Function EnclosingFunction; // self-call allowance is applied to the enclosing function

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Functions.Wellformedness.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Functions.Wellformedness.cs
@@ -48,7 +48,7 @@ public partial class BoogieGenerator {
         var splits = new List<SplitExprInfo>();
         bool splitHappened /*we actually don't care*/ = generator.TrSplitExpr(context, ensures.E, splits, true, functionHeight, true, etran);
         var (errorMessage, successMessage) = generator.CustomErrorMessage(ensures.Attributes);
-        var canCalls = etran.CanCallAssumption(ensures.E, new CanCallOptions(true, f));
+        var canCalls = etran.CanCallAssumption(ensures.E, new CanCallOptions(f, skipIsA: true));
         generator.AddEnsures(ens, generator.FreeEnsures(ensures.E.Origin, canCalls, null, true));
         foreach (var s in splits) {
           if (s.IsChecked && !s.Tok.IsInherited(generator.currentModule)) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -274,7 +274,20 @@ namespace Microsoft.Dafny {
 
         var canCall = FunctionCall(e.Origin, info.CanCallFunctionName(), Bpl.Type.Bool, gExprs);
         var p = Substitute(e.RHSs[0], receiverReplacement, substMap);
-        var canCallBody = etranCC.CanCallAssumption(p);
+        // If this let-such-that occurs in the specification of a function, the such-that constraint may
+        // contain a self-call to that function. Without the self-call allowance (cco), the bare "f#canCall"
+        // emitted here would trigger f's consequence axiom (assuming f's own postcondition), the same
+        // circularity the cco threading avoids for the let body and the exact-let case. This axiom is
+        // generated once, while CurrentDeclaration is the enclosing function, so we build the allowance
+        // here. The allowance compares the self-call's arguments to f's formals; those formals are
+        // represented in this axiom by the same substMap/receiverReplacement that translate the constraint
+        // (only the constraint's free variables are in scope), so we hand them to MakeAllowance via
+        // CanCallOptions. A trivial self-call f(formals) then reduces to a well-scoped tautology, while a
+        // non-trivial call keeps the bare canCall.
+        var cco = BoogieGenerator.CurrentDeclaration is Function enclosingFunction
+          ? new CanCallOptions(true, enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
+          : null;
+        var canCallBody = etranCC.CanCallAssumption(p, cco);
         Bpl.Expr ax = BplImp(canCall, BplAnd(antecedent, BplAnd(canCallBody, etranCC.TrExpr(p))));
         ax = BplForall(gg, tr, ax);
         BoogieGenerator.AddOtherDefinition(canCallFunction, new Bpl.Axiom(e.Origin, ax));

--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -274,16 +274,11 @@ namespace Microsoft.Dafny {
 
         var canCall = FunctionCall(e.Origin, info.CanCallFunctionName(), Bpl.Type.Bool, gExprs);
         var p = Substitute(e.RHSs[0], receiverReplacement, substMap);
-        // If this let-such-that occurs in the specification of a function, the such-that constraint may
-        // contain a self-call to that function. Without the self-call allowance (cco), the bare "f#canCall"
-        // emitted here would trigger f's consequence axiom (assuming f's own postcondition), the same
-        // circularity the cco threading avoids for the let body and the exact-let case. This axiom is
-        // generated once, while CurrentDeclaration is the enclosing function, so we build the allowance
-        // here. The allowance compares the self-call's arguments to f's formals; those formals are
-        // represented in this axiom by the same substMap/receiverReplacement that translate the constraint
-        // (only the constraint's free variables are in scope), so we hand them to MakeAllowance via
-        // CanCallOptions. A trivial self-call f(formals) then reduces to a well-scoped tautology, while a
-        // non-trivial call keeps the bare canCall.
+        // A self-call in the constraint would emit a bare f#canCall here, triggering f's consequence axiom
+        // when checking f's own spec (the same circularity cco avoids elsewhere). This axiom is generated
+        // once, while CurrentDeclaration is the enclosing function, so build the allowance now; pass the
+        // substMap/receiverReplacement that map f's formals and "this" into this axiom's scope (see
+        // MakeAllowance / CanCallOptions.AllowanceSubstMap).
         var cco = BoogieGenerator.CurrentDeclaration is Function enclosingFunction
           ? new CanCallOptions(true, enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
           : null;

--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Dafny {
             canCallRHS = BplAnd(canCallRHS, CanCallAssumption(rhs, cco));
           }
 
-          var bodyCanCall = CanCallAssumption(expr.Body);
+          var bodyCanCall = CanCallAssumption(expr.Body, cco);
           // We'd like to compute the free variables of "bodyCanCall". It would be nice to use the Boogie
           // routine Bpl.Expr.ComputeFreeVariables for this purpose. However, calling it requires the Boogie
           // expression to be resolved. Instead, we do the cheesy thing of computing the set of names of

--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Dafny {
             canCallRHS = BplAnd(canCallRHS, CanCallAssumption(rhs, cco));
           }
 
-          // Only the allowance is wanted: the body previously got no cco, so it keeps its $IsA# facts.
           var bodyCanCall = CanCallAssumption(expr.Body, cco?.AllowanceOnly());
           // We'd like to compute the free variables of "bodyCanCall". It would be nice to use the Boogie
           // routine Bpl.Expr.ComputeFreeVariables for this purpose. However, calling it requires the Boogie
@@ -279,8 +278,7 @@ namespace Microsoft.Dafny {
         // when checking f's own spec (the same circularity cco avoids elsewhere). This axiom is generated
         // once, while CurrentDeclaration is the enclosing function, so build the allowance now; pass the
         // substMap/receiverReplacement that map f's formals and "this" into this axiom's scope (see
-        // MakeAllowance / CanCallOptions.AllowanceSubstMap). Only the allowance is wanted; the constraint
-        // previously got no cco, so it keeps its $IsA# facts (skipIsA defaults to off).
+        // MakeAllowance / CanCallOptions.AllowanceSubstMap).
         var cco = BoogieGenerator.CurrentDeclaration is Function enclosingFunction
           ? new CanCallOptions(enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
           : null;

--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -279,10 +279,10 @@ namespace Microsoft.Dafny {
         // when checking f's own spec (the same circularity cco avoids elsewhere). This axiom is generated
         // once, while CurrentDeclaration is the enclosing function, so build the allowance now; pass the
         // substMap/receiverReplacement that map f's formals and "this" into this axiom's scope (see
-        // MakeAllowance / CanCallOptions.AllowanceSubstMap). Only the allowance is wanted, so skipIsA stays
-        // false: the constraint previously got no cco and must keep its $IsA# facts.
+        // MakeAllowance / CanCallOptions.AllowanceSubstMap). Only the allowance is wanted; the constraint
+        // previously got no cco, so it keeps its $IsA# facts (skipIsA defaults to off).
         var cco = BoogieGenerator.CurrentDeclaration is Function enclosingFunction
-          ? new CanCallOptions(false, enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
+          ? new CanCallOptions(enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
           : null;
         var canCallBody = etranCC.CanCallAssumption(p, cco);
         Bpl.Expr ax = BplImp(canCall, BplAnd(antecedent, BplAnd(canCallBody, etranCC.TrExpr(p))));

--- a/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.LetExpr.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Dafny {
             canCallRHS = BplAnd(canCallRHS, CanCallAssumption(rhs, cco));
           }
 
-          var bodyCanCall = CanCallAssumption(expr.Body, cco);
+          // Only the allowance is wanted: the body previously got no cco, so it keeps its $IsA# facts.
+          var bodyCanCall = CanCallAssumption(expr.Body, cco?.AllowanceOnly());
           // We'd like to compute the free variables of "bodyCanCall". It would be nice to use the Boogie
           // routine Bpl.Expr.ComputeFreeVariables for this purpose. However, calling it requires the Boogie
           // expression to be resolved. Instead, we do the cheesy thing of computing the set of names of
@@ -278,9 +279,10 @@ namespace Microsoft.Dafny {
         // when checking f's own spec (the same circularity cco avoids elsewhere). This axiom is generated
         // once, while CurrentDeclaration is the enclosing function, so build the allowance now; pass the
         // substMap/receiverReplacement that map f's formals and "this" into this axiom's scope (see
-        // MakeAllowance / CanCallOptions.AllowanceSubstMap).
+        // MakeAllowance / CanCallOptions.AllowanceSubstMap). Only the allowance is wanted, so skipIsA stays
+        // false: the constraint previously got no cco and must keep its $IsA# facts.
         var cco = BoogieGenerator.CurrentDeclaration is Function enclosingFunction
-          ? new CanCallOptions(true, enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
+          ? new CanCallOptions(false, enclosingFunction, allowanceSubstMap: substMap, allowanceReceiver: receiverReplacement)
           : null;
         var canCallBody = etranCC.CanCallAssumption(p, cco);
         Bpl.Expr ax = BplImp(canCall, BplAnd(antecedent, BplAnd(canCallBody, etranCC.TrExpr(p))));

--- a/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.Methods.cs
@@ -1101,7 +1101,7 @@ namespace Microsoft.Dafny {
       List<Bpl.Variable> implInParams, Bpl.Variable/*?*/ resultVariable) {
       Contract.Requires(f.Ins.Count <= implInParams.Count);
 
-      var cco = new CanCallOptions(true, f);
+      var cco = new CanCallOptions(f, skipIsA: true);
       //generating class post-conditions
       foreach (var en in ConjunctsOf(f.Ens)) {
         builder.Add(TrAssumeCmd(f.Origin, etran.CanCallAssumption(en.E, cco)));
@@ -1145,7 +1145,7 @@ namespace Microsoft.Dafny {
         .Select(e => e.E)
         .Aggregate((Expression)Expression.CreateBoolLiteral(f.Origin, true), (e0, e1) => Expression.CreateAnd(e0, e1));
       //generating trait post-conditions with class variables
-      cco = new CanCallOptions(true, f, true);
+      cco = new CanCallOptions(f, true, skipIsA: true);
       FunctionCallSubstituter sub = new FunctionCallSubstituter(substMap, typeMap,
         (TraitDecl)f.OverriddenFunction.EnclosingClass, (TopLevelDeclWithMembers)f.EnclosingClass);
       foreach (var en in ConjunctsOf(f.OverriddenFunction.Ens)) {
@@ -1233,7 +1233,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(etran != null);
       Contract.Requires(substMap != null);
       //generating trait pre-conditions with class variables
-      var cco = new CanCallOptions(true, f, true);
+      var cco = new CanCallOptions(f, true, skipIsA: true);
       FunctionCallSubstituter sub = new FunctionCallSubstituter(substMap, typeMap,
         (TraitDecl)f.OverriddenFunction.EnclosingClass, (TopLevelDeclWithMembers)f.EnclosingClass);
       var subReqs = new List<Expression>();
@@ -1246,7 +1246,7 @@ namespace Microsoft.Dafny {
 
       var allTraitReqs = subReqs.Aggregate((Expression)Expression.CreateBoolLiteral(f.Origin, true), (e0, e1) => Expression.CreateAnd(e0, e1));
       //generating class pre-conditions
-      cco = new CanCallOptions(true, f);
+      cco = new CanCallOptions(f, skipIsA: true);
       foreach (var req in ConjunctsOf(f.Req)) {
         foreach (var s in TrSplitExpr(new BodyTranslationContext(false), req.E, etran, false, out _).Where(s => s.IsChecked)) {
           builder.Add(TrAssumeCmd(f.Origin, etran.CanCallAssumption(req.E, cco)));

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
@@ -8,6 +8,8 @@
 // - #6343: a `var` expression, which is already a LetExpr.
 // - a revealed `const` field whose definition is inlined when the field is
 //   selected on the result of a self-call (MemberSelectExpr / ConstantField).
+// - a `var ... :| ...` (let-such-that) whose such-that constraint contains a
+//   self-call (the standalone $let#canCall axiom).
 
 datatype D = Pair(x: int, y: int)
 
@@ -45,3 +47,20 @@ function constField(n: int): Wrapper
 function constFieldOk(n: int): Wrapper
   ensures constFieldOk(n).c == 0
 { Wrap(0) }
+
+// Let-such-that with a self-call in the constraint must not let `false` be proved.
+function letSuchThat(): int
+  ensures var x: int :| x == letSuchThat(); true
+  ensures false
+{ 1 }
+
+// Parameterless predicate variant.
+predicate letSuchThatPred()
+  ensures var x: int :| x == 0 && letSuchThatPred(); true
+  ensures false
+{ true }
+
+// Legitimate let-such-that whose body relies on the witness equality still verifies.
+function letSuchThatOk(n: nat): nat
+  ensures var x :| x == letSuchThatOk(n); x == letSuchThatOk(n)
+{ 0 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
@@ -1,12 +1,13 @@
 // RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s"
 
-// Regression tests: a let-expression body in an ensures clause used to allow
-// proving false, because CanCallAssumption for the let-expression body did
-// not propagate the self-call allowance (cco). Two surface forms hit the
-// same root cause:
+// Regression tests: a recursive self-call in a function's specification used to
+// allow proving false, because CanCallAssumption dropped the self-call allowance
+// (cco) on some sub-expressions. Several surface forms hit the same root cause:
 // - #6405: a match expression on a single-constructor datatype, which the
 //   MatchFlattener lowers to a LetExpr.
 // - #6343: a `var` expression, which is already a LetExpr.
+// - a revealed `const` field whose definition is inlined when the field is
+//   selected on the result of a self-call (MemberSelectExpr / ConstantField).
 
 datatype D = Pair(x: int, y: int)
 
@@ -29,3 +30,18 @@ function h(elements: int): (r: int)
 function k(elements: int): (r: int)
   ensures var i := 1; r >= i - 1
 { 1 }
+
+datatype Wrapper = Wrap(val: int) {
+  const c: int := this.val
+}
+
+// Const field selected on the result of a self-call must not let `false` be proved.
+function constField(n: int): Wrapper
+  ensures constField(n).c == 0
+  ensures false
+{ Wrap(0) }
+
+// Legitimate const-field selection on a self-call still verifies.
+function constFieldOk(n: int): Wrapper
+  ensures constFieldOk(n).c == 0
+{ Wrap(0) }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
@@ -1,0 +1,31 @@
+// RUN: %testDafnyForEachResolver --expect-exit-code=4 "%s"
+
+// Regression tests: a let-expression body in an ensures clause used to allow
+// proving false, because CanCallAssumption for the let-expression body did
+// not propagate the self-call allowance (cco). Two surface forms hit the
+// same root cause:
+// - #6405: a match expression on a single-constructor datatype, which the
+//   MatchFlattener lowers to a LetExpr.
+// - #6343: a `var` expression, which is already a LetExpr.
+
+datatype D = Pair(x: int, y: int)
+
+function f(): D
+  ensures match f() {case Pair(a, b) => a >= 0}
+  ensures false
+{ Pair(0, 0) }
+
+// Also test that legitimate uses still verify:
+function g(): D
+  ensures match g() {case Pair(a, b) => a >= 0}
+{ Pair(0, 0) }
+
+// #6343: `var` in ensures with a recursive self-call.
+function h(elements: int): (r: int)
+  ensures var i := 1; h(elements) == 0
+{ 1 }
+
+// Legitimate `var` in ensures:
+function k(elements: int): (r: int)
+  ensures var i := 1; r >= i - 1
+{ 1 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy
@@ -64,3 +64,52 @@ predicate letSuchThatPred()
 function letSuchThatOk(n: nat): nat
   ensures var x :| x == letSuchThatOk(n); x == letSuchThatOk(n)
 { 0 }
+
+// The self-call allowance must also be withheld when the trivial self-call reaches the function through a
+// let-bound alias of a formal, or of "this": the constraint's free variables are then the alias, so the formal
+// (or "this") is absent from the axiom's scope, and an allowance keyed on its presence would leak.
+function aliasedFormal(n: int): int
+  ensures var a := n; var x: int :| x == aliasedFormal(a); x == aliasedFormal(a)
+  ensures false  // must NOT be provable from the such-that above
+{ 1 }
+
+class Aliased {
+  function aliasedThis(): int
+    ensures var t := this; var x: int :| x == t.aliasedThis(); x == t.aliasedThis()
+    ensures false  // must NOT be provable from the such-that above
+  { 1 }
+}
+
+// Conversely, a self-call on a receiver or with an argument that genuinely is out of the axiom's scope must
+// still translate (the conjunct is simply omitted), rather than emitting an undeclared identifier.
+class OutOfScopeReceiver {
+  function f(o: OutOfScopeReceiver, n: nat): int
+    decreases n
+    ensures n > 0 ==> var x: int :| x == o.f(o, n - 1); true
+  { 0 }
+}
+
+function outOfScopeFormal(n: nat, m: int): int
+  decreases n
+  ensures n > 0 ==> var x: int :| x == outOfScopeFormal(n - 1, n); true
+{ 0 }
+
+// Propagating the allowance into these sub-expressions must not also suppress the $IsA# facts a datatype
+// equality contributes there (see CanCallOptions.AllowanceOnly): without them, the case analysis over D's
+// constructors is unavailable and the assertion below is not provable.
+datatype Two = A(a: int) | B(b: int)
+
+ghost function pick(n: int): int
+{ var z: int :| z == 0 && mk(n) == mk(n); z }
+
+function mk(n: int): Two
+
+predicate Q(d: Two)
+
+lemma IsAFactsSurvive(n: int)
+  requires forall a: int :: Q(A(a))
+  requires forall b: int :: Q(B(b))
+{
+  var q := pick(n);
+  assert Q(mk(n));
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
@@ -1,6 +1,8 @@
-git-issue-6405.dfy(16,2): Error: a postcondition could not be proved on this return path
-git-issue-6405.dfy(15,10): Related location: this is the postcondition that could not be proved
-git-issue-6405.dfy(26,2): Error: a postcondition could not be proved on this return path
-git-issue-6405.dfy(25,34): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(17,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(16,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(27,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(26,34): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(42,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(41,10): Related location: this is the postcondition that could not be proved
 
-Dafny program verifier finished with 2 verified, 2 errors
+Dafny program verifier finished with 3 verified, 3 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
@@ -1,0 +1,6 @@
+git-issue-6405.dfy(16,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(15,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(26,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(25,34): Related location: this is the postcondition that could not be proved
+
+Dafny program verifier finished with 2 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
@@ -1,8 +1,12 @@
-git-issue-6405.dfy(17,2): Error: a postcondition could not be proved on this return path
-git-issue-6405.dfy(16,10): Related location: this is the postcondition that could not be proved
-git-issue-6405.dfy(27,2): Error: a postcondition could not be proved on this return path
-git-issue-6405.dfy(26,34): Related location: this is the postcondition that could not be proved
-git-issue-6405.dfy(42,2): Error: a postcondition could not be proved on this return path
-git-issue-6405.dfy(41,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(19,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(18,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(29,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(28,34): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(44,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(43,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(55,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(54,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(61,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(60,10): Related location: this is the postcondition that could not be proved
 
-Dafny program verifier finished with 3 verified, 3 errors
+Dafny program verifier finished with 4 verified, 5 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6405.dfy.expect
@@ -8,5 +8,9 @@ git-issue-6405.dfy(55,2): Error: a postcondition could not be proved on this ret
 git-issue-6405.dfy(54,10): Related location: this is the postcondition that could not be proved
 git-issue-6405.dfy(61,2): Error: a postcondition could not be proved on this return path
 git-issue-6405.dfy(60,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(74,2): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(73,10): Related location: this is the postcondition that could not be proved
+git-issue-6405.dfy(80,4): Error: a postcondition could not be proved on this return path
+git-issue-6405.dfy(79,12): Related location: this is the postcondition that could not be proved
 
-Dafny program verifier finished with 4 verified, 5 errors
+Dafny program verifier finished with 8 verified, 7 errors

--- a/docs/dev/news/6405.fix
+++ b/docs/dev/news/6405.fix
@@ -1,1 +1,1 @@
-`ensures false` can no longer be proved via a `match` or `var` expression in the ensures clause of a recursive function (soundness)
+`ensures false` can no longer be proved via a `match`, `var`, or revealed `const`-field selection in the ensures clause of a recursive function (soundness)

--- a/docs/dev/news/6405.fix
+++ b/docs/dev/news/6405.fix
@@ -1,0 +1,1 @@
+`ensures false` can no longer be proved via a `match` or `var` expression in the ensures clause of a recursive function (soundness)

--- a/docs/dev/news/6405.fix
+++ b/docs/dev/news/6405.fix
@@ -1,1 +1,1 @@
-`ensures false` can no longer be proved via a `match`, `var`, or revealed `const`-field selection in the ensures clause of a recursive function (soundness)
+`ensures false` can no longer be proved via a `match`, `var`, `var ... :| ...`, or revealed `const`-field selection in the ensures clause of a recursive function (soundness)


### PR DESCRIPTION
## Summary

`ensures false` could be proved in a recursive function's specification. `CanCallAssumption` (Boogie verifier) walks an expression carrying a `cco` (`CanCallOptions`) holding the **self-call allowance**; where a recursive call dropped `cco`, a self-call emitted a bare `f#canCall` instead of the allowance-guarded form, triggering `f`'s consequence axiom (which assumes `f`'s postcondition) and letting `false` be proved. This PR fixes every site that dropped the allowance.

## Fixes

| Site | Surface form | Fix |
| --- | --- | --- |
| `LetCanCallAssumption` (let body) | `match` on a single-ctor datatype, lowered to a `LetExpr` (#6405); `var x := ...` (#6343) | pass `cco` |
| `MemberSelectExpr` / revealed `ConstantField` | `const` field selected on a self-call whose RHS mentions `this` (`f(n).c`, `const c := this.val`) | pass `cco`; also `BplAnd` the receiver's canCall instead of overwriting it (matching the `DatatypeDestructor` case) |
| `SeqConstructionExpr` | self-call in a `seq(n, init)` initializer | pass `cco` to the per-index `init(i)` (latent, fixed for consistency) |
| `AddLetSuchThenCanCallAxiom` (let-such-that) | `var x :| P(x); ...` whose constraint `P` self-calls | build the allowance inside the `$let#canCall` axiom (see below) |

The first three are one-liners — `cco` is already in scope inline. The let-such-that case is the only non-trivial one: a `:|` is skolemized into a standalone, globally-cached `$let#canCall` axiom quantified only over the constraint's free variables, so `f`'s procedure-scope formals aren't in scope there. `MakeAllowance` gains an optional substitution (`CanCallOptions.AllowanceSubstMap` / `AllowanceReceiver`) that rewrites the formals and `this` into the axiom's scope.

A formal or receiver with no representation in that scope simply **contributes no conjunct**, making the allowance weaker — the safe direction, since it is only ever OR'd with `#canCall`. It must not instead be reported as "no allowance at all", which would have the caller fall back to a bare `#canCall` — exactly the leak the allowance exists to prevent. In particular, an absent formal does *not* imply the self-call is non-trivial: the argument can reach the formal through a let-bound alias, so the alias, not the formal, is the constraint's free variable. `aliasedFormal` and `Aliased.aliasedThis` in the test cover both (formal and `this`), and `OutOfScopeReceiver` / `outOfScopeFormal` cover the genuinely-out-of-scope case, which must still translate rather than emit an undeclared identifier.

Whether an allowance applies at all is decided by the caller via `CanCallOptions.MakeAllowance`. Inert for all other callers — only this site sets `AllowanceSubstMap`, and the emitted Boogie is byte-identical for the consequence-axiom and override paths.

**Decoupling `SkipIsA` from the allowance.** `CanCallOptions` also carries `SkipIsA`, an unrelated optimization that suppresses the `$IsA#` conjuncts a datatype (in)equality contributes. `CanCallOptions` was introduced by #5654 to carry the allowance, and `SkipIsA` was attached to the same object in that same commit — the pairing was never a design decision, which is why every original caller passes `true`. That matters here because the four sites above previously received no `cco`, and a `null` `cco` *emits* `$IsA#`; propagating a `cco` for its allowance therefore silently suppressed those facts, losing the constructor case analysis and regressing programs that used to verify.

`skipIsA` is now a defaulted, named-only constructor parameter, so the safe behaviour is what a new caller gets, and `CanCallOptions.AllowanceOnly()` derives allowance-only options where a `cco` must be forwarded into a subexpression. `SkipIsA` is `readonly`. The five sites that assume a whole specification still opt in, now spelled `skipIsA: true` instead of a leading positional bool (also removing the unreadable `new CanCallOptions(true, f, true)`). `IsAFactsSurvive` in the test pins the behaviour down (it fails without the decoupling); the emitted Boogie is byte-identical for the override, precondition and well-formedness paths and across a 127-file sweep.

`$IsA#Dt(d)` is a depth-one case split over `Dt`'s constructors and is deliberately rationed — the prelude notes it is emitted only where the translation inserts it, because "making the RHS disjunction be available too often makes performance go down" (`AddDepthOneCaseSplitFunction`). So it is worth being explicit about the cost. On a program that reaches the changed sites, suppressing gives 29 `$IsA#` / 26121 RU while both master and this branch give 46 / 28914: the fix is ~10.7% more resources than the PR head, and **identical to master**. The PR head's apparent saving was the bug — it bought resources by discarding facts proofs rely on. Across 43 datatype-heavy `dafny0`/`dafny4` files the resource count is unchanged from master (0%).

**Design note (reviewers):** `$let#canCall` is shared with callers of `f`. The allowance makes its consequent `(args == formals || f#canCall(g)) && ...`, so for the self-spec instantiation `args == formals` is trivially true and the implication `$let#canCall(g) ==> f#canCall(g)` is effectively dropped in *all* contexts, not just `f`'s own spec. I found no consumer that relies on it (`f#canCall` is established via the usual `#requires ==> #canCall` axiom and per-call-site `assume`), and the integration suite shows no regression. A context-targeted fix would require splitting `$let#canCall` into two functions — a much larger change that didn't seem warranted; flagging in case a maintainer prefers it.

## Test

`git-issue-6405.dfy` (`%testDafnyForEachResolver`) covers all four forms, each with a must-fail and a must-verify case: `f`/`g` (match), `h`/`k` (`var`), `constField`/`constFieldOk`, and `letSuchThat` + `letSuchThatPred` / `letSuchThatOk` (whose body uses the witness equality), plus the alias, out-of-scope, and `$IsA#` cases described above.

Fixes #6405
Fixes #6343

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
