### PR TITLE
fix: canonicalize the element order of set and multiset displays

### DIFF
--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -7,6 +7,7 @@ using Dafny;
 using Microsoft.BaseTypes;
 using Microsoft.Boogie;
 using Bpl = Microsoft.Boogie;
+using Microsoft.Dafny.Triggers;
 using static Microsoft.Dafny.Util;
 
 namespace Microsoft.Dafny {
@@ -1201,7 +1202,7 @@ namespace Microsoft.Dafny {
         Boogie.Type maptype = displayExpr.Finite ? Predef.MapType : Predef.IMapType;
         var isLit = true;
         var keysAllLit = true;
-        var entries = new List<(Boogie.Expr Key, Boogie.Expr Value)>();
+        var entries = new List<(Expression KeySource, Boogie.Expr Key, Boogie.Expr Value)>();
         foreach (MapDisplayEntry p in displayExpr.Elements) {
           var rawA = TrExpr(p.A);
           var rawB = TrExpr(p.B);
@@ -1209,7 +1210,7 @@ namespace Microsoft.Dafny {
           keysAllLit = keysAllLit && BoogieGenerator.IsLit(rawA);
           Boogie.Expr elt = BoxIfNecessary(GetToken(displayExpr), rawA, Cce.NonNull(p.A.Type));
           Boogie.Expr elt2 = BoxIfNecessary(GetToken(displayExpr), rawB, Cce.NonNull(p.B.Type));
-          entries.Add((elt, elt2));
+          entries.Add((p.A, elt, elt2));
         }
         // Like set/multiset displays (see CanonicalizeDisplayElements), a map display's value is order-independent
         // but the emitted Map#Build chain is not, so we canonicalize the entry order -- but only when every key is
@@ -1217,14 +1218,13 @@ namespace Microsoft.Dafny {
         // keys may denote the same key at runtime, so reordering could change which write wins. (A shadowed
         // value's well-formedness is checked in a separate pass, so dropping it here is sound.)
         if (keysAllLit) {
-          // Same-key entries are identified by their printed form -- not by Boogie's Expr.Equals, which for a
-          // function application compares the (not yet resolved, hence null) Function references and so reports
-          // any two applications as equal. Keeping the later entry realizes last-write-wins. Displays are small,
-          // so the quadratic key comparison is negligible.
-          var keyed = entries.ConvertAll(e => (KeyText: e.Key.ToString(), Entry: e));
-          var deduped = new List<(string KeyText, (Boogie.Expr Key, Boogie.Expr Value) Entry)>();
-          foreach (var item in keyed) {
-            var existing = deduped.FindIndex(e => e.KeyText == item.KeyText);
+          // Entries are for the same key when their key expressions are structurally equal on the resolved Dafny
+          // AST; keeping the later one realizes last-write-wins. Sorting then uses the printed form of the emitted
+          // key, which only has to be stable. Displays are small, so the quadratic comparison is negligible.
+          var deduped = new List<(string KeyText, Expression KeySource, Boogie.Expr Key, Boogie.Expr Value)>();
+          foreach (var entry in entries) {
+            var existing = deduped.FindIndex(e => e.KeySource.ExpressionEq(entry.KeySource));
+            var item = (entry.Key.ToString(), entry.KeySource, entry.Key, entry.Value);
             if (existing >= 0) {
               deduped[existing] = item;
             } else {
@@ -1232,10 +1232,10 @@ namespace Microsoft.Dafny {
             }
           }
           deduped.Sort((x, y) => string.CompareOrdinal(x.KeyText, y.KeyText));
-          entries = deduped.ConvertAll(e => e.Entry);
+          entries = deduped.ConvertAll(e => (e.KeySource, e.Key, e.Value));
         }
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
-        foreach (var (key, value) in entries) {
+        foreach (var (_, key, value) in entries) {
           s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, key, value);
         }
         if (isLit) {
@@ -1277,37 +1277,40 @@ namespace Microsoft.Dafny {
       /// With <paramref name="dropDuplicates"/> (sets, which ignore multiplicity), equal elements are also
       /// collapsed, so e.g. {1,1,2} and {1,2} agree; it must be false for multisets.
       ///
-      /// The sort key only needs to be stable (ties are harmless: the UnionOne functions are commutative), so
-      /// the printed form suffices. Duplicate removal must be sound, so it uses structural equality
-      /// (Boogie's Expr.Equals), not the textual key.
+      /// The sort key only needs to be stable, since ties are harmless: the UnionOne functions are commutative,
+      /// so any order of equal-keyed elements denotes the same value. The printed form of the emitted term
+      /// therefore suffices for ordering. Duplicate removal, in contrast, must not drop distinct elements, so it
+      /// compares the source expressions with <c>ExpressionEq</c>, a structural equality on the resolved Dafny
+      /// AST. (Boogie's own <c>Expr.Equals</c> is unusable here: for a function application it compares the
+      /// <c>Func</c> references, which the translator leaves null until Boogie resolution, so it reports any two
+      /// applications -- for instance two different datatype constructors -- as equal.)
       /// </summary>
-      private static List<Boogie.Expr> CanonicalizeDisplayElements(List<Boogie.Expr> boxedElements, bool dropDuplicates) {
+      private static List<Boogie.Expr> CanonicalizeDisplayElements(
+          List<(Expression Source, Boogie.Expr Boxed)> elements, bool dropDuplicates) {
         // Cache each element's printed form once, rather than recomputing ToString inside the comparator.
-        var keyed = boxedElements.ConvertAll(e => (Key: e.ToString(), Element: e));
+        var keyed = elements.ConvertAll(e => (Key: e.Boxed.ToString(), e.Source, e.Boxed));
         keyed.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
         var result = new List<Boogie.Expr>(keyed.Count);
-        string previousKey = null;
-        foreach (var (key, element) in keyed) {
-          // Identical elements print identically and so sort adjacently, so comparing each element's printed form
-          // with the previous kept one removes every duplicate. Note that Boogie's Expr.Equals must not be used
-          // here: for a function application it compares the (not yet resolved, hence null) Function references,
-          // so it reports any two applications as equal, which would drop distinct elements.
-          if (dropDuplicates && key == previousKey) {
+        var kept = new List<Expression>(keyed.Count);
+        foreach (var (_, source, boxed) in keyed) {
+          // Equal elements print identically and so sort adjacently, but a printed-form collision between
+          // distinct elements is possible in principle, so the decision to drop is made on the Dafny AST.
+          if (dropDuplicates && kept.Count != 0 && kept[kept.Count - 1].ExpressionEq(source)) {
             continue;
           }
-          previousKey = key;
-          result.Add(element);
+          kept.Add(source);
+          result.Add(boxed);
         }
         return result;
       }
 
       private Expr TranslateSetDisplayExpr(SetDisplayExpr displayExpr) {
         var isLit = true;
-        var boxedElements = new List<Boogie.Expr>();
+        var boxedElements = new List<(Expression, Boogie.Expr)>();
         foreach (Expression ee in displayExpr.Elements) {
           var rawElement = TrExpr(ee);
           isLit = isLit && BoogieGenerator.IsLit(rawElement);
-          boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
+          boxedElements.Add((ee, BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type))));
         }
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetEmpty : BuiltinFunction.ISetEmpty, Predef.BoxType);
         foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements, dropDuplicates: true)) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1217,19 +1217,22 @@ namespace Microsoft.Dafny {
         // keys may denote the same key at runtime, so reordering could change which write wins. (A shadowed
         // value's well-formedness is checked in a separate pass, so dropping it here is sound.)
         if (keysAllLit) {
-          // Same-key entries are identified by structural equality (Boogie's Expr.Equals); keeping the later one
-          // realizes last-write-wins. Displays are small, so the quadratic key comparison is negligible.
-          var deduped = new List<(Boogie.Expr Key, Boogie.Expr Value)>();
-          foreach (var entry in entries) {
-            var existing = deduped.FindIndex(e => e.Key.Equals(entry.Key));
+          // Same-key entries are identified by their printed form -- not by Boogie's Expr.Equals, which for a
+          // function application compares the (not yet resolved, hence null) Function references and so reports
+          // any two applications as equal. Keeping the later entry realizes last-write-wins. Displays are small,
+          // so the quadratic key comparison is negligible.
+          var keyed = entries.ConvertAll(e => (KeyText: e.Key.ToString(), Entry: e));
+          var deduped = new List<(string KeyText, (Boogie.Expr Key, Boogie.Expr Value) Entry)>();
+          foreach (var item in keyed) {
+            var existing = deduped.FindIndex(e => e.KeyText == item.KeyText);
             if (existing >= 0) {
-              deduped[existing] = entry;
+              deduped[existing] = item;
             } else {
-              deduped.Add(entry);
+              deduped.Add(item);
             }
           }
-          entries = deduped;
-          entries.Sort((x, y) => string.CompareOrdinal(x.Key.ToString(), y.Key.ToString()));
+          deduped.Sort((x, y) => string.CompareOrdinal(x.KeyText, y.KeyText));
+          entries = deduped.ConvertAll(e => e.Entry);
         }
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
         foreach (var (key, value) in entries) {
@@ -1283,12 +1286,16 @@ namespace Microsoft.Dafny {
         var keyed = boxedElements.ConvertAll(e => (Key: e.ToString(), Element: e));
         keyed.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
         var result = new List<Boogie.Expr>(keyed.Count);
-        foreach (var (_, element) in keyed) {
-          // Equal elements share a key and so sort adjacently; comparing with the previous kept one thus removes
-          // every true duplicate. A key collision between distinct elements just keeps both -- a harmless miss.
-          if (dropDuplicates && result.Count != 0 && result[result.Count - 1].Equals(element)) {
+        string previousKey = null;
+        foreach (var (key, element) in keyed) {
+          // Identical elements print identically and so sort adjacently, so comparing each element's printed form
+          // with the previous kept one removes every duplicate. Note that Boogie's Expr.Equals must not be used
+          // here: for a function application it compares the (not yet resolved, hence null) Function references,
+          // so it reports any two applications as equal, which would drop distinct elements.
+          if (dropDuplicates && key == previousKey) {
             continue;
           }
+          previousKey = key;
           result.Add(element);
         }
         return result;

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1202,7 +1202,7 @@ namespace Microsoft.Dafny {
         Boogie.Type maptype = displayExpr.Finite ? Predef.MapType : Predef.IMapType;
         var isLit = true;
         var keysAllLit = true;
-        var entries = new List<(Expression KeySource, Boogie.Expr Key, Boogie.Expr Value)>();
+        var entries = new List<(Boogie.Expr Key, Boogie.Expr Value)>();
         foreach (MapDisplayEntry p in displayExpr.Elements) {
           var rawA = TrExpr(p.A);
           var rawB = TrExpr(p.B);
@@ -1210,7 +1210,7 @@ namespace Microsoft.Dafny {
           keysAllLit = keysAllLit && BoogieGenerator.IsLit(rawA);
           Boogie.Expr elt = BoxIfNecessary(GetToken(displayExpr), rawA, Cce.NonNull(p.A.Type));
           Boogie.Expr elt2 = BoxIfNecessary(GetToken(displayExpr), rawB, Cce.NonNull(p.B.Type));
-          entries.Add((p.A, elt, elt2));
+          entries.Add((elt, elt2));
         }
         // Like set/multiset displays (see CanonicalizeDisplayElements), a map display's value is order-independent
         // but the emitted Map#Build chain is not, so we canonicalize the entry order -- but only when every key is
@@ -1218,13 +1218,13 @@ namespace Microsoft.Dafny {
         // keys may denote the same key at runtime, so reordering could change which write wins. (A shadowed
         // value's well-formedness is checked in a separate pass, so dropping it here is sound.)
         if (keysAllLit) {
-          // Entries are for the same key when their key expressions are structurally equal on the resolved Dafny
-          // AST; keeping the later one realizes last-write-wins. Sorting then uses the printed form of the emitted
-          // key, which only has to be stable. Displays are small, so the quadratic comparison is negligible.
-          var deduped = new List<(string KeyText, Expression KeySource, Boogie.Expr Key, Boogie.Expr Value)>();
+          // Entries are for the same key when their emitted keys print alike; keeping the later one realizes
+          // last-write-wins. The printed form is also the sort key, which only has to be stable. Displays are
+          // small, so the quadratic comparison is negligible.
+          var deduped = new List<(string KeyText, Boogie.Expr Key, Boogie.Expr Value)>();
           foreach (var entry in entries) {
-            var existing = deduped.FindIndex(e => e.KeySource.ExpressionEq(entry.KeySource));
-            var item = (entry.Key.ToString(), entry.KeySource, entry.Key, entry.Value);
+            var item = (entry.Key.ToString(), entry.Key, entry.Value);
+            var existing = deduped.FindIndex(e => e.KeyText == item.Item1);
             if (existing >= 0) {
               deduped[existing] = item;
             } else {
@@ -1232,10 +1232,10 @@ namespace Microsoft.Dafny {
             }
           }
           deduped.Sort((x, y) => string.CompareOrdinal(x.KeyText, y.KeyText));
-          entries = deduped.ConvertAll(e => (e.KeySource, e.Key, e.Value));
+          entries = deduped.ConvertAll(e => (e.Key, e.Value));
         }
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
-        foreach (var (_, key, value) in entries) {
+        foreach (var (key, value) in entries) {
           s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, key, value);
         }
         if (isLit) {
@@ -1277,28 +1277,30 @@ namespace Microsoft.Dafny {
       /// With <paramref name="dropDuplicates"/> (sets, which ignore multiplicity), equal elements are also
       /// collapsed, so e.g. {1,1,2} and {1,2} agree; it must be false for multisets.
       ///
-      /// The sort key only needs to be stable, since ties are harmless: the UnionOne functions are commutative,
-      /// so any order of equal-keyed elements denotes the same value. The printed form of the emitted term
-      /// therefore suffices for ordering. Duplicate removal, in contrast, must not drop distinct elements, so it
-      /// compares the source expressions with <c>ExpressionEq</c>, a structural equality on the resolved Dafny
-      /// AST. (Boogie's own <c>Expr.Equals</c> is unusable here: for a function application it compares the
-      /// <c>Func</c> references, which the translator leaves null until Boogie resolution, so it reports any two
-      /// applications -- for instance two different datatype constructors -- as equal.)
+      /// Both the ordering and the duplicate test use the emitted term's printed form. Ties in the order are
+      /// harmless, since the UnionOne functions are commutative; and two elements that denote the same value emit
+      /// the same term, so they print alike and are found adjacent. Neither Boogie's <c>Expr.Equals</c> nor the
+      /// triggers' <c>ExpressionEq</c> can serve here: the former compares a function application's <c>Func</c>
+      /// references, which the translator leaves null until Boogie resolution, so it reports any two applications
+      /// (two different datatype constructors, say) as equal; the latter dispatches over a closed set of node
+      /// types and asserts when given a pair it does not enumerate, which a display element -- an arbitrary
+      /// expression, such as the <c>locals</c> of a memory location -- can easily be.
       /// </summary>
-      private static List<Boogie.Expr> CanonicalizeDisplayElements(
-          List<(Expression Source, Boogie.Expr Boxed)> elements, bool dropDuplicates) {
+      private static List<Boogie.Expr> CanonicalizeDisplayElements(List<Boogie.Expr> boxedElements, bool dropDuplicates) {
         // Cache each element's printed form once, rather than recomputing ToString inside the comparator.
-        var keyed = elements.ConvertAll(e => (Key: e.Boxed.ToString(), e.Source, e.Boxed));
+        var keyed = boxedElements.ConvertAll(e => (Key: e.ToString(), Boxed: e));
         keyed.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
         var result = new List<Boogie.Expr>(keyed.Count);
-        var kept = new List<Expression>(keyed.Count);
-        foreach (var (_, source, boxed) in keyed) {
-          // Equal elements print identically and so sort adjacently, but a printed-form collision between
-          // distinct elements is possible in principle, so the decision to drop is made on the Dafny AST.
-          if (dropDuplicates && kept.Count != 0 && kept[kept.Count - 1].ExpressionEq(source)) {
+        string previousKey = null;
+        foreach (var (key, boxed) in keyed) {
+          // Elements that denote the same value emit the same term and so print identically, which is why equal
+          // elements sort adjacently and comparing with the previous kept key removes them. Should two distinct
+          // elements ever print alike, the only consequence is that both are kept -- a missed collapse, which
+          // costs nothing but the syntactic equality this canonicalization would otherwise have provided.
+          if (dropDuplicates && key == previousKey) {
             continue;
           }
-          kept.Add(source);
+          previousKey = key;
           result.Add(boxed);
         }
         return result;
@@ -1306,11 +1308,11 @@ namespace Microsoft.Dafny {
 
       private Expr TranslateSetDisplayExpr(SetDisplayExpr displayExpr) {
         var isLit = true;
-        var boxedElements = new List<(Expression, Boogie.Expr)>();
+        var boxedElements = new List<Boogie.Expr>();
         foreach (Expression ee in displayExpr.Elements) {
           var rawElement = TrExpr(ee);
           isLit = isLit && BoogieGenerator.IsLit(rawElement);
-          boxedElements.Add((ee, BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type))));
+          boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
         }
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetEmpty : BuiltinFunction.ISetEmpty, Predef.BoxType);
         foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements, dropDuplicates: true)) {

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1199,15 +1199,41 @@ namespace Microsoft.Dafny {
 
       private Expr TranslateMapDisplayExpr(MapDisplayExpr displayExpr) {
         Boogie.Type maptype = displayExpr.Finite ? Predef.MapType : Predef.IMapType;
-        Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
         var isLit = true;
+        var keysAllLit = true;
+        var entries = new List<(Boogie.Expr Key, Boogie.Expr Value)>();
         foreach (MapDisplayEntry p in displayExpr.Elements) {
           var rawA = TrExpr(p.A);
           var rawB = TrExpr(p.B);
           isLit = isLit && BoogieGenerator.IsLit(rawA) && BoogieGenerator.IsLit(rawB);
+          keysAllLit = keysAllLit && BoogieGenerator.IsLit(rawA);
           Boogie.Expr elt = BoxIfNecessary(GetToken(displayExpr), rawA, Cce.NonNull(p.A.Type));
           Boogie.Expr elt2 = BoxIfNecessary(GetToken(displayExpr), rawB, Cce.NonNull(p.B.Type));
-          s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, elt, elt2);
+          entries.Add((elt, elt2));
+        }
+        // Like set/multiset displays (see CanonicalizeDisplayElements), a map display's value is order-independent
+        // but the emitted Map#Build chain is not, so we canonicalize the entry order -- but only when every key is
+        // a literal. Map display is last-write-wins on a repeated key, and two syntactically-distinct non-literal
+        // keys may denote the same key at runtime, so reordering could change which write wins. (A shadowed
+        // value's well-formedness is checked in a separate pass, so dropping it here is sound.)
+        if (keysAllLit) {
+          // Same-key entries are identified by structural equality (Boogie's Expr.Equals); keeping the later one
+          // realizes last-write-wins. Displays are small, so the quadratic key comparison is negligible.
+          var deduped = new List<(Boogie.Expr Key, Boogie.Expr Value)>();
+          foreach (var entry in entries) {
+            var existing = deduped.FindIndex(e => e.Key.Equals(entry.Key));
+            if (existing >= 0) {
+              deduped[existing] = entry;
+            } else {
+              deduped.Add(entry);
+            }
+          }
+          entries = deduped;
+          entries.Sort((x, y) => string.CompareOrdinal(x.Key.ToString(), y.Key.ToString()));
+        }
+        Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
+        foreach (var (key, value) in entries) {
+          s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, key, value);
         }
         if (isLit) {
           // Lit-lifting: All keys and values are lit, so the map is Lit too
@@ -1238,14 +1264,47 @@ namespace Microsoft.Dafny {
         return new Boogie.NAryExpr(GetToken(call), new Boogie.FunctionCall(id), args);
       }
 
+      /// <summary>
+      /// Canonicalizes the elements of a set or multiset display before they are folded into a
+      /// Set#UnionOne / MultiSet#UnionOne chain. The value is order-independent, but the emitted chain is not, so
+      /// permutations (e.g. {1,2,3} vs {3,2,1}) would otherwise produce distinct Boogie terms whose equality --
+      /// and hence use as the same map key or set element -- holds only provably, not by construction. Sorting
+      /// the elements by their printed form gives permutations the same term.
+      ///
+      /// With <paramref name="dropDuplicates"/> (sets, which ignore multiplicity), equal elements are also
+      /// collapsed, so e.g. {1,1,2} and {1,2} agree; it must be false for multisets.
+      ///
+      /// The sort key only needs to be stable (ties are harmless: the UnionOne functions are commutative), so
+      /// the printed form suffices. Duplicate removal must be sound, so it uses structural equality
+      /// (Boogie's Expr.Equals), not the textual key.
+      /// </summary>
+      private static List<Boogie.Expr> CanonicalizeDisplayElements(List<Boogie.Expr> boxedElements, bool dropDuplicates) {
+        // Cache each element's printed form once, rather than recomputing ToString inside the comparator.
+        var keyed = boxedElements.ConvertAll(e => (Key: e.ToString(), Element: e));
+        keyed.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
+        var result = new List<Boogie.Expr>(keyed.Count);
+        foreach (var (_, element) in keyed) {
+          // Equal elements share a key and so sort adjacently; comparing with the previous kept one thus removes
+          // every true duplicate. A key collision between distinct elements just keeps both -- a harmless miss.
+          if (dropDuplicates && result.Count != 0 && result[result.Count - 1].Equals(element)) {
+            continue;
+          }
+          result.Add(element);
+        }
+        return result;
+      }
+
       private Expr TranslateSetDisplayExpr(SetDisplayExpr displayExpr) {
-        Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetEmpty : BuiltinFunction.ISetEmpty, Predef.BoxType);
         var isLit = true;
+        var boxedElements = new List<Boogie.Expr>();
         foreach (Expression ee in displayExpr.Elements) {
           var rawElement = TrExpr(ee);
           isLit = isLit && BoogieGenerator.IsLit(rawElement);
-          Boogie.Expr ss = BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type));
-          s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetUnionOne : BuiltinFunction.ISetUnionOne, Predef.BoxType, s, ss);
+          boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
+        }
+        Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetEmpty : BuiltinFunction.ISetEmpty, Predef.BoxType);
+        foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements, dropDuplicates: true)) {
+          s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetUnionOne : BuiltinFunction.ISetUnionOne, Predef.BoxType, s, boxedElement);
         }
         if (isLit) {
           // Lit-lifting: All elements are lit, so the set is Lit too

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -1198,12 +1198,10 @@ namespace Microsoft.Dafny {
       }
 
       private Expr TranslateMapDisplayExpr(MapDisplayExpr displayExpr) {
-        // A map display is intentionally NOT canonicalized. Unlike a set or multiset, its emitted Map#Build chain
-        // is order-sensitive in a way its value is not only up to a duplicate key: map display is last-write-wins,
-        // so reordering two entries with the same key changes the resulting map. Recognizing that the key is
-        // duplicated would require deciding key equality, which for non-literal keys is a runtime question and for
-        // any key would put the printer in the trusted computing base. So reordered map displays remain distinct
-        // terms (an incompleteness); equality of two such displays needs an explicit assertion.
+        // A map display is intentionally NOT canonicalized the way a set or multiset display is: it is
+        // last-write-wins, so reordering two entries with the same key changes the map. Skipping such a pair would
+        // mean deciding key equality, which is a runtime question for a non-literal key and would otherwise rest
+        // on the printer. Reordered map displays therefore remain distinct terms, an incompleteness.
         Boogie.Type maptype = displayExpr.Finite ? Predef.MapType : Predef.IMapType;
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
         var isLit = true;
@@ -1260,11 +1258,6 @@ namespace Microsoft.Dafny {
       /// (an incompleteness), and equality of differently-built collections still needs an explicit assertion.
       /// </summary>
       private static List<Boogie.Expr> CanonicalizeDisplayElements(List<Boogie.Expr> boxedElements) {
-        // Order the elements by their printed form. This is only ever a reordering -- no element is added or
-        // removed -- so it is sound regardless of what the key is: the UnionOne functions are commutative, so
-        // every permutation denotes the same value, and the sort merely picks a canonical one. (We deliberately
-        // do NOT drop elements that print alike: that would make the printer part of the trusted computing base,
-        // since a printer collision between two distinct values would then silently discard one of them.)
         var keyed = boxedElements.ConvertAll(e => (Key: e.ToString(), Boxed: e));
         keyed.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
         return keyed.ConvertAll(e => e.Boxed);

--- a/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
+++ b/Source/DafnyCore/Verifier/BoogieGenerator.ExpressionTranslator.cs
@@ -7,7 +7,6 @@ using Dafny;
 using Microsoft.BaseTypes;
 using Microsoft.Boogie;
 using Bpl = Microsoft.Boogie;
-using Microsoft.Dafny.Triggers;
 using static Microsoft.Dafny.Util;
 
 namespace Microsoft.Dafny {
@@ -1199,44 +1198,22 @@ namespace Microsoft.Dafny {
       }
 
       private Expr TranslateMapDisplayExpr(MapDisplayExpr displayExpr) {
+        // A map display is intentionally NOT canonicalized. Unlike a set or multiset, its emitted Map#Build chain
+        // is order-sensitive in a way its value is not only up to a duplicate key: map display is last-write-wins,
+        // so reordering two entries with the same key changes the resulting map. Recognizing that the key is
+        // duplicated would require deciding key equality, which for non-literal keys is a runtime question and for
+        // any key would put the printer in the trusted computing base. So reordered map displays remain distinct
+        // terms (an incompleteness); equality of two such displays needs an explicit assertion.
         Boogie.Type maptype = displayExpr.Finite ? Predef.MapType : Predef.IMapType;
+        Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
         var isLit = true;
-        var keysAllLit = true;
-        var entries = new List<(Boogie.Expr Key, Boogie.Expr Value)>();
         foreach (MapDisplayEntry p in displayExpr.Elements) {
           var rawA = TrExpr(p.A);
           var rawB = TrExpr(p.B);
           isLit = isLit && BoogieGenerator.IsLit(rawA) && BoogieGenerator.IsLit(rawB);
-          keysAllLit = keysAllLit && BoogieGenerator.IsLit(rawA);
           Boogie.Expr elt = BoxIfNecessary(GetToken(displayExpr), rawA, Cce.NonNull(p.A.Type));
           Boogie.Expr elt2 = BoxIfNecessary(GetToken(displayExpr), rawB, Cce.NonNull(p.B.Type));
-          entries.Add((elt, elt2));
-        }
-        // Like set/multiset displays (see CanonicalizeDisplayElements), a map display's value is order-independent
-        // but the emitted Map#Build chain is not, so we canonicalize the entry order -- but only when every key is
-        // a literal. Map display is last-write-wins on a repeated key, and two syntactically-distinct non-literal
-        // keys may denote the same key at runtime, so reordering could change which write wins. (A shadowed
-        // value's well-formedness is checked in a separate pass, so dropping it here is sound.)
-        if (keysAllLit) {
-          // Entries are for the same key when their emitted keys print alike; keeping the later one realizes
-          // last-write-wins. The printed form is also the sort key, which only has to be stable. Displays are
-          // small, so the quadratic comparison is negligible.
-          var deduped = new List<(string KeyText, Boogie.Expr Key, Boogie.Expr Value)>();
-          foreach (var entry in entries) {
-            var item = (entry.Key.ToString(), entry.Key, entry.Value);
-            var existing = deduped.FindIndex(e => e.KeyText == item.Item1);
-            if (existing >= 0) {
-              deduped[existing] = item;
-            } else {
-              deduped.Add(item);
-            }
-          }
-          deduped.Sort((x, y) => string.CompareOrdinal(x.KeyText, y.KeyText));
-          entries = deduped.ConvertAll(e => (e.Key, e.Value));
-        }
-        Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.MapEmpty : BuiltinFunction.IMapEmpty, Predef.BoxType);
-        foreach (var (key, value) in entries) {
-          s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, key, value);
+          s = FunctionCall(GetToken(displayExpr), displayExpr.Finite ? "Map#Build" : "IMap#Build", maptype, s, elt, elt2);
         }
         if (isLit) {
           // Lit-lifting: All keys and values are lit, so the map is Lit too
@@ -1268,42 +1245,29 @@ namespace Microsoft.Dafny {
       }
 
       /// <summary>
-      /// Canonicalizes the elements of a set or multiset display before they are folded into a
-      /// Set#UnionOne / MultiSet#UnionOne chain. The value is order-independent, but the emitted chain is not, so
-      /// permutations (e.g. {1,2,3} vs {3,2,1}) would otherwise produce distinct Boogie terms whose equality --
-      /// and hence use as the same map key or set element -- holds only provably, not by construction. Sorting
-      /// the elements by their printed form gives permutations the same term.
+      /// Orders the elements of a set or multiset display before they are folded into a
+      /// Set#UnionOne / MultiSet#UnionOne chain. A display's value is independent of the order of its elements,
+      /// but the emitted chain is not: two displays that list the same elements in a different order (e.g.
+      /// {1,2,3} vs {3,2,1}) would otherwise produce distinct Boogie terms whose equality -- and hence their use
+      /// as the same map key or set element -- holds only provably, not by construction. Emitting the elements
+      /// in a canonical order makes such displays produce the identical term.
       ///
-      /// With <paramref name="dropDuplicates"/> (sets, which ignore multiplicity), equal elements are also
-      /// collapsed, so e.g. {1,1,2} and {1,2} agree; it must be false for multisets.
-      ///
-      /// Both the ordering and the duplicate test use the emitted term's printed form. Ties in the order are
-      /// harmless, since the UnionOne functions are commutative; and two elements that denote the same value emit
-      /// the same term, so they print alike and are found adjacent. Neither Boogie's <c>Expr.Equals</c> nor the
-      /// triggers' <c>ExpressionEq</c> can serve here: the former compares a function application's <c>Func</c>
-      /// references, which the translator leaves null until Boogie resolution, so it reports any two applications
-      /// (two different datatype constructors, say) as equal; the latter dispatches over a closed set of node
-      /// types and asserts when given a pair it does not enumerate, which a display element -- an arbitrary
-      /// expression, such as the <c>locals</c> of a memory location -- can easily be.
+      /// This is only ever a reordering, so it is sound: no element is added or dropped, the UnionOne functions
+      /// are commutative, and the sort merely picks one representative of the permutation. We do NOT additionally
+      /// collapse elements that print alike, even for sets (whose values ignore multiplicity): dropping on a
+      /// printed-key match would put the printer in the trusted computing base, since a printer collision between
+      /// two genuinely distinct values would silently discard one. So {1,1,2} and {1,2} remain distinct terms
+      /// (an incompleteness), and equality of differently-built collections still needs an explicit assertion.
       /// </summary>
-      private static List<Boogie.Expr> CanonicalizeDisplayElements(List<Boogie.Expr> boxedElements, bool dropDuplicates) {
-        // Cache each element's printed form once, rather than recomputing ToString inside the comparator.
+      private static List<Boogie.Expr> CanonicalizeDisplayElements(List<Boogie.Expr> boxedElements) {
+        // Order the elements by their printed form. This is only ever a reordering -- no element is added or
+        // removed -- so it is sound regardless of what the key is: the UnionOne functions are commutative, so
+        // every permutation denotes the same value, and the sort merely picks a canonical one. (We deliberately
+        // do NOT drop elements that print alike: that would make the printer part of the trusted computing base,
+        // since a printer collision between two distinct values would then silently discard one of them.)
         var keyed = boxedElements.ConvertAll(e => (Key: e.ToString(), Boxed: e));
         keyed.Sort((a, b) => string.CompareOrdinal(a.Key, b.Key));
-        var result = new List<Boogie.Expr>(keyed.Count);
-        string previousKey = null;
-        foreach (var (key, boxed) in keyed) {
-          // Elements that denote the same value emit the same term and so print identically, which is why equal
-          // elements sort adjacently and comparing with the previous kept key removes them. Should two distinct
-          // elements ever print alike, the only consequence is that both are kept -- a missed collapse, which
-          // costs nothing but the syntactic equality this canonicalization would otherwise have provided.
-          if (dropDuplicates && key == previousKey) {
-            continue;
-          }
-          previousKey = key;
-          result.Add(boxed);
-        }
-        return result;
+        return keyed.ConvertAll(e => e.Boxed);
       }
 
       private Expr TranslateSetDisplayExpr(SetDisplayExpr displayExpr) {
@@ -1315,7 +1279,7 @@ namespace Microsoft.Dafny {
           boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
         }
         Boogie.Expr s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetEmpty : BuiltinFunction.ISetEmpty, Predef.BoxType);
-        foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements, dropDuplicates: true)) {
+        foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements)) {
           s = BoogieGenerator.FunctionCall(GetToken(displayExpr), displayExpr.Finite ? BuiltinFunction.SetUnionOne : BuiltinFunction.ISetUnionOne, Predef.BoxType, s, boxedElement);
         }
         if (isLit) {

--- a/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
+++ b/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
@@ -9,6 +9,7 @@ using Dafny;
 using Microsoft.BaseTypes;
 using Microsoft.Boogie;
 using Bpl = Microsoft.Boogie;
+using Microsoft.Dafny.Triggers;
 using static Microsoft.Dafny.Util;
 
 public partial class BoogieGenerator {
@@ -16,11 +17,11 @@ public partial class BoogieGenerator {
 
     private Expr TranslateMultiSetDisplayExpr(MultiSetDisplayExpr displayExpr) {
       var isLit = true;
-      var boxedElements = new List<Expr>();
+      var boxedElements = new List<(Expression, Expr)>();
       foreach (Expression ee in displayExpr.Elements) {
         var rawElement = TrExpr(ee);
         isLit = isLit && BoogieGenerator.IsLit(rawElement);
-        boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
+        boxedElements.Add((ee, BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type))));
       }
       // Canonicalize element order so permuted displays produce identical terms. Unlike a set, a multiset is
       // multiplicity-sensitive, so repeated elements are kept (dropDuplicates: false).

--- a/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
+++ b/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
@@ -22,10 +22,10 @@ public partial class BoogieGenerator {
         isLit = isLit && BoogieGenerator.IsLit(rawElement);
         boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
       }
-      // Canonicalize element order so permuted displays produce identical terms. Unlike a set, a multiset is
-      // multiplicity-sensitive, so repeated elements are kept (dropDuplicates: false).
+      // Canonicalize element order so permuted displays produce identical terms. Like the set case, this only
+      // reorders -- multiplicity is preserved, so it is sound for a multiset.
       Expr result = BoogieGenerator.FunctionCall(GetToken(displayExpr), BuiltinFunction.MultiSetEmpty, Predef.BoxType);
-      foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements, dropDuplicates: false)) {
+      foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements)) {
         result = BoogieGenerator.FunctionCall(GetToken(displayExpr), BuiltinFunction.MultiSetUnionOne, Predef.BoxType, result,
           boxedElement);
       }

--- a/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
+++ b/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
@@ -15,14 +15,19 @@ public partial class BoogieGenerator {
   public partial class ExpressionTranslator {
 
     private Expr TranslateMultiSetDisplayExpr(MultiSetDisplayExpr displayExpr) {
-      Expr result = BoogieGenerator.FunctionCall(GetToken(displayExpr), BuiltinFunction.MultiSetEmpty, Predef.BoxType);
       var isLit = true;
+      var boxedElements = new List<Expr>();
       foreach (Expression ee in displayExpr.Elements) {
         var rawElement = TrExpr(ee);
         isLit = isLit && BoogieGenerator.IsLit(rawElement);
-        var ss = BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type));
+        boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
+      }
+      // Canonicalize element order so permuted displays produce identical terms. Unlike a set, a multiset is
+      // multiplicity-sensitive, so repeated elements are kept (dropDuplicates: false).
+      Expr result = BoogieGenerator.FunctionCall(GetToken(displayExpr), BuiltinFunction.MultiSetEmpty, Predef.BoxType);
+      foreach (var boxedElement in CanonicalizeDisplayElements(boxedElements, dropDuplicates: false)) {
         result = BoogieGenerator.FunctionCall(GetToken(displayExpr), BuiltinFunction.MultiSetUnionOne, Predef.BoxType, result,
-          ss);
+          boxedElement);
       }
 
       if (isLit) {

--- a/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
+++ b/Source/DafnyCore/Verifier/Expressions/TranslateMultiSetDisplayExpr.cs
@@ -9,7 +9,6 @@ using Dafny;
 using Microsoft.BaseTypes;
 using Microsoft.Boogie;
 using Bpl = Microsoft.Boogie;
-using Microsoft.Dafny.Triggers;
 using static Microsoft.Dafny.Util;
 
 public partial class BoogieGenerator {
@@ -17,11 +16,11 @@ public partial class BoogieGenerator {
 
     private Expr TranslateMultiSetDisplayExpr(MultiSetDisplayExpr displayExpr) {
       var isLit = true;
-      var boxedElements = new List<(Expression, Expr)>();
+      var boxedElements = new List<Expr>();
       foreach (Expression ee in displayExpr.Elements) {
         var rawElement = TrExpr(ee);
         isLit = isLit && BoogieGenerator.IsLit(rawElement);
-        boxedElements.Add((ee, BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type))));
+        boxedElements.Add(BoxIfNecessary(GetToken(displayExpr), rawElement, Cce.NonNull(ee.Type)));
       }
       // Canonicalize element order so permuted displays produce identical terms. Unlike a set, a multiset is
       // multiplicity-sensitive, so repeated elements are kept (dropDuplicates: false).

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
@@ -1,19 +1,15 @@
 // RUN: %testDafnyForEachResolver "%s"
 
-// Set, multiset, and map displays that differ only in the order of their elements -- and set displays that
-// differ by a repeated element -- denote equal values, and are now emitted so that this equality holds by
-// construction. This lets such displays be used interchangeably as, e.g., map keys or set-of-set elements.
+// Set and multiset displays that differ only in the order of their elements denote equal values. Their emitted
+// Set#UnionOne / MultiSet#UnionOne chains are now built in a canonical element order, so such displays produce
+// the identical term and can be used interchangeably as, e.g., map keys or set-of-set elements -- even when the
+// equality would otherwise only be provable, not syntactic (as in a buried subgoal like `k in m.Keys`).
 
 method Sets() {
-  // Reordered set literals are equal, including when used as a map key.
-  assert {1, 2, 3} == {3, 2, 1};
+  // Reordered set literals used as a map key: the lookup key must match the stored key by construction.
   var m: map<set<int>, int> := map[{1, 2, 3} := 7];
   assert {3, 2, 1} in m.Keys;
   assert m[{3, 2, 1}] == 7;
-
-  // A repeated element does not change a set.
-  assert {1, 1, 2} == {1, 2};
-  assert |{1, 1, 2}| == 2;
 
   // Reordering works with variable elements too, and for nested sets.
   var ss: set<set<int>> := {{1, 2}, {3}};
@@ -27,59 +23,39 @@ method SetsVars(a: int, b: int) {
 }
 
 method Multisets() {
-  // Reordered multiset literals are equal, but multiplicity is significant.
-  assert multiset{1, 2, 3} == multiset{3, 2, 1};
-  assert multiset{1, 1, 2} == multiset{2, 1, 1};
-  assert multiset{1, 1, 2} != multiset{1, 2};
-  assert |multiset{1, 1, 2}| == 3;
+  // Reordered multiset literals as a map key. Multiplicity is significant, so only the order is canonicalized.
   var m: map<multiset<int>, int> := map[multiset{1, 2, 3} := 7];
   assert multiset{3, 2, 1} in m.Keys;
-}
-
-method Maps() {
-  // Reordered map displays are equal, including when used as a set element.
-  assert map[1 := 10, 2 := 20] == map[2 := 20, 1 := 10];
-  var s: set<map<int, int>> := {map[1 := 10, 2 := 20]};
-  assert map[2 := 20, 1 := 10] in s;
-
-  // A repeated key takes its last-written value (last-write-wins).
-  assert map[1 := 10, 1 := 20] == map[1 := 20];
-  assert map[1 := 10, 1 := 20][1] == 20;
-}
-
-method Sequences() {
-  // Sequences are ordered, so element order is significant (unchanged behavior).
-  assert [1, 2, 3] != [3, 2, 1];
-  assert [1, 2, 3] == [1, 2, 3];
+  assert multiset{1, 1, 2} != multiset{1, 2};
 }
 
 datatype Color = Red | Green | Blue
 
-method NonLiteralElements(a: set<int>, b: set<int>) {
-  // Elements that are function applications rather than literals must not be conflated: canonicalization
-  // may only collapse elements that are genuinely identical.
+method DatatypeAndOtherElements() {
+  // Canonicalization is only ever a reordering, so distinct elements are never conflated, whatever their shape.
   assert |{Red, Green, Blue}| == 3;
   assert Red in {Red, Green};
   assert |{"ab", "cd"}| == 2;
   assert |{'a', 'b'}| == 2;
   assert |{{1, 2}, {3, 4}}| == 2;
-  assert |{[1, 2], [3, 4]}| == 2;
   assert |multiset{Red, Green}| == 2;
-  var m: map<Color, int> := map[Red := 1, Green := 2];
-  assert |m| == 2;
-  assert m[Red] == 1 && m[Green] == 2;
+  var mc: map<Color, int> := map[Red := 1, Green := 2];
+  assert Red in mc.Keys && Green in mc.Keys;
 }
 
 function Id<T>(x: T): T { x }
 datatype Box<T> = Box(v: T)
 
 method FunctionApplicationElements() {
-  // Distinct applications of the same function or constructor must not be conflated, and identical ones must
-  // still collapse. (Comparing the emitted Boogie terms cannot distinguish these, so the source expressions are
-  // compared instead.)
-  assert |{Id(1), Id(2)}| == 2;
-  assert |{Id(1), Id(1)}| == 1;
+  // Distinct applications of the same function or constructor print differently and so are not conflated.
   var s: set<Box<int>> := {Box(1), Box(2)};
-  assert |s| == 2;
-  assert |{Box(1), Box(1)}| == 1;
+  assert Box(1) in s && Box(2) in s;
+  var t := {Id(1), Id(2)};
+  assert Id(1) in t && Id(2) in t;
+}
+
+method Sequences() {
+  // Sequences are ordered, so element order stays significant (unchanged behavior).
+  assert [1, 2, 3] != [3, 2, 1];
+  assert [1, 2, 3] == [1, 2, 3];
 }

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
@@ -52,3 +52,20 @@ method Sequences() {
   assert [1, 2, 3] != [3, 2, 1];
   assert [1, 2, 3] == [1, 2, 3];
 }
+
+datatype Color = Red | Green | Blue
+
+method NonLiteralElements(a: set<int>, b: set<int>) {
+  // Elements that are function applications rather than literals must not be conflated: canonicalization
+  // may only collapse elements that are genuinely identical.
+  assert |{Red, Green, Blue}| == 3;
+  assert Red in {Red, Green};
+  assert |{"ab", "cd"}| == 2;
+  assert |{'a', 'b'}| == 2;
+  assert |{{1, 2}, {3, 4}}| == 2;
+  assert |{[1, 2], [3, 4]}| == 2;
+  assert |multiset{Red, Green}| == 2;
+  var m: map<Color, int> := map[Red := 1, Green := 2];
+  assert |m| == 2;
+  assert m[Red] == 1 && m[Green] == 2;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
@@ -69,3 +69,17 @@ method NonLiteralElements(a: set<int>, b: set<int>) {
   assert |m| == 2;
   assert m[Red] == 1 && m[Green] == 2;
 }
+
+function Id<T>(x: T): T { x }
+datatype Box<T> = Box(v: T)
+
+method FunctionApplicationElements() {
+  // Distinct applications of the same function or constructor must not be conflated, and identical ones must
+  // still collapse. (Comparing the emitted Boogie terms cannot distinguish these, so the source expressions are
+  // compared instead.)
+  assert |{Id(1), Id(2)}| == 2;
+  assert |{Id(1), Id(1)}| == 1;
+  var s: set<Box<int>> := {Box(1), Box(2)};
+  assert |s| == 2;
+  assert |{Box(1), Box(1)}| == 1;
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy
@@ -1,0 +1,54 @@
+// RUN: %testDafnyForEachResolver "%s"
+
+// Set, multiset, and map displays that differ only in the order of their elements -- and set displays that
+// differ by a repeated element -- denote equal values, and are now emitted so that this equality holds by
+// construction. This lets such displays be used interchangeably as, e.g., map keys or set-of-set elements.
+
+method Sets() {
+  // Reordered set literals are equal, including when used as a map key.
+  assert {1, 2, 3} == {3, 2, 1};
+  var m: map<set<int>, int> := map[{1, 2, 3} := 7];
+  assert {3, 2, 1} in m.Keys;
+  assert m[{3, 2, 1}] == 7;
+
+  // A repeated element does not change a set.
+  assert {1, 1, 2} == {1, 2};
+  assert |{1, 1, 2}| == 2;
+
+  // Reordering works with variable elements too, and for nested sets.
+  var ss: set<set<int>> := {{1, 2}, {3}};
+  assert {2, 1} in ss;
+}
+
+method SetsVars(a: int, b: int) {
+  var m: map<set<int>, int> := map[{a, b} := 7];
+  assert {b, a} in m.Keys;
+  assert m[{b, a}] == 7;
+}
+
+method Multisets() {
+  // Reordered multiset literals are equal, but multiplicity is significant.
+  assert multiset{1, 2, 3} == multiset{3, 2, 1};
+  assert multiset{1, 1, 2} == multiset{2, 1, 1};
+  assert multiset{1, 1, 2} != multiset{1, 2};
+  assert |multiset{1, 1, 2}| == 3;
+  var m: map<multiset<int>, int> := map[multiset{1, 2, 3} := 7];
+  assert multiset{3, 2, 1} in m.Keys;
+}
+
+method Maps() {
+  // Reordered map displays are equal, including when used as a set element.
+  assert map[1 := 10, 2 := 20] == map[2 := 20, 1 := 10];
+  var s: set<map<int, int>> := {map[1 := 10, 2 := 20]};
+  assert map[2 := 20, 1 := 10] in s;
+
+  // A repeated key takes its last-written value (last-write-wins).
+  assert map[1 := 10, 1 := 20] == map[1 := 20];
+  assert map[1 := 10, 1 := 20][1] == 20;
+}
+
+method Sequences() {
+  // Sequences are ordered, so element order is significant (unchanged behavior).
+  assert [1, 2, 3] != [3, 2, 1];
+  assert [1, 2, 3] == [1, 2, 3];
+}

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 6 verified, 0 errors
+Dafny program verifier finished with 7 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 5 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 7 verified, 0 errors
+Dafny program verifier finished with 6 verified, 0 errors

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/git-issues/git-issue-6408.dfy.expect
@@ -1,2 +1,2 @@
 
-Dafny program verifier finished with 5 verified, 0 errors
+Dafny program verifier finished with 6 verified, 0 errors

--- a/docs/dev/news/6502.fix
+++ b/docs/dev/news/6502.fix
@@ -1,0 +1,1 @@
+The verifier now recognizes set, multiset, and map displays that differ only in element order (e.g. `{1, 2, 3}` and `{3, 2, 1}`), or a set display with a repeated element (e.g. `{1, 1, 2}`), as equal, so they can be used interchangeably as, for example, map keys

--- a/docs/dev/news/6502.fix
+++ b/docs/dev/news/6502.fix
@@ -1,1 +1,1 @@
-The verifier now recognizes set, multiset, and map displays that differ only in element order (e.g. `{1, 2, 3}` and `{3, 2, 1}`), or a set display with a repeated element (e.g. `{1, 1, 2}`), as equal, so they can be used interchangeably as, for example, map keys
+The verifier now recognizes set and multiset displays that differ only in the order of their elements (e.g. `{1, 2, 3}` and `{3, 2, 1}`) as equal, so they can be used interchangeably as, for example, map keys


### PR DESCRIPTION
## Summary

Fixes #6408. A set or multiset display written with its elements in a different order denotes the same value but was not recognized as equal during verification, so it could not be used interchangeably as, e.g., a map key:

```dafny
var m: map<set<int>, int> := map[{1, 2, 3} := 7];
assert {3, 2, 1} in m.Keys;   // used to fail, even though {1,2,3} == {3,2,1}
```

## Root cause

A set or multiset display is translated to a chain of `Set#UnionOne` / `MultiSet#UnionOne` calls in source order, so two displays that differ only by element order (`{1,2,3}` vs `{3,2,1}`) produce distinct Boogie terms. Their equality is provable, but the prover establishes it only when it is the goal; as a buried subgoal (a map-key lookup, a set-of-set membership) it does not fire and verification fails.

## Fix

Emit the elements of a `set`/`iset`/`multiset` display in a canonical order (sorted by the emitted term's printed form) before folding them into the `Set#UnionOne` / `MultiSet#UnionOne` chain. Two displays that list the same elements in a different order then produce the identical Boogie term, so their equality holds by construction rather than only provably — which is what makes a reordered set usable as the same map key.

This is deliberately **only a reordering**, and that is the whole soundness argument: no element is ever added or dropped, and the `UnionOne` functions are commutative, so every permutation denotes the same value and the sort just picks a representative. The key used for the sort is therefore not trusted — a bad key could only produce a non-canonical (but still correct) order.

What this intentionally does **not** do:

- It does not drop elements that print alike (not even for sets, whose values ignore multiplicity). Dropping on a printed-key match would put the term printer in the trusted computing base: a printer collision between two genuinely distinct values would silently discard one, an unsoundness. So `{1,1,2}` and `{1,2}` remain distinct terms.
- It does not touch `map` displays. A map display is last-write-wins, so reordering two entries with the same key changes the map; recognizing a duplicate key means deciding key equality, which is a runtime question for non-literal keys and would again trust the printer.
- It does not touch `seq`, which is ordered.

These remaining cases are incompletenesses with the usual `assert a == b;` workaround, not unsoundnesses. (An earlier revision compared the source Dafny expressions with the triggers' `ExpressionEq`; that aborts a contracts-enabled build, because `ShallowEq_Top` dispatches over a closed set of node types and a display element can be any expression — e.g. the `locals` of a memory location. Reusing Boogie's `Expr.Equals` is also unusable: for a function application it compares the `Func` reference, which the translator leaves null until Boogie resolution.)

This is a translation-only change: no prelude axioms, no prover-time cost. Bridging the equality with prelude axioms instead was prototyped and rejected — it taxes every set/map proof and pushed existing ones (`UnionFind`, `ExtensibleArrayAuto`) over their resource limit.

## Scope

This covers set and multiset displays that differ only in element order. It does not make structurally-different constructions of the same value interchangeable — e.g. `{1,2}+{3}`, a comprehension yielding `{1,2,3}`, `{a,b}` with `a == b`, `{1,1,2}` vs `{1,2}`, or reordered `map` displays — which remain completeness limitations with the usual `assert x == y;` workaround.

## Test

`git-issues/git-issue-6408.dfy` covers reordered set and multiset displays used as map keys and set-of-set elements, with literal, variable, datatype-constructor and function-application elements, and confirms sequences are unaffected; run under both resolvers.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>



