### PR TITLE
fix: compile Python reference-type equality to identity comparison

### DIFF
--- a/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
+++ b/Source/DafnyCore/Backends/Python/PythonCodeGenerator.cs
@@ -242,6 +242,74 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override string GetHelperModuleName() => DafnyRuntimeModule;
 
+    /// <summary>
+    /// The Python operator for Dafny equality at the given type. Dafny reference
+    /// types have identity equality, which extern classes can subvert by
+    /// overriding __eq__, so they are compared with "is". This only covers
+    /// statically known reference types: equality at an abstract type parameter
+    /// still compiles to "==", like the universal-equality fallbacks of the other
+    /// backends (e.g. java.util.Objects.equals), because the runtime type is not
+    /// known here. See https://github.com/dafny-lang/dafny/issues/6491.
+    /// </summary>
+    private string EqualityOperator(Type type, bool negated) {
+      var isRefType = DatatypeWrapperEraser.SimplifyType(Options, type).IsRefType;
+      return isRefType ? (negated ? "is not" : "is") : (negated ? "!=" : "==");
+    }
+
+    /// Renders the comparison of one datatype field in the generated __eq__.
+    private string FieldEquality(Formal f) {
+      var lhs = $"self.{IdProtect(f.CompileName)}";
+      var rhs = $"__o.{IdProtect(f.CompileName)}";
+      return NeedsTupleEquality(f.Type)
+        ? $"{DafnyRuntimeModule}.tuple_eq({lhs}, {rhs}, {TupleRefMask(f.Type)})"
+        : $"{lhs} {EqualityOperator(f.Type, negated: false)} {rhs}";
+    }
+
+    /// <summary>
+    /// A Dafny tuple compiles to a native Python tuple, whose __eq__ compares components with "==".
+    /// That is wrong for a component of a reference type, whose Dafny equality is identity, and a
+    /// native tuple cannot be given a custom __eq__. So a tuple is compared by the runtime's
+    /// tuple_eq instead, told which components are references.
+    /// </summary>
+    private TupleTypeDecl AsTupleTypeDecl(Type type) {
+      return DatatypeWrapperEraser.SimplifyType(Options, type) is UserDefinedType { ResolvedClass: TupleTypeDecl tt }
+        ? tt : null;
+    }
+
+    private bool NeedsTupleEquality(Type type) {
+      var tt = AsTupleTypeDecl(type);
+      if (tt == null) {
+        return false;
+      }
+      return NonGhostTupleArguments(type)
+        .Any(a => DatatypeWrapperEraser.SimplifyType(Options, a).IsRefType || NeedsTupleEquality(a));
+    }
+
+    /// Builds the ref-mask literal that tuple_eq takes: True for a reference component, False for a
+    /// value component, and a nested mask for a nested tuple.
+    private string TupleRefMask(Type type) {
+      // Only the non-ghost components are present in the emitted tuple, so the mask has to skip the
+      // ghost ones or it would be misaligned with the values it describes.
+      var entries = NonGhostTupleArguments(type).Select(a =>
+        // A nested tuple only needs a mask of its own if it actually contains a reference; otherwise
+        // "False" lets tuple_eq compare it with "==" in one step instead of recursing through it.
+        NeedsTupleEquality(a)
+          ? TupleRefMask(a)
+          : DatatypeWrapperEraser.SimplifyType(Options, a).IsRefType ? "True" : "False").ToList();
+      // A 1-element Python tuple needs the trailing comma.
+      var joined = string.Join(", ", entries);
+      return entries.Count == 1 ? $"({joined},)" : $"({joined})";
+    }
+
+    private List<Type> NonGhostTupleArguments(Type type) {
+      var simplified = (UserDefinedType)DatatypeWrapperEraser.SimplifyType(Options, type);
+      var tupleDecl = (TupleTypeDecl)simplified.ResolvedClass;
+      Contract.Assert(simplified.TypeArgs.Count == tupleDecl.ArgumentGhostness.Count);
+      return simplified.TypeArgs
+        .Where((_, i) => !tupleDecl.ArgumentGhostness[i])
+        .ToList();
+    }
+
     private static string MangleName(string name) {
       if (ReservedNames.Contains(name)) {
         name = $"{name}_";
@@ -466,7 +534,7 @@ namespace Microsoft.Dafny.Compilers {
 
       var argList = ctor.Formals
         .Where(f => !f.IsGhost)
-        .Select(f => $"self.{IdProtect(f.CompileName)} == __o.{IdProtect(f.CompileName)}");
+        .Select(f => FieldEquality(f));
       var suffix = args.Length > 0 ? $" and {string.Join(" and ", argList)}" : "";
 
       wr.NewBlockPy("def __eq__(self, __o: object) -> bool:")
@@ -758,7 +826,10 @@ namespace Microsoft.Dafny.Compilers {
 
     protected override ConcreteSyntaxTree EmitNullTest(bool testIsNull, ConcreteSyntaxTree wr) {
       var wrTarget = wr.ForkInParens();
-      wr.Write(testIsNull ? " == None" : " != None");
+      // "is"/"is not" rather than "=="/"!=": the operand is a reference (this is only reached for a
+      // NonNullTypeDecl) and an extern class is free to define __eq__, in which case Python's default
+      // __ne__ inverts it and "!= None" can report a real object as null.
+      wr.Write(testIsNull ? " is None" : " is not None");
       return wrTarget;
     }
 
@@ -1758,14 +1829,29 @@ namespace Microsoft.Dafny.Compilers {
         case BinaryExpr.ResolvedOpcode.Prefix:
           opString = "<="; break;
 
+        case BinaryExpr.ResolvedOpcode.EqCommon:
+          if (NeedsTupleEquality(e0Type)) {
+            staticCallString = $"{DafnyRuntimeModule}.tuple_eq_by({TupleRefMask(e0Type)})";
+          } else {
+            opString = EqualityOperator(e0Type, negated: false);
+          }
+          break;
+
         case BinaryExpr.ResolvedOpcode.SeqEq:
         case BinaryExpr.ResolvedOpcode.SetEq:
         case BinaryExpr.ResolvedOpcode.MapEq:
-        case BinaryExpr.ResolvedOpcode.EqCommon:
         case BinaryExpr.ResolvedOpcode.MultiSetEq:
           opString = "=="; break;
 
         case BinaryExpr.ResolvedOpcode.NeqCommon:
+          if (NeedsTupleEquality(e0Type)) {
+            staticCallString = $"{DafnyRuntimeModule}.tuple_eq_by({TupleRefMask(e0Type)})";
+            preOpString = "not ";
+          } else {
+            opString = EqualityOperator(e0Type, negated: true);
+          }
+          break;
+
         case BinaryExpr.ResolvedOpcode.SeqNeq:
         case BinaryExpr.ResolvedOpcode.SetNeq:
         case BinaryExpr.ResolvedOpcode.MapNeq:

--- a/Source/DafnyPipeline/DafnyPipeline.csproj
+++ b/Source/DafnyPipeline/DafnyPipeline.csproj
@@ -118,7 +118,7 @@
       <LinkBase>DafnyRuntimeJs</LinkBase>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimePython\**\*.py">
+    <EmbeddedResource Include="..\DafnyRuntime\DafnyRuntimePython\**\*.py" Exclude="..\DafnyRuntime\DafnyRuntimePython\tests\**">
       <LinkBase>DafnyRuntimePython</LinkBase>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/Source/DafnyRuntime/DafnyRuntimePython/Makefile
+++ b/Source/DafnyRuntime/DafnyRuntimePython/Makefile
@@ -14,7 +14,10 @@ else
 	VIRTUALENV_PYTHON = $(VIRTUALENV)/bin/python
 endif
 
-all: check-system-module
+all: check-system-module test
+
+test:
+	python3 -m unittest discover -s . -p "test_*.py"
 
 build-system-module:
 	$(DAFNY) translate py --no-verify --use-basename-for-filename --system-module:OmitAllOtherModules ../systemModulePopulator.dfy --output:../obj/systemModulePopulator

--- a/Source/DafnyRuntime/DafnyRuntimePython/_dafny/__init__.py
+++ b/Source/DafnyRuntime/DafnyRuntimePython/_dafny/__init__.py
@@ -1,5 +1,6 @@
 """Runtime enabling Dafny language features."""
 import builtins
+import functools
 from dataclasses import dataclass
 from contextlib import contextmanager
 from fractions import Fraction
@@ -41,6 +42,40 @@ def string_of(value) -> str:
         return "Function"
     else:
         return str(value)
+
+@functools.lru_cache(maxsize=None)
+def tuple_eq_by(ref_mask):
+    """Returns a two-argument comparator for tuples with the given ref_mask.
+
+    The compiler emits binary operators as f(left, right), so the mask is bound here
+    rather than passed as a third argument. The emitted call sits wherever the
+    comparison does -- inside a loop, say -- so the result is cached on the mask,
+    which is a compile-time constant, to avoid building a closure per comparison.
+    """
+    return lambda a, b: tuple_eq(a, b, ref_mask)
+
+def tuple_eq(a, b, ref_mask):
+    """Compare two tuples component-wise, using identity for the components whose
+    corresponding entry in ref_mask is true.
+
+    A Dafny tuple compiles to a native Python tuple, whose __eq__ compares components
+    with ==. That is wrong for a component of a reference type, where Dafny's equality
+    is identity and an extern class is free to define its own __eq__. Tuples cannot be
+    given a custom __eq__, so the compiler emits a call to this instead. A nested tuple
+    appears in ref_mask as its own mask.
+    """
+    if len(a) != len(b):
+        return False
+    for x, y, m in zip(a, b, ref_mask):
+        if m is True:
+            if x is not y:
+                return False
+        elif m is False:
+            if x != y:
+                return False
+        elif not tuple_eq(x, y, m):
+            return False
+    return True
 
 @dataclass
 class Break(Exception):

--- a/Source/DafnyRuntime/DafnyRuntimePython/tests/test_tuple_eq.py
+++ b/Source/DafnyRuntime/DafnyRuntimePython/tests/test_tuple_eq.py
@@ -1,0 +1,69 @@
+"""Tests for _dafny.tuple_eq, the comparator the Python backend emits for a tuple
+that holds a reference.
+
+A Dafny tuple compiles to a native Python tuple, whose __eq__ compares components
+with ==. That is wrong for a component of a reference type, whose Dafny equality is
+identity, and a native tuple cannot be given a custom __eq__. So the compiler emits
+tuple_eq with a mask saying which components are references.
+"""
+
+import unittest
+
+import _dafny
+
+
+class Overriding:
+    """Stands for an extern class that defines its own equality, as the extern in
+    dafny-lang/dafny#6491 does."""
+
+    def __eq__(self, other):
+        return isinstance(other, Overriding)
+
+    def __hash__(self):
+        return 0
+
+
+class TupleEqTests(unittest.TestCase):
+
+    def test_reference_component_uses_identity(self):
+        a, b = Overriding(), Overriding()
+        # The components compare equal under ==, which is exactly what must not be used.
+        self.assertEqual(a, b)
+        self.assertFalse(_dafny.tuple_eq((a, 1), (b, 1), (True, False)))
+        self.assertTrue(_dafny.tuple_eq((a, 1), (a, 1), (True, False)))
+
+    def test_value_component_uses_equality(self):
+        a = Overriding()
+        self.assertFalse(_dafny.tuple_eq((a, 1), (a, 2), (True, False)))
+        self.assertTrue(_dafny.tuple_eq((1, 2), (1, 2), (False, False)))
+
+    def test_nested_mask_recurses(self):
+        a, b = Overriding(), Overriding()
+        mask = (True, (True, False))
+        self.assertTrue(_dafny.tuple_eq((a, (b, 2)), (a, (b, 2)), mask))
+        self.assertFalse(_dafny.tuple_eq((a, (a, 2)), (a, (b, 2)), mask))
+        self.assertFalse(_dafny.tuple_eq((a, (b, 2)), (a, (b, 3)), mask))
+
+    def test_nested_mask_is_not_confused_with_the_boolean(self):
+        # A one-element nested mask is a tuple, so it must not be read as True.
+        a, b = Overriding(), Overriding()
+        self.assertFalse(_dafny.tuple_eq(((a,), 1), ((b,), 1), ((True,), False)))
+        self.assertTrue(_dafny.tuple_eq(((a,), 1), ((a,), 1), ((True,), False)))
+
+    def test_differing_lengths(self):
+        self.assertFalse(_dafny.tuple_eq((1, 2), (1, 2, 3), (False, False)))
+
+    def test_comparator_is_cached_per_mask(self):
+        # The emitted call sits wherever the comparison does, so the comparator is
+        # cached to avoid building a closure per comparison.
+        self.assertIs(_dafny.tuple_eq_by((True, False)), _dafny.tuple_eq_by((True, False)))
+
+    def test_comparator_matches_tuple_eq(self):
+        a, b = Overriding(), Overriding()
+        compare = _dafny.tuple_eq_by((True, False))
+        self.assertFalse(compare((a, 1), (b, 1)))
+        self.assertTrue(compare((a, 1), (a, 1)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/Inputs/BoxPkg.py
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/Inputs/BoxPkg.py
@@ -1,0 +1,17 @@
+import sys
+
+assert "BoxPkg" == __name__
+BoxPkg = sys.modules[__name__]
+
+# An extern class that overrides __eq__/__hash__ with structural equality
+# (any two boxes are "equal"), subverting the identity equality Dafny's
+# verifier assumes for classes.
+class Box:
+    def __init__(self) -> None:
+        pass
+
+    def __eq__(self, other):
+        return isinstance(other, Box)
+
+    def __hash__(self):
+        return 0

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-py.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-py.dfy
@@ -1,0 +1,61 @@
+// Reference-type equality must compare identity even when an extern class
+// overrides __eq__ (https://github.com/dafny-lang/dafny/issues/6491).
+// RUN: %run --target py "%s" --input %S/Inputs/BoxPkg.py > "%t"
+// RUN: %diff "%s.expect" "%t"
+module {:extern "BoxPkg"} BoxPkg {
+  class {:extern} Box {
+    constructor {:extern} ()
+  }
+}
+
+module Repro {
+  import opened BoxPkg
+
+  datatype D = D(b: Box, tag: int)
+
+  type NBox = b: Box? | b != null witness *
+
+  method Main() {
+    var a := new Box();
+    var b := new Box(); // distinct object; extern __eq__ calls any two boxes equal
+
+    assert a != b;
+    print a != b, "\n";
+
+    var d1 := D(a, 0);
+    var d2 := D(b, 0);
+    assert d1 != d2;
+    print d1 != d2, "\n";
+
+    // Subset types over reference types compare by identity too.
+    var na: NBox := a;
+    var nb: NBox := b;
+    assert na != nb;
+    print na != nb, "\n";
+
+    // Comparisons against null still work.
+    var c: Box? := null;
+    var d: Box? := a;
+    print c == null, " ", d != null, "\n";
+
+    // A tuple holding a reference compares that component by identity too. A Dafny tuple compiles
+    // to a native Python tuple, which cannot be given a custom __eq__, so this goes through the
+    // runtime's tuple_eq with a mask saying which components are references.
+    var ta := (a, 1);
+    var tb := (b, 1);
+    assert ta != tb;
+    print ta != tb, " ", ta == ta, "\n";
+
+    // Nested tuples, and a tuple in a datatype field, take the same route.
+    var na2 := ((a, 1), 2);
+    var nb2 := ((b, 1), 2);
+    assert na2 != nb2;
+    print na2 != nb2, "\n";
+    print Pair((a, 1), 0) != Pair((b, 1), 0), "\n";
+
+    // A tuple of values is unaffected: no mask is emitted for it at all.
+    print (1, 2) == (1, 2), "\n";
+  }
+
+  datatype Pair = Pair(t: (Box, int), tag: int)
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-py.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-py.dfy.expect
@@ -1,0 +1,10 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+true
+true
+true
+true true
+true true
+true
+true
+true

--- a/docs/DafnyRef/integration-py/IntegrationPython.md
+++ b/docs/DafnyRef/integration-py/IntegrationPython.md
@@ -121,3 +121,17 @@ The correspondence between the Dafny and Python types is shown in this table.
 | function (arrow) types        | class 'function' |
 |-------------------------------|------------------------------|
 
+A Dafny `class` or `trait` has object identity, and the verifier assumes that
+`==` and the built-in collections compare such values by identity. The Python
+backend now compiles `==` and `!=` on reference types to `is` and `is not`, so
+an extern class that overrides `__eq__` no longer changes the result of a direct
+comparison. The built-in
+`set`, `multiset`, and `map` collections, however, still hash and compare their
+elements with `__eq__` and `__hash__`, so an extern class that overrides those
+can still make a compiled program contradict what the verifier proved — for
+example by giving a `set` fewer elements than was verified. A type whose
+equality should be structural is better modelled as a Dafny `datatype`, or, when
+it must be backed by Python code, as an opaque value type `type {:extern} T(==)`,
+whose equality the verifier leaves uninterpreted and whose Python `__eq__` and
+`__hash__` are then used at run time without contradicting any verified fact.
+

--- a/docs/dev/news/6496.fix
+++ b/docs/dev/news/6496.fix
@@ -1,0 +1,1 @@
+The Python backend now compiles equality of reference types to identity comparison (`is`), so an extern class overriding `__eq__` can no longer make verified reference (in)equalities evaluate incorrectly at run time


### PR DESCRIPTION
Part of #6491. Dafny gives class types identity equality and the verifier reasons about them accordingly, but the Python backend compiled `==`/`!=` on reference types to Python's `==`/`!=`, which dispatch to the overridable `__eq__` hook. An extern class overriding `__eq__` therefore made *verified* reference (in)equalities evaluate incorrectly at run time:

```dafny
var a := Box.Make(1);
var b := Box.Make(1);
assert a != b;              // verified
print a != b;               // printed false with a structural __eq__ extern
```

Generated datatype `__eq__` methods compared class-typed fields the same way, so `D(a, 0) != D(b, 0)` was also verified-true but runtime-false.

**Fix.** Emit `is`/`is not` for `EqCommon`/`NeqCommon` at reference types (after `DatatypeWrapperEraser.SimplifyType`, as elsewhere), and identity comparisons for reference-typed fields in generated datatype `__eq__` methods. This mirrors the discrimination the Java and C# backends already make at the same decision point (`JavaCodeGenerator` emits `== (Object)` for ref types; `CsharpCodeGenerator` emits `== (object)`). Python was the only backend where even *direct* equality was affected.

Non-regression checked: `x == null`, trait-typed comparisons, array identity, and the equality-sensitive `comp`/`dafny0` compile tests across all targets. The regression test uses an extern with a structural `__eq__` override, asserting both direct and datatype-field inequality survive compilation.

Known boundary, documented on the new `EqualityOperator` helper: equality at an *abstract type parameter* (e.g. inside `method Eq<T(==)>(x: T, y: T)`, or a generic datatype's `T`-typed field) still compiles to `==` — the static type is not a reference type there. This matches the other backends, whose universal-equality fallbacks (`java.util.Objects.equals`, `object.Equals`) have the same hole; closing it needs runtime type information (the TypeDescriptor discussion in #6491).

Scope note: this intentionally does **not** address the collection-level unsoundness of #6491 (`set<Box>` collapsing etc.), which exists on several backends and needs the runtime collections to key on identity for reference types — a larger, cross-backend design discussed in the issue.

## Follow-up: the non-null test

`EmitNullTest` (`PythonCodeGenerator.cs`) still emitted `== None` / `!= None`, which route through `__eq__` and `__ne__`. A class defining `__eq__` without `__ne__` breaks the test, because Python's default `__ne__` inverts `__eq__`: for a class whose `__eq__` returns `True`, `obj != None` evaluates to `False` and a real object is treated as null. Now `is` / `is not`, which cannot be overridden and is unconditionally correct here — the site is reached only for a `NonNullTypeDecl`, so the operand is a reference and the other side is literally `None`.

Scope, measured rather than assumed: the operator is emitted only into the generated `_Is` constraint-check method of a subset type over a non-null reference (3 of 60 swept `dafny0` files emit it). I could not find a Dafny program that reaches it — a source-level `x is T` is inlined at the use site, where the correct `is not None` was already used, and the only `_Is` call in the swept corpus is on a numeric subset type with no null test. So this is a latent defect in generated-but-uncalled code rather than a program that miscompiles today; it is worth fixing because the method is generated and callable. Differential sweep over 60 files: 2 change, and every changed line is a `None` test.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>

