### PR TITLE
fix: prevent matching-loop rewrite from extracting inner-binder-bound variables

### DIFF
--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -77,26 +77,49 @@ class SplitPartTriggerWriter {
     //    assert forall i :: 0 <= i < a.Length-1 ==> a[i] <= a[i+1];
     // after:
     //    assert forall i,j :: j == i+1 ==> 0 <= i < a.Length-1 ==> a[i] <= a[j];
-    // Collect variables bound by match cases inside the quantifier body.
-    // that should not be extracted into the quantifier range.
+    // Collect variables bound by a binder inside the quantifier body. Such variables must not be
+    // extracted into the quantifier range: the binder's body is desugared/scoped during Boogie generation
+    // (e.g. a match-case variable is replaced by a destructor, a let/comprehension variable is scoped to
+    // its own construct), so an extracted range constraint that mentions the variable would reference an
+    // undeclared identifier in Boogie. This applies to every binder form, not just match, and to binders
+    // appearing in either the quantifier's range or its term (looping subexpressions are gathered from both).
     var innerBoundVars = new HashSet<IVariable>();
-    Comprehension.Term.Visit(node => {
-      var e = node as Expression; if (e == null) return true;
-      if (e is MatchExpr me) {
-        foreach (var mc in me.Cases) {
-          foreach (var arg in mc.Arguments) {
-            innerBoundVars.Add(arg);
-          }
+    void CollectInnerBoundVars(Expression start) {
+      start.Visit(node => {
+        switch (node) {
+          case MatchExpr me:
+            foreach (var mc in me.Cases) {
+              foreach (var arg in mc.Arguments) {
+                innerBoundVars.Add(arg);
+              }
+            }
+            break;
+          case NestedMatchExpr nme:
+            foreach (var mc in nme.Cases) {
+              foreach (var bv in mc.Pat.DescendantsAndSelf.OfType<IdPattern>().Where(p => p.BoundVar != null)) {
+                innerBoundVars.Add(bv.BoundVar);
+              }
+            }
+            break;
+          case LetExpr le:
+            foreach (var bv in le.BoundVars) {
+              innerBoundVars.Add(bv);
+            }
+            break;
+          case ComprehensionExpr ce:
+            // set/map/seq comprehensions, lambdas, and nested quantifiers
+            foreach (var bv in ce.BoundVars) {
+              innerBoundVars.Add(bv);
+            }
+            break;
         }
-      } else if (e is NestedMatchExpr nme) {
-        foreach (var mc in nme.Cases) {
-          foreach (var bv in mc.Pat.DescendantsAndSelf.OfType<IdPattern>().Where(p => p.BoundVar != null)) {
-            innerBoundVars.Add(bv.BoundVar);
-          }
-        }
-      }
-      return true;
-    });
+        return true;
+      });
+    }
+    if (Comprehension.Range != null) {
+      CollectInnerBoundVars(Comprehension.Range);
+    }
+    CollectInnerBoundVars(Comprehension.Term);
 
     var substMap = new List<Tuple<Expression, IdentifierExpr>>();
     foreach (var triggerMatch in loopingMatches) {
@@ -104,12 +127,13 @@ class SplitPartTriggerWriter {
       if (triggersCollector.IsPotentialTriggerCandidate(e) && triggersCollector.IsTriggerKiller(e)) {
         foreach (var sub in e.SubExpressions) {
           if (triggersCollector.IsTriggerKiller(sub) && (!triggersCollector.IsPotentialTriggerCandidate(sub))) {
-            // Don't extract subexpressions that reference match-bound variables.
-            // These get substituted away by DesugarMatchExpr during Boogie
-            // generation, but the extracted range constraint would still
-            // reference the original variable, causing undeclared identifiers.
-            if (sub.DescendantsAndSelf.OfType<IdentifierExpr>().Any(
-                  ie => ie.Var != null && innerBoundVars.Contains(ie.Var))) {
+            // Don't extract subexpressions that have a free reference to a variable bound by a binder
+            // inside the body (match cases, let/such-that, comprehensions, lambdas). These get
+            // substituted/scoped away during Boogie generation, but the extracted range constraint
+            // would still reference the original variable, causing undeclared identifiers. We test
+            // the *free* variables of the subexpression so that a self-contained binder (e.g. a whole
+            // lambda whose parameter never escapes) remains extractable.
+            if (FreeVariablesUtil.ComputeFreeVariables(reporter.Options, sub).Any(innerBoundVars.Contains)) {
               continue;
             }
             var entry = substMap.Find(x => ExprExtensions.ExpressionEq(sub, x.Item1));

--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -77,12 +77,41 @@ class SplitPartTriggerWriter {
     //    assert forall i :: 0 <= i < a.Length-1 ==> a[i] <= a[i+1];
     // after:
     //    assert forall i,j :: j == i+1 ==> 0 <= i < a.Length-1 ==> a[i] <= a[j];
+    // Collect variables bound by match cases inside the quantifier body.
+    // that should not be extracted into the quantifier range.
+    var innerBoundVars = new HashSet<IVariable>();
+    Comprehension.Term.Visit(node => {
+      var e = node as Expression; if (e == null) return true;
+      if (e is MatchExpr me) {
+        foreach (var mc in me.Cases) {
+          foreach (var arg in mc.Arguments) {
+            innerBoundVars.Add(arg);
+          }
+        }
+      } else if (e is NestedMatchExpr nme) {
+        foreach (var mc in nme.Cases) {
+          foreach (var bv in mc.Pat.DescendantsAndSelf.OfType<IdPattern>().Where(p => p.BoundVar != null)) {
+            innerBoundVars.Add(bv.BoundVar);
+          }
+        }
+      }
+      return true;
+    });
+
     var substMap = new List<Tuple<Expression, IdentifierExpr>>();
     foreach (var triggerMatch in loopingMatches) {
       var e = triggerMatch.OriginalExpr;
       if (triggersCollector.IsPotentialTriggerCandidate(e) && triggersCollector.IsTriggerKiller(e)) {
         foreach (var sub in e.SubExpressions) {
           if (triggersCollector.IsTriggerKiller(sub) && (!triggersCollector.IsPotentialTriggerCandidate(sub))) {
+            // Don't extract subexpressions that reference match-bound variables.
+            // These get substituted away by DesugarMatchExpr during Boogie
+            // generation, but the extracted range constraint would still
+            // reference the original variable, causing undeclared identifiers.
+            if (sub.DescendantsAndSelf.OfType<IdentifierExpr>().Any(
+                  ie => ie.Var != null && innerBoundVars.Contains(ie.Var))) {
+              continue;
+            }
             var entry = substMap.Find(x => ExprExtensions.ExpressionEq(sub, x.Item1));
             if (entry == null) {
               var newBv = new BoundVar(sub.Origin, "_t#" + substMap.Count, sub.Type);

--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -77,18 +77,13 @@ class SplitPartTriggerWriter {
     //    assert forall i :: 0 <= i < a.Length-1 ==> a[i] <= a[i+1];
     // after:
     //    assert forall i,j :: j == i+1 ==> 0 <= i < a.Length-1 ==> a[i] <= a[j];
-    // Collect variables bound by a binder inside the quantifier body whose binding does not survive
-    // into Boogie as an enclosing quantifier. Such variables must not be extracted into the quantifier
-    // range: the matching-loop rewrite conjoins the extracted equality (and its fresh bound variable)
-    // onto the nearest enclosing forall/exists (see ExprSubstituter), but a match-case, let/such-that,
-    // comprehension, or lambda variable is desugared/scoped away during Boogie generation, so the
-    // equality would reference an undeclared identifier there.
-    //
-    // Nested forall/exists bound variables are deliberately NOT collected: ExprSubstituter re-homes the
-    // equality onto the innermost enclosing quantifier, where such a variable is still in scope as a
-    // genuine Boogie quantifier binder, so extracting through them is sound (and beneficial).
-    //
-    // Binders are scanned in both the range and the term, since looping subexpressions are gathered from both.
+    // The rewrite below homes each extracted "_t == subexpr" equality on the nearest enclosing
+    // forall/exists (see ExprSubstituter). So if "subexpr" mentions a variable bound *inside* the body by
+    // a binder that doesn't survive Boogie generation as that enclosing quantifier, the equality references
+    // it out of scope -> "undeclared identifier". Collect those variables: match-case, let/such-that,
+    // set/map-comprehension, and lambda bindings (which become destructors, let-scopes, or separate Boogie
+    // constructs). Nested forall/exists vars are NOT collected -- they stay in scope at the home quantifier,
+    // so extracting through them is sound and beneficial. Scan both range and term, as either may loop.
     var innerBoundVars = new HashSet<IVariable>();
     void CollectInnerBoundVars(Expression start) {
       start.Visit(node => {
@@ -112,8 +107,7 @@ class SplitPartTriggerWriter {
               innerBoundVars.Add(bv);
             }
             break;
-          case ComprehensionExpr ce when ce is not QuantifierExpr:
-            // set/map comprehensions and lambdas (but not forall/exists)
+          case ComprehensionExpr ce when ce is not QuantifierExpr: // set/map comprehensions and lambdas
             foreach (var bv in ce.BoundVars) {
               innerBoundVars.Add(bv);
             }
@@ -133,12 +127,9 @@ class SplitPartTriggerWriter {
       if (triggersCollector.IsPotentialTriggerCandidate(e) && triggersCollector.IsTriggerKiller(e)) {
         foreach (var sub in e.SubExpressions) {
           if (triggersCollector.IsTriggerKiller(sub) && (!triggersCollector.IsPotentialTriggerCandidate(sub))) {
-            // Don't extract subexpressions that have a free reference to a variable bound by a binder
-            // inside the body (match cases, let/such-that, comprehensions, lambdas). These get
-            // substituted/scoped away during Boogie generation, but the extracted range constraint
-            // would still reference the original variable, causing undeclared identifiers. We test
-            // the *free* variables of the subexpression so that a self-contained binder (e.g. a whole
-            // lambda whose parameter never escapes) remains extractable.
+            // Skip subexpressions that would dangle (see innerBoundVars above). Test *free* variables, not
+            // all occurrences, so a self-contained binder (e.g. a lambda whose parameter never escapes)
+            // stays extractable.
             if (FreeVariablesUtil.ComputeFreeVariables(reporter.Options, sub).Any(innerBoundVars.Contains)) {
               continue;
             }

--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -77,12 +77,18 @@ class SplitPartTriggerWriter {
     //    assert forall i :: 0 <= i < a.Length-1 ==> a[i] <= a[i+1];
     // after:
     //    assert forall i,j :: j == i+1 ==> 0 <= i < a.Length-1 ==> a[i] <= a[j];
-    // Collect variables bound by a binder inside the quantifier body. Such variables must not be
-    // extracted into the quantifier range: the binder's body is desugared/scoped during Boogie generation
-    // (e.g. a match-case variable is replaced by a destructor, a let/comprehension variable is scoped to
-    // its own construct), so an extracted range constraint that mentions the variable would reference an
-    // undeclared identifier in Boogie. This applies to every binder form, not just match, and to binders
-    // appearing in either the quantifier's range or its term (looping subexpressions are gathered from both).
+    // Collect variables bound by a binder inside the quantifier body whose binding does not survive
+    // into Boogie as an enclosing quantifier. Such variables must not be extracted into the quantifier
+    // range: the matching-loop rewrite conjoins the extracted equality (and its fresh bound variable)
+    // onto the nearest enclosing forall/exists (see ExprSubstituter), but a match-case, let/such-that,
+    // comprehension, or lambda variable is desugared/scoped away during Boogie generation, so the
+    // equality would reference an undeclared identifier there.
+    //
+    // Nested forall/exists bound variables are deliberately NOT collected: ExprSubstituter re-homes the
+    // equality onto the innermost enclosing quantifier, where such a variable is still in scope as a
+    // genuine Boogie quantifier binder, so extracting through them is sound (and beneficial).
+    //
+    // Binders are scanned in both the range and the term, since looping subexpressions are gathered from both.
     var innerBoundVars = new HashSet<IVariable>();
     void CollectInnerBoundVars(Expression start) {
       start.Visit(node => {
@@ -106,8 +112,8 @@ class SplitPartTriggerWriter {
               innerBoundVars.Add(bv);
             }
             break;
-          case ComprehensionExpr ce:
-            // set/map/seq comprehensions, lambdas, and nested quantifiers
+          case ComprehensionExpr ce when ce is not QuantifierExpr:
+            // set/map comprehensions and lambdas (but not forall/exists)
             foreach (var bv in ce.BoundVars) {
               innerBoundVars.Add(bv);
             }

--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -116,10 +116,12 @@ class SplitPartTriggerWriter {
         return true;
       });
     }
-    if (Comprehension.Range != null) {
-      CollectInnerBoundVars(Comprehension.Range);
-    }
-    CollectInnerBoundVars(Comprehension.Term);
+    // Seed from the comprehension itself rather than from Range and Term separately: the looping matches
+    // this guards against are gathered from AllSubExpressions, which walks ComprehensionExpr.SubExpressions
+    // and so also yields the arguments of the comprehension's attributes. Collecting only from Range and
+    // Term left a binder inside an attribute argument unseen, and its variable was then hoisted into the
+    // range, producing "undeclared identifier" in the emitted Boogie.
+    CollectInnerBoundVars(Comprehension);
 
     var substMap = new List<Tuple<Expression, IdentifierExpr>>();
     foreach (var triggerMatch in loopingMatches) {

--- a/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
+++ b/Source/DafnyCore/Triggers/SplitPartTriggerWriter.cs
@@ -107,7 +107,9 @@ class SplitPartTriggerWriter {
               innerBoundVars.Add(bv);
             }
             break;
-          case ComprehensionExpr ce when ce is not QuantifierExpr: // set/map comprehensions and lambdas
+          case ComprehensionExpr ce when ce is not QuantifierExpr && ce != Comprehension:
+            // set/map comprehensions and lambdas, but not the comprehension being rewritten: its own
+            // variables are the ones the rewrite is allowed to hoist, and the visit starts at it.
             foreach (var bv in ce.BoundVars) {
               innerBoundVars.Add(bv);
             }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy
@@ -1,0 +1,17 @@
+// RUN: %verify "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// Regression test: single-constructor match inside forall with seq indexing
+// using the match-bound variable caused a Boogie resolution error.
+
+datatype Instr = Branch(m: nat)
+
+predicate WellTyped(ii: seq<Instr>, typing: seq<nat>)
+  requires forall pc :: 0 <= pc < |ii| ==>
+    match ii[pc] case Branch(n) => pc + n < |typing|
+{
+  forall pc :: 0 <= pc < |ii| ==>
+    match ii[pc]
+    case Branch(n) =>
+      typing[pc + n] == typing[pc]
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy
@@ -1,11 +1,15 @@
-// RUN: %verify "%s" > "%t"
+// RUN: %verify --allow-warnings "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 
-// Regression test: single-constructor match inside forall with seq indexing
-// using the match-bound variable caused a Boogie resolution error.
+// Regression test: a looping-trigger subexpression that references a variable bound by a
+// binder inside the quantifier body used to be hoisted into the quantifier range by the
+// matching-loop rewrite, producing an "undeclared identifier" Boogie resolution error. This
+// affects every binder form (match cases, let/such-that, comprehensions, lambdas), in both
+// the quantifier's term and its range.
 
 datatype Instr = Branch(m: nat)
 
+// match-bound variable in the term
 predicate WellTyped(ii: seq<Instr>, typing: seq<nat>)
   requires forall pc :: 0 <= pc < |ii| ==>
     match ii[pc] case Branch(n) => pc + n < |typing|
@@ -14,4 +18,25 @@ predicate WellTyped(ii: seq<Instr>, typing: seq<nat>)
     match ii[pc]
     case Branch(n) =>
       typing[pc + n] == typing[pc]
+}
+
+// match-bound variable in the range (guard)
+predicate WellTypedRange(ii: seq<Instr>, typing: seq<nat>)
+  requires forall pc :: 0 <= pc < |ii| ==> match ii[pc] case Branch(n) => pc + n < |typing|
+{
+  forall pc | 0 <= pc < |ii| && (match ii[pc] case Branch(n2) => typing[pc + n2] == typing[pc])
+    :: true
+}
+
+// lambda-bound variable (the binder is self-contained, so the lambda itself remains extractable)
+predicate LambdaCase(a: seq<nat>)
+  requires forall i :: 0 <= i < |a| ==> ((x: nat) requires i + x < |a| => a[i + x] == a[i])(0)
+{
+  forall i :: 0 <= i < |a| ==> ((x: nat) requires i + x < |a| => a[i + x] == a[i])(0)
+}
+
+// set-comprehension-bound variable in the term
+predicate SetComprehensionCase(a: seq<nat>, n: nat)
+{
+  forall i :: 0 <= i < |a| ==> (set j | 0 <= j < n && i + j < |a| && a[i + j] == a[i]) == {}
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy
@@ -40,3 +40,21 @@ predicate SetComprehensionCase(a: seq<nat>, n: nat)
 {
   forall i :: 0 <= i < |a| ==> (set j | 0 <= j < n && i + j < |a| && a[i + j] == a[i]) == {}
 }
+
+// let/such-that-bound variable, named in the PR description but not previously covered
+predicate SuchThatCase(a: seq<nat>)
+  requires |a| > 0
+{
+  forall i :: 0 <= i < |a| ==> (var j :| 0 <= j < |a| && a[j] == a[i]; true)
+}
+
+// a binder inside an attribute argument. The looping matches are gathered from
+// ComprehensionExpr.SubExpressions, which yields attribute arguments too, so a binder there has to be
+// collected as well or its variable is hoisted into the range.
+predicate AttributeArgumentCase(ii: seq<Instr>, typing: seq<nat>)
+  requires forall pc :: 0 <= pc < |ii| ==> match ii[pc] case Branch(n) => pc + n < |typing|
+{
+  forall pc {:myattr match ii[pc] case Branch(n) => typing[pc + n] == typing[pc]} ::
+    0 <= pc < |ii| ==> true
+}
+

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy.expect
@@ -1,2 +1,6 @@
+git-issue-6183.dfy(33,11): Warning: Triggers were added to this quantifier that may introduce matching loops, which may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
+git-issue-6183.dfy(35,2): Warning: Triggers were added to this quantifier that may introduce matching loops, which may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
+git-issue-6183.dfy(41,2): Warning: Triggers were added to this quantifier that may introduce matching loops, which may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
+git-issue-6183.dfy(41,32): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
 
-Dafny program verifier finished with 1 verified, 0 errors
+Dafny program verifier finished with 4 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6183.dfy.expect
@@ -3,4 +3,4 @@ git-issue-6183.dfy(35,2): Warning: Triggers were added to this quantifier that m
 git-issue-6183.dfy(41,2): Warning: Triggers were added to this quantifier that may introduce matching loops, which may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
 git-issue-6183.dfy(41,32): Warning: Could not find a trigger for this quantifier. Without a trigger, the quantifier may cause brittle verification. To silence this warning, add an explicit trigger using the {:trigger} attribute. For more information, see the section on quantifier instantiation rules in the reference manual.
 
-Dafny program verifier finished with 4 verified, 0 errors
+Dafny program verifier finished with 6 verified, 0 errors

--- a/docs/dev/news/6183.fix
+++ b/docs/dev/news/6183.fix
@@ -1,0 +1,1 @@
+No longer crash when a `forall` expression contains a single-constructor `match` whose bound variable is used as a sequence index

--- a/docs/dev/news/6183.fix
+++ b/docs/dev/news/6183.fix
@@ -1,1 +1,1 @@
-No longer crash when a `forall` expression contains a single-constructor `match` whose bound variable is used as a sequence index
+No longer crash with an "undeclared identifier" error when a quantifier's matching-loop rewrite would extract a subexpression that uses a variable bound inside the quantifier body (by a `match`, `let`/such-that, comprehension, or lambda), in either the range or the term

--- a/docs/dev/news/6183.fix
+++ b/docs/dev/news/6183.fix
@@ -1,1 +1,1 @@
-No longer crash with an "undeclared identifier" error when a quantifier's matching-loop rewrite would extract a subexpression that uses a variable bound inside the quantifier body (by a `match`, `let`/such-that, comprehension, or lambda), in either the range or the term
+Fix crash ("undeclared identifier") on some quantifiers that use a variable bound by an inner `match`, `let`, comprehension, or lambda


### PR DESCRIPTION
## Summary

Fixes a Boogie resolution error ("undeclared identifier") that occurred when a quantifier's matching-loop rewrite extracted a subexpression referencing a variable bound by a binder inside the quantifier body. The original report (#6183) involved a single-constructor `match`, but the same crash applies to other binder forms too — `let`/such-that, set/map comprehensions, and lambdas — and to binders in the quantifier's range as well as its term.

## Root cause

The matching-loop rewrite (`RewriteMatchingLoop`) hoists looping subexpressions out of a quantifier as fresh bound variables, conjoining an equality `_t == subexpr` onto the range. `ExprSubstituter` homes that equality on the nearest enclosing `forall`/`exists`. For `typing[pc + n]` where `n` is bound by an inner binder, it creates `_t#0 == pc + n`. During Boogie generation the binder is desugared/scoped (e.g. `DesugarMatchExpr` replaces `n` with a destructor; a `let`/comprehension/lambda variable becomes a let-scope or a separate Boogie construct), so `n` is no longer in scope where the equality lands, and it becomes an undeclared identifier.

The previous fix guarded only `match`-case-bound variables and scanned only the quantifier term, leaving the other binder forms and range binders crashing identically.

## Fix

- Generalize the inner-bound-variable collector to the binder forms that get desugared/scoped away (`match`, `let`/such-that, set/map comprehensions, lambdas) and run it over both the quantifier's range and its term (looping subexpressions are gathered from both).
- Deliberately **exclude** nested `forall`/`exists`: `ExprSubstituter` re-homes the equality onto the innermost enclosing quantifier, where a nested-quantifier variable is still in scope as a genuine Boogie quantifier binder. Extracting through those is sound and beneficial, so they must keep working (this is what regressed `dafny4/git-issue96.dfy` in an earlier iteration).
- Decide whether a candidate subexpression is safe to extract by testing its **free** variables against the collected variables. Using free variables (rather than every identifier occurrence) keeps a self-contained binder — e.g. a whole lambda whose parameter never escapes — extractable, preserving the existing rewrite behaviour on programs such as `triggers/InductionWithoutTriggers.dfy`.

When extraction is declined, trigger selection falls back to the original (potentially looping) trigger and Dafny emits the usual "may loop" warning rather than crashing.

## Test

`git-issue-6183.dfy` covers a `match`-bound variable in the term and in the range, a lambda-bound variable, and a set-comprehension-bound variable. Every case crashes before the fix and verifies after.

Fixes #6183

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
