### PR TITLE
fix: suggest 'extends object' in reads/modifies/unchanged/fresh errors on non-reference traits

### DIFF
--- a/Source/DafnyCore/Resolver/ModuleResolver.cs
+++ b/Source/DafnyCore/Resolver/ModuleResolver.cs
@@ -33,6 +33,20 @@ namespace Microsoft.Dafny {
 
   public enum FrameExpressionUse { Reads, Modifies, Unchanged }
 
+  public static class FrameExpressionUseExtensions {
+    /// <summary>
+    /// Returns a short human-readable noun phrase naming the language construct associated with
+    /// <paramref name="use"/>, e.g. "a reads clause", "a modifies clause", or "an unchanged expression".
+    /// Used by diagnostic messages that want to refer to the construct uniformly across resolvers.
+    /// </summary>
+    public static string ClauseDescription(this FrameExpressionUse use) => use switch {
+      FrameExpressionUse.Reads => "a reads clause",
+      FrameExpressionUse.Modifies => "a modifies clause",
+      FrameExpressionUse.Unchanged => "an unchanged expression",
+      _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
+    };
+  }
+
   public partial class ModuleResolver : INewOrOldResolver {
     public ProgramResolver ProgramResolver { get; }
     public DafnyOptions Options { get; }

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -758,7 +758,7 @@ namespace Microsoft.Dafny {
         ResolveExpression(e.E, resolutionContext);
         e.AtLabel = ResolveDominatingLabelInExpr(expr.Origin, e.At, "fresh", resolutionContext);
         // the type of e.E must be either an object or a set/seq of objects
-        AddXConstraint(expr.Origin, "Freshable", e.E.Type, "the argument of a fresh expression must denote an object or a set or sequence of objects (instead got {0})");
+        AddXConstraint(expr.Origin, "Freshable", e.E.Type, FreshGenericFormat);
         expr.Type = Type.Bool;
 
       } else if (expr is UnaryOpExpr) {
@@ -3191,6 +3191,28 @@ namespace Microsoft.Dafny {
     public static readonly string CollectionOfFieldLocations = "a set/iset/multiset/seq of objects or single field locations (with `--referrers`)";
     public static readonly string SingleFieldLocation = "a single field location like o`x or a`[i] of type (object, field)  (with `--referrers`)";
 
+    /// <summary>
+    /// Format string (with a single {0} placeholder for the offending type) for the diagnostic emitted when
+    /// a `fresh` expression's argument is not a reference type. Shared between the legacy and PreType resolvers
+    /// so both produce identical text.
+    /// </summary>
+    public static readonly string FreshGenericFormat = "the argument of a fresh expression must denote an object or a set or sequence of objects (instead got {0})";
+
+    /// <summary>
+    /// If <paramref name="decl"/> represents a non-reference trait (under the default `--general-traits=datatype`),
+    /// return a tailored error message suggesting `extends object`. Otherwise, return null so the caller can fall
+    /// back to its generic message.
+    ///
+    /// <paramref name="clauseDescription"/> is the noun phrase naming the language construct ("a reads clause",
+    /// "a modifies clause", "an unchanged expression", "a fresh expression").
+    /// </summary>
+    public static string NonReferenceTraitFrameMessageOrNull(TopLevelDecl decl, string clauseDescription) {
+      if (decl is TraitDecl traitDecl && !traitDecl.IsReferenceTypeDecl) {
+        return $"{clauseDescription} can only refer to reference types (consider declaring the trait '{traitDecl.Name}' with 'extends object')";
+      }
+      return null;
+    }
+
     public void ResolveFrameExpression(FrameExpression fe, FrameExpressionUse use, ResolutionContext resolutionContext) {
       Contract.Requires(fe != null);
       Contract.Requires(resolutionContext != null);
@@ -3199,15 +3221,18 @@ namespace Microsoft.Dafny {
       Type t = fe.E.Type;
       Contract.Assert(t != null);  // follows from postcondition of ResolveExpression
       var eventualRefType = new InferredTypeProxy();
-      if (use == FrameExpressionUse.Reads) {
-        AddXConstraint(fe.E.Origin, "ReadsFrame", t, eventualRefType,
-          $"a reads-clause expression must denote an object, {SingleFieldLocation}, {CollectionOfFieldLocations}, or a function to {CollectionOfFieldLocations} (instead got {{0}})");
-      } else {
-        AddXConstraint(fe.E.Origin, "ModifiesFrame", t, eventualRefType,
-          use == FrameExpressionUse.Modifies ?
-          $"a modifies-clause expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})" :
-          $"an unchanged expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})");
-      }
+      var errMsgFormat = use switch {
+        FrameExpressionUse.Reads =>
+          $"a reads-clause expression must denote an object, {SingleFieldLocation}, {CollectionOfFieldLocations}, or a function to {CollectionOfFieldLocations} (instead got {{0}})",
+        FrameExpressionUse.Modifies =>
+          $"a modifies-clause expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})",
+        FrameExpressionUse.Unchanged =>
+          $"an unchanged expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})",
+        _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
+      };
+      var types = new Type[] { t, eventualRefType };
+      AllXConstraints.Add(new XConstraintFrame(fe.E.Origin, use, t, eventualRefType,
+        new TypeConstraint.ErrorMsgWithToken(fe.E.Origin, errMsgFormat, types)));
       if (fe.FieldName != null) {
         var member = ResolveMember(fe.E.Origin, eventualRefType, fe.FieldName, out var tentativeReceiverType);
         var ctype = (UserDefinedType)tentativeReceiverType;  // correctness of cast follows from the DenotesClass test above
@@ -5210,7 +5235,7 @@ namespace Microsoft.Dafny {
           GetRelatedTypeProxies(xc.Types[1], proxies);
         } else if (xc.ConstraintName == "Innable" && xc.Types[1].Normalize() == proxy) {
           GetRelatedTypeProxies(xc.Types[0], proxies);
-        } else if ((xc.ConstraintName == "ModifiesFrame" || xc.ConstraintName == "ReadsFrame") && xc.Types[1].Normalize() == proxy) {
+        } else if (xc.ConstraintName == "FrameExpression" && xc.Types[1].Normalize() == proxy) {
           GetRelatedTypeProxies(xc.Types[0], proxies);
         }
       }

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -3213,6 +3213,21 @@ namespace Microsoft.Dafny {
       return null;
     }
 
+    /// <summary>
+    /// The generic diagnostic (a format string with a single {0} placeholder for the offending type) emitted
+    /// when a frame expression's argument has an unsupported type. Shared between the legacy and PreType
+    /// resolvers so both produce identical text.
+    /// </summary>
+    public static string GenericFrameMessageFormat(FrameExpressionUse use) => use switch {
+      FrameExpressionUse.Reads =>
+        $"a reads-clause expression must denote an object, {SingleFieldLocation}, {CollectionOfFieldLocations}, or a function to {CollectionOfFieldLocations} (instead got {{0}})",
+      FrameExpressionUse.Modifies =>
+        $"a modifies-clause expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})",
+      FrameExpressionUse.Unchanged =>
+        $"an unchanged expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})",
+      _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
+    };
+
     public void ResolveFrameExpression(FrameExpression fe, FrameExpressionUse use, ResolutionContext resolutionContext) {
       Contract.Requires(fe != null);
       Contract.Requires(resolutionContext != null);
@@ -3221,15 +3236,7 @@ namespace Microsoft.Dafny {
       Type t = fe.E.Type;
       Contract.Assert(t != null);  // follows from postcondition of ResolveExpression
       var eventualRefType = new InferredTypeProxy();
-      var errMsgFormat = use switch {
-        FrameExpressionUse.Reads =>
-          $"a reads-clause expression must denote an object, {SingleFieldLocation}, {CollectionOfFieldLocations}, or a function to {CollectionOfFieldLocations} (instead got {{0}})",
-        FrameExpressionUse.Modifies =>
-          $"a modifies-clause expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})",
-        FrameExpressionUse.Unchanged =>
-          $"an unchanged expression must denote an object, {SingleFieldLocation}, or {CollectionOfFieldLocations} (instead got {{0}})",
-        _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
-      };
+      var errMsgFormat = GenericFrameMessageFormat(use);
       var types = new Type[] { t, eventualRefType };
       AllXConstraints.Add(new XConstraintFrame(fe.E.Origin, use, t, eventualRefType,
         new TypeConstraint.ErrorMsgWithToken(fe.E.Origin, errMsgFormat, types)));

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/NameResolutionAndTypeInference.cs
@@ -3205,9 +3205,16 @@ namespace Microsoft.Dafny {
     ///
     /// <paramref name="clauseDescription"/> is the noun phrase naming the language construct ("a reads clause",
     /// "a modifies clause", "an unchanged expression", "a fresh expression").
+    ///
+    /// <paramref name="shapeIsAcceptable"/> says whether the type would have been accepted had it been a
+    /// reference type. Only then is reference-ness the sole reason for the failure, and only then does the
+    /// suggestion help: for a reads clause on an arrow that does not return a collection, such as
+    /// `() ~&gt; T`, the shape is what is wrong, and taking the suggestion just produces the shape error
+    /// instead. Callers pass their own shape predicate, since the two resolvers phrase it differently.
     /// </summary>
-    public static string NonReferenceTraitFrameMessageOrNull(TopLevelDecl decl, string clauseDescription) {
-      if (decl is TraitDecl traitDecl && !traitDecl.IsReferenceTypeDecl) {
+    public static string NonReferenceTraitFrameMessageOrNull(TopLevelDecl decl, string clauseDescription,
+      bool shapeIsAcceptable = true) {
+      if (shapeIsAcceptable && decl is TraitDecl traitDecl && !traitDecl.IsReferenceTypeDecl) {
         return $"{clauseDescription} can only refer to reference types (consider declaring the trait '{traitDecl.Name}' with 'extends object')";
       }
       return null;

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/XConstraint.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/XConstraint.cs
@@ -42,6 +42,18 @@ public class XConstraint {
     convertedIntoOtherTypeConstraints = false;
     moreXConstraints = false;
     var t = Types[0].NormalizeExpand();
+
+    // If "type" is a non-reference trait, emit a tailored frame-expression diagnostic
+    // naming "clauseDescription" and return true. Otherwise return false.
+    bool TryReportNonReferenceTraitError(Type type, string clauseDescription) {
+      var hint = ModuleResolver.NonReferenceTraitFrameMessageOrNull((type as UserDefinedType)?.ResolvedClass, clauseDescription);
+      if (hint != null) {
+        resolver.reporter.Error(MessageSource.Resolver, tok, hint);
+        return true;
+      }
+      return false;
+    }
+
     if (t is TypeProxy) {
       switch (ConstraintName) {
         case "Assignable":
@@ -437,10 +449,22 @@ public class XConstraint {
             return false;  // there is not enough information
           }
           satisfied = t.IsRefType;
+          if (!satisfied && TryReportNonReferenceTraitError(t, "a fresh expression")) {
+            return true;
+          }
           break;
         }
-      case "ModifiesFrame": {
+      case "FrameExpression": {
+          var frameConstraint = (XConstraintFrame)this;
+          var isReads = frameConstraint.Use == FrameExpressionUse.Reads;
           var u = Types[1].NormalizeExpand();  // eventual ref type
+
+          // Only reads clauses can contain a function expression (whose result is then what's being read).
+          var arrTy = isReads ? t.AsArrowType : null;
+          if (arrTy != null) {
+            t = arrTy.Result.NormalizeExpand();
+          }
+
           var collType = t is MapType ? null : t.AsCollectionType;
           if (collType != null) {
             t = collType.Arg.NormalizeExpand();
@@ -460,7 +484,10 @@ public class XConstraint {
             if (collType != null || tType != null) {
               // we know enough to convert into a subtyping constraint
               resolver.AddXConstraint(Token.NoToken/*bogus, but it seems this token would be used only when integers are involved*/, "IsRefType", t, errorMsg);
-              moreXConstraints = true;
+              if (!isReads) {
+                // Preserve pre-existing behavior: modifies/unchanged also mark IsRefType as a newly added constraint.
+                moreXConstraints = true;
+              }
               resolver.ConstrainSubtypeRelation_Equal(u, t, errorMsg);
               moreXConstraints = true;
               convertedIntoOtherTypeConstraints = true;
@@ -469,50 +496,15 @@ public class XConstraint {
               return false;  // there is not enough information
             }
           }
-          if (t.IsRefType) {
+          var satisfiesRefRequirement = isReads
+            ? (t.IsRefType || t.IsMemoryLocationType) && (arrTy == null || collType != null)
+            : t.IsRefType;
+          if (satisfiesRefRequirement) {
             resolver.ConstrainSubtypeRelation_Equal(u, t, errorMsg);
             convertedIntoOtherTypeConstraints = true;
             return true;
           }
-          satisfied = false;
-          break;
-        }
-      case "ReadsFrame": {
-          var u = Types[1].NormalizeExpand();  // eventual ref type
-          var arrTy = t.AsArrowType;
-          if (arrTy != null) {
-            t = arrTy.Result.NormalizeExpand();
-          }
-          var collType = t is MapType ? null : t.AsCollectionType;
-          if (collType != null) {
-            t = collType.Arg.NormalizeExpand();
-          }
-
-          var tType = t.AsDatatype is TupleTypeDecl { Dims: 2 } tDecl ? tDecl : null;
-          if (tType != null) {
-            var refType = t.TypeArgs[0];
-            var fieldType = t.TypeArgs[1];
-            t = refType.NormalizeExpand();
-            if (fieldType is not FieldType) {
-              resolver.AddXConstraint(Token.NoToken/*bogus, but it seems this token would be used only when integers are involved*/, "IsFieldType", fieldType, errorMsg);
-              convertedIntoOtherTypeConstraints = true;
-            }
-          }
-          if (t is TypeProxy) {
-            if (collType != null || tType != null) {
-              // we know enough to convert into a subtyping constraint
-              resolver.AddXConstraint(Token.NoToken/*bogus, but it seems this token would be used only when integers are involved*/, "IsRefType", t, errorMsg);
-              resolver.ConstrainSubtypeRelation_Equal(u, t, errorMsg);
-              moreXConstraints = true;
-              convertedIntoOtherTypeConstraints = true;
-              return true;
-            } else {
-              return false;  // there is not enough information
-            }
-          }
-          if ((t.IsRefType || t.IsMemoryLocationType) && (arrTy == null || collType != null)) {
-            resolver.ConstrainSubtypeRelation_Equal(u, t, errorMsg);
-            convertedIntoOtherTypeConstraints = true;
+          if (TryReportNonReferenceTraitError(t, frameConstraint.Use.ClauseDescription())) {
             return true;
           }
           satisfied = false;
@@ -593,6 +585,18 @@ public class XConstraintWithExprs : XConstraint {
     Contract.Requires(exprs != null);
     Contract.Requires(errMsg != null);
     this.Exprs = exprs;
+  }
+}
+
+public class XConstraintFrame : XConstraint {
+  public readonly FrameExpressionUse Use;
+  public XConstraintFrame(IOrigin tok, FrameExpressionUse use, Type t, Type eventualRefType, TypeConstraint.ErrorMsg errMsg)
+    : base(tok, "FrameExpression", [t, eventualRefType], errMsg) {
+    Contract.Requires(tok != null);
+    Contract.Requires(t != null);
+    Contract.Requires(eventualRefType != null);
+    Contract.Requires(errMsg != null);
+    this.Use = use;
   }
 }
 

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/XConstraint.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/XConstraint.cs
@@ -504,7 +504,12 @@ public class XConstraint {
             convertedIntoOtherTypeConstraints = true;
             return true;
           }
-          if (TryReportNonReferenceTraitError(t, frameConstraint.Use.ClauseDescription())) {
+          // Suggest "extends object" only when reference-ness is the sole reason the type was rejected.
+          // For a reads clause the shape matters too -- an arrow has to return a collection -- and for
+          // something like "() ~> T" the shape is what is wrong, so the suggestion would send the user
+          // down a dead end: taking it produces the shape error instead.
+          if ((arrTy == null || collType != null) &&
+              TryReportNonReferenceTraitError(t, frameConstraint.Use.ClauseDescription())) {
             return true;
           }
           satisfied = false;

--- a/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/XConstraint.cs
+++ b/Source/DafnyCore/Resolver/NameResolutionAndTypeInference/XConstraint.cs
@@ -45,8 +45,9 @@ public class XConstraint {
 
     // If "type" is a non-reference trait, emit a tailored frame-expression diagnostic
     // naming "clauseDescription" and return true. Otherwise return false.
-    bool TryReportNonReferenceTraitError(Type type, string clauseDescription) {
-      var hint = ModuleResolver.NonReferenceTraitFrameMessageOrNull((type as UserDefinedType)?.ResolvedClass, clauseDescription);
+    bool TryReportNonReferenceTraitError(Type type, string clauseDescription, bool shapeIsAcceptable = true) {
+      var hint = ModuleResolver.NonReferenceTraitFrameMessageOrNull((type as UserDefinedType)?.ResolvedClass,
+        clauseDescription, shapeIsAcceptable);
       if (hint != null) {
         resolver.reporter.Error(MessageSource.Resolver, tok, hint);
         return true;
@@ -504,12 +505,8 @@ public class XConstraint {
             convertedIntoOtherTypeConstraints = true;
             return true;
           }
-          // Suggest "extends object" only when reference-ness is the sole reason the type was rejected.
-          // For a reads clause the shape matters too -- an arrow has to return a collection -- and for
-          // something like "() ~> T" the shape is what is wrong, so the suggestion would send the user
-          // down a dead end: taking it produces the shape error instead.
-          if ((arrTy == null || collType != null) &&
-              TryReportNonReferenceTraitError(t, frameConstraint.Use.ClauseDescription())) {
+          if (TryReportNonReferenceTraitError(t, frameConstraint.Use.ClauseDescription(),
+                shapeIsAcceptable: arrTy == null || collType != null)) {
             return true;
           }
           satisfied = false;

--- a/Source/DafnyCore/Resolver/PreType/PreTypeConstraints.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeConstraints.cs
@@ -609,6 +609,18 @@ namespace Microsoft.Dafny {
         }));
     }
 
+    /// <summary>
+    /// Like the format-string overload of <see cref="AddConfirmation"/>, but invokes <paramref name="errorMessage"/>
+    /// at error-reporting time to compute the message. This lets the caller inspect the fully resolved pre-type and
+    /// tailor the diagnostic (for example, to suggest `extends object` when the failing type is a non-reference trait).
+    /// </summary>
+    public void AddConfirmation(CommonConfirmationBag check, PreType preType, IOrigin tok, Func<string> errorMessage) {
+      confirmations.Add(new Confirmation(
+        () => ConfirmConstraint(check, preType, null),
+        errorMessage,
+        (ResolverPass reporter) => { reporter.ReportError(tok, errorMessage()); }));
+    }
+
     public void AddConfirmation(IOrigin tok, Func<bool> check, Func<string> errorMessage) {
       confirmations.Add(new Confirmation(check, errorMessage,
         (ResolverPass reporter) => { reporter.ReportError(tok, errorMessage()); }));

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -442,7 +442,23 @@ namespace Microsoft.Dafny {
             ResolveExpression(e.E, resolutionContext);
             e.AtLabel = ResolveDominatingLabelInExpr(freshExpr.Origin, e.At, "fresh", resolutionContext);
             // the type of e.E must be either an object or a set/seq of objects
-            AddConfirmation(PreTypeConstraints.CommonConfirmationBag.Freshable, e.E.PreType, e.E.Origin, "the argument of a fresh expression must denote an object or a set or sequence of objects (instead got {0})");
+            AddConfirmation(PreTypeConstraints.CommonConfirmationBag.Freshable, e.E.PreType, e.E.Origin, () => {
+              // At error-report time, peel off set/iset/seq wrapping to get the element decl, and
+              // suggest `extends object` if that decl is a non-reference trait.
+              var pt = e.E.PreType.Normalize();
+              TopLevelDecl elementDecl = null;
+              if (pt is DPreType dpOuter) {
+                if (dpOuter.Decl.Name is PreType.TypeNameSet or PreType.TypeNameIset or PreType.TypeNameSeq
+                    && dpOuter.Arguments.Count >= 1
+                    && dpOuter.Arguments[0].Normalize() is DPreType dpInner) {
+                  elementDecl = dpInner.Decl;
+                } else {
+                  elementDecl = dpOuter.Decl;
+                }
+              }
+              return ModuleResolver.NonReferenceTraitFrameMessageOrNull(elementDecl, "a fresh expression")
+                     ?? string.Format(ModuleResolver.FreshGenericFormat, e.E.PreType);
+            });
             ConstrainTypeExprBool(e, "result of 'fresh' is boolean, but is used as if it had type {0}");
             break;
           }

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -538,6 +538,10 @@ namespace Microsoft.Dafny {
       Constraints.AddConfirmation(check, preType, tok, errorFormatString, onProxyAction);
     }
 
+    void AddConfirmation(PreTypeConstraints.CommonConfirmationBag check, PreType preType, IOrigin tok, Func<string> errorMessage) {
+      Constraints.AddConfirmation(check, preType, tok, errorMessage);
+    }
+
     void AddComparableConstraint(PreType a, PreType b, IOrigin tok, bool allowBaseTypeCast, string errorFormatString) {
       AddComparableConstraint(a, b, tok, allowBaseTypeCast, () => string.Format(errorFormatString, a, b));
     }
@@ -1641,20 +1645,24 @@ namespace Microsoft.Dafny {
 
         if (!((DPreType.IsReferenceTypeDecl(dp.Decl) ||
                DPreType.IsFieldLocationType(dp)) && (!hasArrowType || hasCollectionType))) {
-          var expressionMustDenoteObject = "expression must denote an object";
-          var fieldLocation = ModuleResolver.SingleFieldLocation;
-          var collection = ModuleResolver.CollectionOfFieldLocations;
-          var instead = "(instead got {0})";
-          var errorMsgFormat = use switch {
-            FrameExpressionUse.Reads =>
-              $"a reads-clause {expressionMustDenoteObject}, {fieldLocation}, {collection}, or a function to {collection} {instead}",
-            FrameExpressionUse.Modifies =>
-              $"a modifies-clause {expressionMustDenoteObject}, {fieldLocation}, or {collection} {instead}",
-            FrameExpressionUse.Unchanged =>
-              $"an unchanged {expressionMustDenoteObject}, {fieldLocation}, or {collection} {instead}",
-            _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
-          };
-          ReportError(fe.E.Origin, errorMsgFormat, fe.E.PreType);
+          if (ModuleResolver.NonReferenceTraitFrameMessageOrNull(dp.Decl, use.ClauseDescription()) is { } traitHint) {
+            ReportError(fe.E.Origin, traitHint);
+          } else {
+            var expressionMustDenoteObject = "expression must denote an object";
+            var fieldLocation = ModuleResolver.SingleFieldLocation;
+            var collection = ModuleResolver.CollectionOfFieldLocations;
+            var instead = "(instead got {0})";
+            var errorMsgFormat = use switch {
+              FrameExpressionUse.Reads =>
+                $"a reads-clause {expressionMustDenoteObject}, {fieldLocation}, {collection}, or a function to {collection} {instead}",
+              FrameExpressionUse.Modifies =>
+                $"a modifies-clause {expressionMustDenoteObject}, {fieldLocation}, or {collection} {instead}",
+              FrameExpressionUse.Unchanged =>
+                $"an unchanged {expressionMustDenoteObject}, {fieldLocation}, or {collection} {instead}",
+              _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
+            };
+            ReportError(fe.E.Origin, errorMsgFormat, fe.E.PreType);
+          }
         }
 
         if (fe.FieldName != null) {

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -1648,20 +1648,7 @@ namespace Microsoft.Dafny {
           if (ModuleResolver.NonReferenceTraitFrameMessageOrNull(dp.Decl, use.ClauseDescription()) is { } traitHint) {
             ReportError(fe.E.Origin, traitHint);
           } else {
-            var expressionMustDenoteObject = "expression must denote an object";
-            var fieldLocation = ModuleResolver.SingleFieldLocation;
-            var collection = ModuleResolver.CollectionOfFieldLocations;
-            var instead = "(instead got {0})";
-            var errorMsgFormat = use switch {
-              FrameExpressionUse.Reads =>
-                $"a reads-clause {expressionMustDenoteObject}, {fieldLocation}, {collection}, or a function to {collection} {instead}",
-              FrameExpressionUse.Modifies =>
-                $"a modifies-clause {expressionMustDenoteObject}, {fieldLocation}, or {collection} {instead}",
-              FrameExpressionUse.Unchanged =>
-                $"an unchanged {expressionMustDenoteObject}, {fieldLocation}, or {collection} {instead}",
-              _ => throw new ArgumentOutOfRangeException(nameof(use), use, null)
-            };
-            ReportError(fe.E.Origin, errorMsgFormat, fe.E.PreType);
+            ReportError(fe.E.Origin, ModuleResolver.GenericFrameMessageFormat(use), fe.E.PreType);
           }
         }
 

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -1645,11 +1645,8 @@ namespace Microsoft.Dafny {
 
         if (!((DPreType.IsReferenceTypeDecl(dp.Decl) ||
                DPreType.IsFieldLocationType(dp)) && (!hasArrowType || hasCollectionType))) {
-          // Suggest "extends object" only when reference-ness is the sole reason the type was rejected;
-          // if the shape is also wrong (an arrow that does not return a collection) the suggestion would
-          // not help, and taking it just produces the shape error instead.
-          if ((!hasArrowType || hasCollectionType) &&
-              ModuleResolver.NonReferenceTraitFrameMessageOrNull(dp.Decl, use.ClauseDescription()) is { } traitHint) {
+          if (ModuleResolver.NonReferenceTraitFrameMessageOrNull(dp.Decl, use.ClauseDescription(),
+                shapeIsAcceptable: !hasArrowType || hasCollectionType) is { } traitHint) {
             ReportError(fe.E.Origin, traitHint);
           } else {
             ReportError(fe.E.Origin, ModuleResolver.GenericFrameMessageFormat(use), fe.E.PreType);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -1645,7 +1645,11 @@ namespace Microsoft.Dafny {
 
         if (!((DPreType.IsReferenceTypeDecl(dp.Decl) ||
                DPreType.IsFieldLocationType(dp)) && (!hasArrowType || hasCollectionType))) {
-          if (ModuleResolver.NonReferenceTraitFrameMessageOrNull(dp.Decl, use.ClauseDescription()) is { } traitHint) {
+          // Suggest "extends object" only when reference-ness is the sole reason the type was rejected;
+          // if the shape is also wrong (an arrow that does not return a collection) the suggestion would
+          // not help, and taking it just produces the shape error instead.
+          if ((!hasArrowType || hasCollectionType) &&
+              ModuleResolver.NonReferenceTraitFrameMessageOrNull(dp.Decl, use.ClauseDescription()) is { } traitHint) {
             ReportError(fe.E.Origin, traitHint);
           } else {
             ReportError(fe.E.Origin, ModuleResolver.GenericFrameMessageFormat(use), fe.E.PreType);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4936c.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-4936c.dfy.expect
@@ -2,5 +2,5 @@ git-issue-4936c.dfy(32,18): Error: The name A ambiguously refers to a type in on
 git-issue-4936c.dfy(42,18): Error: The name A ambiguously refers to a type in one of the modules X1, X0 (try qualifying the type name with the module name)
 git-issue-4936c.dfy(53,18): Error: The name A ambiguously refers to a type in one of the modules X0, X1 (try qualifying the type name with the module name)
 git-issue-4936c.dfy(64,18): Error: The name A ambiguously refers to a type in one of the modules X1, X0 (try qualifying the type name with the module name)
-git-issue-4936c.dfy(95,12): Error: a reads-clause expression must denote an object, a single field location like o`x or a`[i] of type (object, field)  (with `--referrers`), a set/iset/multiset/seq of objects or single field locations (with `--referrers`), or a function to a set/iset/multiset/seq of objects or single field locations (with `--referrers`) (instead got B)
+git-issue-4936c.dfy(95,12): Error: a reads clause can only refer to reference types (consider declaring the trait 'B' with 'extends object')
 5 resolution/type errors detected in git-issue-4936c.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy
@@ -1,0 +1,64 @@
+// RUN: %testDafnyForEachResolver --expect-exit-code=2 "%s" -- --general-traits=datatype --general-newtypes=false
+
+// Regression test for https://github.com/dafny-lang/dafny/issues/6470.
+// Under --general-traits=datatype (the default for Dafny 5.0), a bare trait
+// is not a reference type. Reads/modifies/unchanged/fresh on a non-reference
+// trait should produce a tailored error message suggesting `extends object`,
+// not the generic one that points to `--referrers`.
+
+module Tests {
+  class Bank { }
+
+  trait Account {
+    var bank: Bank
+  }
+
+  // reads clause, directly on a trait value
+  function GetBank(a: Account): Bank
+    reads a // error: non-reference trait
+  { a.bank }
+
+  // reads clause, on a field location of a trait value
+  function GetBank2(a: Account): Bank
+    reads a`bank // error: non-reference trait
+  { a.bank }
+
+  // reads clause, on a set of trait values
+  function GetSize(accts: set<Account>): int
+    reads accts // error: non-reference trait
+  { 0 }
+
+  // modifies clause
+  method SetBank(a: Account, b: Bank)
+    modifies a // error: non-reference trait
+  { a.bank := b; }
+
+  // unchanged expression
+  twostate predicate SameBank(a: Account)
+  { unchanged(a) } // error: non-reference trait
+
+  // fresh expression
+  twostate predicate IsFresh(a: Account)
+  { fresh(a) } // error: non-reference trait
+
+  // fresh on a set of traits
+  twostate predicate AllFresh(s: set<Account>)
+  { fresh(s) } // error: non-reference trait
+}
+
+// Positive control: with `extends object`, the same shapes verify cleanly.
+module TestsOk {
+  class Bank { }
+
+  trait Account extends object {
+    var bank: Bank
+  }
+
+  function GetBank(a: Account): Bank
+    reads a
+  { a.bank }
+
+  method SetBank(a: Account, b: Bank)
+    modifies a
+  { a.bank := b; }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy
@@ -62,3 +62,21 @@ module TestsOk {
     modifies a
   { a.bank := b; }
 }
+
+// The tailored suggestion must not appear when the shape is what is wrong. A reads clause accepts an
+// arrow only if it returns a collection, so `() ~> Account` is rejected on shape regardless of whether
+// Account is a reference type -- and `extends object` would not help, as the second case shows.
+module TestsShapeNotReferenceness {
+  trait Account { }
+
+  function ReadsArrowToTrait(g: () ~> Account): int
+    reads g
+  { 0 } // error: shape, not reference-ness
+
+  trait RefAccount extends object { }
+
+  function ReadsArrowToRefTrait(g: () ~> RefAccount): int
+    reads g
+  { 0 } // error: still the shape, even though the trait is a reference type
+}
+

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.expect
@@ -1,0 +1,9 @@
+NonReferenceTraitsFrames.dfy(18,10): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(23,10): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(23,10): Error: type of the receiver is not fully determined at this program point
+NonReferenceTraitsFrames.dfy(28,10): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(33,13): Error: a modifies clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(38,14): Error: an unchanged expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(42,4): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(46,4): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+8 resolution/type errors detected in NonReferenceTraitsFrames.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.expect
@@ -6,4 +6,6 @@ NonReferenceTraitsFrames.dfy(33,13): Error: a modifies clause can only refer to 
 NonReferenceTraitsFrames.dfy(38,14): Error: an unchanged expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
 NonReferenceTraitsFrames.dfy(42,4): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
 NonReferenceTraitsFrames.dfy(46,4): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
-8 resolution/type errors detected in NonReferenceTraitsFrames.dfy
+NonReferenceTraitsFrames.dfy(73,10): Error: a reads-clause expression must denote an object, a single field location like o`x or a`[i] of type (object, field)  (with `--referrers`), a set/iset/multiset/seq of objects or single field locations (with `--referrers`), or a function to a set/iset/multiset/seq of objects or single field locations (with `--referrers`) (instead got () ~> Account)
+NonReferenceTraitsFrames.dfy(79,10): Error: a reads-clause expression must denote an object, a single field location like o`x or a`[i] of type (object, field)  (with `--referrers`), a set/iset/multiset/seq of objects or single field locations (with `--referrers`), or a function to a set/iset/multiset/seq of objects or single field locations (with `--referrers`) (instead got () ~> RefAccount)
+10 resolution/type errors detected in NonReferenceTraitsFrames.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.refresh.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.refresh.expect
@@ -1,0 +1,8 @@
+NonReferenceTraitsFrames.dfy(18,10): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(23,10): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(28,10): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(33,13): Error: a modifies clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(38,14): Error: an unchanged expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(42,10): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+NonReferenceTraitsFrames.dfy(46,10): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
+7 resolution/type errors detected in NonReferenceTraitsFrames.dfy

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.refresh.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/traits/NonReferenceTraitsFrames.dfy.refresh.expect
@@ -5,4 +5,6 @@ NonReferenceTraitsFrames.dfy(33,13): Error: a modifies clause can only refer to 
 NonReferenceTraitsFrames.dfy(38,14): Error: an unchanged expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
 NonReferenceTraitsFrames.dfy(42,10): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
 NonReferenceTraitsFrames.dfy(46,10): Error: a fresh expression can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
-7 resolution/type errors detected in NonReferenceTraitsFrames.dfy
+NonReferenceTraitsFrames.dfy(73,10): Error: a reads-clause expression must denote an object, a single field location like o`x or a`[i] of type (object, field)  (with `--referrers`), a set/iset/multiset/seq of objects or single field locations (with `--referrers`), or a function to a set/iset/multiset/seq of objects or single field locations (with `--referrers`) (instead got () ~> Account)
+NonReferenceTraitsFrames.dfy(79,10): Error: a reads-clause expression must denote an object, a single field location like o`x or a`[i] of type (object, field)  (with `--referrers`), a set/iset/multiset/seq of objects or single field locations (with `--referrers`), or a function to a set/iset/multiset/seq of objects or single field locations (with `--referrers`) (instead got () ~> RefAccount)
+9 resolution/type errors detected in NonReferenceTraitsFrames.dfy

--- a/docs/dev/news/6470.fix
+++ b/docs/dev/news/6470.fix
@@ -1,0 +1,1 @@
+Improve the error messages produced when `reads`, `modifies`, `unchanged`, and `fresh` are applied to a non-reference trait: the diagnostic now suggests declaring the trait with `extends object` instead of showing the generic message that mentions `--referrers`.

--- a/docs/dev/news/6470.fix
+++ b/docs/dev/news/6470.fix
@@ -1,1 +1,1 @@
-Improve the error messages produced when `reads`, `modifies`, `unchanged`, and `fresh` are applied to a non-reference trait: the diagnostic now suggests declaring the trait with `extends object` instead of showing the generic message that mentions `--referrers`.
+Improve the error messages produced when `reads`, `modifies`, `unchanged`, and `fresh` are applied to a non-reference trait: the diagnostic now suggests declaring the trait with `extends object` instead of showing the generic message that mentions `--referrers`


### PR DESCRIPTION
Closes #6470.

## Problem

Under the upcoming Dafny 5.0 default (`--general-traits=datatype`, set by #6432), a bare `trait` is not a reference type. When such a trait appears in a `reads`, `modifies`, `unchanged`, or `fresh` clause, the resolver previously emitted the generic frame-expression error that points users toward `--referrers`:

```
Error: a reads-clause expression must denote an object, a single field location
like `o\`x` or `a\`[i]` of type (object, field) (with `--referrers`), a
set/iset/multiset/seq of objects or single field locations (with `--referrers`),
or a function to a set/iset/multiset/seq of objects or single field locations
(with `--referrers`) (instead got Account)
```

The `--referrers` hint is misleading for this case: enabling that flag does not make the trait usable in a reads clause. The correct fix is to declare the trait with `extends object` so it is a reference type. Dafny already has a well-designed diagnostic for the declaration of a mutable field on such a trait ("mutable fields are allowed only in reference types (consider declaring... 'extends object')"), but that error is suppressed whenever any earlier error has been reported during resolution — which the reads-clause error does unconditionally.

## Fix

Detect the non-reference-trait case after the existing collection/tuple/arrow unwrapping, in both resolver paths, and emit a tailored message:

```
Error: a reads clause can only refer to reference types (consider declaring the
trait 'Account' with 'extends object')
```

Parallel variants for `modifies`, `unchanged`, and `fresh`. For all other failing types (datatypes, newtypes, type parameters, `int`, `bool`, `map<...>`, arrow-only, etc.), the generic message is unchanged.

Both resolvers route through a small shared helper (`ModuleResolver.NonReferenceTraitFrameMessageOrNull`) so the two runs produce character-identical output for the tailored case.

## Implementation

- Legacy resolver: a new `XConstraintFrame` subclass carries the `FrameExpressionUse` alongside a single constraint name (`FrameExpression`), replacing the two former constraint names (`ReadsFrame` and `ModifiesFrame`; `unchanged` had been routed through `ModifiesFrame`).
- `FrameExpressionUse.ClauseDescription()` extension and shared `FreshGenericFormat` string so both resolvers produce identical text.

## Scope

In scope:
- Reads, modifies, unchanged, and fresh on non-reference traits (direct, collection-wrapped, field-location, arrow-result).
- Both the legacy XConstraint resolver and the PreType resolver.

Explicitly out of scope:
- Datatypes, newtypes, type parameters: these also hit the generic message but `extends object` isn't the right hint for them. Separate UX work.
- Equality-path diagnostics (`==` on non-reference trait, `set<NonRefTrait>` as value): have a legitimate alternative fix (`(==)` type characteristic) that `extends object` alone doesn't cover.
- The architectural gate that suppresses later resolver checks once any earlier error has been reported (`ModuleResolver.cs:1523`): broader concern.

## Testing

- New test file `traits/NonReferenceTraitsFrames.dfy` covering all four constructs plus set-wrapped variants and a positive control. Has both `.expect` and `.refresh.expect` (the two resolvers anchor column positions slightly differently, and the legacy resolver also emits an extra follow-on error for the field-location case).
- Updated `git-issues/git-issue-4936c.dfy.expect` (the only pre-existing test that hits the tailored path — it has `trait B extends X1.A { ... reads this }`, exactly the user's pattern).
- Ran the whole `traits/` suite (29 tests pass) and the 10 other test files matching the old generic message strings (all pass) to check for collateral damage.

## Screenshot from user's example

Before:
```
Bank-bug.dfy(7,44): Error: a reads-clause expression must denote an object, a single field location like o\`x or a\`[i] of type (object, field)  (with \`--referrers\`), a set/iset/multiset/seq of objects or single field locations (with \`--referrers\`), or a function to a set/iset/multiset/seq of objects or single field locations (with \`--referrers\`) (instead got Account)
```

After:
```
Bank-bug.dfy(7,44): Error: a reads clause can only refer to reference types (consider declaring the trait 'Account' with 'extends object')
```
