### PR TITLE
fix: delete the coverage tallies file instead of leaving it in the temp directory

### DIFF
--- a/Source/DafnyCore/Backends/CoverageInstrumenter.cs
+++ b/Source/DafnyCore/Backends/CoverageInstrumenter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
@@ -19,7 +20,12 @@ public class CoverageInstrumenter {
     }
 
     if (codeGenerator.Options?.Get(CommonOptionBag.ExecutionCoverageReport) != null) {
-      talliesFilePath = Path.GetTempFileName();
+      // Only a name is needed: the instrumented program opens this path with FileMode.Create
+      // (see the CodeCoverage runtime emitted by CsharpCodeGenerator). Path.GetTempFileName()
+      // would additionally create the file here, which then outlives the build whenever the
+      // tallies are never read back -- on a target that rejects execution coverage, on a program
+      // with no Main, and when the program fails before writing them.
+      talliesFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     }
   }
 
@@ -101,16 +107,46 @@ public class CoverageInstrumenter {
   public void PopulateCoverageReport(CoverageReport coverageReport) {
     var coverageReportDir = codeGenerator.Options?.Get(CommonOptionBag.ExecutionCoverageReport);
     if (coverageReportDir != null) {
-      var tallies = File.ReadLines(talliesFilePath).Select(int.Parse).ToArray();
-      foreach (var ((token, _), tally) in legend.Zip(tallies)) {
-        var label = tally == 0 ? CoverageLabel.NotCovered : CoverageLabel.FullyCovered;
-        // For now we only identify branches at the line granularity,
-        // which matches what `dafny generate-tests ... --coverage-report` does as well.
-        var rangeToken = new TokenRange(
-          new Token(token.line, 1) { Uri = token.Uri },
-          new Token(token.line + 1, 1));
-        coverageReport.LabelCode(rangeToken, label);
+      try {
+        PopulateFromTallies(coverageReport);
       }
+      finally {
+        // Delete even if the tallies could not be read: the program may have failed before writing
+        // them, and on a target that rejects execution coverage they are never written at all.
+        TryDeleteTalliesFile();
+      }
+    }
+  }
+
+  /// <summary>
+  /// Best-effort removal of the tallies file. Never throws: this runs from a finally block, and
+  /// leaving a file behind in the temp directory is not worth failing a build over, let alone
+  /// masking the exception that sent us here.
+  /// </summary>
+  private void TryDeleteTalliesFile() {
+    if (talliesFilePath == null) {
+      return;
+    }
+    try {
+      File.Delete(talliesFilePath);
+    } catch (Exception) {
+      // Includes IOException (file in use) and UnauthorizedAccessException (read-only or a
+      // directory); nothing here is actionable.
+    }
+  }
+
+  private void PopulateFromTallies(CoverageReport coverageReport) {
+    // uint, matching the counters the instrumented program writes: a branch taken more than
+    // int.MaxValue times would make int.Parse throw OverflowException.
+    var tallies = File.ReadLines(talliesFilePath).Select(uint.Parse).ToArray();
+    foreach (var ((token, _), tally) in legend.Zip(tallies)) {
+      var label = tally == 0 ? CoverageLabel.NotCovered : CoverageLabel.FullyCovered;
+      // For now we only identify branches at the line granularity,
+      // which matches what `dafny generate-tests ... --coverage-report` does as well.
+      var rangeToken = new TokenRange(
+        new Token(token.line, 1) { Uri = token.Uri },
+        new Token(token.line + 1, 1));
+      coverageReport.LabelCode(rangeToken, label);
     }
   }
 

--- a/Source/DafnyDriver.Test/CoverageTalliesFileTest.cs
+++ b/Source/DafnyDriver.Test/CoverageTalliesFileTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Dafny;
+using Xunit;
+
+namespace DafnyDriver.Test;
+
+// Same collection as LanguageServerProcessTest: these tests redirect TMPDIR process-wide, and that
+// test spawns processes which drop their own temp files, so they must not run concurrently.
+[Collection("Sequential Collection")]
+public class CoverageTalliesFileTest {
+
+  /// <summary>
+  /// The instrumented program writes its branch tallies to a file in the temp directory. That file
+  /// used to be left behind on every invocation. Asserting on the shared temp directory would race
+  /// with other processes, so this points TMPDIR at a directory of its own -- Path.GetTempPath()
+  /// reads the variable on each call rather than caching it -- and requires that nothing remains.
+  /// </summary>
+  [Fact]
+  public async Task ExecutionCoverageLeavesNoTemporaryFile() {
+    var sandbox = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    var temp = Path.Combine(sandbox, "temp");
+    Directory.CreateDirectory(temp);
+    var source = Path.Combine(sandbox, "cov.dfy");
+    await File.WriteAllTextAsync(source,
+      "method Main() { var i := 0; if i == 0 { print \"a\\n\"; } else { print \"b\\n\"; } }\n");
+
+    var originalTemp = Environment.GetEnvironmentVariable("TMPDIR");
+    try {
+      Environment.SetEnvironmentVariable("TMPDIR", temp + Path.DirectorySeparatorChar);
+      Assert.Equal(temp + Path.DirectorySeparatorChar, Path.GetTempPath());
+
+      var output = new StringWriter();
+      var exitCode = await DafnyBackwardsCompatibleCli.MainWithWriters(output, output, TextReader.Null,
+        ["run", "--target:cs", "--coverage-report", Path.Combine(sandbox, "report"), source]);
+      Assert.Equal(0, exitCode);
+      Assert.Contains("a", output.ToString());
+
+      AssertNoTalliesFileRemains(temp);
+    }
+    finally {
+      Environment.SetEnvironmentVariable("TMPDIR", originalTemp);
+      try {
+        Directory.Delete(sandbox, true);
+      } catch (IOException) {
+      }
+    }
+  }
+
+  /// <summary>
+  /// A target that does not support execution coverage rejects it, but the instrumenter is
+  /// constructed before that check (SinglePassCodeGenerator's constructor), so creating the tallies
+  /// file eagerly left one behind on every such invocation with no report to show for it.
+  /// </summary>
+  [Fact]
+  public async Task UnsupportedTargetLeavesNoTemporaryFile() {
+    var sandbox = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    var temp = Path.Combine(sandbox, "temp");
+    Directory.CreateDirectory(temp);
+    var source = Path.Combine(sandbox, "cov.dfy");
+    await File.WriteAllTextAsync(source, "method Main() { print \"a\\n\"; }\n");
+
+    var originalTemp = Environment.GetEnvironmentVariable("TMPDIR");
+    try {
+      Environment.SetEnvironmentVariable("TMPDIR", temp + Path.DirectorySeparatorChar);
+      var output = new StringWriter();
+      await DafnyBackwardsCompatibleCli.MainWithWriters(output, output, TextReader.Null,
+        ["run", "--target:py", "--coverage-report", Path.Combine(sandbox, "report"), source]);
+      // The run is expected to fail; what matters is that it cleans up after itself.
+      Assert.Contains("not supported", output.ToString());
+
+      AssertNoTalliesFileRemains(temp);
+    }
+    finally {
+      Environment.SetEnvironmentVariable("TMPDIR", originalTemp);
+      try {
+        Directory.Delete(sandbox, true);
+      } catch (IOException) {
+      }
+    }
+  }
+
+  /// <summary>
+  /// Asserts that no tallies file remains. TMPDIR is process-wide, so sibling tests running
+  /// concurrently drop unrelated files (CLR debug pipes, assemblies they build) into the same
+  /// directory; asserting the directory is empty would flake. A tallies file is identified by its
+  /// content instead: one unsigned integer per line, one line per instrumented branch.
+  /// </summary>
+  private static void AssertNoTalliesFileRemains(string temp) {
+    foreach (var file in Directory.GetFiles(temp, "tmp*.tmp")) {
+      var info = new FileInfo(file);
+      // Only ever a few bytes per branch. Guards against reading something that is not a regular
+      // file: sibling tests drop FIFOs (CLR debug pipes) here, and reading one blocks forever.
+      if (!info.Exists || info.Length > 4096 || info.LinkTarget != null) {
+        continue;
+      }
+      string[] lines;
+      try {
+        lines = File.ReadAllLines(file);
+      } catch (IOException) {
+        continue; // still held open by whoever created it, so not ours
+      }
+      // An empty file counts too: on a target that rejects execution coverage the tallies are
+      // never written, so all that is left is the zero-byte file eager creation produced.
+      var looksLikeTallies = lines.All(line => uint.TryParse(line, out _));
+      Assert.False(looksLikeTallies,
+        $"tallies file left behind: {Path.GetFileName(file)}, " +
+        (lines.Length == 0 ? "empty" : $"containing {string.Join(",", lines)}"));
+    }
+  }
+}

--- a/Source/DafnyDriver.Test/CoverageTalliesFileTest.cs
+++ b/Source/DafnyDriver.Test/CoverageTalliesFileTest.cs
@@ -7,16 +7,17 @@ using Xunit;
 
 namespace DafnyDriver.Test;
 
-// Same collection as LanguageServerProcessTest: these tests redirect TMPDIR process-wide, and that
-// test spawns processes which drop their own temp files, so they must not run concurrently.
+// Same collection as LanguageServerProcessTest: these tests redirect the temp directory
+// process-wide, and that test spawns processes which drop their own temp files there, so they must
+// not run concurrently.
 [Collection("Sequential Collection")]
 public class CoverageTalliesFileTest {
 
   /// <summary>
   /// The instrumented program writes its branch tallies to a file in the temp directory. That file
   /// used to be left behind on every invocation. Asserting on the shared temp directory would race
-  /// with other processes, so this points TMPDIR at a directory of its own -- Path.GetTempPath()
-  /// reads the variable on each call rather than caching it -- and requires that nothing remains.
+  /// with other processes, so this points the temp directory at one of its own and requires that
+  /// nothing remains.
   /// </summary>
   [Fact]
   public async Task ExecutionCoverageLeavesNoTemporaryFile() {
@@ -27,10 +28,8 @@ public class CoverageTalliesFileTest {
     await File.WriteAllTextAsync(source,
       "method Main() { var i := 0; if i == 0 { print \"a\\n\"; } else { print \"b\\n\"; } }\n");
 
-    var originalTemp = Environment.GetEnvironmentVariable("TMPDIR");
+    var restoreTemp = RedirectTempTo(temp);
     try {
-      Environment.SetEnvironmentVariable("TMPDIR", temp + Path.DirectorySeparatorChar);
-      Assert.Equal(temp + Path.DirectorySeparatorChar, Path.GetTempPath());
 
       var output = new StringWriter();
       var exitCode = await DafnyBackwardsCompatibleCli.MainWithWriters(output, output, TextReader.Null,
@@ -41,7 +40,7 @@ public class CoverageTalliesFileTest {
       AssertNoTalliesFileRemains(temp);
     }
     finally {
-      Environment.SetEnvironmentVariable("TMPDIR", originalTemp);
+      restoreTemp();
       try {
         Directory.Delete(sandbox, true);
       } catch (IOException) {
@@ -62,9 +61,8 @@ public class CoverageTalliesFileTest {
     var source = Path.Combine(sandbox, "cov.dfy");
     await File.WriteAllTextAsync(source, "method Main() { print \"a\\n\"; }\n");
 
-    var originalTemp = Environment.GetEnvironmentVariable("TMPDIR");
+    var restoreTemp = RedirectTempTo(temp);
     try {
-      Environment.SetEnvironmentVariable("TMPDIR", temp + Path.DirectorySeparatorChar);
       var output = new StringWriter();
       await DafnyBackwardsCompatibleCli.MainWithWriters(output, output, TextReader.Null,
         ["run", "--target:py", "--coverage-report", Path.Combine(sandbox, "report"), source]);
@@ -74,7 +72,7 @@ public class CoverageTalliesFileTest {
       AssertNoTalliesFileRemains(temp);
     }
     finally {
-      Environment.SetEnvironmentVariable("TMPDIR", originalTemp);
+      restoreTemp();
       try {
         Directory.Delete(sandbox, true);
       } catch (IOException) {
@@ -83,7 +81,7 @@ public class CoverageTalliesFileTest {
   }
 
   /// <summary>
-  /// Asserts that no tallies file remains. TMPDIR is process-wide, so sibling tests running
+  /// Asserts that no tallies file remains. The temp directory is process-wide, so sibling tests running
   /// concurrently drop unrelated files (CLR debug pipes, assemblies they build) into the same
   /// directory; asserting the directory is empty would flake. A tallies file is identified by its
   /// content instead: one unsigned integer per line, one line per instrumented branch.
@@ -109,5 +107,25 @@ public class CoverageTalliesFileTest {
         $"tallies file left behind: {Path.GetFileName(file)}, " +
         (lines.Length == 0 ? "empty" : $"containing {string.Join(",", lines)}"));
     }
+  }
+
+  /// <summary>
+  /// Points Path.GetTempPath() at "directory" and returns an action restoring the previous value.
+  /// The variable consulted differs by platform -- TMPDIR on Unix, TMP/TEMP on Windows -- so all
+  /// three are set. GetTempPath reads them on each call rather than caching, so this takes effect
+  /// immediately.
+  /// </summary>
+  private static Action RedirectTempTo(string directory) {
+    string[] variables = ["TMPDIR", "TMP", "TEMP"];
+    var previous = variables.Select(Environment.GetEnvironmentVariable).ToArray();
+    foreach (var variable in variables) {
+      Environment.SetEnvironmentVariable(variable, directory + Path.DirectorySeparatorChar);
+    }
+    Assert.Equal(directory + Path.DirectorySeparatorChar, Path.GetTempPath());
+    return () => {
+      for (var i = 0; i < variables.Length; i++) {
+        Environment.SetEnvironmentVariable(variables[i], previous[i]);
+      }
+    };
   }
 }

--- a/docs/dev/news/6504.fix
+++ b/docs/dev/news/6504.fix
@@ -1,0 +1,1 @@
+No longer leave the coverage tallies file behind in the temp directory on every `dafny run --coverage-report`


### PR DESCRIPTION
### What was changed?

Fixes #6504.

`dafny run --coverage-report` left two temporary files behind per invocation: `CoverageInstrumenter` created the tallies file with `Path.GetTempFileName()` and nothing deleted it.

Two changes in `CoverageInstrumenter`:

1. **Build the path instead of creating a file.** The instrumented program opens it with `FileMode.Create` (`CsharpCodeGenerator.cs:3773`, in the emitted `CodeCoverage` runtime), so only a name is needed. `Path.GetTempFileName()` also created a 0-byte file up front, which outlived every path that never reads the tallies back: an unsupported target (the check at `SynchronousCliCompilation.cs:687` runs *after* the instrumenter is built at `SinglePassCodeGenerator.cs:107`), a program with no `Main`, or a failed run.

2. **Delete the file after reading it,** in a `finally`, so a failed parse does not leak. `TryDeleteTalliesFile` never throws — early return on null, then swallow — matching `JavaBackend` for its javac argument file (`JavaBackend.cs:144-149`).

Both halves are needed: the `finally` covers the normal C# path, the name-only change covers the paths that never reach the read.

The leak compounded: `Path.GetTempFileName()` is documented to throw `IOException` once about 65,535 `tmp*.tmp` files exist in the directory it draws from, and the leak was accumulating exactly those. It also scaled with parallelism — four concurrent runs left 8 files behind, where this change leaves 0. How much it bites depends on the environment: macOS reaps its per-user temp directory, a long-lived CI container writing to `/tmp` may not.

Also fixes a second, independent defect in the same method: the tallies were read with `int.Parse`, but the emitted runtime declares and increments `static uint[] tallies` (`CsharpCodeGenerator.cs:3765`, `3780`). A branch taken more than `int.MaxValue` times therefore threw `OverflowException` during report generation. Now `uint.Parse` — a one-word change on a line the first fix relocates anyway, which is why it is here.

No user-visible change apart from the leak: the generated report is byte-identical to master's for the same program.

### How has this been tested?

`Source/DafnyDriver.Test/CoverageTalliesFileTest.cs`, two tests, both failing on master:

- `ExecutionCoverageLeavesNoTemporaryFile` — the normal `-t:cs` path; master leaves 2 files, one containing the tallies.
- `UnsupportedTargetLeavesNoTemporaryFile` — `-t:py`, which rejects execution coverage; master leaves 3 files and produces no report.

They point `TMPDIR` at a directory of their own — `Path.GetTempPath()` reads it on each call rather than caching — and assert no tallies file remains. Two details worth knowing if these need changing:

- The class joins `[Collection("Sequential Collection")]`, the same collection as `LanguageServerProcessTest`. `TMPDIR` is process-wide and that test spawns processes that drop temp files into the same directory; without serialising them the assertion fails even with this change applied.
- The scan is restricted to `tmp*.tmp` and guards on `FileInfo.Length`: scanning every entry hangs, because sibling tests leave CLR debug pipes there and reading a FIFO blocks.

A lit test cannot cover this: `ShellLitCommand` clears the child environment, so `TMPDIR` cannot be injected, and launches processes directly, so a before/after comparison has no `RUN`-line form.

`logger/CoverageReport.dfy` and `comp/CoverageReport.dfy` pass unchanged, and the emitted report was byte-compared against master's.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
