### PR TITLE
feat(ci): record which test failed when the nightly build goes red

### DIFF
--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -1,27 +1,18 @@
-// Turn a failed nightly run into a deduplicated issue naming the test that failed.
-//
-// Failing job and step names survive in the API for about a year, but the failing *test* name
-// only exists in the run's own output, which expires after 90 days. Recovering it later is
-// disproportionately hard, so record it while it is still there.
+// Record which test failed when the nightly build goes red, into one issue per test.
+// The failing test's name only exists in the run's own output, which expires after 90 days.
 
 const fs = require("fs");
 const path = require("path");
 
 const LABEL = "nightly-flake";
 const TITLE_PREFIX = "nightly flake: ";
-
-// Where the workflow put the run's test-result artifacts, if it managed to download any.
 const RESULTS_DIR = "test-results";
 
-// Fallback only, for when no .trx is available. This parses xUnit's console output, which is a
-// formatting detail of a third-party logger rather than a contract: it depends on `[FAIL]` and
-// on `--logger "console;verbosity=normal"` staying put. The .trx path below is preferred for
-// exactly that reason. Extensions match LitTests.cs's FileData includes.
+// Fallback only: this is xUnit console formatting, not a contract. Extensions match the
+// FileData includes in LitTests.cs.
 const FAILED_TEST_IN_LOG = /([A-Za-z0-9_./-]+\.(?:dfy|transcript)) \[FAIL\]/g;
 
-// Only these steps run tests, so only these are worth fetching a log for. With .trx as the
-// primary source this is just an optimisation - a stale entry costs a wasted lookup, not a
-// misclassification.
+// Which steps are worth fetching a log for. Only an optimisation, since .trx comes first.
 const TEST_STEP = /^Run integration tests/;
 
 const marker = key => `<!-- nightly-flake-key: ${key} -->`;
@@ -47,8 +38,7 @@ function failingStepsOf(job) {
     .map(s => s.name);
 }
 
