### PR TITLE
fix: resolve datatype discriminator/destructor pre-types on demand

### DIFF
--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -2538,6 +2538,11 @@ namespace Microsoft.Dafny {
             ReportError(pat.Origin, "pattern for constructor {0} has wrong number of formals (found {1}, expected {2})", pat.Id, pat.Arguments.Count, ctor.Formals.Count);
           }
         }
+      // A constructor's formals get their pre-types filled in while the enclosing datatype's signature is
+      // resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked in
+      // StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same call
+      // in ResolveDatatypeConstructor.
+      ResolveDeclarationSignature(dtd);
         // build the type-parameter substitution map for this use of the datatype
         Contract.Assert(dtd.TypeArgs.Count == sourceTypeArguments.Count);  // follows from the type previously having been successfully resolved
         var subst = PreType.PreTypeSubstMap(dtd.TypeArgs, sourceTypeArguments);
@@ -2570,6 +2575,11 @@ namespace Microsoft.Dafny {
       Contract.Requires(datatypeDecl != null);
       Contract.Requires(ty == null || (ty.Decl == datatypeDecl && ty.Arguments.Count == datatypeDecl.TypeArgs.Count));
 
+      // A constructor's formals get their pre-types filled in while the enclosing datatype's signature is
+      // resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked in
+      // StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same call
+      // in ResolveDatatypeConstructor.
+      ResolveDeclarationSignature(datatypeDecl);
       var ok = true;
       List<PreType> gt;
       if (ty == null) {

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -2538,10 +2538,7 @@ namespace Microsoft.Dafny {
             ReportError(pat.Origin, "pattern for constructor {0} has wrong number of formals (found {1}, expected {2})", pat.Id, pat.Arguments.Count, ctor.Formals.Count);
           }
         }
-        // A constructor's formals get their pre-types filled in while the enclosing datatype's signature
-        // is resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked
-        // in StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same
-        // call in ResolveDatatypeConstructor.
+        // ctor.Formals is read below; see ResolveDeclarationSignature.
         ResolveDeclarationSignature(dtd);
         // build the type-parameter substitution map for this use of the datatype
         Contract.Assert(dtd.TypeArgs.Count == sourceTypeArguments.Count);  // follows from the type previously having been successfully resolved
@@ -2575,10 +2572,7 @@ namespace Microsoft.Dafny {
       Contract.Requires(datatypeDecl != null);
       Contract.Requires(ty == null || (ty.Decl == datatypeDecl && ty.Arguments.Count == datatypeDecl.TypeArgs.Count));
 
-      // A constructor's formals get their pre-types filled in while the enclosing datatype's signature is
-      // resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked in
-      // StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same call
-      // in ResolveDatatypeConstructor.
+      // ctor.Formals is read below (via ResolveActualParameters); see ResolveDeclarationSignature.
       ResolveDeclarationSignature(datatypeDecl);
       var ok = true;
       List<PreType> gt;

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.Expressions.cs
@@ -2538,11 +2538,11 @@ namespace Microsoft.Dafny {
             ReportError(pat.Origin, "pattern for constructor {0} has wrong number of formals (found {1}, expected {2})", pat.Id, pat.Arguments.Count, ctor.Formals.Count);
           }
         }
-      // A constructor's formals get their pre-types filled in while the enclosing datatype's signature is
-      // resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked in
-      // StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same call
-      // in ResolveDatatypeConstructor.
-      ResolveDeclarationSignature(dtd);
+        // A constructor's formals get their pre-types filled in while the enclosing datatype's signature
+        // is resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked
+        // in StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same
+        // call in ResolveDatatypeConstructor.
+        ResolveDeclarationSignature(dtd);
         // build the type-parameter substitution map for this use of the datatype
         Contract.Assert(dtd.TypeArgs.Count == sourceTypeArguments.Count);  // follows from the type previously having been successfully resolved
         var subst = PreType.PreTypeSubstMap(dtd.TypeArgs, sourceTypeArguments);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -783,6 +783,14 @@ namespace Microsoft.Dafny {
     }
 
     void ResolvePreTypeSignature(Declaration d) {
+      // Discriminators and destructors are the only members whose pre-types are filled in while resolving the
+      // enclosing datatype (see the DatatypeDecl case of FillInPreTypesInSignature) rather than on their own, so
+      // they are not in "StillNeedsPreTypeSignature" and resolving them directly is a no-op; redirect to the
+      // datatype to fill in the field's pre-type. This must not fire for user-declared members (e.g. a static
+      // const), which are tracked individually and must resolve on their own to preserve, e.g., cycle detection.
+      if (d is DatatypeDiscriminator or DatatypeDestructor) {
+        d = ((SpecialField)d).EnclosingClass;
+      }
       ResolvePreTypeSignature(d, preTypeInferenceModuleState, resolver);
     }
 

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolve.cs
@@ -856,6 +856,13 @@ namespace Microsoft.Dafny {
 
     /// <summary>
     /// Assumes that the type parameters in scope for "d" have been pushed.
+    ///
+    /// Callers that are about to read a datatype constructor's formals must call this for the enclosing
+    /// datatype first. Those formals get their pre-types filled in while the datatype's signature is
+    /// resolved (the DatatypeDecl case of FillInPreTypesInSignature) rather than on their own, and the
+    /// datatype is not tracked in StillNeedsPreTypeSignature, so the formals can otherwise still be
+    /// unresolved. The call is idempotent: it returns immediately for a declaration that no longer needs
+    /// its signature resolved.
     /// </summary>
     public void ResolveDeclarationSignature(Declaration d) {
       Contract.Requires(d is TopLevelDecl or MemberDecl);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolver.Match.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolver.Match.cs
@@ -152,6 +152,11 @@ namespace Microsoft.Dafny {
         return;
       }
 
+      // A constructor's formals get their pre-types filled in while the enclosing datatype's signature is
+      // resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked in
+      // StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same call
+      // in ResolveDatatypeConstructor.
+      ResolveDeclarationSignature(dtd);
       var subst = PreType.PreTypeSubstMap(dtd.TypeArgs, dpreType.Arguments);
       for (var i = 0; i < idPattern.Arguments.Count; i++) {
         var argumentPreType = ctor.Formals[i].PreType.Substitute(subst);

--- a/Source/DafnyCore/Resolver/PreType/PreTypeResolver.Match.cs
+++ b/Source/DafnyCore/Resolver/PreType/PreTypeResolver.Match.cs
@@ -152,10 +152,7 @@ namespace Microsoft.Dafny {
         return;
       }
 
-      // A constructor's formals get their pre-types filled in while the enclosing datatype's signature is
-      // resolved (the DatatypeDecl case of FillInPreTypesInSignature), and the datatype is not tracked in
-      // StillNeedsPreTypeSignature, so reading the formals below can see them unresolved. Cf. the same call
-      // in ResolveDatatypeConstructor.
+      // ctor.Formals is read below; see ResolveDeclarationSignature.
       ResolveDeclarationSignature(dtd);
       var subst = PreType.PreTypeSubstMap(dtd.TypeArgs, dpreType.Arguments);
       for (var i = 0; i < idPattern.Arguments.Count; i++) {

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy
@@ -1,6 +1,4 @@
-// RUN: %baredafny resolve --use-basename-for-filename --show-snippets:false "%s" > "%t"
-// RUN: %baredafny resolve --type-system-refresh --general-newtypes --use-basename-for-filename --show-snippets:false "%s" >> "%t"
-// RUN: %diff "%s.expect" "%t"
+// RUN: %testDafnyForEachResolver "%s"
 
 // An untyped, module-level const whose RHS reads a datatype discriminator or destructor used to
 // crash the resolver: these fields are not tracked individually, so their pre-types were still

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy
@@ -11,3 +11,25 @@ const discriminatorConst := (m: Mode) => m.Owned? || m.Loaned?
 datatype Cell = Cell(value: int)
 
 const destructorConst := (c: Cell) => c.value
+
+// The same staleness affects a constructor's formals, which are filled in at the same place and are
+// likewise untracked. Their three consumers each read Formals[i].PreType: a constructor call, a
+// case pattern, and a match pattern.
+
+const constructorCall := D.Mk(0)
+
+datatype D = Mk(x: int)
+
+const casePattern := (d: D) => var Mk(v) := d; v
+
+const datatypeUpdate := (c: Cell) => c.(value := 5)
+
+// The match case needs an ambiguous constructor name, so that resolution does not first take the
+// constructor-name path (which already resolves the signature on demand).
+
+const matchPattern := (p: P) => match p { case Mk(a, b) => a + b }
+
+datatype P = Mk(x: int, y: int)
+
+datatype R = Mk(u: int, v: int)
+

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy
@@ -1,0 +1,15 @@
+// RUN: %baredafny resolve --use-basename-for-filename --show-snippets:false "%s" > "%t"
+// RUN: %baredafny resolve --type-system-refresh --general-newtypes --use-basename-for-filename --show-snippets:false "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// An untyped, module-level const whose RHS reads a datatype discriminator or destructor used to
+// crash the resolver: these fields are not tracked individually, so their pre-types were still
+// unfilled when the const's RHS was resolved eagerly.
+
+datatype Mode = Owned | Loaned | Other
+
+const discriminatorConst := (m: Mode) => m.Owned? || m.Loaned?
+
+datatype Cell = Cell(value: int)
+
+const destructorConst := (c: Cell) => c.value

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy.expect
@@ -1,0 +1,4 @@
+
+Dafny program verifier did not attempt verification
+
+Dafny program verifier did not attempt verification

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6434.dfy.expect
@@ -1,4 +1,2 @@
 
-Dafny program verifier did not attempt verification
-
-Dafny program verifier did not attempt verification
+Dafny program verifier finished with 0 verified, 0 errors

--- a/docs/dev/news/6434.fix
+++ b/docs/dev/news/6434.fix
@@ -1,0 +1,1 @@
+Fixed a resolver crash when an untyped, module-level `const` read a datatype discriminator (`x.Ctor?`) or destructor (`x.field`)


### PR DESCRIPTION
## Summary

Fixes a resolver crash (`NullReferenceException`) on an untyped, module-level `const` whose RHS reads a datatype discriminator or destructor:

```dafny
datatype Mode = Owned | Loaned
const p := (m: Mode) => m.Owned?
```

## Root cause & fix

Discriminators (`ctor.QueryField`) and destructors are the only *members* whose pre-types are filled in while resolving the enclosing datatype (the `DatatypeDecl` case of `FillInPreTypesInSignature`) rather than on their own, so they are not in `StillNeedsPreTypeSignature` and the on-demand `ResolvePreTypeSignature(member)` in `ResolveExprDotCall` is a no-op for them. An untyped module-level `const` resolves its RHS eagerly, before the datatype's signature, so the field's pre-type is still null when `ResolveExprDotCall` dereferences it.

*Fix:* in `ResolvePreTypeSignature(Declaration)`, redirect a `DatatypeDiscriminator`/`DatatypeDestructor` to its enclosing datatype.

## The same staleness reaches a constructor's formals

"Members" is doing real work in that sentence: a constructor's `Formals` are `Formal`s, not `MemberDecl`s, but they are filled in at the very same place and the datatype is likewise untracked — so the identical crash survives the redirect through three consumers that read `Formals[i].PreType`. All three still NRE'd on this PR's first head:

```dafny
const constructorCall := D.Mk(0)                  // ResolveDatatypeValue
const casePattern := (d: D) => var Mk(v) := d; v  // ResolveCasePattern
const matchPattern := (p: P) => match p { ... }   // ResolveExtendedPattern
```

`ResolveDatatypeConstructor` already calls `ResolveDeclarationSignature` on demand for exactly this reason; the fix does the same at the three sites that lacked it. The call is idempotent — `ResolveDeclarationSignature` early-returns for a declaration not in `StillNeedsPreTypeSignature`.

The match site is easy to miss twice over: it needs its own guard, **and** it needs an *ambiguous* constructor name to reach at all. With a single `Mk`, resolution takes the constructor-name path, which already resolves the signature, and nothing crashes. Two guards are not sufficient.

Verified beyond "it stops crashing": the subset-type cycle `type S = y | D.Mk(y).x == y` with `datatype D = Mk(x: S)` still reports `recursive constraint dependency involving a subset type: S -> D -> S`, and nested generics resolve and verify (`Outer<int>.O(Inner<int>.I(5))` with `x.w.v == 5`). The test now covers all three shapes and crashes three times without the guards. This is keyed on those two field kinds rather than "a field of a datatype" because a user-declared member (e.g. a `static const`) is tracked individually and must resolve on its own to preserve, e.g., cycle detection.

## Test

`git-issue-6434.dfy` covers both a discriminator and a destructor, run under both resolvers.

Fixes #6434

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>

