### PR TITLE
Go runtime: panic on sequence cardinality overflow instead of silent truncation

### DIFF
--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -57,7 +57,7 @@ jobs:
       uses: wtfjoke/setup-tectonic@v4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        tectonic-version: 0.15
+        tectonic-version: 0.16.1
     - name: Build reference manual
       run: |
         eval "$(/usr/libexec/path_helper)"

--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -54,7 +54,7 @@ jobs:
         pandoc -v
         sudo gem install rouge -v 3.30.0
     - name: Install Tectonic
-      uses: wtfjoke/setup-tectonic@v3
+      uses: wtfjoke/setup-tectonic@v4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         tectonic-version: 0.15

--- a/.github/workflows/refman.yml
+++ b/.github/workflows/refman.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-24.04 ]
     steps:
     - name: OS
       run: echo ${{ runner.os }} ${{ matrix.os }}

--- a/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny.go
@@ -779,7 +779,11 @@ func (CompanionStruct_NativeArray_) Copy(other ImmutableArray) NativeArray {
 }
 
 func (g GoNativeArray) Length() uint32 {
-	return uint32(g.underlying.dimensionLength(0))
+	arrLength := g.underlying.dimensionLength(0)
+	if arrLength > int(Companion_Default___.SIZE__T__MAX()) {
+		panic(fmt.Sprintf("array size exceeds memory limit"))
+	}
+	return uint32(arrLength)
 }
 
 func (g GoNativeArray) Select(i uint32) interface{} {

--- a/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny.go
@@ -13,6 +13,8 @@ import (
 	"unicode/utf8"
 )
 
+const ErrArrayLengthExceedsSizeTMax = "array length exceeds SIZE_T_MAX"
+
 func FromMainArguments(args []string) Sequence {
 	var size = len(args)
 	var dafnyArgs []interface{} = make([]interface{}, size)
@@ -781,7 +783,7 @@ func (CompanionStruct_NativeArray_) Copy(other ImmutableArray) NativeArray {
 func (g GoNativeArray) Length() uint32 {
 	arrLength := g.underlying.dimensionLength(0)
 	if arrLength > int(Companion_Default___.SIZE__T__MAX()) {
-		panic(fmt.Sprintf("array size exceeds memory limit"))
+		panic(ErrArrayLengthExceedsSizeTMax)
 	}
 	return uint32(arrLength)
 }

--- a/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny_test.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny_test.go
@@ -183,4 +183,22 @@ func SequenceIsBackedByByteArray(seq Sequence) bool {
 	return ok
 }
 
+func TestMaximumLengthCardinality(t *testing.T) {
+	size := Companion_Default___.SIZE__T__MAX()
+	a := make([]byte, int(size))
+	cardinality := SeqOfBytes(a).Cardinality()
+	if cardinality != size {
+		t.Errorf("Expected cardinality %d, got %d", size, cardinality)
+	}
+}
 
+func TestCardinalityOverflow(t *testing.T) {
+	size := Companion_Default___.SIZE__T__MAX() + 1
+	a := make([]byte, int(size))
+
+	// Expect a panic
+	defer func() { _ = recover() }()
+
+	SeqOfBytes(a).Cardinality()
+	t.Errorf("Expected Cardinality() to panic, but it didn't")
+}

--- a/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny_test.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny_test.go
@@ -196,9 +196,16 @@ func TestCardinalityOverflow(t *testing.T) {
 	size := Companion_Default___.SIZE__T__MAX() + 1
 	a := make([]byte, int(size))
 
-	// Expect a panic
-	defer func() { _ = recover() }()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Expected Cardinality() to panic, but it didn't")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != ErrArrayLengthExceedsSizeTMax {
+			t.Fatalf("Expected array length panic, got: %v", r)
+		}
+	}()
 
 	SeqOfBytes(a).Cardinality()
-	t.Errorf("Expected Cardinality() to panic, but it didn't")
 }

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
@@ -779,7 +779,11 @@ func (CompanionStruct_NativeArray_) Copy(other ImmutableArray) NativeArray {
 }
 
 func (g GoNativeArray) Length() uint32 {
-	return uint32(g.underlying.dimensionLength(0))
+	arrLength := g.underlying.dimensionLength(0)
+	if arrLength > int(Companion_Default___.SIZE__T__MAX()) {
+		panic(fmt.Sprintf("array size exceeds memory limit"))
+	}
+	return uint32(arrLength)
 }
 
 func (g GoNativeArray) Select(i uint32) interface{} {

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
@@ -13,6 +13,8 @@ import (
 	"unicode/utf8"
 )
 
+const ErrArrayLengthExceedsSizeTMax = "array length exceeds SIZE_T_MAX"
+
 func FromMainArguments(args []string) Sequence {
 	var size = len(args)
 	var dafnyArgs []interface{} = make([]interface{}, size)
@@ -781,7 +783,7 @@ func (CompanionStruct_NativeArray_) Copy(other ImmutableArray) NativeArray {
 func (g GoNativeArray) Length() uint32 {
 	arrLength := g.underlying.dimensionLength(0)
 	if arrLength > int(Companion_Default___.SIZE__T__MAX()) {
-		panic(fmt.Sprintf("array size exceeds memory limit"))
+		panic(ErrArrayLengthExceedsSizeTMax)
 	}
 	return uint32(arrLength)
 }

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go
@@ -183,4 +183,22 @@ func SequenceIsBackedByByteArray(seq Sequence) bool {
 	return ok
 }
 
+func TestMaximumLengthCardinality(t *testing.T) {
+	size := Companion_Default___.SIZE__T__MAX()
+	a := make([]byte, int(size))
+	cardinality := SeqOfBytes(a).Cardinality()
+	if cardinality != size {
+		t.Errorf("Expected cardinality %d, got %d", size, cardinality)
+	}
+}
 
+func TestCardinalityOverflow(t *testing.T) {
+	size := Companion_Default___.SIZE__T__MAX() + 1
+	a := make([]byte, int(size))
+
+	// Expect a panic
+	defer func() { _ = recover() }()
+
+	SeqOfBytes(a).Cardinality()
+	t.Errorf("Expected Cardinality() to panic, but it didn't")
+}

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go
@@ -196,9 +196,16 @@ func TestCardinalityOverflow(t *testing.T) {
 	size := Companion_Default___.SIZE__T__MAX() + 1
 	a := make([]byte, int(size))
 
-	// Expect a panic
-	defer func() { _ = recover() }()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Expected Cardinality() to panic, but it didn't")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != ErrArrayLengthExceedsSizeTMax {
+			t.Fatalf("Expected array length panic, got: %v", r)
+		}
+	}()
 
 	SeqOfBytes(a).Cardinality()
-	t.Errorf("Expected Cardinality() to panic, but it didn't")
 }


### PR DESCRIPTION
### What was changed?

`GoNativeArray.Length()` now panics instead of silently truncating when the underlying array length exceeds `SIZE_T_MAX`. This prevents the `int` → `uint32` narrowing in the Go runtime from producing garbage cardinality values for sequences backed by very large arrays.

- Added a bounds check in `GoNativeArray.Length()` before the `uint32` cast
- Extracted panic message as exported constant `ErrArrayLengthExceedsSizeTMax` for test use
- Added `TestMaximumLengthCardinality` (boundary: exact `SIZE_T_MAX` works)
- Added `TestCardinalityOverflow` (boundary+1: panics with the expected message)

Note: the overflow test verifies the exact panic value so that an OOM during the internal `make`/`copy` in `SeqOfBytes` does not false-pass the test.

### How has this been tested?

Unit tests in `Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go` (mirrored to `-gomod`). Both tests allocate ~2 GiB and require a 64-bit environment with sufficient memory.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>