### PR TITLE
chore(ci): add actionlint, and fix three latent workflow bugs it finds

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -51,4 +51,11 @@ jobs:
           ./actionlint --version
 
       - name: Lint workflows
-        run: ./actionlint -color
+        # shellcheck integration is off deliberately. GitHub runners ship shellcheck, so enabling
+        # it here reports 37 pre-existing findings across the existing workflows - almost all
+        # style-level (SC2006, SC2086), plus two SC1072/SC1073 "couldn't parse" errors in
+        # release-downloads-nuget.yml that are artifacts of shellcheck reading a `${{ }}`
+        # interpolation as an arithmetic expansion. Cleaning those up is worth doing, but it is a
+        # separate change: the point of this job is to reject workflow files that GitHub itself
+        # cannot process, which is the failure mode that cost 22 nights of nightly builds.
+        run: ./actionlint -color -shellcheck=

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,12 +1,5 @@
-# Static analysis of the workflow files themselves.
-#
-# This exists because an invalid workflow file fails in the most expensive way available:
-# `startup_failure`, with no jobs and no logs to inspect. In July 2025 a bare `if: prerelease`
-# (an undefined context, so the whole reusable workflow was invalid) stopped the nightly build
-# from producing anything at all for 22 consecutive nights before anyone noticed, and the
-# merge gate reported it as "No completed runs found" rather than as a broken file.
-#
-# actionlint catches exactly that class of mistake statically, in the PR that introduces it.
+# An invalid workflow file fails as `startup_failure`: no jobs, no logs, easy to miss.
+# actionlint catches that statically, in the PR that introduces it.
 
 name: Lint workflows
 
@@ -25,9 +18,7 @@ jobs:
     permissions:
       contents: read
     env:
-      # Pinned by version *and* checksum on purpose: a floating third-party action pin is what
-      # broke the nightly release for four nights in April 2026, when setup-tectonic@v3 stopped
-      # being able to resolve its tool version.
+      # Pinned by version and checksum rather than a floating action reference.
       ACTIONLINT_VERSION: 1.7.7
       ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
     steps:
@@ -51,11 +42,6 @@ jobs:
           ./actionlint --version
 
       - name: Lint workflows
-        # shellcheck integration is off deliberately. GitHub runners ship shellcheck, so enabling
-        # it here reports 37 pre-existing findings across the existing workflows - almost all
-        # style-level (SC2006, SC2086), plus two SC1072/SC1073 "couldn't parse" errors in
-        # release-downloads-nuget.yml that are artifacts of shellcheck reading a `${{ }}`
-        # interpolation as an arithmetic expansion. Cleaning those up is worth doing, but it is a
-        # separate change: the point of this job is to reject workflow files that GitHub itself
-        # cannot process, which is the failure mode that cost 22 nights of nightly builds.
+        # shellcheck off: it flags 37 pre-existing findings in existing workflows, 33 of them
+        # style or informational. Worth fixing separately; this job is about workflow validity.
         run: ./actionlint -color -shellcheck=

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,31 +17,14 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    env:
-      # Pinned by version and checksum rather than a floating action reference.
-      ACTIONLINT_VERSION: 1.7.7
-      ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
     steps:
       - name: Checkout Dafny
         uses: actions/checkout@v7
 
-      - name: Install actionlint
-        run: |
-          set -euo pipefail
-          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
-          for attempt in 1 2 3; do
-            if curl -fsSL --retry 3 --retry-delay 5 -o "$archive" "$url"; then
-              break
-            fi
-            echo "download attempt $attempt failed; retrying"
-            sleep $((attempt * 10))
-          done
-          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum --check --strict
-          tar xzf "$archive" actionlint
-          ./actionlint --version
-
       - name: Lint workflows
-        # shellcheck off: it flags 37 pre-existing findings in existing workflows, 33 of them
+        # actionlint ships no first-party action, so this uses its published container image.
+        # shellcheck is off: it flags 37 pre-existing findings in existing workflows, 33 of them
         # style or informational. Worth fixing separately; this job is about workflow validity.
