### PR TITLE
fix: handle missing definite assignment tracker in assigned()

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -755,7 +755,9 @@ namespace Microsoft.Dafny {
             if (name == null) {
               return Expr.True;
             }
-            BoogieGenerator.DefiniteAssignmentTrackers.TryGetValue(name, out var defass);
+            if (!BoogieGenerator.DefiniteAssignmentTrackers.TryGetValue(name, out var defass)) {
+              return Expr.True;
+            }
             return defass;
           default:
             Contract.Assert(false); throw new Cce.UnreachableException();  // unexpected unary expression

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy
@@ -1,0 +1,10 @@
+// RUN: %verify --relax-definite-assignment "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Regression test: assigned() crashed with --relax-definite-assignment
+// because the definite assignment tracker was not set up.
+
+method M() {
+  var x := 3;
+  assert assigned(x);
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy
@@ -1,10 +1,36 @@
-// RUN: %verify --relax-definite-assignment "%s" > "%t"
+// RUN: %verify "%s" > "%t"
+// RUN: %verify --relax-definite-assignment "%s" >> "%t"
 // RUN: %diff "%s.expect" "%t"
 
-// Regression test: assigned() crashed with --relax-definite-assignment
-// because the definite assignment tracker was not set up.
+// Regression test: assigned() crashed whenever the variable had no definite-assignment
+// tracker. That is not specific to --relax-definite-assignment: NeedsDefiniteAssignmentTracker
+// declines to create one for an auto-initializable local at every level, and in-parameters are
+// never in the table at all, so the default configuration crashed too. Both are run here.
 
-method M() {
+method LocalWithInitializer() {
   var x := 3;
   assert assigned(x);
+}
+
+method LocalWithoutInitializer() {
+  var x: int;
+  x := 3;
+  assert assigned(x);
+}
+
+method InParameter(a: int) {
+  assert assigned(a);
+}
+
+method OutParameter() returns (y: int) {
+  y := 1;
+  assert assigned(y);
+}
+
+class C {
+  var f: int
+  constructor () {
+    f := 3;
+    assert assigned(f);
+  }
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6063.dfy.expect
@@ -1,2 +1,4 @@
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 5 verified, 0 errors
+
+Dafny program verifier finished with 5 verified, 0 errors

--- a/docs/dev/news/6063.fix
+++ b/docs/dev/news/6063.fix
@@ -1,0 +1,1 @@
+No longer crash when using `assigned()` with `--relax-definite-assignment`


### PR DESCRIPTION
## Summary

Fixes a crash when using `assigned()`. Not specific to `--relax-definite-assignment`: it reproduces at default options.

## Root cause

`TrExpr` for `assigned(x)` looked up the tracker via `DefiniteAssignmentTrackers.TryGetValue` and returned the out-value without checking the bool. The resulting null Boogie expression caused a `NullReferenceException` in `TrSplitExpr` when accessing `e.tok`.

A tracker is missing far more often than under `--relax-definite-assignment` alone: `NeedsDefiniteAssignmentTracker` declines to create one for an auto-initializable local at *every* level, and in-parameters are never entered in the table at any level. So the default configuration crashed too — including on this PR's original test program, `var x := 3; assert assigned(x);`, which needs no flags to fail.

## Fix

Return `Expr.True` when the tracker is not found. Absence of a tracker means the variable is known to be assigned — either because its type is auto-initializable or because it is an in-parameter — so `true` is the right answer, independent of the flag.

## Test

`git-issue-6063.dfy` runs **both** the default configuration and `--relax-definite-assignment`, over five shapes: a local with and without an initializer, an in-parameter, an out-parameter, and a field in a constructor. Each crashes on the base commit with no flags (9 exceptions) and verifies here. The previous RUN line used `--relax-definite-assignment` only, so CI never exercised the fixed line at default options.

Fixes #6063

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
