### PR TITLE
fix: accumulate verification resource counts in long to avoid overflow

### DIFF
--- a/Source/DafnyDriver.Test/ResourceCountOverflowTest.cs
+++ b/Source/DafnyDriver.Test/ResourceCountOverflowTest.cs
@@ -57,4 +57,23 @@ public class ResourceCountOverflowTest {
 
     Assert.Contains($"Total resources used is {ExpectedTotal}", writer.ToString());
   }
+
+  /// <summary>
+  /// measure-complexity keeps its own accumulator. Its --worst-amount option is private, but it
+  /// defaults to 10, which is more than the three runs here, so the summary is reachable anyway.
+  /// </summary>
+  [Fact]
+  public async Task MeasureComplexityReportsTotalWiderThanInt() {
+    var writer = new StringWriter();
+    var options = DafnyOptions.CreateUsingOldParser(writer);
+    var compilation = CliCompilation.Create(options);
+
+    var results = new Subject<CanVerifyResult>();
+    var summary = MeasureComplexityCommand.ReportResourceSummary(compilation, results);
+    results.OnNext(new CanVerifyResult(null, ScopeWithThreeExpensiveRuns().Results));
+    results.OnCompleted();
+    await summary;
+
+    Assert.Contains($"The total consumed resources are {ExpectedTotal}", writer.ToString());
+  }
 }

--- a/Source/DafnyDriver.Test/ResourceCountOverflowTest.cs
+++ b/Source/DafnyDriver.Test/ResourceCountOverflowTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive.Subjects;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using DafnyDriver.Commands;
 using Microsoft.Boogie;
@@ -51,7 +52,7 @@ public class ResourceCountOverflowTest {
 
     var results = new Subject<CanVerifyResult>();
     var summary = VerifyCommand.ReportVerificationSummary(compilation, results);
-    results.OnNext(new CanVerifyResult(null, ScopeWithThreeExpensiveRuns().Results));
+    results.OnNext(new CanVerifyResult(null!, ScopeWithThreeExpensiveRuns().Results));
     results.OnCompleted();
     await summary;
 
@@ -70,10 +71,30 @@ public class ResourceCountOverflowTest {
 
     var results = new Subject<CanVerifyResult>();
     var summary = MeasureComplexityCommand.ReportResourceSummary(compilation, results);
-    results.OnNext(new CanVerifyResult(null, ScopeWithThreeExpensiveRuns().Results));
+    results.OnNext(new CanVerifyResult(null!, ScopeWithThreeExpensiveRuns().Results));
     results.OnCompleted();
     await summary;
 
     Assert.Contains($"The total consumed resources are {ExpectedTotal}", writer.ToString());
+  }
+
+  /// <summary>
+  /// The JSON logger sums independently of the text logger, and its value is consumed by tools
+  /// rather than read by a person, so a wrapped negative number here is the least likely to be
+  /// noticed. Lit tests cannot cover it: logger .expect files scrub resource counts with wildcards.
+  /// </summary>
+  [Fact]
+  public async Task JsonLoggerRoundTripsTotalWiderThanInt() {
+    var logFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".json");
+    var options = DafnyOptions.CreateUsingOldParser(new StringWriter());
+    var logger = new JsonVerificationLogger(new ProofDependencyManager(),
+      new HumanReadableOutputWriter(options));
+    logger.Initialize(new Dictionary<string, string> { ["LogFileName"] = logFile });
+    logger.LogScopeResults(ScopeWithThreeExpensiveRuns());
+    await logger.Flush();
+
+    var scopes = JsonNode.Parse(await File.ReadAllTextAsync(logFile))!["verificationResults"]!.AsArray();
+    File.Delete(logFile);
+    Assert.Equal(ExpectedTotal, scopes[0]!["resourceCount"]!.GetValue<long>());
   }
 }

