### PR TITLE
docs: document extern-type contracts (equality and datatype members)

### DIFF
--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1804,9 +1804,10 @@ compiled program can behave in ways the verifier proved impossible: two objects
 that were proved unequal may compare equal at run time, and a `set` containing
 them may turn out to have fewer elements than was verified. Dafny does not
 currently detect this situation, so it is the user's responsibility to avoid it;
-the target-specific behavior, and any supported way for an extern type to opt in
-to structural equality, are described in the integration guide for each
-language.
+the target-specific behavior is described in the integration guide for each
+language. Some backends let an extern override the equality used by the runtime
+collections, but doing so on a reference type reintroduces exactly this
+unsoundness; it is sound only for value types (see below).
 
 A type whose equality should be structural rather than by object identity is
 better not written as an `{:extern}` `class` at all. When the value need not be

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1801,9 +1801,13 @@ implementation instead gives the type some other equality — for example a
 structural equality obtained by overriding `equals` and `hashCode` in Java,
 `Equals` and `GetHashCode` in C#, or `__eq__` and `__hash__` in Python — then a
 compiled program can behave in ways the verifier proved impossible: two objects
-that were proved unequal may compare equal at run time, and a `set` containing
-them may turn out to have fewer elements than was verified. Dafny does not
-currently detect this situation, so it is the user's responsibility to avoid it;
+that were proved unequal may compare equal at run time, a `set` containing them
+may turn out to have fewer elements than was verified, and, where the collections
+of the target language are organized by hash value, an object whose hash depends
+on mutable state may no longer be found once it is mutated, so that a verified
+`x in s` is false at run time. The last of these needs only the hash to be
+overridden, with equality left as object identity. Dafny does not currently
+detect this situation, so it is the user's responsibility to avoid it;
 the target-specific behavior is described in the integration guide for each
 language. Some backends let an extern override the equality used by the runtime
 collections, but doing so on a reference type reintroduces exactly this

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1769,6 +1769,14 @@ the only options that result in valid target code. Traits with
 `{:extern}` can refer to existing traits or interfaces in the target
 language, or can refer to the interfaces of existing classes.
 
+Unlike a class, a `datatype` cannot have `{:extern}` members. The compiler
+generates no way for external code to supply such a member's implementation,
+and the emitted target code fails to compile. To combine a datatype with
+external code, keep its members in Dafny and put the external operations in
+module-level `{:extern}` functions or methods that take the datatype as a
+parameter; use an `{:extern}` class when you need external members on a
+reference type.
+
 Member variables marked with `{:extern}` refer to fields or properties
 in existing target-language code. Constructors, methods, and functions
 refer to the equivalent concepts in the target language. They

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1782,6 +1782,37 @@ Types marked with `{:extern}` must be opaque. The name argument, if any,
 usually refers to the type name in the target language, but some
 compilers treat it differently.
 