-        run: ./actionlint -color -shellcheck=
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color -shellcheck=

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,54 @@
+# Static analysis of the workflow files themselves.
+#
+# This exists because an invalid workflow file fails in the most expensive way available:
+# `startup_failure`, with no jobs and no logs to inspect. In July 2025 a bare `if: prerelease`
+# (an undefined context, so the whole reusable workflow was invalid) stopped the nightly build
+# from producing anything at all for 22 consecutive nights before anyone noticed, and the
+# merge gate reported it as "No completed runs found" rather than as a broken file.
+#
+# actionlint catches exactly that class of mistake statically, in the PR that introduces it.
+
+name: Lint workflows
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      # Pinned by version *and* checksum on purpose: a floating third-party action pin is what
+      # broke the nightly release for four nights in April 2026, when setup-tectonic@v3 stopped
+      # being able to resolve its tool version.
+      ACTIONLINT_VERSION: 1.7.7
+      ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+    steps:
+      - name: Checkout Dafny
+        uses: actions/checkout@v7
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          for attempt in 1 2 3; do
+            if curl -fsSL --retry 3 --retry-delay 5 -o "$archive" "$url"; then
+              break
+            fi
+            echo "download attempt $attempt failed; retrying"
+            sleep $((attempt * 10))
+          done
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum --check --strict
+          tar xzf "$archive" actionlint
+          ./actionlint --version
+
+      - name: Lint workflows
+        run: ./actionlint -color

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -73,9 +73,7 @@ jobs:
       if: matrix.os == 'ubuntu-24.04'
       run: |
         sudo apt-get install -y build-essential
-    # The matrix has no target-language-version dimension, so the conditions this step used to
-    # carry meant "oldest always, newest never". Testing the newest JDK too needs a real matrix
-    # dimension, which doubles the matrix.
+    # Only the oldest supported JDK is exercised; adding the newest needs a matrix dimension.
     - name: Set up oldest supported JDK
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -159,6 +159,9 @@ jobs:
         XUNIT_SHARD_COUNT: ${{ inputs.num_shards }}
         DAFNY_RELEASE: ${{ github.workspace }}\unzippedRelease\dafny
         DAFNY_INTEGRATION_TESTS_ONLY_COMPILERS: ${{ inputs.compilers }}
+      # pwsh is already the default on Windows; naming it lets actionlint pick the right shell
+      # instead of running shellcheck over a PowerShell script.
+      shell: pwsh
       run: |
         cmd /c mklink ${{ env.DAFNY_RELEASE }}\z3\bin\z3-4.16.0 ${{ env.DAFNY_RELEASE }}\z3\bin\z3-4.16.0.exe
         dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" --settings dafny/Source/IntegrationTests/coverlet.runsettings dafny/Source/IntegrationTests/IntegrationTests.csproj

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -40,14 +40,6 @@ jobs:
         id: populate-os-mapping
         run: |
           echo "os-mapping={\"ubuntu-24.04\": \"ubuntu\", \"macos-14\": \"macos\", \"windows-2022\": \"windows\"}" >> $GITHUB_OUTPUT
-      - name: Populate target runtime version list (all platforms)
-        id: populate-target-runtime-version-all
-        if: inputs.all_platforms
-        run: echo "target-runtime-version=[\"oldest\", \"newest\"]" >> $GITHUB_OUTPUT
-      - name: Populate target runtime version list (one platform)
-        id: populate-target-runtime-version-one
-        if: "!inputs.all_platforms"
-        run: echo "target-runtime-version=[\"oldest\"]" >> $GITHUB_OUTPUT
       - name: Populate shard list
         id: populate-shard-list
         run: echo "shard-list=[`seq -s , 1 ${{ inputs.num_shards }}`]" >> $GITHUB_OUTPUT
@@ -81,17 +73,16 @@ jobs:
       if: matrix.os == 'ubuntu-24.04'
       run: |
         sudo apt-get install -y build-essential
