### PR TITLE
fix: load the standard library for the lib target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ Source/IntegrationTests/TestFiles/LitTests/LitTest/comp/**/*.html
 Source/IntegrationTests/TestFiles/LitTests/LitTest/**/*.dtr
 /Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/libs/usesLibrary-lib
 /Source/IntegrationTests/TestFiles/LitTests/LitTest/cli/projectFile/libs/usesLibrary.doo
+/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/fileIOProject/usesFileIO-lib
+/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/fileIOProject/usesFileIO.doo
 Source/IntegrationTests/TestFiles/LitTests/LitTest/**/*.deps.json
 Source/IntegrationTests/TestFiles/LitTests/LitTest/**/*.csproj
 /Source/IntegrationTests/TestFiles/LitTests/LitTest/pythonmodule/multimodule/PythonModule2

--- a/Source/DafnyCore/AST/ShouldCompileOrVerify.cs
+++ b/Source/DafnyCore/AST/ShouldCompileOrVerify.cs
@@ -25,7 +25,7 @@ public static class ShouldCompileOrVerify {
       return true;
     }
 
-    if (program.Options.Backend?.TargetId != "lib") {
+    if (program.Options.Backend?.TargetId != Compilers.LibraryBackend.Id) {
       if (!ProgramResolver.ShouldCompile(module)) {
         return false;
       }

--- a/Source/DafnyCore/Backends/Library/LibraryBackend.cs
+++ b/Source/DafnyCore/Backends/Library/LibraryBackend.cs
@@ -21,8 +21,10 @@ public class LibraryBackend : ExecutableBackend {
   /// such as empty constructors with ensures clauses, generated from iterators
   public override bool IsStable => false;
 
+  public const string Id = "lib";
+
   public override string TargetExtension => "doo";
-  public override string TargetId => "lib";
+  public override string TargetId => Id;
 
   public override string TargetBaseDir(string dafnyProgramName) =>
     $"{Path.GetFileNameWithoutExtension(dafnyProgramName)}-lib";

--- a/Source/DafnyCore/DafnyMain.cs
+++ b/Source/DafnyCore/DafnyMain.cs
@@ -28,6 +28,19 @@ namespace Microsoft.Dafny {
       }
     }
 
+    /// <summary>
+    /// The URI of the target-specific standard-library doo to load for the given options,
+    /// or null if no target-specific standard library exists for that target.
+    /// Verification-only use (no compiler chosen) and the library backend translate nothing,
+    /// so they use the target-agnostic "notarget" flavor.
+    /// </summary>
+    public static Uri StandardLibrariesDooUriForTarget(DafnyOptions options) {
+      var target = options.CompilerName is null || options.CompilerName == Compilers.LibraryBackend.Id
+        ? "notarget"
+        : options.CompilerName;
+      return StandardLibrariesDooUriTarget.GetValueOrDefault(target);
+    }
+
     public static void MaybePrintProgram(Program program, string filename, bool afterResolver) {
       if (filename == null) {
         return;

--- a/Source/DafnyCore/Pipeline/Compilation.cs
+++ b/Source/DafnyCore/Pipeline/Compilation.cs
@@ -187,9 +187,7 @@ public class Compilation : IDisposable {
       // This creates issues with separate compilation and will be addressed in https://github.com/dafny-lang/dafny/pull/4877
       var asLibrary = !Options.Get(CommonOptionBag.TranslateStandardLibrary);
 
-      if (Options.CompilerName is null or "cs" or "java" or "go" or "py" or "js") {
-        var targetName = Options.CompilerName ?? "notarget";
-        var stdlibDooUri = DafnyMain.StandardLibrariesDooUriTarget[targetName];
+      if (DafnyMain.StandardLibrariesDooUriForTarget(Options) is { } stdlibDooUri) {
         await foreach (var targetSpecificFile in DafnyFile.CreateAndValidate(OnDiskFileSystem.Instance, errorReporter,
                          Options, stdlibDooUri, Project.StartingToken, asLibrary)) {
           result.Add(targetSpecificFile);

--- a/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
+++ b/Source/DafnyDriver/Legacy/SynchronousCliCompilation.cs
@@ -213,9 +213,7 @@ namespace Microsoft.Dafny {
         var asLibrary = !options.Get(CommonOptionBag.TranslateStandardLibrary);
 
         var reporter = new ConsoleErrorReporter(options);
-        if (options.CompilerName is null or "cs" or "java" or "go" or "py" or "js") {
-          var targetName = options.CompilerName ?? "notarget";
-          var stdlibDooUri = DafnyMain.StandardLibrariesDooUriTarget[targetName];
+        if (DafnyMain.StandardLibrariesDooUriForTarget(options) is { } stdlibDooUri) {
           options.CliRootSourceUris.Add(stdlibDooUri);
           await foreach (var targetSpecificFile in DafnyFile.CreateAndValidate(OnDiskFileSystem.Instance, reporter, options, stdlibDooUri, Token.Cli, asLibrary)) {
             dafnyFiles.Add(targetSpecificFile);

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/fileIOProject/dfyconfig.toml
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/fileIOProject/dfyconfig.toml
@@ -1,0 +1,4 @@
+includes = ["*.dfy"]
+
+[options]
+standard-libraries = true

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/fileIOProject/usesFileIO.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/fileIOProject/usesFileIO.dfy
@@ -1,0 +1,10 @@
+module UsesFileIO {
+  import Std.FileIO
+
+  method WriteGreeting(path: string)
+    decreases *
+  {
+    var res := FileIO.WriteBytesToFile(path, [104, 105]);
+    expect res.Success?;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/usesFileIO.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/Inputs/usesFileIO.dfy
@@ -1,0 +1,10 @@
+module UsesFileIO {
+  import Std.FileIO
+
+  method WriteGreeting(path: string)
+    decreases *
+  {
+    var res := FileIO.WriteBytesToFile(path, [104, 105]);
+    expect res.Success?;
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibBuild.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibBuild.dfy
@@ -1,0 +1,18 @@
+// NONUNIFORM: tests the lib target specifically
+// Building a library from code that uses target-dependent standard-library modules
+// (https://github.com/dafny-lang/dafny/issues/6485): the lib target loads the
+// target-agnostic standard library, and the produced .doo defers the choice of
+// target-specific implementation to the eventual concrete compilation.
+// RUN: %build -t=lib --standard-libraries:true "%S/Inputs/usesFileIO.dfy" --output "%S/Output/usesFileIO" > "%t"
+// RUN: %run -t=cs --standard-libraries:true "%s" --input "%S/Output/usesFileIO.doo" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+module LibBuildMain {
+  import UsesFileIO
+
+  method Main()
+    decreases *
+  {
+    UsesFileIO.WriteGreeting("greeting.txt");
+    print "wrote greeting\n";
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibBuild.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibBuild.dfy.expect
@@ -1,0 +1,5 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors
+wrote greeting

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibDependency.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibDependency.dfy
@@ -1,0 +1,16 @@
+// NONUNIFORM: tests the implicit lib target used for dependency projects
+// A dependency project is built through DafnyNewCli.HandleDafnyProject, which constructs a
+// LibraryBackend itself rather than taking -t=lib from the command line. That is a second
+// entry into the guard fixed for https://github.com/dafny-lang/dafny/issues/6485, so it
+// needs its own test: StandardLibraries_LibBuild.dfy only covers the explicit -t=lib path.
+// RUN: %verify --standard-libraries:true "%s" --library "%S/Inputs/fileIOProject/dfyconfig.toml" > "%t"
+// RUN: %diff "%s.expect" "%t"
+module DepMain {
+  import UsesFileIO
+
+  method Uses(p: string)
+    decreases *
+  {
+    UsesFileIO.WriteGreeting(p);
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibDependency.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/stdlibs/StandardLibraries_LibDependency.dfy.expect
@@ -1,0 +1,4 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/docs/dev/news/6485.fix
+++ b/docs/dev/news/6485.fix
@@ -1,0 +1,1 @@
+`dafny build -t=lib --standard-libraries` (and dependency-project builds via `--library`) can now use target-dependent standard-library modules such as `Std.FileIO` and `Std.Concurrent`; the produced library defers the choice of target-specific implementation to the eventual concrete compilation


### PR DESCRIPTION
Fixes #6485: `dafny build -t=lib --standard-libraries` on code importing `Std.FileIO` (or any target-dependent standard-library module) failed with `module FileIO does not exist`, although `verify` and every concrete target succeeded.

**Cause.** The standard library ships as embedded per-target `.doo` files. The guard selecting which one to load (`SynchronousCliCompilation.GetDafnyFiles`) enumerated the concrete targets and mapped only a *missing* compiler to the `notarget` flavor — `CompilerName == "lib"` matched nothing, so no target-specific standard library was loaded at all. That is the guard on the path for `build`/`run`/`test`, and also for dependency-project builds (`--library some/dfyconfig.toml`), which `DafnyNewCli.HandleDafnyProject` runs with the lib target — so both symptoms have the one cause. A verbatim copy in `Compilation.DetermineRootFiles` serves `verify`/`resolve`, which have no `--target` option and so only ever reach it with a null `CompilerName`; it is not reachable with `lib` today and is updated only to keep the two sites from diverging.

**Fix.** Both hand-maintained target lists are replaced by one helper next to the doo registry (`DafnyMain.StandardLibrariesDooUriForTarget`), which derives availability from the registry keys and maps no-compiler and lib to `notarget`. Targets without a standard library (cpp, rs, dfy) have no registry entry and keep failing as before (asserted by the existing `StandardLibraries_TargetSpecific` checks). This also removes the staleness failure mode: a new target needs only a registry entry, not two synchronized guard edits as well (cf. #6307, which currently has to touch both guards to add `rs` — this PR shrinks that to the registry entry alone). The lib target id itself is now the constant `LibraryBackend.Id`, shared with the serialization-skip check in `ShouldCompileOrVerify` that the semantics below depend on — the two places that must agree on what "the lib target" is can no longer drift.

**Semantics.** The produced library still excludes the standard library from its program text (it is loaded as a library and skipped by the serialization printer), so the `.doo` defers the choice of target-specific `FileIO` implementation to the eventual concrete compilation. A library importing modules that only exist for some targets (e.g. `Std.Statistics`, cs-only) will resolve at lib-build time and fail when compiled for a target lacking them — the same error as compiling directly, surfaced where the target is actually chosen.

**Tests.** Two lit tests, covering the two CLI entries into the guard:

- `StandardLibraries_LibBuild.dfy` — the round trip through an explicit `-t=lib`: build a `.doo` from `Std.FileIO`-using code, then compile and run it under `-t=cs`, exercising a real file write.
- `StandardLibraries_LibDependency.dfy` — the *implicit* lib target, where `DafnyNewCli.HandleDafnyProject` constructs a `LibraryBackend` itself and sets `CompilerName` from its `TargetId`. Dropping that assignment fails this test while `LibBuild` still passes, so it is not redundant.

Measured which copy of the guard each test actually exercises, with a probe at both sites: `LibDependency` reaches `Compilation.DetermineRootFiles` *and* the `SynchronousCliCompilation` copy, `LibBuild` only the latter. Reverting the `Compilation` copy alone leaves both tests passing — the legacy copy loads the standard library first — so that half of the change is a consistency fix rather than a separately observable one. Reverting both fails both tests.

`dafny verify` rather than `run` for the dependency test: `dafny run -t=cs --library <project.toml>` fails with a pre-existing `CS0103`, reproducible on master with a plain non-stdlib dependency project, because `--library` deliberately skips code generation for those files. Unrelated to this guard.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>


