### PR TITLE
fix: readable doo-anchored diagnostics and a notice when lib builds embed doo dependencies

### DIFF
--- a/Source/DafnyCore/Backends/Library/LibraryBackend.cs
+++ b/Source/DafnyCore/Backends/Library/LibraryBackend.cs
@@ -45,9 +45,12 @@ public class LibraryBackend : ExecutableBackend {
     return null;
   }
 
-  public override Task<bool> OnPostGenerate(string dafnyProgramName, string targetFilename, IDafnyOutputWriter outputWriter) {
+  public override async Task<bool> OnPostGenerate(string dafnyProgramName, string targetFilename, IDafnyOutputWriter outputWriter) {
     // Not calling base.OnPostCompile() since it references `compiler`
-    return Task.FromResult(true);
+    foreach (var message in embeddedLibraryMessages) {
+      await outputWriter.Status(message);
+    }
+    return true;
   }
 
   public override string PublicIdProtect(string name) {
@@ -59,8 +62,81 @@ public class LibraryBackend : ExecutableBackend {
       throw new UnsupportedFeatureException(dafnyProgram.GetStartOfFirstFileToken(), Feature.LegacyCLI);
     }
 
+    ReportEmbeddedLibraries(dafnyProgram);
+
     var dooFile = new DooFile(dafnyProgram.AfterParsingClone);
     dooFile.Write(output);
+  }
+
+  private readonly List<string> embeddedLibraryMessages = [];
+
+  /// <summary>
+  /// A .doo file passed as a source input (as opposed to via --library) is compiled along with the
+  /// rest of the program, which for this backend means its modules are copied into the produced library.
+  /// Each copy is a separate module declaration, so using two libraries that embed the same module
+  /// together later fails with "Duplicate module name" (see issue #6486). Notify so that users who did
+  /// not intend to bundle their dependencies find out at the point where the embedding happens.
+  /// This is a plain status message rather than a diagnostic: warnings fail the build by default,
+  /// and working around that with --allow-warnings would force the same flag onto every consumer
+  /// of the produced library (that option is part of the recorded library options), while Info
+  /// diagnostics are only shown with --show-hints.
+  /// </summary>
+  private void ReportEmbeddedLibraries(Program dafnyProgram) {
+    var embeddedByDoo = EmbeddedDeclarations(dafnyProgram, dafnyProgram.DefaultModuleDef, "")
+      .Where(embedded => embedded.Uri is { IsFile: true } uri &&
+                         uri.LocalPath.EndsWith(DooFile.Extension, StringComparison.Ordinal))
+      .GroupBy(embedded => embedded.Uri);
+    foreach (var group in embeddedByDoo) {
+      var names = string.Join(", ", group.Select(embedded => embedded.Name).Distinct().OrderBy(name => name));
+      embeddedLibraryMessages.Add(
+        $"Note: the library {Options.GetPrintPath(group.Key.LocalPath)} was passed as a source file, " +
+        $"so a copy of its declarations ({names}) is embedded in the produced library. " +
+        "If that is not intended, pass it with --library instead; combining two libraries that embed " +
+        "the same declaration fails with a \"Duplicate module name\" or \"duplicate name of top-level " +
+        "declaration\" error.");
+    }
+  }
+
+  /// Whether declarations from "uri" get embedded in the output rather than merely referenced. A .doo
+  /// passed with --library is recorded in AlreadyCompiledRoots and is not embedded, so it must not be
+  /// reported.
+  ///
+  /// This is the only test used here, for every kind of declaration. ModuleDefinition.ShouldCompile answers
+  /// the same question for a module -- it agrees with this on every case exercised by the tests, including
+  /// excluding a --library module -- but it returns true unconditionally for the default module, which is
+  /// where a top-level type declaration and a default-class member live. Using it for modules and something
+  /// else for the rest is what let a --library .doo be reported as embedded.
+  private static bool IsEmbeddedFrom(Program dafnyProgram, Uri uri) {
+    return uri != null && dafnyProgram.Compilation.AlreadyCompiledRoots?.Contains(uri) is not true;
+  }
+
+  /// <summary>
+  /// The declarations of "module" that came from another file, paired with that file. Anything a .doo
+  /// contributes can collide when two libraries embed the same one, so this covers more than modules:
+  /// a .doo may hold only top-level type declarations, or only members of the default class, and a
+  /// dotted module name (module A.B) introduces a synthesized parent that has no origin of its own,
+  /// so the real declarations are one level down.
+  /// </summary>
+  private IEnumerable<(Uri Uri, string Name)> EmbeddedDeclarations(Program dafnyProgram,
+      ModuleDefinition module, string prefix) {
+    foreach (var decl in module.TopLevelDecls) {
+      var qualified = prefix + decl.Name;
+      if (decl is LiteralModuleDecl nested) {
+        if (nested.Origin.Uri == null) {
+          foreach (var embedded in EmbeddedDeclarations(dafnyProgram, nested.ModuleDef, qualified + ".")) {
+            yield return embedded;
+          }
+        } else if (IsEmbeddedFrom(dafnyProgram, nested.Origin.Uri)) {
+          yield return (nested.Origin.Uri, qualified);
+        }
+      } else if (decl is DefaultClassDecl defaultClass) {
+        foreach (var member in defaultClass.Members.Where(member => IsEmbeddedFrom(dafnyProgram, member.Origin.Uri))) {
+          yield return (member.Origin.Uri, prefix + member.Name);
+        }
+      } else if (IsEmbeddedFrom(dafnyProgram, decl.Origin.Uri)) {
+        yield return (decl.Origin.Uri, qualified);
+      }
+    }
   }
 
   public override void EmitCallToMain(Method mainMethod, string baseName, ConcreteSyntaxTree callToMainTree) {

--- a/Source/DafnyCore/DafnyFile.cs
+++ b/Source/DafnyCore/DafnyFile.cs
@@ -41,6 +41,14 @@ public class DafnyFile {
     return externalUri;
   }
 
+  /// <summary>
+  /// Maps an externally visible URI of an embedded file, as created by ExposeInternalUri,
+  /// back to the internal URI it stands for. Returns the given URI unchanged for all others.
+  /// </summary>
+  public static Uri ResolveEmbeddedUri(Uri uri) {
+    return ExternallyVisibleEmbeddedFiles.GetValueOrDefault(uri) ?? uri;
+  }
+
   public delegate IAsyncEnumerable<DafnyFile> HandleExtension(DafnyOptions options, IFileSystem
     fileSystem, ErrorReporter reporter, Uri uri, IOrigin origin, bool asLibrary);
 

--- a/Source/DafnyCore/DooFile.cs
+++ b/Source/DafnyCore/DooFile.cs
@@ -108,6 +108,38 @@ public class DooFile {
     return await Read(archive);
   }
 
+  /// <summary>
+  /// Reads only the program text stored in a .doo file, without validating the manifest.
+  /// Accepts file URIs as well as dllresource:// URIs of embedded .doo files.
+  /// </summary>
+  public static string ReadProgramText(Uri uri) {
+    if (uri.Scheme == "dllresource") {
+      var assembly = System.Reflection.Assembly.Load(uri.Host);
+      // Skip the leading "/"
+      var resourceName = uri.LocalPath[1..];
+      using var stream = assembly.GetManifestResourceStream(resourceName);
+      if (stream == null) {
+        throw new InvalidDataException($"Cannot find embedded resource: {resourceName}");
+      }
+      using var archive = new ZipArchive(stream);
+      return ReadProgramText(archive);
+    }
+
+    using var fileArchive = ZipFile.Open(uri.LocalPath, ZipArchiveMode.Read);
+    return ReadProgramText(fileArchive);
+  }
+
+  private static string ReadProgramText(ZipArchive archive) {
+    var programTextEntry = archive.GetEntry(ProgramFileEntry);
+    if (programTextEntry == null) {
+      throw new ArgumentException(".doo file missing program text entry");
+    }
+
+    using var programTextStream = programTextEntry.Open();
+    using var reader = new StreamReader(programTextStream, Encoding.UTF8);
+    return reader.ReadToEnd();
+  }
+
   public static async Task<DooFile> Read(Stream stream) {
     using var archive = new ZipArchive(stream);
     return await Read(archive);

--- a/Source/DafnyCore/Snippets.cs
+++ b/Source/DafnyCore/Snippets.cs
@@ -46,6 +46,13 @@ public class Snippets {
     var fsCache = FsCaches.GetOrCreateValue(options)!;
     List<string> lines = fsCache.GetOrAdd(uri, key => {
       try {
+        var resolvedKey = DafnyFile.ResolveEmbeddedUri(key);
+        if (string.Equals(Path.GetExtension(resolvedKey.LocalPath), DooFile.Extension, StringComparison.OrdinalIgnoreCase)) {
+          // Positions in doo-sourced declarations refer to the program text stored inside
+          // the .doo archive, not to the raw bytes of the archive itself.
+          using var dooReader = new StringReader(DooFile.ReadProgramText(resolvedKey));
+          return Util.Lines(dooReader).ToList();
+        }
         // Note: This is not guaranteed to be the same file that Dafny parsed. To ensure that, Dafny should keep
         // an in-memory version of each file it parses.
         var file = DafnyFile.HandleDafnyFile(OnDiskFileSystem.Instance, new ErrorReporterSink(options), options, uri, Token.NoToken);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/diamondBase.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/diamondBase.dfy
@@ -1,0 +1,1 @@
+module A {}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/diamondMid.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/diamondMid.dfy
@@ -1,0 +1,3 @@
+module B {
+  import A
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/embedDotted.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/embedDotted.dfy
@@ -1,0 +1,5 @@
+// A dotted module name: the synthesized parent "Outer" has no origin of its own, so the
+// declaration that came from the .doo is one level down.
+module Outer.Inner {
+  function G(): int { 2 }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/embedDottedUser.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/embedDottedUser.dfy
@@ -1,0 +1,4 @@
+module UserD {
+  import Outer.Inner
+  method M() { var x := Inner.G(); }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/embedTypeOnly.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/Inputs/embedTypeOnly.dfy
@@ -1,0 +1,2 @@
+// A .doo whose only declaration is a top-level type: no module for the flat query to find.
+datatype Color = Red | Blue

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooDiamondDependency.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooDiamondDependency.dfy
@@ -1,0 +1,15 @@
+// Diamond dependencies through .doo files (https://github.com/dafny-lang/dafny/issues/6486):
+// passing a .doo positionally embeds its modules into the produced library, and combining
+// two libraries that embed the same module fails. Check that the embedding is announced
+// and that the failure renders the embedded program text rather than raw archive bytes.
+// RUN: %build -t=lib --use-basename-for-filename "%S/Inputs/diamondBase.dfy" --output "%S/Output/diamondBase" > "%t"
+// RUN: %build -t=lib --use-basename-for-filename "%S/Output/diamondBase.doo" "%S/Inputs/diamondMid.dfy" --output "%S/Output/diamondMid" >> "%t"
+// RUN: %exits-with 2 %build -t=lib --use-basename-for-filename --show-snippets:true "%S/Output/diamondBase.doo" "%S/Output/diamondMid.doo" "%s" --output "%S/Output/diamondTop" >> "%t"
+// Passing every transitive dependency via --library is the intended workflow and keeps working:
+// RUN: %build -t=lib --use-basename-for-filename --library "%S/Output/diamondBase.doo" "%S/Inputs/diamondMid.dfy" --output "%S/Output/diamondMidLib" >> "%t"
+// RUN: %build -t=lib --use-basename-for-filename --library "%S/Output/diamondBase.doo" --library "%S/Output/diamondMidLib.doo" "%s" --output "%S/Output/diamondTopLib" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+module C {
+  import A
+  import B
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooDiamondDependency.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooDiamondDependency.dfy.expect
@@ -1,0 +1,20 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+Note: the library diamondBase.doo was passed as a source file, so a copy of its declarations (A) is embedded in the produced library. If that is not intended, pass it with --library instead; combining two libraries that embed the same declaration fails with a "Duplicate module name" or "duplicate name of top-level declaration" error.
+diamondMid.doo(4,7): Error: Duplicate module name: A
+  |
+4 | module A {
+  |        ^
+
+diamondBase.doo(4,7): Related location
+  |
+4 | module A {
+  |        ^
+
+1 resolution/type errors detected in the_program
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooEmbedNonModule.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooEmbedNonModule.dfy
@@ -1,0 +1,15 @@
+// The embedding note has to cover what a .doo can actually contribute, not just top-level modules
+// (https://github.com/dafny-lang/dafny/issues/6486). A .doo may hold only a top-level type
+// declaration, and a dotted module name puts the real declaration under a synthesized parent that
+// has no origin of its own; a flat scan for top-level modules passed over both.
+// RUN: %build -t=lib --use-basename-for-filename "%S/Inputs/embedTypeOnly.dfy" --output "%S/Output/embedTypeOnly" > "%t"
+// RUN: %build -t=lib --use-basename-for-filename --show-hints "%S/Output/embedTypeOnly.doo" "%s" --output "%S/Output/embedTypeTop" >> "%t"
+// RUN: %build -t=lib --use-basename-for-filename "%S/Inputs/embedDotted.dfy" --output "%S/Output/embedDotted" >> "%t"
+// RUN: %build -t=lib --use-basename-for-filename --show-hints "%S/Output/embedDotted.doo" "%S/Inputs/embedDottedUser.dfy" --output "%S/Output/embedDottedTop" >> "%t"
+// Passing the same .doo with --library embeds nothing, so it must not be announced:
+// RUN: %build -t=lib --use-basename-for-filename --show-hints --library "%S/Output/embedTypeOnly.doo" "%s" --output "%S/Output/embedTypeLib" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method UseColor() {
+  var c: Color := Red;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooEmbedNonModule.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/doofiles/dooEmbedNonModule.dfy.expect
@@ -1,0 +1,12 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+Note: the library embedTypeOnly.doo was passed as a source file, so a copy of its declarations (Color) is embedded in the produced library. If that is not intended, pass it with --library instead; combining two libraries that embed the same declaration fails with a "Duplicate module name" or "duplicate name of top-level declaration" error.
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+Note: the library embedDotted.doo was passed as a source file, so a copy of its declarations (Outer.Inner) is embedded in the produced library. If that is not intended, pass it with --library instead; combining two libraries that embed the same declaration fails with a "Duplicate module name" or "duplicate name of top-level declaration" error.
+
+Dafny program verifier finished with 0 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_ModuleClashSnippet.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_ModuleClashSnippet.dfy
@@ -1,0 +1,16 @@
+// A module clashing with a standard-library module anchors a diagnostic inside the
+// bundled standard-library .doo. Check that the snippet shows the library's program
+// text rather than raw archive bytes (https://github.com/dafny-lang/dafny/issues/6486).
+// RUN: %exits-with 2 %resolve --standard-libraries:true --show-snippets:true "%s" > "%t"
+// RUN: %OutputCheck --file-to-check "%t" "%s"
+// The snippet lines must be anchored to the .doo-anchored error: an unanchored search is also
+// satisfied by the identical module text in this file's own "Related location" snippet, which
+// master already prints correctly -- the header was never broken, the snippet body was.
+// The line number must be four digits or more so that only the library's own snippet can match;
+// this file is a dozen lines long, while the module sits deep inside the bundled .doo.
+// CHECK: DafnyStandardLibraries.dfy\(\d+,\d+\): Error: Duplicate module name: Wrappers
+// CHECK-NEXT: ^ +\|$
+// CHECK-NEXT: ^\d{4,} \| module Std.Wrappers \{$
+module Std.Wrappers {
+  const x := 1
+}

--- a/docs/dev/news/6486.fix
+++ b/docs/dev/news/6486.fix
@@ -1,0 +1,1 @@
+Diagnostics anchored in `.doo` files now show the relevant source line instead of raw archive bytes, and `dafny build -t=lib` announces when modules from a positionally-passed `.doo` dependency are embedded in the produced library


### PR DESCRIPTION
Two mitigations for the `.doo` diamond-dependency trap of #6486.

**Readable diagnostics for `.doo` positions.** Positions in doo-sourced declarations refer to the archive's extracted program text, but `Snippets.GetFileLine` read the raw zip bytes, rendering binary garbage (`manifest.tomlPK…`). Snippets now come from the extracted program text:

```
b.doo(4,7): Error: Duplicate module name: A
  |
4 | module A {
  |        ^
```

This includes the bundled standard-library doos, reached through a `dafny:` URI mapping to a `dllresource://` archive — hence `DafnyFile.ResolveEmbeddedUri` and the `Uri` overload of `DooFile.ReadProgramText`. A user module clashing with a standard-library module previously rendered the same garbage.

**A notice when lib builds embed doo dependencies.** The root of the trap: `dafny build -t=lib b.dfy a.doo` (positional, not `--library`) silently copies `a.doo`'s modules into `b.doo`, and any program later consuming two libraries that embed the same module fails, even with consistent `--library` use at that point. Positional-input embedding is documented behavior (#4721), so it stays — the library backend now announces it:

```
Note: the library a.doo was passed as a source file, so a copy of its modules (A) is embedded in the produced library. If that is not intended, pass it with --library instead; combining two libraries that embed the same module fails with a "Duplicate module name" error.
```

A status message rather than a warning, because warnings fail builds by default and `--allow-warnings` is recorded in the library's options, forcing the flag onto all consumers. The note describes the produced artifact, so it is only emitted when one is actually written.

The collision itself is intentionally not addressed: the durable fix is checksum-based module identity per #5335, to which #6486 adds the diamond-dedup motivation.

Lit tests cover the diamond scenario (with the `--library` workflow as a passing control) and a diagnostic anchored in the embedded standard-library doo.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>

