### PR TITLE
chore(ci): migrate NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/nightly-build-manual.yml
+++ b/.github/workflows/nightly-build-manual.yml
@@ -18,9 +18,14 @@ on:
       
 jobs:
   nightly-build:
+    # Inherited by the reusable chain (which can only reduce these); id-token is
+    # needed for the downstream NuGet Trusted Publishing login.
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: ${{ inputs.ref }}
       publish-prerelease: ${{ inputs.publish-prerelease }}
     secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+      nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/nightly-build-reusable.yml
+++ b/.github/workflows/nightly-build-reusable.yml
@@ -14,13 +14,16 @@ on:
         type: boolean
         default: false
     secrets:
-      # Required if publish-prerelease is true
-      nuget_api_key:
+      # nuget.org profile name of the Trusted Publishing policy creator.
+      nuget_user:
         required: false
 
 jobs:
   deep-integration-tests:
     if: github.repository_owner == 'dafny-lang'
+    # Drop the caller's id-token grant: only publish-release needs it.
+    permissions:
+      contents: read
     uses: ./.github/workflows/integration-tests-reusable.yml
     with:
       ref: ${{ inputs.ref }}
@@ -32,6 +35,8 @@ jobs:
   determine-vars:
     if: github.repository_owner == 'dafny-lang' && inputs.publish-prerelease
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout Dafny
         uses: actions/checkout@v7
@@ -49,6 +54,11 @@ jobs:
       name: nightly-${{ env.date }}-${{ env.sha_short }}
 
   publish-release:
+    # Re-grant id-token here: this hop's permissions are inherited by the
+    # reusable workflow, which can only reduce them, not add id-token back.
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/publish-release-reusable.yml
     needs: [deep-integration-tests, determine-vars]
     with:
@@ -60,4 +70,4 @@ jobs:
       release_notes: "This is an automatically published nightly release. This release may not be as stable as versioned releases and does not contain release notes."
       prerelease: true
     secrets:
-      nuget_api_key: ${{ secrets.nuget_api_key }}
+      nuget_user: ${{ secrets.nuget_user }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -25,9 +25,14 @@ on:
 jobs:
   nightly-build-for-master:
     if: github.repository_owner == 'dafny-lang'
+    # Inherited by the reusable chain, which can only reduce these; id-token is
+    # needed for the downstream NuGet Trusted Publishing login.
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/nightly-build-reusable.yml
     with:
       ref: master
       publish-prerelease: true
     secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+      nuget_user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -25,8 +25,8 @@ on:
         required: true
         type: boolean
     secrets:
-      # Required if release_nuget is true
-      nuget_api_key:
+      # nuget.org profile name (not an email) of the Trusted Publishing policy creator.
+      nuget_user:
         required: false
 
 env:
@@ -36,6 +36,9 @@ jobs:
 
   publish-release:
     runs-on: macos-14     # Put back 'ubuntu-22.04' if macos-14 fails in any way
+    permissions:
+      id-token: write   # for NuGet Trusted Publishing (NuGet/login step below)
+      contents: write   # tag push, action-gh-release, and asset cleanup below
     steps:
     - name: Print version
       run: echo ${{ inputs.name }}
@@ -91,12 +94,21 @@ jobs:
         name: nuget-packages
         path: dafny/Binaries/*.nupkg
 
+    # The nuget.org Trusted Publishing policy must name THIS file, not the caller:
+    # NuGet matches the OIDC job_workflow_ref claim (the file defining this job).
+    - name: NuGet login (OIDC -> short-lived API key)
+      if: ${{ inputs.release_nuget }}
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.nuget_user }}
+
     - name: Upload package to NuGet
       if: ${{ inputs.release_nuget }}
       # Need --skip-duplicate for cases where we release a new Dafny
       # version but the runtime hasn't changed and is still the old
       # version.
-      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
     - name: Install pandoc - Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,6 +30,11 @@ jobs:
 
   publish-release:
     needs: [deep-integration-tests, get-version]
+    # The reusable workflow inherits these; a called workflow can only reduce,
+    # never add, permissions, so id-token must be granted here for its NuGet login.
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/publish-release-reusable.yml
     with:
       name: ${{ needs.get-version.outputs.version }}
@@ -40,4 +45,4 @@ jobs:
       # We can probably automate pulling this out of RELEASE_NOTES.md in the future
       release_notes: ""
     secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+      nuget_user: ${{ secrets.NUGET_USER }}


### PR DESCRIPTION
## Problem

The nightly build fails every night at the final `dotnet nuget push`:

```
error: 403 (The specified API key is invalid, has expired, or does not have permission...)
```

The long-lived `NUGET_API_KEY` secret expired. nuget.org now caps API-key lifetimes, so re-issuing only delays the next outage.

## Fix

Migrate to [nuget.org Trusted Publishing](https://learn.microsoft.com/en-gb/nuget/nuget-org/trusted-publishing): a [`NuGet/login@v1`](https://github.com/NuGet/login) step exchanges a GitHub OIDC token for a short-lived key right before the push — no stored key to expire.

Two facts drive the diff:
- **The policy names the reusable file, not the caller.** nuget.org matches the OIDC `job_workflow_ref` claim (the file defining the publishing job), so a single policy for `publish-release-reusable.yml` covers both the release and nightly paths.
- **`id-token: write` is granted at every `uses:` hop.** A called workflow can only reduce, never add, permissions, so the grant must exist at each hop down to the publish job. Each block also re-grants `contents: write` (a permissions block is an allowlist, and the publish job pushes a tag, creates a release, and cleans up assets). The nightly test/`determine-vars` jobs are pinned to `contents: read`.

## Validation

Verified end-to-end by dispatching `nightly-build-manual.yml` on this branch (`publish-prerelease: true`), exercising the full 2-level nightly nesting: [run 29867559641](https://github.com/dafny-lang/dafny/actions/runs/29867559641). The `NuGet login (OIDC -> short-lived API key)` and `Upload package to NuGet` steps both succeeded, and `4.11.1-nightly-2026-07-21-33399e2` (this branch's HEAD) is now published on nuget.org — no stored API key involved.

## Setup completed

- ✅ Trusted Publishing policy created (Repository Owner `dafny-lang`, Repository `dafny`, Workflow File `publish-release-reusable.yml`, no Environment).
- ✅ Repo Actions secret `NUGET_USER` added (nuget.org profile name of the policy creator).

After merge, the old `NUGET_API_KEY` secret can be deleted. Rollback = revert this PR (the two mechanisms are independent).