### PR TITLE
docs: require EqualsGeneric on extern Go types, and identity for extern classes

### DIFF
--- a/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny.go
@@ -39,6 +39,14 @@ func UnicodeFromMainArguments(args []string) Sequence {
 
 // An EqualsGeneric can be compared to any other object.  This method should
 // *only* return true when the other value is of the same type.
+//
+// An extern Go type reached by Dafny's == or by a built-in collection must
+// implement this interface. Dafny cannot supply it: Go does not allow methods to
+// be declared on a type from another package. A reference type (an extern class
+// or trait) must implement it as identity, since that is the equality the
+// verifier assumes; see MutableMap, AtomicBox and Lock in the Std_Concurrent
+// externs for the conventional implementation. Without it, AreEqual falls back
+// to refl.DeepEqual, which follows the pointer and compares structurally.
 type EqualsGeneric interface {
 	EqualsGeneric(other interface{}) bool
 }

--- a/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny_test.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo-gomod/dafny/dafny_test.go
@@ -209,3 +209,59 @@ func TestCardinalityOverflow(t *testing.T) {
 
 	SeqOfBytes(a).Cardinality()
 }
+
+// An extern type that implements EqualsGeneric as identity, which is what an
+// extern class or trait must do (see the EqualsGeneric doc comment). Dafny
+// cannot generate this: Go forbids declaring methods on a foreign package's type.
+type externReference struct {
+	v int
+}
+
+func (_this *externReference) Equals(other *externReference) bool {
+	return _this == other
+}
+
+func (_this *externReference) EqualsGeneric(x interface{}) bool {
+	other, ok := x.(*externReference)
+	return ok && _this.Equals(other)
+}
+
+// An extern type that implements nothing, standing for a Go type whose author
+// has not followed the contract.
+type externOpaque struct {
+	v int
+}
+
+func TestAreEqualUsesEqualsGenericForExternReferences(t *testing.T) {
+	a := &externReference{v: 1}
+	b := &externReference{v: 1}
+	if !AreEqual(a, a) {
+		t.Error("an extern reference must equal itself")
+	}
+	if AreEqual(a, b) {
+		t.Error("distinct extern references must not be equal, even when structurally identical")
+	}
+	if AreEqual(a, &externOpaque{v: 1}) {
+		t.Error("references of different types must not be equal")
+	}
+}
+
+func TestAreEqualFallsBackToDeepEqual(t *testing.T) {
+	// Without EqualsGeneric there is nothing to distinguish a reference from a
+	// value, so the fallback compares structurally. This is why an extern class
+	// must implement EqualsGeneric to get the identity equality Dafny assumes.
+	if !AreEqual(&externOpaque{v: 1}, &externOpaque{v: 1}) {
+		t.Error("a pointer without EqualsGeneric keeps DeepEqual semantics")
+	}
+	if !AreEqual([]interface{}{1, 2}, []interface{}{1, 2}) {
+		t.Error("non-pointer values must keep DeepEqual semantics")
+	}
+}
+
+func TestAreEqualObjectIdentity(t *testing.T) {
+	// Dafny-generated reference types implement EqualsGeneric themselves.
+	o := New_Object()
+	if !AreEqual(o, o) || AreEqual(o, New_Object()) {
+		t.Error("Object identity equality must be preserved")
+	}
+}

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny.go
@@ -39,6 +39,14 @@ func UnicodeFromMainArguments(args []string) Sequence {
 
 // An EqualsGeneric can be compared to any other object.  This method should
 // *only* return true when the other value is of the same type.
+//
+// An extern Go type reached by Dafny's == or by a built-in collection must
+// implement this interface. Dafny cannot supply it: Go does not allow methods to
+// be declared on a type from another package. A reference type (an extern class
+// or trait) must implement it as identity, since that is the equality the
+// verifier assumes; see MutableMap, AtomicBox and Lock in the Std_Concurrent
+// externs for the conventional implementation. Without it, AreEqual falls back
+// to refl.DeepEqual, which follows the pointer and compares structurally.
 type EqualsGeneric interface {
 	EqualsGeneric(other interface{}) bool
 }

--- a/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go
+++ b/Source/DafnyRuntime/DafnyRuntimeGo/dafny/dafny_test.go
@@ -209,3 +209,59 @@ func TestCardinalityOverflow(t *testing.T) {
 
 	SeqOfBytes(a).Cardinality()
 }
+
+// An extern type that implements EqualsGeneric as identity, which is what an
+// extern class or trait must do (see the EqualsGeneric doc comment). Dafny
+// cannot generate this: Go forbids declaring methods on a foreign package's type.
+type externReference struct {
+	v int
+}
+
+func (_this *externReference) Equals(other *externReference) bool {
+	return _this == other
+}
+
+func (_this *externReference) EqualsGeneric(x interface{}) bool {
+	other, ok := x.(*externReference)
+	return ok && _this.Equals(other)
+}
+
+// An extern type that implements nothing, standing for a Go type whose author
+// has not followed the contract.
+type externOpaque struct {
+	v int
+}
+
+func TestAreEqualUsesEqualsGenericForExternReferences(t *testing.T) {
+	a := &externReference{v: 1}
+	b := &externReference{v: 1}
+	if !AreEqual(a, a) {
+		t.Error("an extern reference must equal itself")
+	}
+	if AreEqual(a, b) {
+		t.Error("distinct extern references must not be equal, even when structurally identical")
+	}
+	if AreEqual(a, &externOpaque{v: 1}) {
+		t.Error("references of different types must not be equal")
+	}
+}
+
+func TestAreEqualFallsBackToDeepEqual(t *testing.T) {
+	// Without EqualsGeneric there is nothing to distinguish a reference from a
+	// value, so the fallback compares structurally. This is why an extern class
+	// must implement EqualsGeneric to get the identity equality Dafny assumes.
+	if !AreEqual(&externOpaque{v: 1}, &externOpaque{v: 1}) {
+		t.Error("a pointer without EqualsGeneric keeps DeepEqual semantics")
+	}
+	if !AreEqual([]interface{}{1, 2}, []interface{}{1, 2}) {
+		t.Error("non-pointer values must keep DeepEqual semantics")
+	}
+}
+
+func TestAreEqualObjectIdentity(t *testing.T) {
+	// Dafny-generated reference types implement EqualsGeneric themselves.
+	o := New_Object()
+	if !AreEqual(o, o) || AreEqual(o, New_Object()) {
+		t.Error("Object identity equality must be preserved")
+	}
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/Inputs/BoxPkg.go
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/Inputs/BoxPkg.go
@@ -1,0 +1,26 @@
+// An extern Go class that follows the contract in the reference manual's
+// "Equality of extern types": it implements EqualsGeneric as identity, which is
+// the equality Dafny assumes for a class. Dafny cannot generate this, because Go
+// does not allow methods to be declared on another package's type.
+package BoxPkg
+
+type Box struct {
+	dummy byte
+}
+
+type CompanionStruct_Box_ struct{}
+
+var Companion_Box_ = CompanionStruct_Box_{}
+
+func New_Box_() *Box {
+	return &Box{}
+}
+
+func (_this *Box) Equals(other *Box) bool {
+	return _this == other
+}
+
+func (_this *Box) EqualsGeneric(x interface{}) bool {
+	other, ok := x.(*Box)
+	return ok && _this.Equals(other)
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-go.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-go.dfy
@@ -1,0 +1,28 @@
+// An extern Go class is compared correctly by the built-in collections only if it
+// implements the runtime's EqualsGeneric interface as identity; Dafny cannot
+// generate that method for a type declared in another Go package. See "Equality of
+// extern types" in the reference manual, and Inputs/BoxPkg.go for the
+// implementation this test relies on (https://github.com/dafny-lang/dafny/issues/6491).
+// RUN: %run --target go "%s" --input %S/Inputs/BoxPkg.go > "%t"
+// RUN: %diff "%s.expect" "%t"
+module {:extern "BoxPkg"} BoxPkg {
+  class {:extern} Box {
+    constructor {:extern} ()
+  }
+}
+
+module Repro {
+  import opened BoxPkg
+
+  method Main() {
+    var a := new Box();
+    var b := new Box(); // distinct object; structurally identical
+
+    assert a != b;
+    print a != b, "\n";
+
+    var s := {a, b};
+    assert |s| == 2;
+    print |s|, "\n";
+  }
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-go.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6491-go.dfy.expect
@@ -1,0 +1,4 @@
+
+Dafny program verifier finished with 1 verified, 0 errors
+true
+2

--- a/docs/Compilation/Go.md
+++ b/docs/Compilation/Go.md
@@ -267,7 +267,10 @@ func TestNil() {
 As illustrated in this example, values of Dafny class types can be compared directly
 with `==` in Go, but values of other Dafny reference types need to be compared
 by the runtime function `_dafny.AreEqual`, which handles the two representations of
-`null`.
+`null`. `_dafny.AreEqual` compares by identity only for types that implement the
+runtime's `EqualsGeneric` interface; every Dafny-generated reference type does, but
+an extern Go type must implement it itself (see
+[Equality of extern types](../DafnyRef/integration-go/IntegrationGo)).
 
 Datatypes
 ---------

--- a/docs/DafnyRef/integration-go/IntegrationGo.md
+++ b/docs/DafnyRef/integration-go/IntegrationGo.md
@@ -40,3 +40,48 @@ Alternatively the build and run steps can be combined:
 ## **Combining Go and Dafny source files**
 
 The dafny tool is not yet able to automatically combined Go and Dafny source files.
+
+## **Equality of extern types**
+
+A Dafny `class` or `trait` has object identity, and the verifier assumes that `==`
+and the built-in collections compare such values by identity.
+
+An extern Go type must implement the runtime's `EqualsGeneric` interface to be
+compared correctly. This is the opposite of what the other backends require: in
+C# and Java an extern class inherits reference equality and is correct as written,
+so the guidance there is to leave `Equals` alone. Go's default is structural, so
+an extern type has to opt in to identity. Dafny cannot supply the implementation,
+because Go does not allow methods to be declared on a type belonging to another
+package. Where it is
+missing, the runtime's `AreEqual` falls back to `reflect.DeepEqual`, which follows
+the pointer and compares the pointees structurally; two distinct objects that
+happen to hold equal fields then compare equal, contradicting what the verifier
+proved. Direct `==` on an extern class is unaffected, since it compiles to Go's
+`==`; the discrepancy shows up through the built-in collections, for instance in
+the cardinality of a set of extern objects.
+
+For an extern `class` or `trait`, implement it as identity:
+
+```go
+func (_this *Box) Equals(other *Box) bool {
+	return _this == other
+}
+
+func (_this *Box) EqualsGeneric(x interface{}) bool {
+	other, ok := x.(*Box)
+	return ok && _this.Equals(other)
+}
+```
+
+`MutableMap`, `AtomicBox` and `Lock` in the `Std_Concurrent` externs of the Dafny
+standard libraries are written exactly this way.
+
+Implementing `EqualsGeneric` structurally on a `class` or `trait` is worse than
+leaving it out, because it makes the two comparison paths disagree: `a != b`
+evaluates to `true` while `{a, b}` has one element, so a verified assertion
+`|{a, b}| == 2` fails at run time even though the program never compares the two
+objects directly. Structural equality is sound only for a type whose equality the
+verifier leaves uninterpreted, such as an opaque `type {:extern} T(==)`. A type
+whose equality should be structural is otherwise better modelled as a Dafny
+`datatype`. See also the equality discussion in
+[Dafny compilation to Go](../Compilation/Go).

--- a/docs/dev/news/6497.fix
+++ b/docs/dev/news/6497.fix
@@ -1,0 +1,1 @@
+Document that an extern Go type must implement the runtime's `EqualsGeneric` interface, and that an extern `class` or `trait` must implement it as identity, since Dafny cannot generate it for a type declared in another Go package


### PR DESCRIPTION
## Summary

An extern Go type reached by Dafny's `==` or by a built-in collection must implement the runtime's `EqualsGeneric` interface. Where it is missing, `AreEqual` falls back to `reflect.DeepEqual`, which follows the pointer and compares the pointees structurally — so two distinct extern objects holding equal fields compare equal, contradicting the identity equality the verifier assumes for a `class`. This is the Go instance of the hazard reported for Java in #6491.

**Dafny cannot fix this for the user.** Go does not allow a method to be declared on a type belonging to another package, so the compiler can neither generate `EqualsGeneric` for an extern class nor mark it for the runtime to recognise. The requirement is therefore documented, with the identity implementation spelled out; `MutableMap`, `AtomicBox` and `Lock` in the `Std_Concurrent` externs are already written this way.

Direct `==` on an extern class is unaffected — it compiles to Go's `==`. The discrepancy shows up only through the built-in collections, for instance in the cardinality of a set of extern objects.

## Why not change the runtime

An earlier revision of this PR compared any remaining pointer in `AreEqual` by identity, justified by "every Dafny-generated reference type implements `EqualsGeneric`, so a pointer without one is an extern reference". Neither half holds, and each was a reachable soundness regression — the verifier proves equality in both cases, so these are not cosmetic:

| kind | verifier proves | master | with that change |
| --- | --- | --- | --- |
| newtype with traits, boxed at a trait type | `a == b` for equal values | `true` | **`false`** |
| opaque `type {:extern} T(==)` | `MakeT(5) == MakeT(5)` | `true` | **`false`** |

The first needs **no extern code at all** — a trait, a newtype extending it, a datatype field of the trait type, under `--general-traits=full`. `DeclareNewtype` passes `includeEquals: false`, so a boxed newtype has no `EqualsGeneric` either. The second is the pattern the doc section added by that revision recommended as the safe way to get structural equality.

Three alternatives were tried and rejected:

- **Emit identity `EqualsGeneric` for extern classes.** Illegal: `cannot define new methods on non-local type pkg.Box`.
- **Marker interface on generated reference types.** The two kinds Dafny cannot mark — extern class and opaque extern — are exactly the two that must behave differently, so it cannot separate them; and an unmarked extern class falls back to `DeepEqual`, i.e. #6491 again.
- **Move the decision to codegen** (predicate on `ClassDecl`/`TraitDecl`, redirect the `AreEqual` call sites, revert the runtime branch). Implemented and measured: **#6491 stays unfixed**, because collections compare elements inside the runtime where no static type exists (`type Set struct { contents []interface{} }`, `SetOf(values ...interface{})`).

Closing the gap for uncooperative externs would require threading element-type descriptors through `Set`/`Map`/`MultiSet`/`Sequence` — a runtime/ABI change well beyond this PR, and worth its own discussion.

## Changes

- `docs/DafnyRef/integration-go/IntegrationGo.md`: new "Equality of extern types" section stating the contract, with the identity implementation and a pointer to `Std_Concurrent`.
- `docs/Compilation/Go.md`: corrected — it had the rule backwards, saying extern types are compared by identity *unless* they implement `EqualsGeneric`.
- `git-issue-6491-go.dfy` + `Inputs/BoxPkg.go`: the extern class now implements the contract, so the test exercises it. Discriminating: without the method the set has **1** element, with it **2**.
- `dafny_test.go` (both runtime copies): unit tests for the contract — `EqualsGeneric` gives identity, its absence gives `DeepEqual`.
- `AreEqual` itself is unchanged from master; the only runtime edit is the doc comment on `EqualsGeneric`.

## Relationship to #6500

#6500 documents the same contract for C#, Java and Rust; there is no file overlap (it touches `integration-cs`, `integration-java`, `integration-rust` and `UserGuide.md`, this touches `integration-go` and `Compilation/Go.md`). The guidance is deliberately *opposite* in direction, which the Go section now says explicitly: a C# or Java extern class inherits reference equality and is correct as written — I checked, both print `true` and `2` for an empty extern class — so the advice there is to leave `Equals` alone, whereas Go's `DeepEqual` default is structural and has to be opted out of.

Note also that #6500 recommends `type {:extern} T(==)` as the structural-equality idiom. That is sound for C#/Java, and sound for Go too now that the runtime is unchanged — but it would *not* have been sound under this PR's earlier revision, which is one of the two regressions described above.

## Scope

#6491 is reported against **Java**, where the user overrides `equals()`/`hashCode()` structurally and a verified `|s| == 2` evaluates to `1`. That case is unchanged by this PR — I confirmed it still reproduces on this branch — so this is one backend's part of the issue, not a fix for it. #6496 (Python) and #6498 (JavaScript) are the siblings.

What this PR does is document the Go side of the same hazard, which is worse in one respect: on Java and C# an extern class is correct *by default* and only breaks if the author overrides equality, whereas on Go it is broken by default and only correct if the author implements `EqualsGeneric`. The Go documentation now states that, and the reference-manual text records the failure mode common to both: the two comparison paths disagree, so `a != b` is `true` while `{a, b}` has one element.

Fixing #6491 itself — making Dafny detect or prevent a non-identity equality on an extern reference type — is not attempted here. On Go it is impossible from the compiler side (Go forbids declaring methods on another package's type, so Dafny can neither supply nor mark the implementation), and on Java/C# it would mean checking user code for overridden `equals`. Both are worth their own discussion.

Part of #6491

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
