### PR TITLE
fix: pass type substitution for const RHS in CanCallAssumption

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1771,7 +1771,8 @@ BplBoundVar(varNameGen.FreshId(string.Format("#{0}#", bv.Name)), Predef.BoxType,
               r = BplAnd(r, correctConstructor);
             }
           } else if (e.Member is ConstantField { Rhs: { } rhs } && BoogieGenerator.RevealedInScope(e.Member)) {
-            r = CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), null));
+            var constTypeMap = e.TypeArgumentSubstitutionsWithParents();
+            r = CanCallAssumption(Substitute(rhs, e.Obj, new Dictionary<IVariable, Expression>(), constTypeMap));
           }
           return r;
         } else if (expr is SeqSelectExpr) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy
@@ -1,0 +1,14 @@
+// RUN: %testDafnyForEachResolver "%s"
+
+// Regression test: accessing a const with a default value that calls a static
+// function of a generic parent trait caused a Boogie resolution error because
+// the type parameter substitution was missing.
+
+trait T<E> {
+  static ghost function h(): seq<E>
+  ghost const c: seq<E> := h()
+  function f(): int ensures |c| >= 0
+}
+class C<E> extends T<E> {
+  function f(): int ensures |c| >= 0 { 0 }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy
@@ -19,11 +19,11 @@ class C<E> extends T<E> {
   function f(): int ensures |c| >= 0 { 0 }
 }
 
-// No override involved: C declares its own f, which reads the inherited const.
-trait T2<E> {
-  static ghost function h2(): seq<E>
-  ghost const c2: seq<E> := h2()
+// No override involved: the class declares a member of its own that reads the inherited const.
+trait GenericTrait<E> {
+  static ghost function staticCall(): seq<E>
+  ghost const inherited: seq<E> := staticCall()
 }
-class C2<E> extends T2<E> {
-  function f2(): int ensures |c2| >= 0 { 0 }
+class ReadInheritedConst<E> extends GenericTrait<E> {
+  function usesIt(): int ensures |inherited| >= 0 { 0 }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy
@@ -1,8 +1,14 @@
 // RUN: %testDafnyForEachResolver "%s"
 
-// Regression test: accessing a const with a default value that calls a static
-// function of a generic parent trait caused a Boogie resolution error because
-// the type parameter substitution was missing.
+// Regression test: reading a const inherited from a generic trait, whose default value calls a
+// static function of that trait, caused a Boogie resolution error ("undeclared identifier:
+// _module.T$E") because the type parameter substitution was missing.
+//
+// All three ingredients are needed, checked by ablation against the base commit: the trait has to
+// be generic, the const's default value has to contain the call (a bare `const c: seq<E>` does
+// not trigger it), and the function it calls has to be static. Overriding a trait member is not
+// needed -- reading the const from any member of the class is enough, as ReadInheritedConst below
+// shows.
 
 trait T<E> {
   static ghost function h(): seq<E>
@@ -11,4 +17,13 @@ trait T<E> {
 }
 class C<E> extends T<E> {
   function f(): int ensures |c| >= 0 { 0 }
+}
+
+// No override involved: C declares its own f, which reads the inherited const.
+trait T2<E> {
+  static ghost function h2(): seq<E>
+  ghost const c2: seq<E> := h2()
+}
+class C2<E> extends T2<E> {
+  function f2(): int ensures |c2| >= 0 { 0 }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 3 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6398.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 3 verified, 0 errors
+Dafny program verifier finished with 4 verified, 0 errors

--- a/docs/dev/news/6398.fix
+++ b/docs/dev/news/6398.fix
@@ -1,0 +1,1 @@
+No longer crash when a class overrides a function from a generic trait whose `const` default value calls a static function

--- a/docs/dev/news/6398.fix
+++ b/docs/dev/news/6398.fix
@@ -1,1 +1,1 @@
-No longer crash when a class overrides a function from a generic trait whose `const` default value calls a static function
+No longer crash when reading a `const` inherited from a generic trait whose default value calls a static function of that trait


### PR DESCRIPTION
## Summary

Fixes a crash (Boogie resolution error) when a class overrides a function from a generic trait that has a const with a default value calling a static function.

## Root cause

`CanCallAssumption` for `MemberSelectExpr` on a `ConstantField` with RHS called `Substitute(rhs, e.Obj, ..., null)` with a null type map. The const's RHS (`hack()`) references the parent trait's type parameter `E`, which needs substitution with the class's type argument.

## Fix

Pass `e.TypeArgumentSubstitutionsWithParents()` as the type map to `Substitute`.

## Test

`git-issue-6398.dfy` — generic trait with static function const default + overriding class.

Fixes #6398

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>