### PR TITLE
fix: respect the OS path case-sensitivity when matching source files

### DIFF
--- a/Source/DafnyCore.Test/DafnyProjectTest.cs
+++ b/Source/DafnyCore.Test/DafnyProjectTest.cs
@@ -34,4 +34,44 @@ public class DafnyProjectTest {
     second.Options.Add("m", "3, 2, 1");
     Assert.NotEqual(first, second);
   }
+
+  // Regression test for https://github.com/dafny-lang/dafny/issues/6476: on a case-sensitive OS, an include
+  // such as `file.dfy` must not also match `File.dfy`.
+  //
+  // The strong assertion only applies when this run is on a case-sensitive OS (so the fix is in effect) AND
+  // the underlying filesystem actually distinguishes the two files (so the scenario is even constructible).
+  // On a typical Linux CI runner both hold, so the regression is genuinely exercised there; on Windows/macOS
+  // the test still runs but only checks that ordinary matching keeps working. The OS-keyed approach does not
+  // cover atypical volumes (a case-sensitive volume on macOS, or a case-insensitive mount on Linux); those
+  // are a known limitation rather than something this test pins down.
+  [Fact]
+  public void IncludeMatchingDoesNotMatchOtherCasingsOnCaseSensitiveOs() {
+    var directory = Path.Combine(Path.GetTempPath(), "dafny-6476-" + Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(directory);
+    try {
+      File.WriteAllText(Path.Combine(directory, "file.dfy"), "");
+      // On a case-insensitive filesystem this overwrites file.dfy (one file remains); on a case-sensitive
+      // one it creates a distinct second file.
+      File.WriteAllText(Path.Combine(directory, "File.dfy"), "");
+      var distinctFilesExist = Directory.GetFiles(directory, "*.dfy").Length == 2;
+
+      var projectUri = new Uri(Path.Combine(directory, DafnyProject.FileName));
+      var project = new DafnyProject(null, projectUri, null, new HashSet<string> { "file.dfy" });
+
+      var matched = project.GetRootSourceUris(OnDiskFileSystem.Instance)
+        .Select(uri => Path.GetFileName(uri.LocalPath)).ToHashSet();
+
+      var caseSensitiveOs = DafnyProject.FileSystemCaseComparison == StringComparison.Ordinal;
+      if (caseSensitiveOs && distinctFilesExist) {
+        // The include `file.dfy` selects only `file.dfy`, never the unrelated `File.dfy`.
+        Assert.Contains("file.dfy", matched);
+        Assert.DoesNotContain("File.dfy", matched);
+      } else {
+        // Case-insensitive OS/filesystem: the include still resolves the (single) file.
+        Assert.NotEmpty(matched);
+      }
+    } finally {
+      Directory.Delete(directory, true);
+    }
+  }
 }

--- a/Source/DafnyCore.Test/DafnyProjectTest.cs
+++ b/Source/DafnyCore.Test/DafnyProjectTest.cs
@@ -70,7 +70,8 @@ public class DafnyProjectTest {
         // Case-insensitive OS/filesystem: the include still resolves the (single) file.
         Assert.NotEmpty(matched);
       }
-    } finally {
+    }
+    finally {
       Directory.Delete(directory, true);
     }
   }

--- a/Source/DafnyCore.Test/DafnyProjectTest.cs
+++ b/Source/DafnyCore.Test/DafnyProjectTest.cs
@@ -35,15 +35,9 @@ public class DafnyProjectTest {
     Assert.NotEqual(first, second);
   }
 
