### PR TITLE
fix: parse the --cores percentage with the invariant culture

### DIFF
--- a/Source/DafnyCore.Test/CoresOptionCultureTest.cs
+++ b/Source/DafnyCore.Test/CoresOptionCultureTest.cs
@@ -15,10 +15,10 @@ public class CoresOptionCultureTest {
   /// somewhere, but xunit runs test classes in parallel on pool threads it reuses, so mutating the
   /// caller's culture could be observed by a concurrently running test.
   /// </summary>
-  private static (uint Cores, string Error) ParseCores(string value, string culture) {
+  private static (uint Cores, string? Error) ParseCores(string value, string culture) {
     uint cores = 0;
-    string error = null;
-    Exception failure = null;
+    string? error = null;
+    Exception? failure = null;
     var thread = new Thread(() => {
       CultureInfo.CurrentCulture = new CultureInfo(culture);
       try {

--- a/Source/DafnyCore.Test/CoresOptionCultureTest.cs
+++ b/Source/DafnyCore.Test/CoresOptionCultureTest.cs
@@ -1,0 +1,83 @@
+using System;
+using System.CommandLine;
+using System.Globalization;
+using System.Threading;
+using Microsoft.Dafny;
+using Xunit;
+
+namespace DafnyCore.Test;
+
+public class CoresOptionCultureTest {
+
+  /// <summary>
+  /// Parses "--cores &lt;value&gt;" with "culture" as the ambient culture, returning the resulting core
+  /// count and any parse error. The culture is set on a thread this test owns: it has to be set
+  /// somewhere, but xunit runs test classes in parallel on pool threads it reuses, so mutating the
+  /// caller's culture could be observed by a concurrently running test.
+  /// </summary>
+  private static (uint Cores, string Error) ParseCores(string value, string culture) {
+    uint cores = 0;
+    string error = null;
+    Exception failure = null;
+    var thread = new Thread(() => {
+      CultureInfo.CurrentCulture = new CultureInfo(culture);
+      try {
+        var command = new Command("test") { BoogieOptionBag.Cores };
+        var parsed = command.Parse(["test", "--cores", value]);
+        error = parsed.Errors.Count == 0 ? null : parsed.Errors[0].Message;
+        if (error == null) {
+          cores = parsed.GetValueForOption(BoogieOptionBag.Cores);
+        }
+      } catch (Exception e) {
+        failure = e;
+      }
+    });
+    thread.Start();
+    Assert.True(thread.Join(60_000), "parsing did not finish");
+    Assert.Null(failure);
+    return (cores, error);
+  }
+
+  /// <summary>
+  /// A command-line value is not written in the ambient locale's number format. Parsing "50.5%" with
+  /// the ambient separators is silently wrong under a culture where "." groups digits: it yields
+  /// 505%, asking for five times the machine's cores.
+  /// </summary>
+  [Theory]
+  [InlineData("en-US")]
+  [InlineData("de-DE")]
+  public void PercentageIsParsedInvariantlyAcrossCultures(string culture) {
+    // Not asserting an absolute core count: that would restate the percentage-to-cores formula, and
+    // the point here is only that the ambient culture does not change how the number is read.
+    // "50.5%" and "50%" round to the same count at every processor count, whereas reading "50.5"
+    // with "." as a group separator gives 505%, an order of magnitude more.
+    var whole = ParseCores("50%", culture);
+    var fractional = ParseCores("50.5%", culture);
+    Assert.Null(whole.Error);
+    Assert.Null(fractional.Error);
+    Assert.Equal(whole.Cores, fractional.Cores);
+    Assert.Equal(ParseCores("50%", "en-US").Cores, whole.Cores);
+  }
+
+  [Theory]
+  [InlineData("en-US")]
+  [InlineData("de-DE")]
+  public void ThousandsSeparatorIsRejectedRatherThanGuessed(string culture) {
+    // "1,000" means 1 under a comma-decimal culture and 1000 under a comma-grouping one, so on a
+    // command line it is ambiguous and NumberStyles.Float rejects it.
+    Assert.Contains("Could not parse percentage", ParseCores("1,000%", culture).Error);
+  }
+
+  /// <summary>
+  /// NumberStyles.Float accepts "NaN" and "Infinity", and casting either to uint is unchecked, so
+  /// they would silently become 1 core and uint.MaxValue cores respectively. A finite value whose
+  /// product exceeds uint is rejected for the same reason: the cast would wrap rather than report.
+  /// </summary>
+  [Theory]
+  [InlineData("NaN%")]
+  [InlineData("Infinity%")]
+  [InlineData("1e30%")]
+  public void NonFiniteOrUnrepresentablePercentageIsRejected(string value) {
+    Assert.Contains("does not denote a usable number of cores", ParseCores(value, "en-US").Error);
+  }
+}

--- a/Source/DafnyCore/Options/BoogieOptionBag.cs
+++ b/Source/DafnyCore/Options/BoogieOptionBag.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Transactions;
@@ -21,8 +22,26 @@ public static class BoogieOptionBag {
 
     var value = result.Tokens[^1].Value;
     if (value.EndsWith('%')) {
-      if (double.TryParse(value.Substring(0, value.Length - 1), out var percentage)) {
-        return Math.Max(1U, (uint)(percentage / 100.0 * Environment.ProcessorCount));
+      // Invariant culture: a command-line value is not written in the ambient locale's number
+      // format. Without this, "50.5%" is read with the ambient separators, which can be silently
+      // WRONG rather than merely rejected: under a culture where "." groups digits (e.g. en-DE)
+      // it parses as 505%, so --cores:50.5% asks for five times the machine's cores. Float rather
+      // than Number, so a thousands separator is rejected instead of guessed at -- "1,000" means
+      // 1 under some cultures and 1000 under others.
+      if (double.TryParse(value.Substring(0, value.Length - 1), NumberStyles.Float,
+            CultureInfo.InvariantCulture, out var percentage)) {
+        // NumberStyles.Float also accepts "NaN" and "Infinity", and casting either to uint is
+        // unchecked: NaN would silently become 0 (then 1 core) and infinity uint.MaxValue. Reject
+        // them rather than act on a number the user cannot have meant. A merely large percentage is
+        // left alone, since the non-percentage branch already accepts any positive count.
+        var cores = percentage / 100.0 * Environment.ProcessorCount;
+        if (double.IsFinite(cores) && cores <= uint.MaxValue) {
+          return Math.Max(1U, (uint)cores);
+        }
+
+        result.ErrorMessage =
+          $"Percentage {value} does not denote a usable number of cores on this machine";
+        return 1;
       }
 
       result.ErrorMessage = $"Could not parse percentage {value}";

--- a/docs/dev/news/6505.fix
+++ b/docs/dev/news/6505.fix
@@ -1,0 +1,1 @@
+Parse the `--cores` percentage with the invariant culture, so a fractional percentage such as `--cores:50.5%` means the same on every machine


### PR DESCRIPTION
### What was changed?

Fixes #6505.

`--cores:<XX>%` parsed the percentage with `double.TryParse(string, out double)`, which uses `CultureInfo.CurrentCulture`. A fractional percentage therefore meant different things on different machines: on a locale that groups digits with a period, `--cores:50.5%` read as **505%**, silently running with five times the machine's cores. Whole percentages were unaffected, which is why this went unnoticed.

Parsing is now `NumberStyles.Float` with `CultureInfo.InvariantCulture`.

Two deliberate details:

- **`Float`, not `Number`,** so `AllowThousands` stays off. `"1,000"` means 1 where the comma is a decimal separator and 1000 where it groups; on a command line that is ambiguous, so it is rejected rather than resolved arbitrarily.
- **A finiteness guard.** `NumberStyles.Float` also accepts `NaN` and `Infinity`, and the `(uint)` cast is unchecked, so they became 1 core and 4294967295 respectively; a finite product exceeding `uint` (`1e30%`) saturated the same way. All are now rejected with a message naming the value.

A large but representable percentage is still accepted: the non-percentage branch already accepts any positive `uint`, so capping only this path would make the two inconsistent, and choosing a limit is a policy decision beyond this fix.

Worth flagging, and noted in the issue: `System.CommandLine`'s own `Option<double>` also parses with the current culture, so master is consistent with the framework Dafny builds on. The argument for changing it is that a command-line value is machine-readable data rather than user-entered text — the line `System.Text.Json` and `XmlConvert` draw. If you would rather reject fractional percentages outright, that resolves the ambiguity equally well.

### How has this been tested?

`Source/DafnyCore.Test/CoresOptionCultureTest.cs`, seven cases, six of which fail on master. It parses the public `BoogieOptionBag.Cores` option directly, so no compilation is involved:

- `PercentageIsParsedInvariantlyAcrossCultures` (en-US, de-DE) — `50.5%` and `50%` must resolve to the same core count, and to the same count in both cultures. On master the de-DE case gives 50 where 5 is expected.
- `ThousandsSeparatorIsRejectedRatherThanGuessed` — `1,000%` must be rejected, in both cultures.
- `NonFiniteOrUnrepresentablePercentageIsRejected` — `NaN%`, `Infinity%`, `1e30%`.

The culture is set on a thread the test owns, not the calling thread: xunit runs test classes in parallel on pool threads it reuses, so mutating the caller's culture could be observed by a concurrent test.

A lit test cannot cover this, because `ShellLitCommand` pins `LANG=C.UTF-8` for child processes.

`cli/zeroCores.dfy` passes unchanged; it pins three existing messages (`Could not parse number …`, `Could not parse percentage …`, `Number of cores to use must be greater than 0`), all preserved. Behaviour on the surrounding edge cases is unchanged from master: bare `%` rejected, `" 50 %"` and `+50%` accepted.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