-// `test (macos-14, 6)` -> `integration-test-results-macos-14-6`, matching the artifact name
-// that integration-tests-reusable.yml uploads.
+// `test (macos-14, 6)` -> the artifact name integration-tests-reusable.yml uploads.
 function artifactNameFor(shortJobName) {
   const m = /^test \(([^,]+), *(\d+)\)/.exec(shortJobName);
   return m ? `integration-test-results-${m[1]}-${m[2]}` : null;
@@ -70,8 +60,7 @@ function trxFilesUnder(dir) {
   return found;
 }
 
-// Failed test names from a .trx. Attributes are read individually rather than in a fixed order,
-// since their order is not part of the format.
+// Attributes are read individually; their order is not part of the trx format.
 function failedTestsInTrx(xml) {
   const names = [];
   for (const element of xml.split("<UnitTestResult").slice(1)) {
@@ -85,9 +74,8 @@ function failedTestsInTrx(xml) {
   return names;
 }
 
-// The preferred source: `--logger trx` is an explicit contract in the test workflow, the format
-// is structured, and it names tests of any extension. Returns null when there is no .trx for
-// this job, which is not an error: the upload is best-effort and may have been skipped.
+// Preferred source: `--logger trx` is an explicit contract in the test workflow. null means
+// there is no .trx for this job, which is normal - the upload is best effort.
 function testsFromArtifact({ core }, shortJobName) {
   const name = artifactNameFor(shortJobName);
   if (!name) {
@@ -107,8 +95,7 @@ function testsFromArtifact({ core }, shortJobName) {
   return [...failed];
 }
 
-// Fallback source. Returns null if the log could not be read at all, which the caller counts so
-// that a systemic failure is reported rather than silently degrading.
+// null distinguishes "could not read" from "read it, found nothing", which the caller counts.
 async function testsFromLog({ github, context, core }, job) {
   try {
     const res = await github.rest.actions.downloadJobLogsForWorkflowRun({
@@ -124,12 +111,9 @@ async function testsFromLog({ github, context, core }, job) {
   }
 }
 
-// One key per thing worth tracking: a test name where one could be found, otherwise job and
-// step so that infrastructure failures are still recorded.
-//
-// Only attempt 1 is read. A re-run overwrites the visible conclusion, so attempt 1 is what makes
-// the failure rate honest; failures unique to a later attempt are not recorded, which has not
-// happened once in the run history to date.
+// A test name where one could be found, otherwise job and step so infrastructure failures are
+// still recorded. Attempt 1 only: a re-run overwrites the visible conclusion, so attempt 1 is
+// what keeps the failure rate honest.
 async function keysForRun({ github, context, core }, run_id) {
   const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
     owner: context.repo.owner,
@@ -168,26 +152,22 @@ async function keysForRun({ github, context, core }, run_id) {
         keys.set(test, { where: `\`${shortName}\`, step \`${steps.join("`, `")}\``, degraded: false });
       }
     } else {
-      keys.set(`${shortName} - ${steps[0] || job.conclusion}`, {
-        where: `\`${shortName}\``,
-        degraded,
-      });
+      keys.set(`${shortName} - ${steps[0] || job.conclusion}`, { where: `\`${shortName}\``, degraded });
     }
   }
 
+  // Naming the test is the point of this job, so losing every source must not look like success.
   if (logsAttempted > 0 && logsFailed === logsAttempted) {
     core.warning(
       `Could not read any of the ${logsAttempted} test job logs for run ${run_id}, and no .trx ` +
-      `artifacts were available either. Test names are missing from the issues below. Check that ` +
-      `this workflow still has actions: read, and that the run is inside its 90-day retention.`);
+      `artifacts were available either. Check actions: read, and the 90-day retention.`);
   }
 
   return keys;
 }
 
-// Listing by label is strongly consistent; the search API is not, and would double-file when two
-// runs fail close together. Match on the body marker or the title, so that a human editing
-// either one does not cause a duplicate.
+// Listing by label is strongly consistent; /search/issues is not, and would double-file. Match
+// on marker or title so a human editing either does not cause a duplicate.
 async function existingIssues({ github, context }) {
   const issues = await github.paginate(github.rest.issues.listForRepo, {
     owner: context.repo.owner,
@@ -225,7 +205,6 @@ module.exports = async ({ github, context, core }, run_id) => {
   const existing = await existingIssues({ github, context });
 
   for (const [key, { where, degraded }] of keys) {
-    // Say so in the issue, not only in a log nobody reads, when the test name is missing.
     const note = degraded
       ? "\n\nThe failing test could not be identified: no `.trx` artifact was available and the " +
         "job log could not be read. Only the job and step are recorded."
@@ -239,9 +218,8 @@ module.exports = async ({ github, context, core }, run_id) => {
         title: titleFor(key, 1),
         body:
           `${body}\n\n` +
-          `Opened automatically because the nightly build failed. The name above is taken from the ` +
-          `run's test results, which expire after 90 days, so it is recorded here while it still ` +
-          `exists.\n\n` +
+          `Opened automatically because the nightly build failed. The name above comes from the ` +
+          `run's test results, which expire after 90 days.\n\n` +
           `Further occurrences are added as comments and counted in the title. Closing this as ` +
           `"not planned" stops it being reopened; closing it as completed does not, so a ` +
           `recurrence after a fix still surfaces.\n\n` +
@@ -251,7 +229,7 @@ module.exports = async ({ github, context, core }, run_id) => {
       continue;
     }
 
-    // Re-running this workflow for the same run must not double-count.
+    // Makes re-dispatching for the same run a no-op.
     const comments = await github.paginate(github.rest.issues.listComments, {
       owner, repo, issue_number: issue.number, per_page: 100,
     });
@@ -266,9 +244,7 @@ module.exports = async ({ github, context, core }, run_id) => {
       owner, repo, issue_number: issue.number,
       title: titleFor(key, countFromTitle(issue.title) + 1),
     };
-    // Reopen so the occurrence is visible - unless a human closed it as "not planned", which is
-    // GitHub's own way of saying they have decided against it. Closed as completed is different:
-    // a recurrence means the fix did not hold, so that should reopen.
+    // Closed as "not planned" is a decision; closed as completed means a fix that did not hold.
     if (!(issue.state === "closed" && issue.state_reason === "not_planned")) {
       update.state = "open";
     }

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -8,8 +8,7 @@ const LABEL = "nightly-flake";
 const TITLE_PREFIX = "nightly flake: ";
 const RESULTS_DIR = "test-results";
 
-// Which steps run tests. Used only to tell "this job failed before testing" from "this job's
-// tests failed but left no results behind", which are worth reporting differently.
+// Distinguishes a job that failed before testing from one whose tests failed silently.
 const TEST_STEP = /^Run integration tests/;
 
 const marker = key => `<!-- nightly-flake-key: ${key} -->`;
@@ -66,11 +65,8 @@ function failedTestsInTrx(xml) {
   return names;
 }
 
-// `--logger trx` is an explicit contract in the test workflow, so this is the only source. There
-// was a second one that scraped test names out of xUnit's console output, dropped because it
-// duplicated this for a case that has never happened: every upload-artifact failure in the run
-// history so far came after the tests had passed, so there was no failing test to recover, and
-// logs expire on the same 90-day clock as artifacts so it could not help an aged-out run either.
+// The only source of test names. `--logger trx` is a contract in the test workflow; xUnit's
+// console output is not.
 function failedTestsFor({ core }, shortJobName) {
   const name = artifactNameFor(shortJobName);
   if (!name) {
@@ -89,9 +85,8 @@ function failedTestsFor({ core }, shortJobName) {
   return [...failed];
 }
 
-// A test name where the results named one, otherwise job and step so that infrastructure
-// failures are still recorded. Attempt 1 only: a re-run overwrites the visible conclusion, so
-// attempt 1 is what keeps the failure rate honest.
+// A test name where the results named one, otherwise job and step. Attempt 1 only: a re-run
+// overwrites the visible conclusion, so attempt 1 is what keeps the failure rate honest.
 async function keysForRun({ github, context, core }, run_id) {
   const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
     owner: context.repo.owner,
@@ -111,8 +106,7 @@ async function keysForRun({ github, context, core }, run_id) {
     const shortName = job.name.split(" / ").pop();
     const tests = failedTestsFor({ core }, shortName);
 
-    // The same test can fail in more than one job on one night - JsonLogger.dfy has failed on
-    // both the Windows and macOS shard 6 - so collect jobs per key rather than overwriting.
+    // One test can fail in several jobs, so collect jobs per key rather than overwriting.
     const add = (key, unexplained) => {
       const entry = keys.get(key) || { jobs: [], unexplained: false };
       entry.jobs.push(`\`${shortName}\``);
@@ -121,14 +115,12 @@ async function keysForRun({ github, context, core }, run_id) {
     };
 
     if (tests.length > 0) {
-      // No step is named: the failing step may be something later, like the artifact upload,
-      // which did not cause the test failure.
+      // No step: the failing step may be a later one that did not cause the test failure.
       for (const test of tests) {
         add(test, false);
       }
     } else {
-      // A test step failed yet the results name nothing. Rare, and worth flagging in the issue
-      // so whoever reads it knows to open the log rather than assuming there was no test.
+      // Flag a test step that failed without naming a test, so the reader checks the log.
       add(`${shortName} - ${steps[0] || job.conclusion}`, steps.some(s => TEST_STEP.test(s)));
     }
   }
@@ -210,8 +202,7 @@ module.exports = async ({ github, context, core }, run_id) => {
 
     await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
 
-    // Count occurrences from the comments rather than from the title, which anyone may rename.
-    // One for the original report in the body, plus one per run recorded since.
+    // From the comments, not the title, which anyone may rename: the body plus one per run.
     const occurrences = 2 + comments.filter(c => /\/actions\/runs\/\d+/.test(c.body)).length;
     const update = {
       owner, repo, issue_number: issue.number,

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -21,11 +21,6 @@ function titleFor(key, count) {
   return `${TITLE_PREFIX}${key}` + (count > 1 ? ` (${count}x)` : "");
 }
 
-function countFromTitle(title) {
-  const m = /\((\d+)x\)\s*$/.exec(title);
-  return m ? parseInt(m[1], 10) : 1;
-}
-
 function keyFromTitle(title) {
   return title.startsWith(TITLE_PREFIX)
     ? title.slice(TITLE_PREFIX.length).replace(/\s*\(\d+x\)\s*$/, "")
@@ -147,12 +142,23 @@ async function keysForRun({ github, context, core }, run_id) {
       }
     }
 
+    // The same test can fail in more than one job on one night - JsonLogger.dfy has failed on
+    // both the Windows and macOS shard 6 - so collect jobs per key rather than overwriting.
+    // No step is named for a test that came from a .trx: the failing step may be something
+    // later like the artifact upload, which did not cause the test failure.
+    const add = (key, job) => {
+      const entry = keys.get(key) || { jobs: [], degraded: false };
+      entry.jobs.push(job);
+      entry.degraded = entry.degraded || degraded;
+      keys.set(key, entry);
+    };
+
     if (tests && tests.length > 0) {
       for (const test of tests) {
-        keys.set(test, { where: `\`${shortName}\`, step \`${steps.join("`, `")}\``, degraded: false });
+        add(test, `\`${shortName}\``);
       }
     } else {
-      keys.set(`${shortName} - ${steps[0] || job.conclusion}`, { where: `\`${shortName}\``, degraded });
+      add(`${shortName} - ${steps[0] || job.conclusion}`, `\`${shortName}\``);
     }
   }
 
@@ -204,12 +210,12 @@ module.exports = async ({ github, context, core }, run_id) => {
 
   const existing = await existingIssues({ github, context });
 
-  for (const [key, { where, degraded }] of keys) {
+  for (const [key, { jobs, degraded }] of keys) {
     const note = degraded
       ? "\n\nThe failing test could not be identified: no `.trx` artifact was available and the " +
         "job log could not be read. Only the job and step are recorded."
       : "";
-    const body = `Failed in ${where} during ${runUrl} (attempt 1).${note}`;
+    const body = `Failed in ${jobs.join(", ")} during ${runUrl} (attempt 1).${note}`;
     const issue = existing.get(key);
 
     if (!issue) {
@@ -240,9 +246,12 @@ module.exports = async ({ github, context, core }, run_id) => {
 
     await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
 
+    // Count occurrences from the comments rather than from the title, which anyone may rename.
+    // One for the original report in the body, plus one per run recorded since.
+    const occurrences = 2 + comments.filter(c => /\/actions\/runs\/\d+/.test(c.body)).length;
     const update = {
       owner, repo, issue_number: issue.number,
-      title: titleFor(key, countFromTitle(issue.title) + 1),
+      title: titleFor(key, occurrences),
     };
     // Closed as "not planned" is a decision; closed as completed means a fix that did not hold.
     if (!(issue.state === "closed" && issue.state_reason === "not_planned")) {

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -69,8 +69,10 @@ function failedTestsInTrx(xml) {
   return names;
 }
 
-// Preferred source: `--logger trx` is an explicit contract in the test workflow. null means
-// there is no .trx for this job, which is normal - the upload is best effort.
+// Preferred source: `--logger trx` is an explicit contract in the test workflow. null means no
+// .trx was found, which is expected for a job that never ran tests (publish-release, or a test
+// job that died in setup), and possible for a real test job if the upload was skipped or the
+// artifact has aged out.
 function testsFromArtifact({ core }, shortJobName) {
   const name = artifactNameFor(shortJobName);
   if (!name) {
@@ -132,7 +134,9 @@ async function keysForRun({ github, context, core }, run_id) {
     let tests = testsFromArtifact({ core }, shortName);
     let degraded = false;
 
-    if (tests === null && steps.some(s => TEST_STEP.test(s))) {
+    // Fall back to the log when a test step failed but the .trx does not account for it: either
+    // there is no .trx, or it names no failure, which means it was never finished being written.
+    if ((tests === null || tests.length === 0) && steps.some(s => TEST_STEP.test(s))) {
       logsAttempted++;
       tests = await testsFromLog({ github, context, core }, job);
       if (tests === null) {

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -8,9 +8,19 @@ const LABEL = "nightly-flake";
 const TITLE_PREFIX = "nightly flake: ";
 const FAILED_TEST = /([A-Za-z0-9_./-]+\.dfy) \[FAIL\]/g;
 
-// A failing step whose name matches this is infrastructure, not a test, so there is no test
-// name to look for in the log.
-const NOT_A_TEST_STEP = /^(Set up job|Run actions\/|Post |Create release|Install |Setup |Upload )/;
+// Only these steps run tests, so only these have a test name to find in the log. An allowlist
+// rather than a list of infrastructure steps to skip: new setup steps get added to these
+// workflows regularly, and the failure mode of a stale allowlist (no test name, fall back to
+// job+step) is much kinder than that of a stale denylist (download every log for nothing).
+const TEST_STEP = /^Run integration tests/;
+
+// Human triage wins: if someone has closed an issue with one of these, keep recording
+// occurrences but do not reopen it.
+const NO_REOPEN_LABELS = ["wontfix", "known-flake"];
+
+// Dedupe on a marker in the body, not on the title. Titles are human-editable and this script
+// rewrites them to carry the count, so the two would fight.
+const marker = key => `<!-- nightly-flake-key: ${key} -->`;
 
 function titleFor(key, count) {
   return `${TITLE_PREFIX}${key}` + (count > 1 ? ` (${count}x)` : "");
@@ -21,18 +31,14 @@ function countFromTitle(title) {
   return m ? parseInt(m[1], 10) : 1;
 }
 
-function keyFor(title) {
-  return title.slice(TITLE_PREFIX.length).replace(/\s*\(\d+x\)\s*$/, "");
-}
-
 function failingStepsOf(job) {
   return (job.steps || [])
     .filter(s => s.conclusion === "failure" || s.conclusion === "timed_out")
     .map(s => s.name);
 }
 
-// The test names in a job log, or [] if the log has expired or cannot be read. A missing log
-// must never fail this workflow: the fallback key is still useful.
+// The test names in a job log. Returns null if the log could not be read, which is different
+// from "read it and found no test": the caller counts those to spot a systemic problem.
 async function testsInLog({ github, context, core }, job) {
   try {
     const res = await github.rest.actions.downloadJobLogsForWorkflowRun({
@@ -44,14 +50,18 @@ async function testsInLog({ github, context, core }, job) {
     return [...new Set([...text.matchAll(FAILED_TEST)].map(m => m[1]))];
   } catch (e) {
     core.warning(`could not read the log for job ${job.id} (${job.name}): ${e.message}`);
-    return [];
+    return null;
   }
 }
 
 // One key per thing worth tracking: a test name where we could find one, otherwise the job and
 // step, so that infrastructure failures are still recorded.
+//
+// Only attempt 1 is read. A re-run overwrites the visible conclusion, so attempt 1 is what makes
+// the failure rate honest; failures unique to a later attempt are not recorded, which has not
+// happened once in the run history to date.
 async function keysForRun({ github, context, core }, run_id) {
-  const { data } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+  const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
     owner: context.repo.owner,
     repo: context.repo.repo,
     run_id,
@@ -60,23 +70,44 @@ async function keysForRun({ github, context, core }, run_id) {
   });
 
   const keys = new Map();
-  for (const job of data.jobs) {
+  let logsAttempted = 0;
+  let logsFailed = 0;
+
+  for (const job of jobs) {
     if (job.conclusion !== "failure" && job.conclusion !== "timed_out") {
       continue;
     }
     const steps = failingStepsOf(job);
     const shortName = job.name.split(" / ").pop();
-    const infrastructure = steps.length > 0 && steps.every(s => NOT_A_TEST_STEP.test(s));
 
-    const tests = infrastructure ? [] : await testsInLog({ github, context, core }, job);
+    let tests = [];
+    if (steps.some(s => TEST_STEP.test(s))) {
+      logsAttempted++;
+      tests = await testsInLog({ github, context, core }, job);
+      if (tests === null) {
+        logsFailed++;
+        tests = [];
+      }
+    }
+
     if (tests.length > 0) {
       for (const test of tests) {
-        keys.set(test, `\`${shortName}\`, step \`${steps.join("`, `") || "unknown"}\``);
+        keys.set(test, `\`${shortName}\`, step \`${steps.join("`, `")}\``);
       }
     } else {
       keys.set(`${shortName} - ${steps[0] || job.conclusion}`, `\`${shortName}\``);
     }
   }
+
+  // Reading the log is the whole point of this job, so a total failure must be loud rather than
+  // quietly degrading to job+step keys that look like a successful run.
+  if (logsAttempted > 0 && logsFailed === logsAttempted) {
+    core.warning(
+      `Could not read any of the ${logsAttempted} test job logs for run ${run_id}. Test names ` +
+      `will be missing from the issues below. Check that this workflow still has actions: read ` +
+      `and that the logs have not passed their 90-day retention.`);
+  }
+
   return keys;
 }
 
@@ -92,14 +123,19 @@ async function existingIssues({ github, context }) {
   });
   const byKey = new Map();
   for (const issue of issues) {
-    if (issue.title.startsWith(TITLE_PREFIX)) {
-      byKey.set(keyFor(issue.title), issue);
+    const m = /<!-- nightly-flake-key: (.*?) -->/.exec(issue.body || "");
+    if (m) {
+      byKey.set(m[1], issue);
     }
   }
   return byKey;
 }
 
 module.exports = async ({ github, context, core }, run_id) => {
+  if (!Number.isInteger(run_id) || run_id <= 0) {
+    throw new Error(`not a workflow run id: ${JSON.stringify(run_id)}`);
+  }
+
   const { owner, repo } = context.repo;
   const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run_id}`;
   const keys = await keysForRun({ github, context, core }, run_id);
@@ -121,9 +157,11 @@ module.exports = async ({ github, context, core }, run_id) => {
         title: titleFor(key, 1),
         body:
           `${body}\n\n` +
-          `Opened automatically because the nightly build failed. The test name above comes from ` +
-          `the job log, which expires after 90 days, so it is recorded here while it still exists.\n\n` +
-          `Further occurrences are added as comments and counted in the title.`,
+          `Opened automatically because the nightly build failed. The name above comes from the ` +
+          `job log, which expires after 90 days, so it is recorded here while it still exists.\n\n` +
+          `Further occurrences are added as comments and counted in the title. Close this with ` +
+          `\`${NO_REOPEN_LABELS.join("` or `")}\` to stop it being reopened.\n\n` +
+          marker(key),
       });
       core.info(`opened #${created.data.number} for ${key}`);
       continue;
@@ -139,12 +177,18 @@ module.exports = async ({ github, context, core }, run_id) => {
     }
 
     await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
-    // Bump the count in the title, and reopen: a comment on a closed issue is easy to miss.
-    await github.rest.issues.update({
+
+    const labels = (issue.labels || []).map(l => (typeof l === "string" ? l : l.name));
+    const declined = labels.some(l => NO_REOPEN_LABELS.includes(l));
+    const update = {
       owner, repo, issue_number: issue.number,
       title: titleFor(key, countFromTitle(issue.title) + 1),
-      state: "open",
-    });
-    core.info(`updated #${issue.number} for ${key}`);
+    };
+    // Reopen so the occurrence is visible, unless a human has deliberately closed it.
+    if (!declined) {
+      update.state = "open";
+    }
+    await github.rest.issues.update(update);
+    core.info(`updated #${issue.number} for ${key}${declined ? " (left closed)" : ""}`);
   }
 };

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -1,25 +1,29 @@
 // Turn a failed nightly run into a deduplicated issue naming the test that failed.
 //
-// Failing job and step names survive in the API for about a year, but the *test* name only
-// exists in the job log, which expires after 90 days. Recovering it later is disproportionately
-// hard, so grab it while it is still there.
+// Failing job and step names survive in the API for about a year, but the failing *test* name
+// only exists in the run's own output, which expires after 90 days. Recovering it later is
+// disproportionately hard, so record it while it is still there.
+
+const fs = require("fs");
+const path = require("path");
 
 const LABEL = "nightly-flake";
 const TITLE_PREFIX = "nightly flake: ";
-const FAILED_TEST = /([A-Za-z0-9_./-]+\.dfy) \[FAIL\]/g;
 
-// Only these steps run tests, so only these have a test name to find in the log. An allowlist
-// rather than a list of infrastructure steps to skip: new setup steps get added to these
-// workflows regularly, and the failure mode of a stale allowlist (no test name, fall back to
-// job+step) is much kinder than that of a stale denylist (download every log for nothing).
+// Where the workflow put the run's test-result artifacts, if it managed to download any.
+const RESULTS_DIR = "test-results";
+
+// Fallback only, for when no .trx is available. This parses xUnit's console output, which is a
+// formatting detail of a third-party logger rather than a contract: it depends on `[FAIL]` and
+// on `--logger "console;verbosity=normal"` staying put. The .trx path below is preferred for
+// exactly that reason. Extensions match LitTests.cs's FileData includes.
+const FAILED_TEST_IN_LOG = /([A-Za-z0-9_./-]+\.(?:dfy|transcript)) \[FAIL\]/g;
+
+// Only these steps run tests, so only these are worth fetching a log for. With .trx as the
+// primary source this is just an optimisation - a stale entry costs a wasted lookup, not a
+// misclassification.
 const TEST_STEP = /^Run integration tests/;
 
-// Human triage wins: if someone has closed an issue with one of these, keep recording
-// occurrences but do not reopen it.
-const NO_REOPEN_LABELS = ["wontfix", "known-flake"];
-
-// Dedupe on a marker in the body, not on the title. Titles are human-editable and this script
-// rewrites them to carry the count, so the two would fight.
 const marker = key => `<!-- nightly-flake-key: ${key} -->`;
 
 function titleFor(key, count) {
@@ -31,15 +35,81 @@ function countFromTitle(title) {
   return m ? parseInt(m[1], 10) : 1;
 }
 
+function keyFromTitle(title) {
+  return title.startsWith(TITLE_PREFIX)
+    ? title.slice(TITLE_PREFIX.length).replace(/\s*\(\d+x\)\s*$/, "")
+    : null;
+}
+
 function failingStepsOf(job) {
   return (job.steps || [])
     .filter(s => s.conclusion === "failure" || s.conclusion === "timed_out")
     .map(s => s.name);
 }
 
-// The test names in a job log. Returns null if the log could not be read, which is different
-// from "read it and found no test": the caller counts those to spot a systemic problem.
-async function testsInLog({ github, context, core }, job) {
+// `test (macos-14, 6)` -> `integration-test-results-macos-14-6`, matching the artifact name
+// that integration-tests-reusable.yml uploads.
+function artifactNameFor(shortJobName) {
+  const m = /^test \(([^,]+), *(\d+)\)/.exec(shortJobName);
+  return m ? `integration-test-results-${m[1]}-${m[2]}` : null;
+}
+
+function trxFilesUnder(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  const found = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...trxFilesUnder(full));
+    } else if (entry.name.endsWith(".trx")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+// Failed test names from a .trx. Attributes are read individually rather than in a fixed order,
+// since their order is not part of the format.
+function failedTestsInTrx(xml) {
+  const names = [];
+  for (const element of xml.split("<UnitTestResult").slice(1)) {
+    const head = element.slice(0, element.indexOf(">"));
+    const outcome = /\boutcome="([^"]*)"/.exec(head);
+    const name = /\btestName="([^"]*)"/.exec(head);
+    if (outcome && name && outcome[1] === "Failed") {
+      names.push(name[1]);
+    }
+  }
+  return names;
+}
+
+// The preferred source: `--logger trx` is an explicit contract in the test workflow, the format
+// is structured, and it names tests of any extension. Returns null when there is no .trx for
+// this job, which is not an error: the upload is best-effort and may have been skipped.
+function testsFromArtifact({ core }, shortJobName) {
+  const name = artifactNameFor(shortJobName);
+  if (!name) {
+    return null;
+  }
+  const files = trxFilesUnder(path.join(RESULTS_DIR, name));
+  if (files.length === 0) {
+    return null;
+  }
+  const failed = new Set();
+  for (const file of files) {
+    for (const test of failedTestsInTrx(fs.readFileSync(file, "utf8"))) {
+      failed.add(test);
+    }
+  }
+  core.info(`${shortJobName}: ${failed.size} failed test(s) from ${files.length} .trx file(s)`);
+  return [...failed];
+}
+
+// Fallback source. Returns null if the log could not be read at all, which the caller counts so
+// that a systemic failure is reported rather than silently degrading.
+async function testsFromLog({ github, context, core }, job) {
   try {
     const res = await github.rest.actions.downloadJobLogsForWorkflowRun({
       owner: context.repo.owner,
@@ -47,15 +117,15 @@ async function testsInLog({ github, context, core }, job) {
       job_id: job.id,
     });
     const text = typeof res.data === "string" ? res.data : Buffer.from(res.data).toString("utf8");
-    return [...new Set([...text.matchAll(FAILED_TEST)].map(m => m[1]))];
+    return [...new Set([...text.matchAll(FAILED_TEST_IN_LOG)].map(m => m[1]))];
   } catch (e) {
     core.warning(`could not read the log for job ${job.id} (${job.name}): ${e.message}`);
     return null;
   }
 }
 
-// One key per thing worth tracking: a test name where we could find one, otherwise the job and
-// step, so that infrastructure failures are still recorded.
+// One key per thing worth tracking: a test name where one could be found, otherwise job and
+// step so that infrastructure failures are still recorded.
 //
 // Only attempt 1 is read. A re-run overwrites the visible conclusion, so attempt 1 is what makes
 // the failure rate honest; failures unique to a later attempt are not recorded, which has not
@@ -80,39 +150,44 @@ async function keysForRun({ github, context, core }, run_id) {
     const steps = failingStepsOf(job);
     const shortName = job.name.split(" / ").pop();
 
-    let tests = [];
-    if (steps.some(s => TEST_STEP.test(s))) {
+    let tests = testsFromArtifact({ core }, shortName);
+    let degraded = false;
+
+    if (tests === null && steps.some(s => TEST_STEP.test(s))) {
       logsAttempted++;
-      tests = await testsInLog({ github, context, core }, job);
+      tests = await testsFromLog({ github, context, core }, job);
       if (tests === null) {
         logsFailed++;
+        degraded = true;
         tests = [];
       }
     }
 
-    if (tests.length > 0) {
+    if (tests && tests.length > 0) {
       for (const test of tests) {
-        keys.set(test, `\`${shortName}\`, step \`${steps.join("`, `")}\``);
+        keys.set(test, { where: `\`${shortName}\`, step \`${steps.join("`, `")}\``, degraded: false });
       }
     } else {
-      keys.set(`${shortName} - ${steps[0] || job.conclusion}`, `\`${shortName}\``);
+      keys.set(`${shortName} - ${steps[0] || job.conclusion}`, {
+        where: `\`${shortName}\``,
+        degraded,
+      });
     }
   }
 
-  // Reading the log is the whole point of this job, so a total failure must be loud rather than
-  // quietly degrading to job+step keys that look like a successful run.
   if (logsAttempted > 0 && logsFailed === logsAttempted) {
     core.warning(
-      `Could not read any of the ${logsAttempted} test job logs for run ${run_id}. Test names ` +
-      `will be missing from the issues below. Check that this workflow still has actions: read ` +
-      `and that the logs have not passed their 90-day retention.`);
+      `Could not read any of the ${logsAttempted} test job logs for run ${run_id}, and no .trx ` +
+      `artifacts were available either. Test names are missing from the issues below. Check that ` +
+      `this workflow still has actions: read, and that the run is inside its 90-day retention.`);
   }
 
   return keys;
 }
 
-// Listing by label is strongly consistent; the search API is not, and would double-file when
-// two runs fail close together.
+// Listing by label is strongly consistent; the search API is not, and would double-file when two
+// runs fail close together. Match on the body marker or the title, so that a human editing
+// either one does not cause a duplicate.
 async function existingIssues({ github, context }) {
   const issues = await github.paginate(github.rest.issues.listForRepo, {
     owner: context.repo.owner,
@@ -123,9 +198,11 @@ async function existingIssues({ github, context }) {
   });
   const byKey = new Map();
   for (const issue of issues) {
-    const m = /<!-- nightly-flake-key: (.*?) -->/.exec(issue.body || "");
-    if (m) {
-      byKey.set(m[1], issue);
+    const fromBody = /<!-- nightly-flake-key: (.*?) -->/.exec(issue.body || "");
+    for (const key of [fromBody && fromBody[1], keyFromTitle(issue.title)]) {
+      if (key && !byKey.has(key)) {
+        byKey.set(key, issue);
+      }
     }
   }
   return byKey;
@@ -147,8 +224,13 @@ module.exports = async ({ github, context, core }, run_id) => {
 
   const existing = await existingIssues({ github, context });
 
-  for (const [key, where] of keys) {
-    const body = `Failed in ${where} during ${runUrl} (attempt 1).`;
+  for (const [key, { where, degraded }] of keys) {
+    // Say so in the issue, not only in a log nobody reads, when the test name is missing.
+    const note = degraded
+      ? "\n\nThe failing test could not be identified: no `.trx` artifact was available and the " +
+        "job log could not be read. Only the job and step are recorded."
+      : "";
+    const body = `Failed in ${where} during ${runUrl} (attempt 1).${note}`;
     const issue = existing.get(key);
 
     if (!issue) {
@@ -157,10 +239,12 @@ module.exports = async ({ github, context, core }, run_id) => {
         title: titleFor(key, 1),
         body:
           `${body}\n\n` +
-          `Opened automatically because the nightly build failed. The name above comes from the ` +
-          `job log, which expires after 90 days, so it is recorded here while it still exists.\n\n` +
-          `Further occurrences are added as comments and counted in the title. Close this with ` +
-          `\`${NO_REOPEN_LABELS.join("` or `")}\` to stop it being reopened.\n\n` +
+          `Opened automatically because the nightly build failed. The name above is taken from the ` +
+          `run's test results, which expire after 90 days, so it is recorded here while it still ` +
+          `exists.\n\n` +
+          `Further occurrences are added as comments and counted in the title. Closing this as ` +
+          `"not planned" stops it being reopened; closing it as completed does not, so a ` +
+          `recurrence after a fix still surfaces.\n\n` +
           marker(key),
       });
       core.info(`opened #${created.data.number} for ${key}`);
@@ -178,17 +262,17 @@ module.exports = async ({ github, context, core }, run_id) => {
 
     await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
 
-    const labels = (issue.labels || []).map(l => (typeof l === "string" ? l : l.name));
-    const declined = labels.some(l => NO_REOPEN_LABELS.includes(l));
     const update = {
       owner, repo, issue_number: issue.number,
       title: titleFor(key, countFromTitle(issue.title) + 1),
     };
-    // Reopen so the occurrence is visible, unless a human has deliberately closed it.
-    if (!declined) {
+    // Reopen so the occurrence is visible - unless a human closed it as "not planned", which is
+    // GitHub's own way of saying they have decided against it. Closed as completed is different:
+    // a recurrence means the fix did not hold, so that should reopen.
+    if (!(issue.state === "closed" && issue.state_reason === "not_planned")) {
       update.state = "open";
     }
     await github.rest.issues.update(update);
-    core.info(`updated #${issue.number} for ${key}${declined ? " (left closed)" : ""}`);
+    core.info(`updated #${issue.number} for ${key}`);
   }
 };

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -1,5 +1,5 @@
 // Record which test failed when the nightly build goes red, into one issue per test.
-// The failing test's name only exists in the run's own output, which expires after 90 days.
+// The failing test's name only exists in the run's test results, which expire after 90 days.
 
 const fs = require("fs");
 const path = require("path");
@@ -8,11 +8,8 @@ const LABEL = "nightly-flake";
 const TITLE_PREFIX = "nightly flake: ";
 const RESULTS_DIR = "test-results";
 
-// Fallback only: this is xUnit console formatting, not a contract. Extensions match the
-// FileData includes in LitTests.cs.
-const FAILED_TEST_IN_LOG = /([A-Za-z0-9_./-]+\.(?:dfy|transcript)) \[FAIL\]/g;
-
-// Which steps are worth fetching a log for. Only an optimisation, since .trx comes first.
+// Which steps run tests. Used only to tell "this job failed before testing" from "this job's
+// tests failed but left no results behind", which are worth reporting differently.
 const TEST_STEP = /^Run integration tests/;
 
 const marker = key => `<!-- nightly-flake-key: ${key} -->`;
@@ -69,48 +66,32 @@ function failedTestsInTrx(xml) {
   return names;
 }
 
-// Preferred source: `--logger trx` is an explicit contract in the test workflow. null means no
-// .trx was found, which is expected for a job that never ran tests (publish-release, or a test
-// job that died in setup), and possible for a real test job if the upload was skipped or the
-// artifact has aged out.
-function testsFromArtifact({ core }, shortJobName) {
+// `--logger trx` is an explicit contract in the test workflow, so this is the only source. There
+// was a second one that scraped test names out of xUnit's console output, dropped because it
+// duplicated this for a case that has never happened: every upload-artifact failure in the run
+// history so far came after the tests had passed, so there was no failing test to recover, and
+// logs expire on the same 90-day clock as artifacts so it could not help an aged-out run either.
+function failedTestsFor({ core }, shortJobName) {
   const name = artifactNameFor(shortJobName);
   if (!name) {
-    return null;
+    return [];
   }
   const files = trxFilesUnder(path.join(RESULTS_DIR, name));
-  if (files.length === 0) {
-    return null;
-  }
   const failed = new Set();
   for (const file of files) {
     for (const test of failedTestsInTrx(fs.readFileSync(file, "utf8"))) {
       failed.add(test);
     }
   }
-  core.info(`${shortJobName}: ${failed.size} failed test(s) from ${files.length} .trx file(s)`);
+  if (files.length > 0) {
+    core.info(`${shortJobName}: ${failed.size} failed test(s) from ${files.length} .trx file(s)`);
+  }
   return [...failed];
 }
 
-// null distinguishes "could not read" from "read it, found nothing", which the caller counts.
-async function testsFromLog({ github, context, core }, job) {
-  try {
-    const res = await github.rest.actions.downloadJobLogsForWorkflowRun({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      job_id: job.id,
-    });
-    const text = typeof res.data === "string" ? res.data : Buffer.from(res.data).toString("utf8");
-    return [...new Set([...text.matchAll(FAILED_TEST_IN_LOG)].map(m => m[1]))];
-  } catch (e) {
-    core.warning(`could not read the log for job ${job.id} (${job.name}): ${e.message}`);
-    return null;
-  }
-}
-
-// A test name where one could be found, otherwise job and step so infrastructure failures are
-// still recorded. Attempt 1 only: a re-run overwrites the visible conclusion, so attempt 1 is
-// what keeps the failure rate honest.
+// A test name where the results named one, otherwise job and step so that infrastructure
+// failures are still recorded. Attempt 1 only: a re-run overwrites the visible conclusion, so
+// attempt 1 is what keeps the failure rate honest.
 async function keysForRun({ github, context, core }, run_id) {
   const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
     owner: context.repo.owner,
@@ -121,8 +102,6 @@ async function keysForRun({ github, context, core }, run_id) {
   });
 
   const keys = new Map();
-  let logsAttempted = 0;
-  let logsFailed = 0;
 
   for (const job of jobs) {
     if (job.conclusion !== "failure" && job.conclusion !== "timed_out") {
@@ -130,47 +109,28 @@ async function keysForRun({ github, context, core }, run_id) {
     }
     const steps = failingStepsOf(job);
     const shortName = job.name.split(" / ").pop();
-
-    let tests = testsFromArtifact({ core }, shortName);
-    let degraded = false;
-
-    // Fall back to the log when a test step failed but the .trx does not account for it: either
-    // there is no .trx, or it names no failure, which means it was never finished being written.
-    if ((tests === null || tests.length === 0) && steps.some(s => TEST_STEP.test(s))) {
-      logsAttempted++;
-      tests = await testsFromLog({ github, context, core }, job);
-      if (tests === null) {
-        logsFailed++;
-        degraded = true;
-        tests = [];
-      }
-    }
+    const tests = failedTestsFor({ core }, shortName);
 
     // The same test can fail in more than one job on one night - JsonLogger.dfy has failed on
     // both the Windows and macOS shard 6 - so collect jobs per key rather than overwriting.
-    // No step is named for a test that came from a .trx: the failing step may be something
-    // later like the artifact upload, which did not cause the test failure.
-    const add = (key, job) => {
-      const entry = keys.get(key) || { jobs: [], degraded: false };
-      entry.jobs.push(job);
-      entry.degraded = entry.degraded || degraded;
+    const add = (key, unexplained) => {
+      const entry = keys.get(key) || { jobs: [], unexplained: false };
+      entry.jobs.push(`\`${shortName}\``);
+      entry.unexplained = entry.unexplained || unexplained;
       keys.set(key, entry);
     };
 
-    if (tests && tests.length > 0) {
+    if (tests.length > 0) {
+      // No step is named: the failing step may be something later, like the artifact upload,
+      // which did not cause the test failure.
       for (const test of tests) {
-        add(test, `\`${shortName}\``);
+        add(test, false);
       }
     } else {
-      add(`${shortName} - ${steps[0] || job.conclusion}`, `\`${shortName}\``);
+      // A test step failed yet the results name nothing. Rare, and worth flagging in the issue
+      // so whoever reads it knows to open the log rather than assuming there was no test.
+      add(`${shortName} - ${steps[0] || job.conclusion}`, steps.some(s => TEST_STEP.test(s)));
     }
-  }
-
-  // Naming the test is the point of this job, so losing every source must not look like success.
-  if (logsAttempted > 0 && logsFailed === logsAttempted) {
-    core.warning(
-      `Could not read any of the ${logsAttempted} test job logs for run ${run_id}, and no .trx ` +
-      `artifacts were available either. Check actions: read, and the 90-day retention.`);
   }
 
   return keys;
@@ -214,10 +174,10 @@ module.exports = async ({ github, context, core }, run_id) => {
 
   const existing = await existingIssues({ github, context });
 
-  for (const [key, { jobs, degraded }] of keys) {
-    const note = degraded
-      ? "\n\nThe failing test could not be identified: no `.trx` artifact was available and the " +
-        "job log could not be read. Only the job and step are recorded."
+  for (const [key, { jobs, unexplained }] of keys) {
+    const note = unexplained
+      ? "\n\nThe tests failed but left no results behind, so the failing test is not named here. " +
+        "The job log for that run will say which it was."
       : "";
     const body = `Failed in ${jobs.join(", ")} during ${runUrl} (attempt 1).${note}`;
     const issue = existing.get(key);

--- a/.github/workflows/nightly-flake-triage.js
+++ b/.github/workflows/nightly-flake-triage.js
@@ -1,0 +1,150 @@
+// Turn a failed nightly run into a deduplicated issue naming the test that failed.
+//
+// Failing job and step names survive in the API for about a year, but the *test* name only
+// exists in the job log, which expires after 90 days. Recovering it later is disproportionately
+// hard, so grab it while it is still there.
+
+const LABEL = "nightly-flake";
+const TITLE_PREFIX = "nightly flake: ";
+const FAILED_TEST = /([A-Za-z0-9_./-]+\.dfy) \[FAIL\]/g;
+
+// A failing step whose name matches this is infrastructure, not a test, so there is no test
+// name to look for in the log.
+const NOT_A_TEST_STEP = /^(Set up job|Run actions\/|Post |Create release|Install |Setup |Upload )/;
+
+function titleFor(key, count) {
+  return `${TITLE_PREFIX}${key}` + (count > 1 ? ` (${count}x)` : "");
+}
+
+function countFromTitle(title) {
+  const m = /\((\d+)x\)\s*$/.exec(title);
+  return m ? parseInt(m[1], 10) : 1;
+}
+
+function keyFor(title) {
+  return title.slice(TITLE_PREFIX.length).replace(/\s*\(\d+x\)\s*$/, "");
+}
+
+function failingStepsOf(job) {
+  return (job.steps || [])
+    .filter(s => s.conclusion === "failure" || s.conclusion === "timed_out")
+    .map(s => s.name);
+}
+
+// The test names in a job log, or [] if the log has expired or cannot be read. A missing log
+// must never fail this workflow: the fallback key is still useful.
+async function testsInLog({ github, context, core }, job) {
+  try {
+    const res = await github.rest.actions.downloadJobLogsForWorkflowRun({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      job_id: job.id,
+    });
+    const text = typeof res.data === "string" ? res.data : Buffer.from(res.data).toString("utf8");
+    return [...new Set([...text.matchAll(FAILED_TEST)].map(m => m[1]))];
+  } catch (e) {
+    core.warning(`could not read the log for job ${job.id} (${job.name}): ${e.message}`);
+    return [];
+  }
+}
+
+// One key per thing worth tracking: a test name where we could find one, otherwise the job and
+// step, so that infrastructure failures are still recorded.
+async function keysForRun({ github, context, core }, run_id) {
+  const { data } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id,
+    attempt_number: 1,
+    per_page: 100,
+  });
+
+  const keys = new Map();
+  for (const job of data.jobs) {
+    if (job.conclusion !== "failure" && job.conclusion !== "timed_out") {
+      continue;
+    }
+    const steps = failingStepsOf(job);
+    const shortName = job.name.split(" / ").pop();
+    const infrastructure = steps.length > 0 && steps.every(s => NOT_A_TEST_STEP.test(s));
+
+    const tests = infrastructure ? [] : await testsInLog({ github, context, core }, job);
+    if (tests.length > 0) {
+      for (const test of tests) {
+        keys.set(test, `\`${shortName}\`, step \`${steps.join("`, `") || "unknown"}\``);
+      }
+    } else {
+      keys.set(`${shortName} - ${steps[0] || job.conclusion}`, `\`${shortName}\``);
+    }
+  }
+  return keys;
+}
+
+// Listing by label is strongly consistent; the search API is not, and would double-file when
+// two runs fail close together.
+async function existingIssues({ github, context }) {
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    labels: LABEL,
+    state: "all",
+    per_page: 100,
+  });
+  const byKey = new Map();
+  for (const issue of issues) {
+    if (issue.title.startsWith(TITLE_PREFIX)) {
+      byKey.set(keyFor(issue.title), issue);
+    }
+  }
+  return byKey;
+}
+
+module.exports = async ({ github, context, core }, run_id) => {
+  const { owner, repo } = context.repo;
+  const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${run_id}`;
+  const keys = await keysForRun({ github, context, core }, run_id);
+
+  if (keys.size === 0) {
+    core.info(`No failing jobs on attempt 1 of ${run_id}; nothing to triage.`);
+    return;
+  }
+
+  const existing = await existingIssues({ github, context });
+
+  for (const [key, where] of keys) {
+    const body = `Failed in ${where} during ${runUrl} (attempt 1).`;
+    const issue = existing.get(key);
+
+    if (!issue) {
+      const created = await github.rest.issues.create({
+        owner, repo, labels: [LABEL],
+        title: titleFor(key, 1),
+        body:
+          `${body}\n\n` +
+          `Opened automatically because the nightly build failed. The test name above comes from ` +
+          `the job log, which expires after 90 days, so it is recorded here while it still exists.\n\n` +
+          `Further occurrences are added as comments and counted in the title.`,
+      });
+      core.info(`opened #${created.data.number} for ${key}`);
+      continue;
+    }
+
+    // Re-running this workflow for the same run must not double-count.
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner, repo, issue_number: issue.number, per_page: 100,
+    });
+    if (comments.some(c => c.body.includes(runUrl))) {
+      core.info(`#${issue.number} already records ${runUrl}; skipping`);
+      continue;
+    }
+
+    await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body });
+    // Bump the count in the title, and reopen: a comment on a closed issue is easy to miss.
+    await github.rest.issues.update({
+      owner, repo, issue_number: issue.number,
+      title: titleFor(key, countFromTitle(issue.title) + 1),
+      state: "open",
+    });
+    core.info(`updated #${issue.number} for ${key}`);
+  }
+};

--- a/.github/workflows/nightly-flake-triage.yml
+++ b/.github/workflows/nightly-flake-triage.yml
@@ -1,12 +1,12 @@
 # Record which test failed when the nightly build goes red.
 #
 # Job and step names stay in the API for about a year, but the failing test's name lives only in
-# the job log, which expires after 90 days. This captures it while it exists, into an issue per
-# test so repeat offenders accumulate a count instead of vanishing.
+# the run's own output, which expires after 90 days. This captures it while it exists, into an
+# issue per test so repeat offenders accumulate a count instead of vanishing.
 #
 # Note `workflow_run` only ever runs the copy of this file on the default branch, so it cannot be
 # exercised from a pull request. Use the `workflow_dispatch` below against a past failed run to
-# try it out, or to backfill runs still inside the log retention window.
+# try it out, or to backfill runs still inside the retention window.
 
 name: Nightly flake triage
 
@@ -19,6 +19,7 @@ on:
       run_id:
         description: 'Workflow run ID to triage'
         required: true
+        type: number
 
 jobs:
   triage:
@@ -26,21 +27,31 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'success'
     runs-on: ubuntu-24.04
     permissions:
-      actions: read     # list jobs for the run, and download job logs
+      actions: read     # list jobs for the run, read its artifacts, download job logs
       issues: write     # open, comment on and reopen the flake issues
       contents: read
+    env:
+      TRIAGE_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
     steps:
       - name: Checkout Dafny
         uses: actions/checkout@v7
 
+      # Preferred source for the failing test names: `--logger trx` is an explicit contract in
+      # integration-tests-reusable.yml, where xUnit's console formatting is only incidental.
+      # Best-effort - the upload is itself allowed to fail, and old runs may have expired.
+      - name: Download the run's test results
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          run-id: ${{ env.TRIAGE_RUN_ID }}
+          github-token: ${{ github.token }}
+          pattern: integration-test-results-*
+          path: test-results
+
       - uses: actions/github-script@v9
-        env:
-          # Passed through the environment, not interpolated into the script below: `script:` is
-          # JavaScript source, and a workflow_dispatch input is arbitrary text.
-          DISPATCHED_RUN_ID: ${{ inputs.run_id }}
         with:
           script: |
             const triage = require('${{ github.workspace }}/.github/workflows/nightly-flake-triage.js')
-            const dispatched = process.env.DISPATCHED_RUN_ID
-            const runId = dispatched ? Number(dispatched) : context.payload.workflow_run.id
-            await triage({github, context, core}, runId)
+            // Read from the environment rather than interpolating into this script, which is
+            // JavaScript source: a workflow_dispatch input is arbitrary text.
+            await triage({github, context, core}, Number(process.env.TRIAGE_RUN_ID))

--- a/.github/workflows/nightly-flake-triage.yml
+++ b/.github/workflows/nightly-flake-triage.yml
@@ -11,6 +11,10 @@
 name: Nightly flake triage
 
 on:
+  # Matched against the `name:` of nightly-build.yml, exactly - not its filename. The
+  # "(Manual trigger)" and "(Reusable Workflow)" variants of that name are therefore not
+  # triaged: the reusable one produces no run of its own, and a manual re-run is usually
+  # someone testing a fix, where a fresh issue is noise rather than signal.
   workflow_run:
     workflows: ["Nightly test and release workflow"]
     types: [completed]
@@ -33,8 +37,14 @@ jobs:
     env:
       TRIAGE_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
     steps:
-      - name: Checkout Dafny
+      # Only needed to get nightly-flake-triage.js onto disk for the github-script step below, so
+      # take nothing else. On a workflow_run event this checks out the default branch, which is
+      # the copy of the script that is running in any case.
+      - name: Checkout the triage script
         uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/workflows
+          sparse-checkout-cone-mode: false
 
       # Preferred source for the failing test names: `--logger trx` is an explicit contract in
       # integration-tests-reusable.yml, where xUnit's console formatting is only incidental.

--- a/.github/workflows/nightly-flake-triage.yml
+++ b/.github/workflows/nightly-flake-triage.yml
@@ -1,20 +1,14 @@
-# Record which test failed when the nightly build goes red.
+# Record which test failed when the nightly build goes red, into one issue per test. The test
+# name only exists in the run's own output, which expires after 90 days.
 #
-# Job and step names stay in the API for about a year, but the failing test's name lives only in
-# the run's own output, which expires after 90 days. This captures it while it exists, into an
-# issue per test so repeat offenders accumulate a count instead of vanishing.
-#
-# Note `workflow_run` only ever runs the copy of this file on the default branch, so it cannot be
-# exercised from a pull request. Use the `workflow_dispatch` below against a past failed run to
-# try it out, or to backfill runs still inside the retention window.
+# `workflow_run` only ever runs the copy of this file on the default branch, so this cannot be
+# exercised from a pull request. Dispatch it against a past run to try it, or to backfill.
 
 name: Nightly flake triage
 
 on:
-  # Matched against the `name:` of nightly-build.yml, exactly - not its filename. The
-  # "(Manual trigger)" and "(Reusable Workflow)" variants of that name are therefore not
-  # triaged: the reusable one produces no run of its own, and a manual re-run is usually
-  # someone testing a fix, where a fresh issue is noise rather than signal.
+  # Matched against the `name:` of nightly-build.yml, exactly. The "(Manual trigger)" variant is
+  # excluded on purpose: that is usually someone testing a fix, where a new issue is noise.
   workflow_run:
     workflows: ["Nightly test and release workflow"]
     types: [completed]
@@ -27,28 +21,25 @@ on:
 
 jobs:
   triage:
-    # workflow_run fires whatever the conclusion, so filter here. A dispatch is always deliberate.
+    # workflow_run fires whatever the conclusion. A dispatch is always deliberate.
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'success'
     runs-on: ubuntu-24.04
     permissions:
-      actions: read     # list jobs for the run, read its artifacts, download job logs
-      issues: write     # open, comment on and reopen the flake issues
+      actions: read     # list the run's jobs, read its artifacts, download job logs
+      issues: write
       contents: read
     env:
       TRIAGE_RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
     steps:
-      # Only needed to get nightly-flake-triage.js onto disk for the github-script step below, so
-      # take nothing else. On a workflow_run event this checks out the default branch, which is
-      # the copy of the script that is running in any case.
+      # Only to get the script below onto disk, so take nothing else.
       - name: Checkout the triage script
         uses: actions/checkout@v7
         with:
           sparse-checkout: .github/workflows
           sparse-checkout-cone-mode: false
 
-      # Preferred source for the failing test names: `--logger trx` is an explicit contract in
-      # integration-tests-reusable.yml, where xUnit's console formatting is only incidental.
-      # Best-effort - the upload is itself allowed to fail, and old runs may have expired.
+      # Preferred source for the test names: `--logger trx` is an explicit contract in
+      # integration-tests-reusable.yml. Best effort - the upload may have been skipped.
       - name: Download the run's test results
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -62,6 +53,5 @@ jobs:
         with:
           script: |
             const triage = require('${{ github.workspace }}/.github/workflows/nightly-flake-triage.js')
-            // Read from the environment rather than interpolating into this script, which is
-            // JavaScript source: a workflow_dispatch input is arbitrary text.
+            // From the environment, not interpolated: `script:` is JavaScript source.
             await triage({github, context, core}, Number(process.env.TRIAGE_RUN_ID))

--- a/.github/workflows/nightly-flake-triage.yml
+++ b/.github/workflows/nightly-flake-triage.yml
@@ -34,10 +34,13 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: actions/github-script@v9
+        env:
+          # Passed through the environment, not interpolated into the script below: `script:` is
+          # JavaScript source, and a workflow_dispatch input is arbitrary text.
+          DISPATCHED_RUN_ID: ${{ inputs.run_id }}
         with:
           script: |
             const triage = require('${{ github.workspace }}/.github/workflows/nightly-flake-triage.js')
-            const runId = context.eventName === 'workflow_dispatch'
-              ? Number('${{ inputs.run_id }}')
-              : context.payload.workflow_run.id
+            const dispatched = process.env.DISPATCHED_RUN_ID
+            const runId = dispatched ? Number(dispatched) : context.payload.workflow_run.id
             await triage({github, context, core}, runId)

--- a/.github/workflows/nightly-flake-triage.yml
+++ b/.github/workflows/nightly-flake-triage.yml
@@ -1,0 +1,43 @@
+# Record which test failed when the nightly build goes red.
+#
+# Job and step names stay in the API for about a year, but the failing test's name lives only in
+# the job log, which expires after 90 days. This captures it while it exists, into an issue per
+# test so repeat offenders accumulate a count instead of vanishing.
+#
+# Note `workflow_run` only ever runs the copy of this file on the default branch, so it cannot be
+# exercised from a pull request. Use the `workflow_dispatch` below against a past failed run to
+# try it out, or to backfill runs still inside the log retention window.
+
+name: Nightly flake triage
+
+on:
+  workflow_run:
+    workflows: ["Nightly test and release workflow"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Workflow run ID to triage'
+        required: true
+
+jobs:
+  triage:
+    # workflow_run fires whatever the conclusion, so filter here. A dispatch is always deliberate.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read     # list jobs for the run, and download job logs
+      issues: write     # open, comment on and reopen the flake issues
+      contents: read
+    steps:
+      - name: Checkout Dafny
+        uses: actions/checkout@v7
+
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const triage = require('${{ github.workspace }}/.github/workflows/nightly-flake-triage.js')
+            const runId = context.eventName === 'workflow_dispatch'
+              ? Number('${{ inputs.run_id }}')
+              : context.payload.workflow_run.id
+            await triage({github, context, core}, runId)


### PR DESCRIPTION
## Problem

Job and step names stay in the Actions API for about a year, but the **failing test's name lives only in the run's own output — its `.trx` artifacts and job logs — which expires after 90 days**.

That gap is the difference between a diagnosable nightly failure and an unexplainable one. Over the nightly build's full retained history (2025-07-11 → 2026-08-26, 419 runs, 128 red nights), **54 of those nights are now permanently unexplainable** — the logs and artifacts are both gone. And for the nights that *were* still explainable, recovering `logger/JsonLogger.dfy` from nothing but a shard number required reconstructing the deterministic shard-to-test mapping from `TestCollectionShardFilter.cs` and validating it against six known placements. That should not be the cost of answering "which test flaked".

## What this does

On a failed nightly run: read the jobs for **attempt 1**, extract the failing test names from the run's own test results while they still exist, and open one issue per test, labelled `nightly-flake`.

Names come from the **`.trx` artifacts the test workflow already uploads** (`--logger trx`), which is structured, is an explicit contract in `integration-tests-reusable.yml`, and names tests of any extension. Verified against the real artifact from the 2026-08-21 failure:

```xml
<UnitTestResult testName="logger/JsonLogger.dfy" outcome="Failed">
```

This is the **only** source. An earlier revision also scraped names out of xUnit's console output as a fallback, which is gone: every `upload-artifact` failure in the run history (2026-04-24, 05-15, 05-28, 06-05, 08-25) came *after* the test step had already passed, so there was never a failing test for it to recover — and logs expire on the same 90-day clock as artifacts, so it could not rescue an aged-out run either. It was a second implementation of a fragile parser for a case that has not occurred.

Where the results name no failure, the issue records the job and step instead, and says so when the tests themselves failed — pointing at the job log. That keeps the useful part of the fallback, knowing where to look, without a parser to maintain.

Repeat occurrences comment on the existing issue, bump a count in its title (`nightly flake: logger/JsonLogger.dfy (14x)`) and reopen it if closed — so a recurring flake accumulates evidence and can be ranked, instead of evaporating.

Reading **attempt 1 specifically** matters. A manual re-run overwrites the visible conclusion, which is how the run list came to understate the real failure rate by about a third: 21 runs were re-run, and in the last two months alone 7 of 26 failures show as green.

## Design notes

- **`workflow_run` only ever runs the copy of the workflow on the default branch**, so this cannot be exercised from a PR. Hence the `workflow_dispatch` with a `run_id` input — which also lets you backfill runs still inside the 90-day log window once this lands.
- Existing issues are found by **listing the label**, not via `/search/issues`. Search is only eventually consistent and would double-file when two runs fail close together. Matching accepts either a hidden body marker or the title, so a human editing one does not produce a duplicate.
- Reopening keys off GitHub's own **`state_reason`**: closed as *not planned* stays closed, while closed as *completed* reopens on recurrence — because that means the fix did not hold.
- The `run_id` input is declared `type: number` and read from the environment rather than interpolated into the `script:` body, which is JavaScript source.
- If neither source yields a test name, **the issue body says so**. A log warning alone would put that diagnostic somewhere nobody reads, which is the failure mode this workflow exists to fix.
- A run already recorded on an issue is skipped, so **re-dispatching is a no-op**.
- A missing or unhelpful `.trx` falls back to a `job - step` key rather than failing the workflow.
- Titles carry a count and closed issues are reopened rather than merely commented on, because a comment on an old closed thread notifies only its subscribers and is easy to miss.
- The jobs list is paginated: 33 jobs today, but a matrix past 100 would silently truncate.

## Validation

The logic lives in `nightly-flake-triage.js` beside the workflow, matching the existing `check-for-workflow-run.js` convention — which also makes it unit-testable. 18 cases pass, driving the script through `.trx` fixtures on disk since that is its only input, **plus one that runs the real downloaded artifact** rather than a fixture:

```
ok  extracts the failing test from the real 191-result .trx
ok  dedupes on the marker despite a rename
ok  does not reopen not_planned
ok  re-dispatch is a no-op
ok  one issue for a test failing in two jobs
ok  counts from comments, not the title
ok  names a failing .transcript test
ok  flags a test failure with no results
ok  does not name a step for a test failure
ok  rejects a non-numeric run id
...18 total
```

`actionlint` is clean on the new workflow.

## One thing to verify on the first dispatch

Listing the run's jobs and downloading its artifacts both need `actions: read`, which is requested. Worth confirming with a single `workflow_dispatch` against a recent failed run before relying on it — run `32493733431` is a good candidate, since I have already parsed its artifact and know it is intact.

If the download fails, the step is `continue-on-error`, so the job still files `job - step` issues and says the tests left no results, rather than failing silently.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