--- a/Source/DafnyDriver.Test/ResourceCountOverflowTest.cs
+++ b/Source/DafnyDriver.Test/ResourceCountOverflowTest.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using DafnyDriver.Commands;
+using Microsoft.Boogie;
+using Microsoft.Dafny;
+using VC;
+using Xunit;
+
+namespace DafnyDriver.Test;
+
+/// <summary>
+/// Each verification run reports its resource count as an int, but a scope sums them, and a
+/// program sums the scopes. Three expensive assertion batches are enough to pass int.MaxValue,
+/// at which point the sum silently wrapped negative (https://github.com/dafny-lang/dafny/issues/6281).
+/// </summary>
+public class ResourceCountOverflowTest {
+
+  private const int PerRunResourceCount = 800_000_000;
+  private const long ExpectedTotal = 3L * PerRunResourceCount; // 2_400_000_000 > int.MaxValue
+
+  private static VerificationScopeResult ScopeWithThreeExpensiveRuns() {
+    var results = Enumerable.Range(0, 3).Select(vcNum =>
+      new VerificationTaskResult(null,
+        new VerificationRunResult(vcNum, 0, System.DateTime.UnixEpoch, SolverOutcome.Valid,
+          System.TimeSpan.Zero, 0, null!, new List<AssertCmd>(), new List<TrackedNodeComponent>(),
+          PerRunResourceCount, null, new List<Microsoft.Boogie.Declaration>()))).ToList();
+    return new VerificationScopeResult(new VerificationScope("MyMethod", Microsoft.Boogie.Token.NoToken), results);
+  }
+
+  [Fact]
+  public void TextLoggerReportsTotalWiderThanInt() {
+    var writer = new StringWriter();
+    TextVerificationLogger.LogResults(new ProofDependencyManager(), writer, ScopeWithThreeExpensiveRuns());
+    Assert.Contains($"Overall resource count: {ExpectedTotal}", writer.ToString());
+  }
+
+  /// <summary>
+  /// --performance-stats accumulates into a separate field, which wrapped silently rather than
+  /// throwing, so this is the only mode where the defect produced a plausible-looking negative
+  /// number instead of a crash.
+  /// </summary>
+  [Fact]
+  public async Task PerformanceStatisticsReportTotalWiderThanInt() {
+    var writer = new StringWriter();
+    var options = DafnyOptions.CreateUsingOldParser(writer);
+    options.Set(VerifyCommand.PerformanceStatisticsOption, 1);
+    var compilation = CliCompilation.Create(options);
+
+    var results = new Subject<CanVerifyResult>();
+    var summary = VerifyCommand.ReportVerificationSummary(compilation, results);
+    results.OnNext(new CanVerifyResult(null, ScopeWithThreeExpensiveRuns().Results));
+    results.OnCompleted();
+    await summary;
+
+    Assert.Contains($"Total resources used is {ExpectedTotal}", writer.ToString());
+  }
+}

--- a/Source/DafnyDriver/AssemblyInfo.cs
+++ b/Source/DafnyDriver/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+// MeasureComplexityCommand is internal, so its resource-count accumulator is otherwise unreachable
+// from a test. This project sets GenerateAssemblyInfo=false, so the attribute has to be written out
+// rather than declared as an MSBuild InternalsVisibleTo item, which would be silently ignored.
+[assembly: InternalsVisibleTo("DafnyDriver.Test")]

--- a/Source/DafnyDriver/CliCompilation.cs
+++ b/Source/DafnyDriver/CliCompilation.cs
@@ -389,6 +389,6 @@ record VerificationStatistics {
   public int OutOfResourceCount;
   public int OutOfMemoryCount;
   public int SolverExceptionCount;
-  public int TotalResourcesUsed;
+  public long TotalResourcesUsed;
   public int MaxVcResourcesUsed;
 }