-  // Regression test for https://github.com/dafny-lang/dafny/issues/6476: on a case-sensitive OS, an include
-  // such as `file.dfy` must not also match `File.dfy`.
-  //
-  // The strong assertion only applies when this run is on a case-sensitive OS (so the fix is in effect) AND
-  // the underlying filesystem actually distinguishes the two files (so the scenario is even constructible).
-  // On a typical Linux CI runner both hold, so the regression is genuinely exercised there; on Windows/macOS
-  // the test still runs but only checks that ordinary matching keeps working. The OS-keyed approach does not
-  // cover atypical volumes (a case-sensitive volume on macOS, or a case-insensitive mount on Linux); those
-  // are a known limitation rather than something this test pins down.
+  // Regression test for https://github.com/dafny-lang/dafny/issues/6476: an include like `file.dfy` must not
+  // also match `File.dfy`. The strict check only applies where it's both relevant and constructible -- a
+  // case-sensitive OS whose filesystem actually distinguishes the two files (e.g. a typical Linux runner).
   [Fact]
   public void IncludeMatchingDoesNotMatchOtherCasingsOnCaseSensitiveOs() {
     var directory = Path.Combine(Path.GetTempPath(), "dafny-6476-" + Guid.NewGuid().ToString("N"));

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -173,12 +173,8 @@ public class DafnyProject : IEquatable<DafnyProject> {
     var excludes = Excludes;
     var fullPaths = includes.Concat(excludes).Select(p => Path.GetFullPath(p, projectRoot)).ToList();
     commonRoot = GetCommonParentDirectory(fullPaths) ?? diskRoot;
-    // Match include/exclude globs using the operating system's default path case-sensitivity, rather than
-    // the Matcher's default (which is always case-insensitive). On a case-sensitive OS this prevents an
-    // include like `file.dfy` from also matching unrelated files such as `File.dfy` (#6476); on a
-    // case-insensitive one it preserves the lenient matching users there expect. Note this keys off the OS,
-    // not the actual filesystem, so it does not cover atypical volumes (e.g. a case-sensitive volume on
-    // macOS, or a case-insensitive mount on Linux).
+    // The Matcher default is always case-insensitive, which makes an include like `file.dfy` also match
+    // `File.dfy` on a case-sensitive OS (#6476); use the OS's path case-sensitivity instead.
     var matcher = new Matcher(FileSystemCaseComparison);
     foreach (var includeGlob in includes) {
       matcher.AddInclude(Path.GetRelativePath(commonRoot, Path.GetFullPath(includeGlob, projectRoot)));
@@ -192,10 +188,10 @@ public class DafnyProject : IEquatable<DafnyProject> {
   }
 
   /// <summary>
-  /// The string comparison to use when matching source-file paths, based on the operating system's default
-  /// path case-sensitivity. This mirrors how .NET's own path APIs compare paths: case-insensitive on Windows
-  /// and macOS, case-sensitive elsewhere. It is an OS-level heuristic, not a per-filesystem probe, so it can
-  /// be wrong on atypical volumes (a case-sensitive volume on macOS, or a case-insensitive mount on Linux).
+  /// Path comparison based on the operating system's default case-sensitivity (case-insensitive on Windows
+  /// and macOS, case-sensitive elsewhere), mirroring .NET's own path APIs. This is an OS-level heuristic, not
+  /// a per-filesystem probe, so it can be wrong on atypical volumes such as a case-sensitive volume on macOS
+  /// or a case-insensitive mount on Linux.
   /// </summary>
   public static StringComparison FileSystemCaseComparison =>
     OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -189,9 +189,11 @@ public class DafnyProject : IEquatable<DafnyProject> {
 
   /// <summary>
   /// Path comparison based on the operating system's default case-sensitivity (case-insensitive on Windows
-  /// and macOS, case-sensitive elsewhere), mirroring .NET's own path APIs. This is an OS-level heuristic, not
-  /// a per-filesystem probe, so it can be wrong on atypical volumes such as a case-sensitive volume on macOS
-  /// or a case-insensitive mount on Linux.
+  /// and macOS, case-sensitive elsewhere). This reconstructs .NET's own path-comparison predicate
+  /// (System.IO.PathInternal.IsCaseSensitive), which is internal and has no public equivalent; neither does
+  /// the globbing Matcher offer a platform-aware constructor. It is an OS-level heuristic, not a per-filesystem
+  /// probe, so it can be wrong on atypical volumes such as a case-sensitive volume on macOS or a
+  /// case-insensitive mount on Linux.
   /// </summary>
   public static StringComparison FileSystemCaseComparison =>
     OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()

--- a/Source/DafnyCore/Options/DafnyProject.cs
+++ b/Source/DafnyCore/Options/DafnyProject.cs
@@ -173,7 +173,13 @@ public class DafnyProject : IEquatable<DafnyProject> {
     var excludes = Excludes;
     var fullPaths = includes.Concat(excludes).Select(p => Path.GetFullPath(p, projectRoot)).ToList();
     commonRoot = GetCommonParentDirectory(fullPaths) ?? diskRoot;
-    var matcher = new Matcher();
+    // Match include/exclude globs using the operating system's default path case-sensitivity, rather than
+    // the Matcher's default (which is always case-insensitive). On a case-sensitive OS this prevents an
+    // include like `file.dfy` from also matching unrelated files such as `File.dfy` (#6476); on a
+    // case-insensitive one it preserves the lenient matching users there expect. Note this keys off the OS,
+    // not the actual filesystem, so it does not cover atypical volumes (e.g. a case-sensitive volume on
+    // macOS, or a case-insensitive mount on Linux).
+    var matcher = new Matcher(FileSystemCaseComparison);
     foreach (var includeGlob in includes) {
       matcher.AddInclude(Path.GetRelativePath(commonRoot, Path.GetFullPath(includeGlob, projectRoot)));
     }
@@ -184,6 +190,17 @@ public class DafnyProject : IEquatable<DafnyProject> {
 
     return matcher;
   }
+
+  /// <summary>
+  /// The string comparison to use when matching source-file paths, based on the operating system's default
+  /// path case-sensitivity. This mirrors how .NET's own path APIs compare paths: case-insensitive on Windows
+  /// and macOS, case-sensitive elsewhere. It is an OS-level heuristic, not a per-filesystem probe, so it can
+  /// be wrong on atypical volumes (a case-sensitive volume on macOS, or a case-insensitive mount on Linux).
+  /// </summary>
+  public static StringComparison FileSystemCaseComparison =>
+    OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()
+      ? StringComparison.OrdinalIgnoreCase
+      : StringComparison.Ordinal;
 
   string? GetCommonParentDirectory(IReadOnlyList<string> strings) {
     if (!strings.Any()) {

--- a/docs/dev/news/6476.fix
+++ b/docs/dev/news/6476.fix
@@ -1,0 +1,1 @@
+On case-sensitive operating systems, a Dafny file or project include such as `file.dfy` no longer also matches differently-cased files like `File.dfy`


### PR DESCRIPTION
## Summary

Fixes #6476: on a case-sensitive OS, `dafny verify file.dfy` (and project `includes`) also matched differently-cased files like `File.dfy`.

## Cause and fix

`DafnyProject.GetMatcher` used `new Matcher()`, whose default matching is case-insensitive on every platform. The fix constructs it with the OS's default path case-sensitivity instead — case-insensitive on Windows/macOS, case-sensitive elsewhere — mirroring how .NET compares paths. Case-insensitive systems keep their lenient matching; case-sensitive ones no longer match other casings.

## Known limitation

This keys off the OS, not the actual filesystem, so it doesn't cover atypical volumes (a case-sensitive volume on macOS, or a case-insensitive mount on Linux). Covering those would need a per-filesystem probe (as git does for `core.ignorecase`), which writes files on the project-resolution/IDE path — not worth it here. The chosen approach is a strict improvement over the previous always-case-insensitive behavior, with no regressions, and matches .NET's own path handling.

## Test

`DafnyProjectTest.IncludeMatchingDoesNotMatchOtherCasingsOnCaseSensitiveOs` checks that an `includes` of `file.dfy` selects only `file.dfy`. The strict assertion runs only on a case-sensitive OS whose filesystem creates distinct case-variant files (a typical Linux CI runner, where the regression is genuinely exercised); elsewhere it just confirms ordinary matching still resolves the file. Because the change is OS-keyed, its effect is only observable on a case-sensitive OS.

Fixes #6476

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