+Because Dafny models objects by reference, the reference types (`class` and
+`trait` types) have object identity: `x == y` holds exactly when `x` and `y`
+denote the same object. The verifier reasons about equality on these types, and
+about the `set`, `multiset`, and `map` collections built over them, on the
+assumption that object identity is their only equality, and this assumption is
+not checked against external code. An `{:extern}` `class` is therefore expected
+to preserve object identity in the target language. If the external
+implementation instead gives the type some other equality — for example a
+structural equality obtained by overriding `equals` and `hashCode` in Java,
+`Equals` and `GetHashCode` in C#, or `__eq__` and `__hash__` in Python — then a
+compiled program can behave in ways the verifier proved impossible: two objects
+that were proved unequal may compare equal at run time, and a `set` containing
+them may turn out to have fewer elements than was verified. Dafny does not
+currently detect this situation, so it is the user's responsibility to avoid it;
+the target-specific behavior, and any supported way for an extern type to opt in
+to structural equality, are described in the integration guide for each
+language.
+
+A type whose equality should be structural rather than by object identity is
+better not written as an `{:extern}` `class` at all. When the value need not be
+backed by an external object, a Dafny `datatype` has structural equality that
+the verifier understands. When it must be backed by external code, an opaque
+value type declared as `type {:extern} T(==)` can be used instead: the verifier
+makes no assumption about which values of such a type are equal — it can prove
+neither that two values are equal nor that they are unequal — so the target
+language's own equality is used at run time, including within the built-in
+collections, without contradicting anything the verifier established. An
+`{:extern}` `class` may still define its state and some of its members in Dafny
+while implementing others externally; equality of such a class remains by object
+identity.
+
 Detailed description of the `dafny build` and `dafny run` commands and 
 the `--input` option (needed when `dafny run` has more than one input file)
 is contained [in the section on command-line structure](#command-line).

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1795,7 +1795,8 @@ compilers treat it differently.
 Because Dafny models objects by reference, the reference types (`class` and
 `trait` types) have object identity: `x == y` holds exactly when `x` and `y`
 denote the same object. The verifier reasons about equality on these types, and
-about the `set`, `multiset`, and `map` collections built over them, on the
+about every construct built over them — the `set`, `multiset`, `map` and `seq`
+collections, and `==` at a type parameter instantiated with them — on the
 assumption that object identity is their only equality, and this assumption is
 not checked against external code. An `{:extern}` `class` is therefore expected
 to preserve object identity in the target language. If the external

--- a/docs/DafnyRef/UserGuide.md
+++ b/docs/DafnyRef/UserGuide.md
@@ -1769,12 +1769,14 @@ the only options that result in valid target code. Traits with
 `{:extern}` can refer to existing traits or interfaces in the target
 language, or can refer to the interfaces of existing classes.
 
-Unlike a class, a `datatype` cannot have `{:extern}` members. The compiler
-generates no way for external code to supply such a member's implementation,
-and the emitted target code fails to compile. To combine a datatype with
-external code, keep its members in Dafny and put the external operations in
-module-level `{:extern}` functions or methods that take the datatype as a
-parameter; use an `{:extern}` class when you need external members on a
+Unlike a class, the value-type declarations — `datatype`, `codatatype` and
+`newtype` — do not support `{:extern}` members. Such a declaration resolves and
+verifies, but the compiler generates no way for external code to supply the
+member's implementation, so a call to it either fails to compile or, on targets
+whose generated code still builds, fails when the call is reached. To combine one
+of these with external code, keep its members in Dafny and put the external
+operations in module-level `{:extern}` functions or methods that take the value as
+a parameter; use an `{:extern}` class when you need external members on a
 reference type.
 
 Member variables marked with `{:extern}` refer to fields or properties

--- a/docs/DafnyRef/integration-cs/IntegrationCS.md
+++ b/docs/DafnyRef/integration-cs/IntegrationCS.md
@@ -172,13 +172,14 @@ Here, `T'` for a type parameter `T` indicates the C# type corresponding to a Daf
 | function (arrow) types        | Func<T',U'> |
 |-------------------------------|------------------------------|
 
-A Dafny `class` or `trait` has object identity: the verifier assumes that `==`
-on such a type, and the `set`, `multiset`, and `map` collections over it, compare
-by identity. A C# class named by an `{:extern}` declaration should therefore not
-override `Equals` and `GetHashCode`: the verifier assumes object identity, so any
-other equality — structural equality being the common case — can let the
-compiled program contradict what was proved. Dafny does not currently check
-this. A type whose equality should be structural is better modelled as a Dafny
+A Dafny `class` or `trait` has object identity, and the verifier assumes that
+`==` and the built-in collections compare such values by identity. A C# class
+named by an `{:extern}` declaration should therefore not override `Equals` and
+`GetHashCode`: any other equality — structural equality being the common case —
+can let the compiled program contradict what was proved, for example by making
+two distinct objects that were proved unequal compare equal, or by giving a
+`set` fewer elements than was verified. Dafny does not currently check this. A
+type whose equality should be structural is better modelled as a Dafny
 `datatype`, or, when it must be backed by C# code, as an opaque value type
 `type {:extern} T(==)`, whose equality the verifier leaves uninterpreted and
 whose C# `Equals` and `GetHashCode` are then used at run time without

--- a/docs/DafnyRef/integration-cs/IntegrationCS.md
+++ b/docs/DafnyRef/integration-cs/IntegrationCS.md
@@ -172,3 +172,15 @@ Here, `T'` for a type parameter `T` indicates the C# type corresponding to a Daf
 | function (arrow) types        | Func<T',U'> |
 |-------------------------------|------------------------------|
 
+A Dafny `class` or `trait` has object identity: the verifier assumes that `==`
+on such a type, and the `set`, `multiset`, and `map` collections over it, compare
+by identity. A C# class named by an `{:extern}` declaration should therefore not
+override `Equals` and `GetHashCode`: the verifier assumes object identity, so any
+other equality — structural equality being the common case — can let the
+compiled program contradict what was proved. Dafny does not currently check
+this. A type whose equality should be structural is better modelled as a Dafny
+`datatype`, or, when it must be backed by C# code, as an opaque value type
+`type {:extern} T(==)`, whose equality the verifier leaves uninterpreted and
+whose C# `Equals` and `GetHashCode` are then used at run time without
+contradicting any verified fact.
+

--- a/docs/DafnyRef/integration-java/IntegrationJava.md
+++ b/docs/DafnyRef/integration-java/IntegrationJava.md
@@ -218,18 +218,18 @@ Often this requires defining a Dafny class that corresponds to the Java class.
 the Dafny-generated (Java) types and the types used in the desired method.
 The wrapper will do appropriate conversions and call the desired method.
 
-A Dafny `class` or `trait` has object identity: the verifier assumes that `==`
-on such a type, and the `set`, `multiset`, and `map` collections over it, compare
-by identity. A Java class named by an `{:extern}` declaration should therefore
-not override `equals` and `hashCode`: the verifier assumes object identity, so
-any other equality — structural equality being the common case — can let the
-compiled program contradict what was proved, for example by making two distinct
-objects that were proved unequal compare equal, or by giving a `set` fewer
-elements than was verified. Dafny does not currently check this. A type whose
-equality should be structural is better modelled as a Dafny `datatype`, or, when
-it must be backed by Java code, as an opaque value type `type {:extern} T(==)`,
-whose equality the verifier leaves uninterpreted and whose Java `equals` and
-`hashCode` are then used at run time without contradicting any verified fact.
+A Dafny `class` or `trait` has object identity, and the verifier assumes that
+`==` and the built-in collections compare such values by identity. A Java class
+named by an `{:extern}` declaration should therefore not override `equals` and
+`hashCode`: any other equality — structural equality being the common case — can
+let the compiled program contradict what was proved, for example by making two
+distinct objects that were proved unequal compare equal, or by giving a `set`
+fewer elements than was verified. Dafny does not currently check this. A type
+whose equality should be structural is better modelled as a Dafny `datatype`,
+or, when it must be backed by Java code, as an opaque value type
+`type {:extern} T(==)`, whose equality the verifier leaves uninterpreted and
+whose Java `equals` and `hashCode` are then used at run time without
+contradicting any verified fact.
 
 ## Performance notes
 

--- a/docs/DafnyRef/integration-java/IntegrationJava.md
+++ b/docs/DafnyRef/integration-java/IntegrationJava.md
@@ -218,6 +218,19 @@ Often this requires defining a Dafny class that corresponds to the Java class.
 the Dafny-generated (Java) types and the types used in the desired method.
 The wrapper will do appropriate conversions and call the desired method.
 
+A Dafny `class` or `trait` has object identity: the verifier assumes that `==`
+on such a type, and the `set`, `multiset`, and `map` collections over it, compare
+by identity. A Java class named by an `{:extern}` declaration should therefore
+not override `equals` and `hashCode`: the verifier assumes object identity, so
+any other equality — structural equality being the common case — can let the
+compiled program contradict what was proved, for example by making two distinct
+objects that were proved unequal compare equal, or by giving a `set` fewer
+elements than was verified. Dafny does not currently check this. A type whose
+equality should be structural is better modelled as a Dafny `datatype`, or, when
+it must be backed by Java code, as an opaque value type `type {:extern} T(==)`,
+whose equality the verifier leaves uninterpreted and whose Java `equals` and
+`hashCode` are then used at run time without contradicting any verified fact.
+
 ## Performance notes
 
 If you have the choice, given a `m: map<K, V>`, prefer iterating over the map itself like `forall k <- m` rather than over the keys `forall k <- m.Keys`. The latter currently results in `O(N²)` steps, whereas the first one remains linear.

--- a/docs/DafnyRef/integration-rust/IntegrationRust.md
+++ b/docs/DafnyRef/integration-rust/IntegrationRust.md
@@ -168,6 +168,10 @@ To implement this in your extern file, use the following template:
 
 For classes, make sure all your mutable fields are wrapped in a `::dafny_runtime::Field` so that it's always possible to share the reference.
 
+Equality of extern reference types is by object identity and cannot be
+overridden by the Rust implementation, so the run-time behaviour always matches
+what the verifier assumes.
+
 ## Other externs
 
 The best way to see what you have to implement as an extern Rust file is to compile your code with extern attributes and adding an external Rust file. For extra methods or static methods, you would then define an additional implementation in the extern Rust file. For other class or struct types, you just need to define them without any `mod` wrapper, or using the module structure as defined in the `{:extern}` attribute.

--- a/docs/DafnyRef/integration-rust/IntegrationRust.md
+++ b/docs/DafnyRef/integration-rust/IntegrationRust.md
@@ -168,9 +168,11 @@ To implement this in your extern file, use the following template:
 
 For classes, make sure all your mutable fields are wrapped in a `::dafny_runtime::Field` so that it's always possible to share the reference.
 
-Equality of extern reference types is by object identity and cannot be
-overridden by the Rust implementation, so the run-time behaviour always matches
-what the verifier assumes.
+A Dafny `class` or `trait` has object identity, and the verifier assumes that
+`==` and the built-in collections compare such values by identity. In Rust this
+holds by construction: extern reference types are compared by object identity
+and this cannot be overridden, so the run-time behaviour always matches what the
+verifier assumes.
 
 ## Other externs
 


### PR DESCRIPTION
Two extern contracts that were documented nowhere. This adds both to the RefMan `{:extern}` section (and, for equality, the per-language integration guides). No behavior change.

**1. Equality of extern reference types (relates to #6491).** Dafny reference types (`class`, `trait`) have object identity, and the verifier reasons about `==` and the `set`/`multiset`/`map` collections on that assumption — unchecked against external code. An `{:extern}` class that gives its target type some other equality (structural, via `equals`/`hashCode`, `Equals`/`GetHashCode`, `__eq__`/`__hash__`, …) can make a compiled program contradict a verified fact. Documented in the RefMan, with two sound alternatives for a type that should compare structurally — a Dafny `datatype`, or an opaque `type {:extern} T(==)` whose equality the verifier leaves uninterpreted — plus target-specific notes in the Java, C#, and Rust integration guides. The section also records a third consequence that needs less than the others: overriding **only** the hash (`hashCode` / `GetHashCode` / `__hash__`), with equality left as object identity, is enough to break collection membership where the target language's collections are organized by hash value — a mutated object is no longer found, so a verified `x in s` is false at run time even though `|s|` still counts it. Verified on each backend with an extern class that overrides only the hash: Java, C# and Python all reproduce it (and still report `|{a,b}| == 2`, confirming equality itself was untouched); Go and JavaScript do not, because their collections scan linearly rather than hashing. (Go and Python are covered by their own PRs: #6497 documents `EqualsGeneric` in `Compilation/Go.md`; the JS/Python notes land with #6498/#6496.)

**2. Datatypes cannot have `{:extern}` members (relates to #6499).** Such a datatype resolves and verifies but emits uncompilable target code on every backend, because the compiler generates no implementation hook for the member. Documented with the supported alternative: keep the datatypes members in Dafny and put external operations in module-level `{:extern}` functions/methods over the datatype, or use an `{:extern}` class for external members on a reference type.

Both are the documentation half of the extern-soundness work; the shipped fixes (#6496, #6497, #6498) handle the cases where the extern was blameless. Enforcing the equality contract for Java/C# collections, and fixing #6499s codegen, are possible future enhancements not attempted here.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
