### PR TITLE
fix: enable reads checks for array allocation expressions

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionWellformed.cs
@@ -1930,7 +1930,7 @@ namespace Microsoft.Dafny {
       var q = new Bpl.ForallExpr(tok, bvs, BplImp(ante, pre));
       var indicesDesc = new IndicesInDomain(forArray ? "array" : "sequence", dims, init);
       builder.Add(AssertAndForget(builder.Context, tok, q, indicesDesc));
-      if (!forArray && options.DoReadsChecks) {
+      if (options.DoReadsChecks) {
         // unwrap renamed local lambdas
         var unwrappedFunc = init;
         while (unwrappedFunc is ConcreteSyntaxExpression { ResolvedExpression: not null } cse) {
@@ -1942,7 +1942,7 @@ namespace Microsoft.Dafny {
         // check read effects
         Type objset = program.SystemModuleManager.ObjectSetType();
         Expression wrap = new BoogieWrapper(
-          FunctionCall(tok, Reads(1), TrType(objset), args),
+          FunctionCall(tok, Reads(dims.Count), TrType(objset), args),
           objset);
         var reads = new FrameExpression(tok, wrap, null);
         Action<IOrigin, Bpl.Expr, ProofObligationDescription, Bpl.QKeyValue> maker = (t, e, d, qk) => {
@@ -1966,7 +1966,7 @@ namespace Microsoft.Dafny {
           Utils.MakeDafnyFrameCheck(contextReads, readsCall, null),
           null
         );
-        var readsDesc = new ReadFrameSubset("invoke the function passed as an argument to the sequence constructor", readsDescExpr);
+        var readsDesc = new ReadFrameSubset($"invoke the function passed as an argument to the {(forArray ? "array initializer" : "sequence constructor")}", readsDescExpr);
         CheckFrameSubset(tok, [reads], null, null,
           etran, etran.ReadsFrame(tok), maker, (ta, qa) => builder.Add(new Bpl.AssumeCmd(ta, qa)), readsDesc, options.AssertKv);
       }

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrAssignment.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrAssignment.cs
@@ -517,7 +517,7 @@ public partial class BoogieGenerator {
         i++;
       }
       if (allocateArray.ElementInit != null) {
-        CheckElementInit(tok, true, allocateArray.ArrayDimensions, allocateArray.ElementType, allocateArray.ElementInit, nw, builder, etran, new WFOptions());
+        CheckElementInit(tok, true, allocateArray.ArrayDimensions, allocateArray.ElementType, allocateArray.ElementInit, nw, builder, etran, new WFOptions(null, etran.readsFrame != null));
       } else if (allocateArray.InitDisplay != null) {
         int ii = 0;
         foreach (var v in allocateArray.InitDisplay) {

--- a/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrAssignment.cs
+++ b/Source/DafnyCore/Verifier/Statements/BoogieGenerator.TrAssignment.cs
@@ -475,22 +475,25 @@ public partial class BoogieGenerator {
       CheckSubrange(tok, nw, allocateClass.Type, rhsTypeConstraint, null, builder);
       return HandleGivenLhs(tok, bGivenLhs, lhsType, builder, stmt, bLhs, nw, allocateClass);
     } else if (rhs is AllocateArray allocateArray) {
+      // Reads checks apply to the allocation's sub-expressions exactly when the enclosing method has an
+      // active reads frame (i.e. under --reads-clauses-on-methods); otherwise etran.readsFrame is null.
+      var arrayWfOptions = new WFOptions(null, etran.readsFrame != null);
       int j = 0;
       foreach (Expression dim in allocateArray.ArrayDimensions) {
-        CheckWellformed(dim, new WFOptions(), locals, builder, etran);
+        CheckWellformed(dim, arrayWfOptions, locals, builder, etran);
         var desc = new NonNegative(allocateArray.ArrayDimensions.Count == 1
           ? "array size" : $"array size (dimension {j})", dim);
         builder.Add(Assert(GetToken(dim), Bpl.Expr.Le(Bpl.Expr.Literal(0), etran.TrExpr(dim)), desc, builder.Context));
         j++;
       }
       if (allocateArray.ElementInit != null) {
-        CheckWellformed(allocateArray.ElementInit, new WFOptions(), locals, builder, etran);
+        CheckWellformed(allocateArray.ElementInit, arrayWfOptions, locals, builder, etran);
       } else if (allocateArray.InitDisplay != null) {
         var dim = allocateArray.ArrayDimensions[0];
         var desc = new ArrayInitSizeValid(allocateArray, dim);
         builder.Add(Assert(GetToken(dim), Bpl.Expr.Eq(etran.TrExpr(dim), Bpl.Expr.Literal(allocateArray.InitDisplay.Count)), desc, builder.Context));
         foreach (var v in allocateArray.InitDisplay) {
-          CheckWellformed(v, new WFOptions(), locals, builder, etran);
+          CheckWellformed(v, arrayWfOptions, locals, builder, etran);
         }
       } else if (options.DefiniteAssignmentLevel == 0) {
         // cool
@@ -517,7 +520,7 @@ public partial class BoogieGenerator {
         i++;
       }
       if (allocateArray.ElementInit != null) {
-        CheckElementInit(tok, true, allocateArray.ArrayDimensions, allocateArray.ElementType, allocateArray.ElementInit, nw, builder, etran, new WFOptions(null, etran.readsFrame != null));
+        CheckElementInit(tok, true, allocateArray.ArrayDimensions, allocateArray.ElementType, allocateArray.ElementInit, nw, builder, etran, arrayWfOptions);
       } else if (allocateArray.InitDisplay != null) {
         int ii = 0;
         foreach (var v in allocateArray.InitDisplay) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy
@@ -1,0 +1,14 @@
+// RUN: %exits-with 4 %verify --reads-clauses-on-methods "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Regression test: array initializer lambdas were not checked for reads
+// clause compliance, unlike seq() constructor lambdas.
+
+class Cell { var data: int }
+
+method Test(c: Cell)
+  reads {}
+{
+  var arr := new int[1](_ reads c => c.data);  // error: insufficient reads
+  var mat := new int[2, 2]((_, _) reads c => c.data);  // error: insufficient reads
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy
@@ -2,13 +2,50 @@
 // RUN: %diff "%s.expect" "%t"
 
 // Regression test: array initializer lambdas were not checked for reads
-// clause compliance, unlike seq() constructor lambdas.
+// clause compliance, unlike seq() constructor lambdas. The same gap applied to
+// the other expressions in an array allocation: the dimension (size)
+// expressions, the initializer expression itself, and explicit-display
+// elements. All of these now respect the method's reads frame.
 
-class Cell { var data: int }
+class Cell { var data: nat }
+
+// A function whose call reads the heap (the returned lambda does not).
+function GetArrow(c: Cell): (int -> int)
+  reads c
+{ (i: int) => 0 }
 
 method Test(c: Cell)
   reads {}
 {
   var arr := new int[1](_ reads c => c.data);  // error: insufficient reads
   var mat := new int[2, 2]((_, _) reads c => c.data);  // error: insufficient reads
+}
+
+// The array dimension (size) expression must respect the reads frame.
+method TestDimension(c: Cell)
+  reads {}
+{
+  var arr := new int[c.data];  // error: insufficient reads
+}
+
+// The initializer expression itself (not just per-index application) must
+// respect the reads frame.
+method TestInitExpr(c: Cell)
+  reads {}
+{
+  var arr := new int[5](GetArrow(c));  // error: insufficient reads
+}
+
+// Explicit-display element expressions must respect the reads frame.
+method TestDisplay(c: Cell)
+  reads {}
+{
+  var arr := new int[1] [c.data];  // error: insufficient reads
+}
+
+// Legitimate use: reading state that is in the method's reads frame verifies.
+method TestOk(c: Cell)
+  reads c
+{
+  var arr := new int[c.data](_ reads c => c.data);
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy.expect
@@ -1,0 +1,4 @@
+git-issue-6410.dfy(12,13): Error: insufficient reads clause to invoke the function passed as an argument to the array initializer
+git-issue-6410.dfy(13,13): Error: insufficient reads clause to invoke the function passed as an argument to the array initializer
+
+Dafny program verifier finished with 0 verified, 2 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6410.dfy.expect
@@ -1,4 +1,7 @@
-git-issue-6410.dfy(12,13): Error: insufficient reads clause to invoke the function passed as an argument to the array initializer
-git-issue-6410.dfy(13,13): Error: insufficient reads clause to invoke the function passed as an argument to the array initializer
+git-issue-6410.dfy(20,13): Error: insufficient reads clause to invoke the function passed as an argument to the array initializer
+git-issue-6410.dfy(21,13): Error: insufficient reads clause to invoke the function passed as an argument to the array initializer
+git-issue-6410.dfy(28,23): Error: insufficient reads clause to read field; Consider adding 'reads c' or 'reads c`data' in the enclosing method specification for resolution
+git-issue-6410.dfy(36,32): Error: insufficient reads clause to invoke function
+git-issue-6410.dfy(43,27): Error: insufficient reads clause to read field; Consider adding 'reads c' or 'reads c`data' in the enclosing method specification for resolution
 
-Dafny program verifier finished with 0 verified, 2 errors
+Dafny program verifier finished with 1 verified, 5 errors

--- a/docs/dev/news/6410.fix
+++ b/docs/dev/news/6410.fix
@@ -1,0 +1,1 @@
+With `--reads-clauses-on-methods`, reads-clause compliance is now checked for array initializer lambdas, matching the behaviour for `seq()` constructor lambdas

--- a/docs/dev/news/6410.fix
+++ b/docs/dev/news/6410.fix
@@ -1,1 +1,1 @@
-With `--reads-clauses-on-methods`, reads-clause compliance is now checked for array initializer lambdas, matching the behaviour for `seq()` constructor lambdas
+With `--reads-clauses-on-methods`, reads-clause compliance is now checked for array initializer expressions (the dimensions, the initializer function, and explicit-display elements), matching the behaviour for `seq()` constructors


### PR DESCRIPTION
### What was changed?

Enable reads-clause checks for array allocation expressions when using `--reads-clauses-on-methods`. Previously, only `seq()` constructor lambdas were checked; the corresponding array expressions silently bypassed the method's reads frame. This PR closes the asymmetry for all of them:

- the **initializer lambda**, checked per index (`new int[n](i => ...)`, including multi-dimensional);
- the **array dimension/size** expressions (`new int[Get(c)]`);
- the **initializer expression itself** (`new int[n](GetArrow(c))`), distinct from invoking the resulting function per index;
- explicit-**display** elements (`new int[1] [c.data]`).

Changes in the verifier:

1. In `CheckElementInit`, remove the `!forArray` gate from the reads check and change `Reads(1)` to `Reads(dims.Count)` (needed for multi-dimensional arrays); interpolate the error-message descriptor as 'array initializer' vs 'sequence constructor'.

2. In `TrAssignmentRhs`'s `AllocateArray` branch, well-formedness-check the dimension, initializer, and display sub-expressions with `WFOptions(null, etran.readsFrame != null)` instead of a fresh `WFOptions()` (which had reads checks off). The options are hoisted into a single local that all four call sites (the three sub-expression checks plus `CheckElementInit`) share. Gating on `etran.readsFrame != null` enables the check exactly when the method has an active reads frame (i.e. under `--reads-clauses-on-methods`), matching the `seq()`/plain-read behaviour and avoiding spurious checks otherwise.

### How has this been tested?

`git-issue-6410.dfy` exercises, under `--reads-clauses-on-methods`, a lambda initializer (1D and 2D), a dimension expression, an initializer expression, and a display element — each reading state outside the method's reads frame and each producing the expected 'insufficient reads clause' error — plus a legitimate in-frame allocation that still verifies. Each case was confirmed to be a genuine regression test by checking that it is silently accepted without the fix and rejected with it.

### Base branch

Based on #6473, which first stabilizes the `Base64.EncodeRecursively` proof. The additional Boogie assertions introduced by this verifier change destabilize that proof on macOS CI, so the stabilization is landed as a preparatory PR.

### Related

- #6414 by @shinlee03 addresses the same issue (#6410). This PR takes the verifier-based approach that @RustanLeino's review on #6414 recommended. #6414 has been inactive since December 2025.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
