### PR TITLE
fix(docs): silence Sass deprecation warnings and fix YAML front matter

### DIFF
--- a/docs/HowToFAQ/FAQForallTricks.md
+++ b/docs/HowToFAQ/FAQForallTricks.md
@@ -1,5 +1,5 @@
 ---
-title: Why can't I write `forall t: Test :: t.i == 1` for an object `t`?
+title: "Why can't I write `forall t: Test :: t.i == 1` for an object `t`?"
 ---
 
 ## Question

--- a/docs/HowToFAQ/FAQNoBody.md
+++ b/docs/HowToFAQ/FAQNoBody.md
@@ -1,5 +1,5 @@
 ---
-title: Is there a way to prevent 'Warning: note, this forall statement has no body' from occurring? I have a forall loop with no body that results in the lemma verifying, but if I add a body (even an empty body) the lemma doesn't verify.
+title: "Is there a way to prevent 'Warning: note, this forall statement has no body' from occurring? I have a forall loop with no body that results in the lemma verifying, but if I add a body (even an empty body) the lemma doesn't verify."
 ---
 
 ## Question

--- a/docs/HowToFAQ/FAQSetConstructor.md
+++ b/docs/HowToFAQ/FAQSetConstructor.md
@@ -1,5 +1,5 @@
 ---
-title: Why does Dafny complain about this use of a set constructor: `set i: int | Contains(i)`?
+title: "Why does Dafny complain about this use of a set constructor: `set i: int | Contains(i)`?"
 ---
 
 ## Question

--- a/docs/HowToFAQ/FAQTriggers.md
+++ b/docs/HowToFAQ/FAQTriggers.md
@@ -1,5 +1,5 @@
 ---
-title: What does `forall v :: v in vals ==> false` evaluate to if `vals` is nonempty?
+title: "What does `forall v :: v in vals ==> false` evaluate to if `vals` is nonempty?"
 ---
 
 ## Question

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,6 +26,8 @@ url: "https://dafny-lang.github.io/dafny" # the base hostname & protocol for you
 
 # Build settings
 theme: minima
+sass:
+  quiet_deps: true
 
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
## Changes

- Add `sass: quiet_deps: true` to `docs/_config.yml` to suppress Sass `/` division deprecation warnings from the minima theme (upstream issue, no fix released)
- Quote titles in 4 FAQ files that contain colons inside backtick-wrapped code, fixing YAML parsing exceptions on Ruby 3.2+

### Files with YAML front matter fixes
- `docs/HowToFAQ/FAQSetConstructor.md`
- `docs/HowToFAQ/FAQTriggers.md`
- `docs/HowToFAQ/FAQNoBody.md`
- `docs/HowToFAQ/FAQForallTricks.md`

### Context
The YAML exceptions became visible after bumping Ruby from 3.1 to 3.2 in #6349 (Psych 4.x is stricter about colons in unquoted strings). The Sass warnings are a known minima 2.5.x issue with no upstream fix available.

### Testing
- Verified locally with `bundle exec jekyll build` — clean build with no warnings
- Triggered the Jekyll Pages workflow on the branch ([run 24235510787](https://github.com/dafny-lang/dafny/actions/runs/24235510787)): build step passes with no Sass deprecation warnings and no YAML exceptions (deploy step fails as expected due to branch protection rules)
- Compared against the [previous master build](https://github.com/dafny-lang/dafny/actions/runs/24234559369/job/70753806705) which had 5+ Sass deprecation warnings and 4 YAML exceptions

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>