### PR TITLE
fix: make format --stdin actually format the input

### DIFF
--- a/Source/DafnyDriver/Commands/FormatCommand.cs
+++ b/Source/DafnyDriver/Commands/FormatCommand.cs
@@ -91,7 +91,9 @@ Use '--print' to output the content of the formatted files instead of overwritin
       string tempFileName = null;
       if (dafnyFile.Uri.Scheme == "stdin") {
         tempFileName = Path.GetTempFileName() + ".dfy";
-        SynchronousCliCompilation.WriteFile(tempFileName, await Console.In.ReadToEndAsync());
+        var stdinContent = dafnyFile.GetContent();
+        var stdinText = await stdinContent.Reader.ReadToEndAsync();
+        SynchronousCliCompilation.WriteFile(tempFileName, stdinText);
         dafnyFile = DafnyFile.HandleDafnyFile(OnDiskFileSystem.Instance, new ConsoleErrorReporter(options), options, new Uri(tempFileName), Token.NoToken);
       }
 
@@ -106,11 +108,11 @@ Use '--print' to output the content of the formatted files instead of overwritin
         await errorWriter.WriteLineAsync(err);
         failedToParseFiles.Add(dafnyFile.BaseName);
       } else {
-        var firstToken = dafnyProgram.GetFirstTokenForUri(file.Uri);
+        var firstToken = dafnyProgram.GetFirstTokenForUri(dafnyFile.Uri);
         var result = originalText;
         if (firstToken != null) {
           result = Formatting.__default.ReindentProgramFromFirstToken(firstToken,
-            IndentationFormatter.ForProgram(dafnyProgram, file.Uri));
+            IndentationFormatter.ForProgram(dafnyProgram, dafnyFile.Uri));
           if (result != originalText) {
             neededFormatting += 1;
             if (doCheck) {

--- a/Source/DafnyDriver/Commands/FormatCommand.cs
+++ b/Source/DafnyDriver/Commands/FormatCommand.cs
@@ -90,7 +90,9 @@ Use '--print' to output the content of the formatted files instead of overwritin
 
       string tempFileName = null;
       if (dafnyFile.Uri.Scheme == "stdin") {
-        tempFileName = Path.GetTempFileName() + ".dfy";
+        // Not Path.GetTempFileName(): that creates a 0-byte file, and appending ".dfy" yields a
+        // different path, so the created file is orphaned and never cleaned up below.
+        tempFileName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".dfy");
         var stdinContent = dafnyFile.GetContent();
         var stdinText = await stdinContent.Reader.ReadToEndAsync();
         SynchronousCliCompilation.WriteFile(tempFileName, stdinText);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6435.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6435.dfy
@@ -1,0 +1,13 @@
+// RUN: %exits-with 5 %stdin "function f(): int\n{\n0\n}" %baredafny format --check --stdin
+// RUN: %exits-with 0 %stdin "function f(): int {\n  0\n}" %baredafny format --check --stdin
+
+// Also verify --print produces the correctly formatted output.
+// RUN: %exits-with 0 %stdin "function f(): int\n{\n0\n}\n" %baredafny format --print --stdin > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Regression test: format --stdin always reported the input as already
+// formatted. After reading stdin, the input is parsed from a temp file, but
+// the formatter looked up the program by the original stdin URI: both
+// GetFirstTokenForUri and IndentationFormatter.ForProgram were passed the
+// stdin URI instead of the temp file URI, so no first token was found and
+// formatting was skipped. The fix passes the temp file URI to both.

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6435.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6435.dfy.expect
@@ -1,0 +1,4 @@
+function f(): int
+{
+  0
+}

--- a/docs/dev/news/6435.fix
+++ b/docs/dev/news/6435.fix
@@ -1,0 +1,1 @@
+`dafny format --stdin` now reformats input instead of always reporting it as correctly formatted


### PR DESCRIPTION
## Summary

Fixes `dafny format --stdin`, which always reported the input as correctly formatted (or empty) regardless of its content, in both `--check` and `--print` modes.

## Root cause

After reading stdin into a temp file and re-parsing, `FormatCommand.cs` looked up the parsed program by the original stdin URI (`stdin:///`) rather than the temp-file URI under which the tokens were actually parsed:

- `GetFirstTokenForUri(file.Uri)` was passed the stdin URI, so it found no first token — and formatting is skipped entirely when there is no first token, which is why the input was always reported as already formatted.
- `IndentationFormatter.ForProgram(dafnyProgram, file.Uri)` was likewise passed the stdin URI.

## Fix

- Pass `dafnyFile.Uri` (the temp-file URI) to both `GetFirstTokenForUri` and `IndentationFormatter.ForProgram`. This is the load-bearing fix.
- Also read the stdin content via `dafnyFile.GetContent()` instead of `Console.In` directly. This is **not** required to fix the bug — in the CLI, `options.Input` is `Console.In`, and nothing consumes it before the format loop — but it reads from the same content abstraction the rest of the method uses, is robust to embeddings where `options.Input` differs from `Console.In`, and makes the in-process integration-test harness work.

## Test

`git-issue-6435.dfy` covers both modes (verified to fail on the pre-fix binary and pass after):

- `%exits-with 5 … format --check --stdin` on badly-formatted input (needs formatting).
- `%exits-with 0 … format --check --stdin` on already-formatted input.
- `%exits-with 0 … format --print --stdin` on badly-formatted input, with `%diff` against `.expect` to verify the reformatted output.

Fixes #6435

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
