### PR TITLE
Verification coverage improve assertions range displayed

### DIFF
--- a/Source/DafnyDriver/TextVerificationLogger.cs
+++ b/Source/DafnyDriver/TextVerificationLogger.cs
@@ -53,9 +53,17 @@ public class TextVerificationLogger : IVerificationResultFormatLogger {
       textWriter.WriteLine($"    Resource count: {vcResult.ResourceCount}");
       textWriter.WriteLine("");
       textWriter.WriteLine("    Assertions:");
+
       foreach (var cmd in vcResult.Asserts) {
-        textWriter.WriteLine(
-          $"      {cmd.tok.filename}({cmd.tok.line},{cmd.tok.col}): {cmd.Description.SuccessDescription}");
+        var dafnyOrigin = BoogieGenerator.ToDafnyToken(cmd.tok);
+        var range = dafnyOrigin?.EntireRangeWithFallback;
+        if (range?.StartToken != null) {
+          textWriter.WriteLine(
+            $"      {range.StartToken.filename}({range.StartToken.line},{range.StartToken.col})-({range.EndToken.line},{range.EndToken.col}): {cmd.Description.SuccessDescription}");
+        } else {
+          textWriter.WriteLine(
+            $"      {cmd.tok.filename}({cmd.tok.line},{cmd.tok.col}): {cmd.Description.SuccessDescription}");
+        }
       }
 
       if (vcResult.CoveredElements.Any() && vcResult.Outcome == SolverOutcome.Valid) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/TextLogger.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/TextLogger.dfy
@@ -13,7 +13,7 @@
 // CHECK: Outcome: Invalid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*
-// CHECK: TextLogger.dfy\(35,3\): assertion always holds
+// CHECK: TextLogger.dfy\(35,3\)-\(35,21\): assertion always holds
 // CHECK: Overall outcome: Errors
 // CHECK: Overall time: .*
 // CHECK: Overall resource count: .*
@@ -26,7 +26,7 @@
 // CHECK: Outcome: Invalid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*
-// CHECK: TextLogger.dfy\(35,3\): assertion always holds
+// CHECK: TextLogger.dfy\(35,3\)-\(35,21\): assertion always holds
 method M(x: int, y: int)
   requires y > 0
   requires x > 0

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/TextLogger.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/TextLogger.dfy
@@ -9,7 +9,7 @@
 // CHECK: Outcome: Valid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*
-// CHECK: TextLogger.dfy\(34,14\): divisor is always non-zero
+// CHECK: TextLogger.dfy\(34,12\)-\(34,16\): divisor is always non-zero
 // CHECK: Outcome: Invalid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*
@@ -22,7 +22,7 @@
 // CHECK: Outcome: Valid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*
-// CHECK: TextLogger.dfy\(34,14\): divisor is always non-zero
+// CHECK: TextLogger.dfy\(34,12\)-\(34,16\): divisor is always non-zero
 // CHECK: Outcome: Invalid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/TextLoggerBatch.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/TextLoggerBatch.dfy
@@ -8,8 +8,8 @@
 // CHECK: Outcome: Invalid
 // CHECK: Duration: .*
 // CHECK: Resource count: .*
-// CHECK: TextLoggerBatch.dfy\(17,14\): divisor is always non-zero
-// CHECK: TextLoggerBatch.dfy\(18,3\): assertion always holds
+// CHECK: TextLoggerBatch.dfy\(17,12\)-\(17,16\): divisor is always non-zero
+// CHECK: TextLoggerBatch.dfy\(18,3\)-\(18,21\): assertion always holds
 method M(x: int, y: int)
   requires y > 0
   requires x > 0
@@ -17,3 +17,4 @@ method M(x: int, y: int)
   var d := x / y;
   assert(d * y == x); // Should fail
 }
+


### PR DESCRIPTION
# Description 

Before this changes when running a "dafny verify Some_file.txt --verification-coverage-report cov --log-format text"

A log text was created such as this example
```txt
 Assertion batch 1:
    Outcome: Valid
    Duration: 00:00:00.1137611
    Resource count: 3886

    Assertions:
      test_pre_cov_test.dfy(9,19): the precondition always holds

    Proof dependencies:
      test_pre_cov_test.dfy(9,9)-(9,23): requires clause at test_pre_cov_test.dfy(2,14)-(2,19) from call

    Unused by proof:
      test_pre_cov_test.dfy(9,9)-(9,23): call
      test_pre_cov_test.dfy(9,9)-(9,23): assignment (or return)
``` 

The problem with the report is that, for an assertion, the range is not displayed; instead, only a point position is shown (and, although in this example it is mostly obvious which token range it refers to, it is not in other cases). (And as the complexity does not allow for easy use of this report for other scripts due to the mismatch).

This PR changes the text message to indicate a range (if the converted node from Boogie to Dafny has a companion range node).

With this change, this log in particular looks more like so
```txt
  Assertion batch 1:
    Outcome: Valid
    Duration: 00:00:00.1012403
    Resource count: 3886

    Assertions:
      test_pre_cov_test.dfy(9,9)-(9,23): the precondition always holds

    Proof dependencies:
      test_pre_cov_test.dfy(9,9)-(9,23): requires clause at test_pre_cov_test.dfy(2,14)-(2,19) from call

    Unused by proof:
      test_pre_cov_test.dfy(9,9)-(9,23): call
      test_pre_cov_test.dfy(9,9)-(9,23): assignment (or return)
```

allowing easy match the new range:
    Assertions:
      test_pre_cov_test.dfy(9,9)-(9,23): the precondition always holds 

with  the one on the dependencies
    Proof dependencies:
      test_pre_cov_test.dfy(9,9)-(9,23): requires clause at test_pre_cov_test.dfy(2,14)-(2,19) from call

      

# Effects 
This change only affects this verification log report.




<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
