### PR TITLE
chore(ci): remove the top recurring causes of nightly build failures

### DIFF
--- a/.github/workflows/check-for-workflow-run.js
+++ b/.github/workflows/check-for-workflow-run.js
@@ -18,6 +18,12 @@ module.exports = async ({github, context, core, workflow_id, sha, ...config}) =>
   const workflow_runs_completed = workflow_runs.filter(run => run.status === "completed")
   // The status property can be one of: “queued”, “in_progress”, or “completed”.
   const workflow_runs_in_progress = workflow_runs.filter(run => run.status !== "completed")
+  // Conclusions that are neither a pass nor a fail (see the list below) are skipped, so that an
+  // older successful run can still satisfy the gate. They are collected here purely so that the
+  // final message can say what was actually found: reporting "No completed runs found" when there
+  // were completed runs with, say, a startup_failure sends the reader looking for a missing run
+  // instead of a broken workflow file. That happened for 22 consecutive nights in July 2025.
+  const inconclusive = []
   for (const run of workflow_runs_completed) {
     // The conclusion property can be one of:
     // “success”, “failure”, “neutral”, “cancelled”, “skipped”, “timed_out”, or “action_required”.
@@ -40,7 +46,20 @@ module.exports = async ({github, context, core, workflow_id, sha, ...config}) =>
         ` their PRs and add the label [run-deep-tests] to their PRs`;
       core.setFailed(`Last run of ${runFilterDesc} did not succeed: ${run.html_url}${extraMessage}`)
       return
+    } else {
+      inconclusive.push(run)
     }
+  }
+  if (inconclusive.length > 0) {
+    const found = inconclusive
+      .map(run => `  - ${run.conclusion}: ${run.html_url}`)
+      .join("\n")
+    core.setFailed(
+      `No run of ${runFilterDesc} either succeeded or failed outright. Completed runs found:\n${found}\n` +
+      `A "startup_failure" means the workflow file itself could not be processed, so no jobs ran ` +
+      `and there are no logs to inspect - look for an invalid expression or context in the ` +
+      `workflow and the workflows it calls, rather than for a missing run.`)
+    return
   }
   core.setFailed(`No completed runs of ${runFilterDesc} found!`)
 }

--- a/.github/workflows/check-for-workflow-run.js
+++ b/.github/workflows/check-for-workflow-run.js
@@ -18,11 +18,8 @@ module.exports = async ({github, context, core, workflow_id, sha, ...config}) =>
   const workflow_runs_completed = workflow_runs.filter(run => run.status === "completed")
   // The status property can be one of: “queued”, “in_progress”, or “completed”.
   const workflow_runs_in_progress = workflow_runs.filter(run => run.status !== "completed")
