### PR TITLE
chore: raise oldest supported Go to 1.25 in CI

### DIFF
--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -96,12 +96,12 @@ jobs:
     - name: Set up oldest supported Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.21'
+        go-version: '1.25'
         cache: false
     - name: Set up goimports
       env:
         GO111MODULE: on
-      run: go install golang.org/x/tools/cmd/goimports@v0.24.0
+      run: go install golang.org/x/tools/cmd/goimports@latest
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.25'
           cache: false
       - name: Set up goimports
         env:
           GO111MODULE: on
-        run: go install golang.org/x/tools/cmd/goimports@v0.24.0
+        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Build Dafny
         run: dotnet build Source/Dafny.sln
       - name: Get Z3

--- a/.github/workflows/standard-libraries.yml
+++ b/.github/workflows/standard-libraries.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.25'
           cache: false
       - name: Set up goimports
         env:
           GO111MODULE: on
-        run: go install golang.org/x/tools/cmd/goimports@v0.24.0
+        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Build Dafny
         run: dotnet build Source/Dafny.sln
       - name: Get Z3


### PR DESCRIPTION
Follow-up to #6464.

## Why

#6464 bumps `actions/setup-go` from v5 to v6. setup-go v6 sets `GOTOOLCHAIN=local` by default, which stops Go from auto-downloading a newer toolchain when an installed tool needs one. `goimports@latest` now pulls `golang.org/x/tools` v0.44.0, which declares `go 1.25.0`, so under the v6 default it refuses to install on Go 1.21. #6464 worked around that by pinning goimports to v0.24.0 (the last release that still supports Go 1.21).

Go 1.21 is also no longer upstream-supported. [Shubham suggested](https://github.com/dafny-lang/dafny/pull/6464#discussion_r3150363400) bumping the CI Go floor instead of pinning goimports, and this PR does that. An earlier version of this PR tried Go 1.23, but CI confirmed what `x/tools`' `go.mod` says: the current `goimports@latest` truly does require 1.25, not just some version newer than 1.21.

## What

Only CI workflows change:

- `.github/workflows/integration-tests-reusable.yml`
- `.github/workflows/runtime-tests.yml`
- `.github/workflows/standard-libraries.yml`

In each: `go-version: '1.21'` -> `'1.25'`, and `goimports@v0.24.0` -> `@latest`.

## Why 1.25 specifically

It is the minimum that lets `goimports@latest` install under setup-go v6's `GOTOOLCHAIN=local` default. It is also upstream-supported. Picking a higher floor (e.g. 1.26) would buy a little more runway before the next `x/tools` minimum-Go bump, but at the cost of excluding more Go versions from the "oldest supported" compatibility check.

## What is NOT changed

The in-tree `go.mod` files are untouched. In particular, the published `DafnyRuntimeGo` runtime keeps its `go 1.21` directive — raising that would be a breaking change for downstream users of Dafny-generated Go code still on Go 1.21/1.22. The `gomodule` integration-test fixtures also stay at `go 1.21`; since `1.21 <= 1.25`, they build fine under the new CI Go version as-is.

No `docs/dev/news/` fragment added: this is pure CI/infrastructure, not a user-facing change.