--- a/Source/DafnyDriver/Commands/MeasureComplexityCommand.cs
+++ b/Source/DafnyDriver/Commands/MeasureComplexityCommand.cs
@@ -91,7 +91,7 @@ static class MeasureComplexityCommand {
 
     PriorityQueue<VerificationTaskResult, int> worstPerformers = new();
 
-    var totalResources = 0;
+    long totalResources = 0;
     var worstAmount = cliCompilation.Options.Get(TopX);
     verificationResults.Subscribe(result => {
       foreach (var taskResult in result.Results) {

--- a/Source/DafnyDriver/Commands/VerifyCommand.cs
+++ b/Source/DafnyDriver/Commands/VerifyCommand.cs
@@ -129,7 +129,7 @@ public static class VerifyCommand {
     await WriteTrailer(cliCompilation, statistics);
     var performanceStatisticsDivisor = cliCompilation.Options.Get(PerformanceStatisticsOption);
     if (performanceStatisticsDivisor != 0) {
-      int Round(int number) {
+      long Round(long number) {
         var numberForUpRounding = number + performanceStatisticsDivisor / 2;
         return (numberForUpRounding / performanceStatisticsDivisor) * performanceStatisticsDivisor;
       }

--- a/Source/DafnyDriver/JsonVerificationLogger.cs
+++ b/Source/DafnyDriver/JsonVerificationLogger.cs
@@ -89,7 +89,7 @@ public class JsonVerificationLogger : IVerificationResultFormatLogger {
       ["name"] = scope.Name,
       ["outcome"] = SerializeOutcome(results.Aggregate(VcOutcome.Correct, (o, r) => MergeOutcomes(o, r.Result.Outcome))),
       ["runTime"] = SerializeTimeSpan(TimeSpan.FromSeconds(results.Sum(r => r.Result.RunTime.Seconds))),
-      ["resourceCount"] = results.Sum(r => r.Result.ResourceCount),
+      ["resourceCount"] = results.Sum(r => (long)r.Result.ResourceCount),
       ["vcResults"] = new JsonArray(results.Select(r => SerializeVcResult(dependencyManager, potentialDependencies, r)).ToArray())
     };
     if (potentialDependencies is not null) {

--- a/Source/DafnyDriver/TextVerificationLogger.cs
+++ b/Source/DafnyDriver/TextVerificationLogger.cs
@@ -35,7 +35,7 @@ public class TextVerificationLogger : IVerificationResultFormatLogger {
     textWriter.WriteLine($"Results for {verificationScope.Name}");
     textWriter.WriteLine($"  Overall outcome: {outcome}");
     textWriter.WriteLine($"  Overall time: {runtime}");
-    textWriter.WriteLine($"  Overall resource count: {results.Sum(r => r.ResourceCount)}");
+    textWriter.WriteLine($"  Overall resource count: {results.Sum(r => (long)r.ResourceCount)}");
     // It doesn't seem possible to get a result with zero VCResults, but being careful with nulls just in case :)
     var maximumTime = results.MaxBy(r => r.RunTime).RunTime.ToString() ?? "N/A";
     var maximumResourceCount = results.MaxBy(r => r.ResourceCount).ResourceCount.ToString() ?? "N/A";

--- a/Source/DafnyLanguageServer/Workspace/GutterIconAndHoverVerificationDetailsManager.cs
+++ b/Source/DafnyLanguageServer/Workspace/GutterIconAndHoverVerificationDetailsManager.cs
@@ -246,7 +246,7 @@ Send notifications about the verification status of each line in the program.
   /// Called when the verifier finished to visit an implementation
   /// </summary>
   public void ReportEndVerifyImplementation(IdeState state, Implementation implementation,
-    int implementationResourceCount,
+    long implementationResourceCount,
     VcOutcome implementationOutcome) {
 
     var uri = ((IOrigin)implementation.tok).Uri;

--- a/Source/DafnyLanguageServer/Workspace/IdeState.cs
+++ b/Source/DafnyLanguageServer/Workspace/IdeState.cs
@@ -525,7 +525,7 @@ public record IdeState(
           new AssertionBatchResult(boogieUpdate.VerificationTask.Split.Implementation, result));
       }
 
-      var resourceCount = results.Sum(e => e.ResourceCount);
+      var resourceCount = results.Sum(e => (long)e.ResourceCount);
       var outcome = results.Select(e => Compilation.GetOutcome(e.Outcome)).Max();
       gutterIconManager.ReportEndVerifyImplementation(this, boogieUpdate.VerificationTask.Split.Implementation, resourceCount, outcome);
     }

--- a/docs/dev/news/6281.fix
+++ b/docs/dev/news/6281.fix
@@ -1,1 +1,1 @@
-`--log-format text` no longer throws `OverflowException` on programs with very large resource counts
+Verification resource counts no longer overflow (throwing an `OverflowException`, or reporting a wrong and possibly negative total) when a program's total resource use exceeds about 2.1 billion

--- a/docs/dev/news/6281.fix
+++ b/docs/dev/news/6281.fix
@@ -1,0 +1,1 @@
+`--log-format text` no longer throws `OverflowException` on programs with very large resource counts


### PR DESCRIPTION
## Summary

Fixes resource-count overflow when a program's total resource usage exceeds `Int32.MaxValue` (~2.1 billion RU). The reported symptom (#6281) was an `OverflowException` from `--log-format text`, but the same per-VC-`int` sum is aggregated in several other places; some of those throw, and some silently wrap to a wrong (possibly negative) total.

## Root cause

A per-VC resource count is an `int`. A program has many VCs and Z3 resource counts per VC are routinely in the hundreds of millions, so any roll-up across a whole scope/run can exceed `int.MaxValue`. Two failure modes:

- `Enumerable.Sum` over `IEnumerable<int>` accumulates in a *checked* `int` and throws `OverflowException` (the reported crash).
- `int += …` and `Interlocked.Add(ref int, …)` accumulate *unchecked* and silently wrap.

## Fix

Accumulate every cross-VC resource-count roll-up in `long`:

- `TextVerificationLogger.cs`, `JsonVerificationLogger.cs` — cast to `long` before `Sum` (text/JSON log output).
- `IdeState.cs` — sum as `long` (LSP gutter icons).
- `GutterIconAndHoverVerificationDetailsManager.cs` — widen `ReportEndVerifyImplementation`'s `implementationResourceCount` parameter from `int` to `long`. The tree node's `ResourceCount` field is already `long`, so this preserves full fidelity instead of capping at `int.MaxValue`.
- `VerificationStatistics.TotalResourcesUsed` (`CliCompilation.cs`) + `VerifyCommand.cs` — widen the field to `long` (`--performance-stats` "Total resources used"); this also makes the `Interlocked.Add` bind the `long` overload, fixing the silent wrap. `Round` is widened to match. `MaxVcResourcesUsed` stays `int` — it is a per-VC `Math.Max`, never a sum.
- `MeasureComplexityCommand.cs` — accumulate "total consumed resources" in `long`.

## Scope note

A single implementation's count is still capped upstream: Boogie sums per-split counts into an `int` (`SplitAndVerifyWorker.totalResourceCount`) before Dafny sees the value. Fixing that requires a change in the Boogie repository and is out of scope here; this PR makes every Dafny-side aggregation correct.

## Test

This manifests only at very large resource counts (>2.1B RU), so the counts are synthesized rather than provoked. `Source/DafnyDriver.Test/ResourceCountOverflowTest.cs` builds three `VerificationRunResult`s of 800,000,000 RU each (2.4e9 total, past `int.MaxValue`) and drives two public entry points:

- `TextVerificationLogger.LogResults` — the exact method in the #6281 stack trace; throws `OverflowException` without the `(long)` cast;
- `VerifyCommand.ReportVerificationSummary` with `--performance-stats` — prints `-1894967296` with an `int` accumulator. This is the only mode where the defect yielded a plausible-looking negative number instead of a crash, so it is the one worth pinning.

A lit test cannot cover this: logger `.expect` files scrub resource counts with wildcards precisely because the values are nondeterministic.

`MeasureComplexityCommand.ReportResourceSummary` is covered too, via the same seam: it is public, and `--worst-amount` needs no setting because its default of 10 exceeds the three synthetic runs. Reverting its accumulator to `int` makes the test print `-1894967296`, so both silent-wrap sites are now pinned rather than argued. The class is internal, so this needs `InternalsVisibleTo` — written as an explicit attribute, because `DafnyDriver` sets `GenerateAssemblyInfo=false` and the MSBuild `<InternalsVisibleTo>` item used by `DafnyRuntime` is silently ignored there.

Only the LSP gutter-icon path remains covered by inspection; it needs a full `IdeState` harness.

Fixes #6281

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>