+    # NOTE: this job's matrix has only `os` and `shard` dimensions, so there is no
+    # target-language-version to branch on. The two JDK steps that used to be guarded by
+    # `matrix.target-language-version` therefore resolved to "oldest always, newest never",
+    # which is the behaviour preserved here. Restoring coverage of the newest supported JDK
+    # means adding a real matrix dimension and doubling the matrix; that is a separate
+    # decision, deliberately not made in this PR.
     - name: Set up oldest supported JDK
-      if: matrix.target-language-version != 'newest'
       uses: actions/setup-java@v5
       with:
         java-version: 8
-        distribution: corretto
-    - name: Set up newest supported JDK
-      if: matrix.target-language-version == 'newest'
-      uses: actions/setup-java@v5
-      with:
-        java-version: 18
         distribution: corretto
     - name: Set up oldest supported Go
       uses: actions/setup-go@v7

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -73,12 +73,9 @@ jobs:
       if: matrix.os == 'ubuntu-24.04'
       run: |
         sudo apt-get install -y build-essential
-    # NOTE: this job's matrix has only `os` and `shard` dimensions, so there is no
-    # target-language-version to branch on. The two JDK steps that used to be guarded by
-    # `matrix.target-language-version` therefore resolved to "oldest always, newest never",
-    # which is the behaviour preserved here. Restoring coverage of the newest supported JDK
-    # means adding a real matrix dimension and doubling the matrix; that is a separate
-    # decision, deliberately not made in this PR.
+    # The matrix has no target-language-version dimension, so the conditions this step used to
+    # carry meant "oldest always, newest never". Testing the newest JDK too needs a real matrix
+    # dimension, which doubles the matrix.
     - name: Set up oldest supported JDK
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-24.04
     # Don't include in run-deep-tests, because those tests run on
     # release builds instead of source packages.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-deep-tests') && !contains(github.event.push.labels.*.name, 'run-deep-tests')}}))
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-deep-tests') && !contains(github.event.push.labels.*.name, 'run-deep-tests') }}
     needs: [xunit-tests, integration-tests]
     steps:
       # Check out Dafny so that highlighted source is possible

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -57,14 +57,6 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{env.dotnet-version}}
-    - name: C++ for ubuntu 20.04
-      if: matrix.os == 'ubuntu-22.04'
-      run: |
-        sudo apt-get install -y build-essential
-    - name: Choose the right C++ for ubuntu 20.04
-      if: matrix.os == 'ubuntu-22.04'
-      run: |
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 60
     - name: Set up JDK 18
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/release-downloads-nuget.yml
+++ b/.github/workflows/release-downloads-nuget.yml
@@ -74,7 +74,10 @@ jobs:
       run: echo "${PWD}/bin" >> $GITHUB_PATH
     - name: Set Path - Windows
       if: runner.os == 'Windows'
-      run: $((Resolve-Path -Path "bin").providerPath) | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append   
+      # pwsh is already the default on Windows; naming it lets actionlint pick the right shell
+      # instead of running shellcheck over a PowerShell script.
+      shell: pwsh
+      run: $((Resolve-Path -Path "bin").providerPath) | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Download NuGet package
       run: dotnet tool install --global Dafny
     ## Record versions, checking that executables run


### PR DESCRIPTION
## Problem

An invalid workflow file fails in the most expensive way GitHub offers: `startup_failure`, with no jobs and no logs to inspect.

In July 2025 a bare `if: prerelease` — an undefined context, which makes the whole reusable workflow invalid — stopped the nightly build from producing **anything at all for 22 consecutive nights** (2025-07-11 → 2025-08-01) before it was noticed and fixed in #6319. It was hard to notice precisely because there was nothing to look at, and the merge gate reported it as `No completed runs of nightly-build.yml found!`, which sends the reader hunting for a missing run rather than a broken file.

`actionlint` catches that class of mistake statically, in the PR that introduces it. Against the July 2025 file it reports exactly:

```
.github/workflows/publish-release-reusable.yml:148:11: undefined variable "prerelease".
  available variables are "env", "github", "inputs", "job", "matrix", "needs", "runner",
  "secrets", "steps", "strategy", "vars" [expression]
```