-  // Conclusions that are neither a pass nor a fail (see the list below) are skipped, so that an
-  // older successful run can still satisfy the gate. They are collected here purely so that the
-  // final message can say what was actually found: reporting "No completed runs found" when there
-  // were completed runs with, say, a startup_failure sends the reader looking for a missing run
-  // instead of a broken workflow file. That happened for 22 consecutive nights in July 2025.
+  // Conclusions other than success and failure/timed_out are skipped, so an older success can
+  // still satisfy the gate; collected only so the final message can say what it actually found.
   const inconclusive = []
   for (const run of workflow_runs_completed) {
     // The conclusion property can be one of:

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -193,8 +193,18 @@ jobs:
       run: |
         ${{ inputs.all_platforms }} && export DAFNY_RELEASE="${{ github.workspace }}/unzippedRelease/dafny"
         dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" --settings dafny/Source/IntegrationTests/coverlet.runsettings dafny/Source/IntegrationTests
+    # A transient failure uploading test results should not fail a job whose tests passed:
+    # this cost the nightly build five red nights between 2026-04 and 2026-08, each time after
+    # the test run itself had already succeeded.
+    #
+    # Caveat for reviewers: this artifact carries both .trx diagnostics *and* the coverage report
+    # that test-coverage-analysis consumes with fail_below_min. If a shard's upload is ever
+    # skipped, coverage will be computed from fewer shards. If that turns out to matter, the
+    # follow-up is to upload diagnostics and coverage as two separate artifacts so only the
+    # diagnostics one tolerates failure.
     - uses: actions/upload-artifact@v7
       if: always()
+      continue-on-error: true
       with:
         name: integration-test-results-${{ matrix.os }}-${{ matrix.shard }}
         path: |

--- a/.github/workflows/integration-tests-reusable.yml
+++ b/.github/workflows/integration-tests-reusable.yml
@@ -193,15 +193,8 @@ jobs:
       run: |
         ${{ inputs.all_platforms }} && export DAFNY_RELEASE="${{ github.workspace }}/unzippedRelease/dafny"
         dotnet test --logger trx --logger "console;verbosity=normal" --collect:"XPlat Code Coverage" --settings dafny/Source/IntegrationTests/coverlet.runsettings dafny/Source/IntegrationTests
-    # A transient failure uploading test results should not fail a job whose tests passed:
-    # this cost the nightly build five red nights between 2026-04 and 2026-08, each time after
-    # the test run itself had already succeeded.
-    #
-    # Caveat for reviewers: this artifact carries both .trx diagnostics *and* the coverage report
-    # that test-coverage-analysis consumes with fail_below_min. If a shard's upload is ever
-    # skipped, coverage will be computed from fewer shards. If that turns out to matter, the
-    # follow-up is to upload diagnostics and coverage as two separate artifacts so only the
-    # diagnostics one tolerates failure.
+    # Don't fail a job whose tests passed just because uploading the results flaked. Note the
+    # ubuntu artifacts also feed test-coverage-analysis, which has fail_below_min set.
     - uses: actions/upload-artifact@v7
       if: always()
       continue-on-error: true

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -107,8 +107,8 @@ jobs:
       if: ${{ inputs.release_nuget }}
       # Need --skip-duplicate for cases where we release a new Dafny
       # version but the runtime hasn't changed and is still the old
-      # version, and it makes the retry below safe to repeat. The default push timeout is 300s,
-      # which a slow nuget.org has hit, so raise it.
+      # version, and it makes the retry below safe to repeat. The 300s default push timeout is
+      # not always enough.
       env:
         NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -107,10 +107,8 @@ jobs:
       if: ${{ inputs.release_nuget }}
       # Need --skip-duplicate for cases where we release a new Dafny
       # version but the runtime hasn't changed and is still the old
-      # version. It also makes the retry below safe to repeat.
-      #
-      # `dotnet nuget push` defaults to a 300s timeout. On 2026-03-18 the nightly release failed
-      # after exactly 301s against an unresponsive nuget.org, so allow longer and retry.
+      # version, and it makes the retry below safe to repeat. The default push timeout is 300s,
+      # which a slow nuget.org has hit, so raise it.
       env:
         NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |

--- a/.github/workflows/publish-release-reusable.yml
+++ b/.github/workflows/publish-release-reusable.yml
@@ -107,8 +107,27 @@ jobs:
       if: ${{ inputs.release_nuget }}
       # Need --skip-duplicate for cases where we release a new Dafny
       # version but the runtime hasn't changed and is still the old
-      # version.
-      run: dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      # version. It also makes the retry below safe to repeat.
+      #
+      # `dotnet nuget push` defaults to a 300s timeout. On 2026-03-18 the nightly release failed
+      # after exactly 301s against an unresponsive nuget.org, so allow longer and retry.
+      env:
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+      run: |
+        set -euo pipefail
+        attempts=3
+        for attempt in $(seq 1 $attempts); do
+          if dotnet nuget push --skip-duplicate "dafny/Binaries/Dafny*.nupkg" \
+               -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json --timeout 900; then
+            exit 0
+          fi
+          if [ "$attempt" -lt "$attempts" ]; then
+            echo "nuget push attempt $attempt failed, retrying in $((attempt * 30))s"
+            sleep $((attempt * 30))
+          fi
+        done
+        echo "nuget push failed after $attempts attempts" >&2
+        exit 1
 
     - name: Install pandoc - Linux
       if: runner.os == 'Linux'

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -12,7 +12,7 @@ import sys
 import time
 from urllib import request
 from http.client import IncompleteRead
-from urllib.error import HTTPError
+from urllib.error import URLError
 import zipfile
 import shutil
 import ntpath
@@ -24,6 +24,8 @@ Z3_URL_BASE = "https://github.com/dafny-lang/solver-builds/releases/download/sna
 
 ## How many times we allow ourselves to try to download Z3
 Z3_MAX_DOWNLOAD_ATTEMPTS = 5
+# Doubles per attempt, so 5 attempts wait 2 + 4 + 8 + 16 = 30s in total.
+Z3_DOWNLOAD_RETRY_BASE_SECONDS = 2
 
 ## Allowed Dafny release names
 DAFNY_RELEASE_REGEX = re.compile("\\d+\\.\\d+\\.\\d+(-[\w\d_-]+)?$")
@@ -126,9 +128,19 @@ class Release:
                                 writer.write(reader.read())
                         flush("done!")
                         break
-                    except (IncompleteRead, HTTPError):
+                    # The retries below need to back off. Without a delay all
+                    # Z3_MAX_DOWNLOAD_ATTEMPTS are spent within milliseconds, which is no use
+                    # against the transient server-side conditions that actually occur here: a
+                    # bare 504 from the release CDN takes seconds to clear, so an immediate retry
+                    # just returns the same 504. This failed the nightly release on 2026-05-01 and
+                    # 2026-07-24, and the same download runs in the test matrix as "Create
+                    # release", which accounts for three more red nights.
+                    except (IncompleteRead, URLError) as e:
                         if currentAttempt == Z3_MAX_DOWNLOAD_ATTEMPTS - 1:
                             raise
+                        delay = Z3_DOWNLOAD_RETRY_BASE_SECONDS * (2 ** currentAttempt)
+                        flush("failed ({}), retrying in {}s ... ".format(e, delay))
+                        time.sleep(delay)
 
 
     @staticmethod

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -128,13 +128,8 @@ class Release:
                                 writer.write(reader.read())
                         flush("done!")
                         break
-                    # The retries below need to back off. Without a delay all
-                    # Z3_MAX_DOWNLOAD_ATTEMPTS are spent within milliseconds, which is no use
-                    # against the transient server-side conditions that actually occur here: a
-                    # bare 504 from the release CDN takes seconds to clear, so an immediate retry
-                    # just returns the same 504. This failed the nightly release on 2026-05-01 and
-                    # 2026-07-24, and the same download runs in the test matrix as "Create
-                    # release", which accounts for three more red nights.
+                    # Back off: with no delay the attempts all go out in quick succession, which
+                    # is little use against a server-side 504.
                     except (IncompleteRead, URLError) as e:
                         if currentAttempt == Z3_MAX_DOWNLOAD_ATTEMPTS - 1:
                             raise

--- a/Scripts/package.py
+++ b/Scripts/package.py
@@ -24,7 +24,7 @@ Z3_URL_BASE = "https://github.com/dafny-lang/solver-builds/releases/download/sna
 
 ## How many times we allow ourselves to try to download Z3
 Z3_MAX_DOWNLOAD_ATTEMPTS = 5
-# Doubles per attempt, so 5 attempts wait 2 + 4 + 8 + 16 = 30s in total.
+## Doubles per attempt: 2s, 4s, 8s, ...
 Z3_DOWNLOAD_RETRY_BASE_SECONDS = 2
 
 ## Allowed Dafny release names
@@ -128,8 +128,7 @@ class Release:
                                 writer.write(reader.read())
                         flush("done!")
                         break
-                    # Back off: with no delay the attempts all go out in quick succession, which
-                    # is little use against a server-side 504.
+                    # Backoff matters: an immediate retry just hits the same server-side 504.
                     except (IncompleteRead, URLError) as e:
                         if currentAttempt == Z3_MAX_DOWNLOAD_ATTEMPTS - 1:
                             raise

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/JsonLogger.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/JsonLogger.dfy
@@ -1,6 +1,10 @@
-// RUN: %exits-with 4 %baredafny verify --show-snippets:false --log-format:json --isolate-assertions "%s" > "%t"
+// The CHECK directives below assert an *ordering* of vcResults, but the logger emits them in VC
+// completion order, and with assertions isolated the VCs are verified in parallel. Verify with a
+// single core so that order is deterministic, as every other test that pins per-VC or per-assertion
+// output already does (see verification/progress.dfy and verification/proofDivision/*).
+// RUN: %exits-with 4 %baredafny verify --show-snippets:false --log-format:json --isolate-assertions --cores=1 "%s" > "%t"
 // Also test old CLI
-// RUN: %exits-with 4 %baredafny /compile:0 /verificationLogger:json /vcsSplitOnEveryAssert "%s" >> "%t"
+// RUN: %exits-with 4 %baredafny /compile:0 /verificationLogger:json /vcsSplitOnEveryAssert /vcsCores:1 "%s" >> "%t"
 // RUN: %OutputCheck --file-to-check "%t" "%s"
 // CHECK: vcNum.:1,.outcome.:.Valid.*vcNum.:2,.outcome.:.Invalid
 // CHECK: vcNum.:1,.outcome.:.Valid.*vcNum.:2,.outcome.:.Invalid

--- a/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/JsonLogger.dfy
+++ b/Source/IntegrationTests/TestFiles/LitTests/LitTest/logger/JsonLogger.dfy
@@ -1,7 +1,5 @@
-// The CHECK directives below assert an *ordering* of vcResults, but the logger emits them in VC
-// completion order, and with assertions isolated the VCs are verified in parallel. Verify with a
-// single core so that order is deterministic, as every other test that pins per-VC or per-assertion
-// output already does (see verification/progress.dfy and verification/proofDivision/*).
+// The CHECKs pin an ordering, but vcResults is emitted in completion order and the VCs are
+// verified in parallel. Verify on one core, as the other order-pinning tests do.
 // RUN: %exits-with 4 %baredafny verify --show-snippets:false --log-format:json --isolate-assertions --cores=1 "%s" > "%t"
 // Also test old CLI
 // RUN: %exits-with 4 %baredafny /compile:0 /verificationLogger:json /vcsSplitOnEveryAssert /vcsCores:1 "%s" >> "%t"


### PR DESCRIPTION
## Problem

Over the nightly build's full retained history — 2025-07-11 → 2026-08-26, 419 runs — **128 of 412 nights were red on attempt 1 (31%)**, and the rate never dropped below 7% in any month. Because a manual re-run overwrites the visible conclusion, the run list understates this by about a third: 21 runs were re-run, and in the last two months alone 7 of 26 failures show as green.

Almost none of it was a code regression. In 13.5 months only two outages traced to a merged change. The rest is a small number of recurring, well-identified causes, and the five changes here are the cheap end of that list — together they account for roughly a third of all red nights.

## Changes

### `logger/JsonLogger.dfy` — pass `--cores=1` (≈21 nights)

The `CHECK` directives assert an **ordering** of `vcResults`:

```
// CHECK: vcNum.:1,.outcome.:.Valid.*vcNum.:2,.outcome.:.Invalid
```

but the logger emits results in VC *completion* order, and `--isolate-assertions` verifies the VCs in parallel — so the order is a race. From a failing run:

```json
"vcResults":[{"vcNum":2,"outcome":"Invalid","runTime":"00:00:00.1113555",...},
             {"vcNum":1,"outcome":"Valid","runTime":"00:00:00.1394068",...}]
```

`vcNum 2` finished faster, so it was serialised first and the assertion broke. This one test is **half of every single-cell test failure in the recorded history, and 9 of the last 10** — it reproduces on Windows and macOS and never on Linux, which fits a timing race on the slower runners.

Verifying with a single core makes the order deterministic. This is what **all five** other tests that pin per-VC or per-assertion output already do: `verification/progress.dfy`, the three `verification/proofDivision/*`, and `verification/outOfResourceAndIsolateAssertions.dfy` all pass `--cores=1`. `JsonLogger.dfy` was the only one that did not.

Note this fixes the *test*, not the *product*: anyone consuming `--log-format:json` still gets a nondeterministic order. Sorting `vcResults` by `(VcNum, Iteration)` in both loggers is a separate, product-level change worth doing on its own merits — `VerificationResultLogger.cs:130` already sorts by `VcNum`, so the JSON loggers are the inconsistent ones. Happy to open that as a follow-up.

### `Scripts/package.py` — back off between Z3 download retries (≈5 nights)

`download_z3` already retried `Z3_MAX_DOWNLOAD_ATTEMPTS` (5) times, but with **no delay between attempts**, so all five went out in quick succession. That is little use against a server-side `504 Gateway Time-out`, where an immediate retry tends to get the same 504. The nightly release died this way on 2026-05-01 and 2026-07-24, and the same download runs inside the test matrix as `Create release`, which accounts for three more red nights.

Added exponential backoff (2 + 4 + 8 + 16 = 30s across five attempts) and widened the caught exception from `HTTPError` to `URLError` so connection resets are retried too.

### `integration-tests-reusable.yml` — tolerate a failed results upload (≈5 nights)

Five red nights between 2026-04 and 2026-08 were an `upload-artifact` failure *after* the test run had already succeeded. A transient failure uploading diagnostics should not fail a job whose tests passed.

**Reviewer note:** that artifact carries both the `.trx` diagnostics and the coverage report. `test-coverage-analysis` downloads the `integration-test-results-ubuntu-24.04-*` pattern and runs with `fail_below_min`, so a skipped upload on an *ubuntu* shard means coverage is computed from fewer shards. macOS and Windows uploads do not feed it. I have left this as one artifact to keep the change small; if it turns out to matter, the follow-up is to upload diagnostics and coverage separately so only the diagnostics tolerate failure. (#6516 reduces the exposure, since it makes that job correctly skip on `run-deep-tests` PRs.)

### `publish-release-reusable.yml` — NuGet push timeout and retry (1 night)

`dotnet nuget push` defaults to a 300s timeout. On 2026-03-18 the nightly release failed after **exactly 301s** against an unresponsive nuget.org — distinguishable from the July key-expiry failures, which all returned in 0–1s. Raised the timeout and added a retry; `--skip-duplicate` already makes the push safe to repeat.

### `check-for-workflow-run.js` — a wrong error message (0 nights)

Unlike the rest of this PR, this recovers no nights. It is here because the message is *incorrect*, not merely unhelpful: conclusions that are neither `success` nor `failure`/`timed_out` fall through to `No completed runs of nightly-build.yml found!` — reported when completed runs demonstrably exist. Reachable whenever every completed run on the API's first page has a non-verdict conclusion; `cancelled` is the likely trigger (6 in the last 13.5 months), with `startup_failure` the rarer one.

The skip semantics are deliberately unchanged — an older successful run still satisfies the gate — only the final message now names what it found, and points at the workflow file when a `startup_failure` is involved.

I originally justified this by the July 2025 outage, where the gate said exactly this for 22 nights while every nightly run ended in `startup_failure`. That justification does not hold up: **no commits landed on master between 2025-07-11 and 2025-08-02**, so nobody was hitting the gate and a better message would not have shortened the outage. Happy to drop this hunk if you would rather keep the PR strictly to the recurring failure causes.

## Validation

- **`package.py` backoff** unit-tested against a stubbed `urlopen`: recovers after two transient 504s having slept 2s then 4s, and gives up after five attempts having slept 30s in total.
- **`check-for-workflow-run.js`** tested over five cases, including a regression guard confirming that a `cancelled` newest run still lets an older success pass, so the existing skip semantics are preserved.
- `--cores=1` and `/vcsCores:1` are the flags used by existing lit tests and by the legacy CLI respectively, so no new option is introduced.
- `actionlint` reports no new findings relative to `master`.

## Relationship to the other PR

Independent of #6516 — two files in common, disjoint regions, conflict-free test-merge. Either can land first; neither needs a rebase.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
