### PR TITLE
Bump setup-tectonic to v4/0.16.1 in publish-release-reusable.yml

### DIFF
--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -116,10 +116,10 @@ jobs:
         pandoc -v
         sudo gem install rouge -v 3.30.0
     - name: Install Tectonic
-      uses: wtfjoke/setup-tectonic@v3
+      uses: wtfjoke/setup-tectonic@v4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        tectonic-version: 0.15
+        tectonic-version: 0.16.1
 
     - name: Clean Dafny
       run: dotnet clean dafny/Source/Dafny.sln


### PR DESCRIPTION
The nightly build is failing because `wtfjoke/setup-tectonic@v3` with `tectonic-version: 0.15` can no longer resolve the latest tectonic release. This bumps it to `@v4` / `0.16.1`, matching the fix already applied to `refman.yml` in #6344.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>