## Fix

Adds a `Lint workflows` job, fixes the three latent bugs that running it over current `master` turns up, and names the shell on the two steps where actionlint was guessing wrong.

### 1. `msbuild.yml` — a guard that is always true

```yaml
if: ${{ !contains(...) && !contains(...)}}))
```

The stray `))` sits **outside** the `${{ }}`, so the whole thing is a non-empty string, which is truthy. `test-coverage-analysis` therefore always ran, including on `run-deep-tests` PRs that the comment directly above it says to exclude. **This is the only behaviour change in this PR.**

### 2. `integration-tests-reusable.yml` — the newest JDK has never been tested

The two JDK steps branched on `matrix.target-language-version`, which the matrix never defines — it has only `os` and `shard`. So `!= 'newest'` was always true and `== 'newest'` always false: the oldest JDK was always installed and the newest never was, including in the nightly build with `all_platforms: true`.

Three separate defects combined to hide this:

- the `test` matrix has no runtime-version dimension;
- the two steps that computed `target-runtime-version` were never exported in the job's `outputs:` block, so the value was thrown away;
- and those steps use the name `target-runtime-version`, while the conditions read `target-language-version` — so even wired up, the names would not have matched.

Collapsed to the single step that actually ran, which **preserves current behaviour**. Restoring coverage of the newest supported JDK means adding a real matrix dimension and doubling the matrix, so I have deliberately left that as a separate decision rather than smuggling a 2× CI increase into a lint PR. Happy to open a follow-up issue.

### 3. `publish-release-reusable.yml` — two steps that never run

Two steps guarded on `matrix.os` in a job that has no matrix, so they were always skipped. Removed. Note they were leftovers from when this job ran on `ubuntu-22.04`; if it is ever moved back (see the comment on `runs-on`), correct C++ setup steps would need to be added anyway, since these could not have worked.

### 4. Two Windows-only steps did not name their shell

Both are guarded on `runner.os == 'Windows'` with no `shell:` key, so they already run under pwsh — but actionlint assumes bash and runs shellcheck over them. That accounted for **9 of its 37 shellcheck findings, including every error-level one**: 6× SC1001 on the Windows path separators in `cmd /c mklink …\z3\bin\…`, and SC1009/1072/1073 where shellcheck reads PowerShell's `$((Resolve-Path …))` as a bash arithmetic expansion.

Naming the shell is a no-op at runtime and takes the findings to 28 with none at error level, which is what makes enabling shellcheck tractable — see #6519, stacked on this.

## Validation

- `actionlint` reports the July 2025 bug when run against `publish-release-reusable.yml` at 73878d4f, naming `inputs` as the available context.
- `actionlint` exits 0 on this branch, including on the workflow it adds. With shellcheck enabled it reports 28 pre-existing findings, down from 37, and none at error level; #6519 clears the rest.
- actionlint runs from its published container image, `docker://rhysd/actionlint:1.7.12`.

  An earlier revision of this PR downloaded the release tarball and verified a SHA256, justified as avoiding a "floating" reference. That reasoning was backwards: the April 2026 Tectonic outage (#6462) was caused by a **pin going stale** — `wtfjoke/setup-tectonic@v3` with `tectonic-version: 0.15` stopped being able to resolve its tool version — so it argues for keeping things current, not for hand-pinning. Worse, a version in an `env:` var plus a shell download is invisible to Dependabot, which is how this repo keeps every other action current, so it would have rotted the same way. It was already five releases behind upstream when written.

  A `uses:` reference sits where Dependabot already looks, and replaces fifteen lines of download-and-checksum shell with one line. Note actionlint publishes no first-party action (`rhysd/actionlint` has no `action.yml`); upstream recommends a `curl | bash` of a script from `main`, which is less pinned than the container tag.

## Relationship to the other PR

Independent of #6517 — they touch two files in common but in disjoint regions. Test-merging them is conflict-free and `actionlint` is clean on the result, so either can land first and neither needs a rebase.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
